### PR TITLE
feat: enable submission email deletion

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -173,7 +173,7 @@ function EditorNavMenu() {
           accessibleBy: "*",
           disabled: !referenceCode,
         },
-        { 
+        {
           title: "Analytics",
           Icon: LeaderboardIcon,
           route: teamAnalyticsLink ? teamAnalyticsLink : `#`,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -18,7 +18,11 @@ import { StyledTableRow } from "../../../../Team/styles";
 import { EmailsUpsertModal } from "./EmailsUpsertModal";
 import { GET_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
 import { RemoveEmailModal } from "./RemoveEmailModal";
-import { GetSubmissionEmails, SubmissionEmailInput } from "./types";
+import {
+  GetSubmissionEmails,
+  SubmissionEmailInput,
+  SubmissionEmailWithFlows,
+} from "./types";
 
 const TableRowButton = styled(Button)(({ theme }) => ({
   textDecoration: "underline",
@@ -60,43 +64,54 @@ const EmailsTableContent = () => {
     },
   );
 
-  const emails = data?.submissionIntegrations;
+  const submissionIntegrations = data?.submissionIntegrations.map(
+    (submissionIntegration) => ({
+      submissionEmail: submissionIntegration.submissionEmail,
+      defaultEmail: submissionIntegration.defaultEmail,
+      teamId: submissionIntegration.teamId,
+      id: submissionIntegration.id,
+      flows: submissionIntegration.flows.map((flow) => ({
+        id: flow.id,
+        name: flow.name,
+        slug: flow.slug,
+      })),
+    }),
+  );
 
   const [showUpsertModal, setShowUpsertModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+
   const [actionType, setActionType] = useState<"add" | "edit" | "remove">(
     "add",
-  );
-  const [initialValues, setInitialValues] = useState<
+  ); // TODO: do we need this if props are now separate types?
+
+  const [selectedUpsertIntegration, setSelectedUpsertIntegration] = useState<
     SubmissionEmailInput | undefined
+  >();
+  const [selectedDeleteIntegration, setSelectedDeleteIntegration] = useState<
+    SubmissionEmailWithFlows | undefined
   >();
 
   const addEmail = () => {
     setActionType("add");
     setShowUpsertModal(true);
-
-    if (!emails || emails.length === 0) {
-      setInitialValues({ defaultEmail: true } as SubmissionEmailInput);
-    } else {
-      setInitialValues(undefined);
-    }
   };
 
   const handleEditEmail = (email: SubmissionEmailInput) => {
     setActionType("edit");
-    setInitialValues(email);
+    setSelectedUpsertIntegration(email);
     setShowUpsertModal(true);
   };
 
-  const deleteEmail = (email: SubmissionEmailInput) => {
+  const deleteEmail = (email: SubmissionEmailWithFlows) => {
     setActionType("remove");
     setShowDeleteModal(true);
-    setInitialValues(email);
+    setSelectedDeleteIntegration(email);
   };
 
   if (loading) return <div>Loading...</div>;
 
-  if (!emails || emails.length === 0) {
+  if (!submissionIntegrations || submissionIntegrations.length === 0) {
     return (
       <>
         <Table>
@@ -119,7 +134,7 @@ const EmailsTableContent = () => {
           <EmailsUpsertModal
             showModal={showUpsertModal}
             setShowModal={setShowUpsertModal}
-            initialValues={initialValues}
+            initialValues={selectedUpsertIntegration}
             actionType={actionType}
             refetch={refetch}
           />
@@ -140,28 +155,36 @@ const EmailsTableContent = () => {
             </StyledTableRow>
           </TableHead>
           <TableBody>
-            {emails.map((email: SubmissionEmailInput) => (
-              <StyledTableRow key={email.id}>
-                <TableCell sx={{ wordWrap: "break-word", maxWidth: "280px" }}>
-                  {email.submissionEmail}
-                </TableCell>
-                <TableCell align="center">
-                  {email.defaultEmail && <CheckIcon color="primary" />}
-                </TableCell>
-                <TableCell>
-                  <EditEmailButton onClick={() => handleEditEmail(email)}>
-                    Edit
-                  </EditEmailButton>
-                </TableCell>
-                <TableCell>
-                  {!email.defaultEmail && (
-                    <RemoveEmailButton onClick={() => deleteEmail(email)}>
-                      Remove
-                    </RemoveEmailButton>
-                  )}
-                </TableCell>
-              </StyledTableRow>
-            ))}
+            {submissionIntegrations.map(
+              (submissionIntegration: SubmissionEmailWithFlows) => (
+                <StyledTableRow key={submissionIntegration.id}>
+                  <TableCell sx={{ wordWrap: "break-word", maxWidth: "280px" }}>
+                    {submissionIntegration.submissionEmail}
+                  </TableCell>
+                  <TableCell align="center">
+                    {submissionIntegration.defaultEmail && (
+                      <CheckIcon color="primary" />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <EditEmailButton
+                      onClick={() => handleEditEmail(submissionIntegration)}
+                    >
+                      Edit
+                    </EditEmailButton>
+                  </TableCell>
+                  <TableCell>
+                    {!submissionIntegration.defaultEmail && (
+                      <RemoveEmailButton
+                        onClick={() => deleteEmail(submissionIntegration)}
+                      >
+                        Remove
+                      </RemoveEmailButton>
+                    )}
+                  </TableCell>
+                </StyledTableRow>
+              ),
+            )}
             <TableRow>
               <TableCell colSpan={4}>
                 <AddButton onClick={addEmail}>Add a new email</AddButton>
@@ -174,19 +197,19 @@ const EmailsTableContent = () => {
         <EmailsUpsertModal
           showModal={showUpsertModal}
           setShowModal={setShowUpsertModal}
-          initialValues={initialValues}
+          initialValues={selectedUpsertIntegration}
           actionType={actionType}
-          currentEmails={data.submissionIntegrations.map(
+          currentEmails={submissionIntegrations.map(
             (email) => email.submissionEmail,
           )}
           refetch={refetch}
         />
       )}
-      {showDeleteModal && (
+      {showDeleteModal && selectedDeleteIntegration && (
         <RemoveEmailModal
           showModal={showDeleteModal}
           setShowModal={setShowDeleteModal}
-          initialValues={initialValues}
+          initialValues={selectedDeleteIntegration}
           actionType={actionType}
           refetch={refetch}
         />

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -17,8 +17,8 @@ import { AddButton } from "ui/editor/AddButton";
 import { StyledTableRow } from "../../../../Team/styles";
 import { EmailsUpsertModal } from "./EmailsUpsertModal";
 import { GET_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
-import { GetSubmissionEmails, SubmissionEmailInput } from "./types";
 import { RemoveEmailModal } from "./RemoveEmailModal";
+import { GetSubmissionEmails, SubmissionEmailInput } from "./types";
 
 const TableRowButton = styled(Button)(({ theme }) => ({
   textDecoration: "underline",
@@ -64,7 +64,9 @@ const EmailsTableContent = () => {
 
   const [showUpsertModal, setShowUpsertModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [actionType, setActionType] = useState<"add" | "edit" | "remove">("add");
+  const [actionType, setActionType] = useState<"add" | "edit" | "remove">(
+    "add",
+  );
   const [initialValues, setInitialValues] = useState<
     SubmissionEmailInput | undefined
   >();
@@ -181,14 +183,14 @@ const EmailsTableContent = () => {
         />
       )}
       {showDeleteModal && (
-          <RemoveEmailModal
-            showModal={showDeleteModal}
-            setShowModal={setShowDeleteModal}
-            initialValues={initialValues}
-            actionType={actionType}
-            refetch={refetch}
-          />
-        )}
+        <RemoveEmailModal
+          showModal={showDeleteModal}
+          setShowModal={setShowDeleteModal}
+          initialValues={initialValues}
+          actionType={actionType}
+          refetch={refetch}
+        />
+      )}
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -18,6 +18,7 @@ import { StyledTableRow } from "../../../../Team/styles";
 import { EmailsUpsertModal } from "./EmailsUpsertModal";
 import { GET_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
 import { GetSubmissionEmails, SubmissionEmailInput } from "./types";
+import { RemoveEmailModal } from "./RemoveEmailModal";
 
 const TableRowButton = styled(Button)(({ theme }) => ({
   textDecoration: "underline",
@@ -36,6 +37,13 @@ const EditEmailButton = styled(TableRowButton)(({ theme }) => ({
   },
 }));
 
+const RemoveEmailButton = styled(TableRowButton)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  "&:hover": {
+    color: theme.palette.secondary.contrastText,
+  },
+}));
+
 const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.light}`,
   borderRadius: theme.shape.borderRadius,
@@ -45,7 +53,7 @@ const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
 const EmailsTableContent = () => {
   const teamId = useStore((state) => state.teamId);
 
-  const { data, loading } = useQuery<GetSubmissionEmails>(
+  const { data, loading, refetch } = useQuery<GetSubmissionEmails>(
     GET_TEAM_SUBMISSION_INTEGRATIONS,
     {
       variables: { teamId },
@@ -54,15 +62,16 @@ const EmailsTableContent = () => {
 
   const emails = data?.submissionIntegrations;
 
-  const [showModal, setShowModal] = useState(false);
-  const [actionType, setActionType] = useState<"add" | "edit">("add");
+  const [showUpsertModal, setShowUpsertModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [actionType, setActionType] = useState<"add" | "edit" | "remove">("add");
   const [initialValues, setInitialValues] = useState<
     SubmissionEmailInput | undefined
   >();
 
   const addEmail = () => {
     setActionType("add");
-    setShowModal(true);
+    setShowUpsertModal(true);
 
     if (!emails || emails.length === 0) {
       setInitialValues({ defaultEmail: true } as SubmissionEmailInput);
@@ -74,7 +83,13 @@ const EmailsTableContent = () => {
   const handleEditEmail = (email: SubmissionEmailInput) => {
     setActionType("edit");
     setInitialValues(email);
-    setShowModal(true);
+    setShowUpsertModal(true);
+  };
+
+  const deleteEmail = (email: SubmissionEmailInput) => {
+    setActionType("remove");
+    setShowDeleteModal(true);
+    setInitialValues(email);
   };
 
   if (loading) return <div>Loading...</div>;
@@ -98,12 +113,13 @@ const EmailsTableContent = () => {
             </TableRow>
           </TableBody>
         </Table>
-        {showModal && (
+        {showUpsertModal && (
           <EmailsUpsertModal
-            showModal={showModal}
-            setShowModal={setShowModal}
+            showModal={showUpsertModal}
+            setShowModal={setShowUpsertModal}
             initialValues={initialValues}
             actionType={actionType}
+            refetch={refetch}
           />
         )}
       </>
@@ -135,6 +151,13 @@ const EmailsTableContent = () => {
                     Edit
                   </EditEmailButton>
                 </TableCell>
+                <TableCell>
+                  {!email.defaultEmail && (
+                    <RemoveEmailButton onClick={() => deleteEmail(email)}>
+                      Remove
+                    </RemoveEmailButton>
+                  )}
+                </TableCell>
               </StyledTableRow>
             ))}
             <TableRow>
@@ -145,17 +168,27 @@ const EmailsTableContent = () => {
           </TableBody>
         </Table>
       </StyledTableContainer>
-      {showModal && (
+      {showUpsertModal && (
         <EmailsUpsertModal
-          showModal={showModal}
-          setShowModal={setShowModal}
+          showModal={showUpsertModal}
+          setShowModal={setShowUpsertModal}
           initialValues={initialValues}
           actionType={actionType}
           currentEmails={data.submissionIntegrations.map(
             (email) => email.submissionEmail,
           )}
+          refetch={refetch}
         />
       )}
+      {showDeleteModal && (
+          <RemoveEmailModal
+            showModal={showDeleteModal}
+            setShowModal={setShowDeleteModal}
+            initialValues={initialValues}
+            actionType={actionType}
+            refetch={refetch}
+          />
+        )}
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -132,6 +132,7 @@ const EmailsTableContent = () => {
               <TableCell>Email</TableCell>
               <TableCell align="center">Default</TableCell>
               <TableCell></TableCell>
+              <TableCell></TableCell>
             </StyledTableRow>
           </TableHead>
           <TableBody>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -83,7 +83,7 @@ const EmailsTableContent = () => {
 
   const [actionType, setActionType] = useState<"add" | "edit" | "remove">(
     "add",
-  ); // TODO: do we need this if props are now separate types?
+  );
 
   const [selectedUpsertIntegration, setSelectedUpsertIntegration] = useState<
     SubmissionEmailInput | undefined
@@ -104,7 +104,6 @@ const EmailsTableContent = () => {
   };
 
   const deleteEmail = (email: SubmissionEmailWithFlows) => {
-    setActionType("remove");
     setShowDeleteModal(true);
     setSelectedDeleteIntegration(email);
   };
@@ -210,7 +209,7 @@ const EmailsTableContent = () => {
           showModal={showDeleteModal}
           setShowModal={setShowDeleteModal}
           initialValues={selectedDeleteIntegration}
-          actionType={actionType}
+          actionType={"remove"}
           refetch={refetch}
         />
       )}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -20,6 +20,7 @@ import { GET_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
 import { RemoveEmailModal } from "./RemoveEmailModal";
 import {
   GetSubmissionEmails,
+  ModalState,
   SubmissionEmailInput,
   SubmissionEmailWithFlows,
 } from "./types";
@@ -66,34 +67,28 @@ const EmailsTableContent = () => {
 
   const submissionIntegrations = data?.submissionIntegrations;
 
-  const [showUpsertModal, setShowUpsertModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const [actionType, setActionType] = useState<"add" | "edit" | "remove">(
-    "add",
-  );
-
-  const [selectedUpsertIntegration, setSelectedUpsertIntegration] = useState<
-    SubmissionEmailInput | undefined
-  >();
-  const [selectedDeleteIntegration, setSelectedDeleteIntegration] = useState<
-    SubmissionEmailWithFlows | undefined
-  >();
+  const [modalState, setModalState] = useState<ModalState>(null);
 
   const addEmail = () => {
-    setActionType("add");
-    setShowUpsertModal(true);
+    setModalState({
+      type: "upsert",
+      actionType: "add",
+    });
   };
 
   const handleEditEmail = (email: SubmissionEmailInput) => {
-    setActionType("edit");
-    setSelectedUpsertIntegration(email);
-    setShowUpsertModal(true);
+    setModalState({
+      type: "upsert",
+      actionType: "edit",
+      integration: email,
+    });
   };
 
   const deleteEmail = (email: SubmissionEmailWithFlows) => {
-    setShowDeleteModal(true);
-    setSelectedDeleteIntegration(email);
+    setModalState({
+      type: "delete",
+      integration: email,
+    });
   };
 
   if (loading) return <div>Loading...</div>;
@@ -117,12 +112,10 @@ const EmailsTableContent = () => {
             </TableRow>
           </TableBody>
         </Table>
-        {showUpsertModal && (
+        {modalState && modalState?.type === "upsert" && (
           <EmailsUpsertModal
-            showModal={showUpsertModal}
-            setShowModal={setShowUpsertModal}
-            initialValues={selectedUpsertIntegration}
-            actionType={actionType}
+            modalState={modalState}
+            setModalState={setModalState}
             refetch={refetch}
           />
         )}
@@ -180,24 +173,20 @@ const EmailsTableContent = () => {
           </TableBody>
         </Table>
       </StyledTableContainer>
-      {showUpsertModal && (
+      {modalState && modalState.type === "upsert" && (
         <EmailsUpsertModal
-          showModal={showUpsertModal}
-          setShowModal={setShowUpsertModal}
-          initialValues={selectedUpsertIntegration}
-          actionType={actionType}
+          modalState={modalState}
+          setModalState={setModalState}
+          refetch={refetch}
           currentEmails={submissionIntegrations.map(
             (email) => email.submissionEmail,
           )}
-          refetch={refetch}
         />
       )}
-      {showDeleteModal && selectedDeleteIntegration && (
+      {modalState && modalState.type === "delete" && (
         <RemoveEmailModal
-          showModal={showDeleteModal}
-          setShowModal={setShowDeleteModal}
-          initialValues={selectedDeleteIntegration}
-          actionType={"remove"}
+          modalState={modalState}
+          setModalState={setModalState}
           refetch={refetch}
         />
       )}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -64,19 +64,7 @@ const EmailsTableContent = () => {
     },
   );
 
-  const submissionIntegrations = data?.submissionIntegrations.map(
-    (submissionIntegration) => ({
-      submissionEmail: submissionIntegration.submissionEmail,
-      defaultEmail: submissionIntegration.defaultEmail,
-      teamId: submissionIntegration.teamId,
-      id: submissionIntegration.id,
-      flows: submissionIntegration.flows.map((flow) => ({
-        id: flow.id,
-        name: flow.name,
-        slug: flow.slug,
-      })),
-    }),
-  );
+  const submissionIntegrations = data?.submissionIntegrations;
 
   const [showUpsertModal, setShowUpsertModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -21,36 +21,39 @@ import {
 import { UpsertModalProps } from "./types";
 
 export const EmailsUpsertModal = ({
-  setShowModal,
-  showModal,
-  initialValues,
-  actionType,
+  modalState,
+  setModalState,
+  refetch,
   currentEmails,
 }: UpsertModalProps) => {
   const teamId = useStore((state) => state.teamId);
   const toast = useToast();
-
   const [upsertEmail] = useMutation(UPSERT_TEAM_SUBMISSION_INTEGRATIONS);
 
+  if (!modalState || modalState.type !== "upsert") {
+    throw new Error("RemoveEmailModal requires an upsert modalState");
+  }
+
   const isFirstEmail = !currentEmails || currentEmails.length === 0;
-  const isDefaultEmail = isFirstEmail || initialValues?.defaultEmail || false;
+  const isDefaultEmail =
+    isFirstEmail || modalState?.integration?.defaultEmail || false;
 
   return (
     <Formik
       initialValues={{
-        submissionEmail: initialValues?.submissionEmail || "",
+        submissionEmail: modalState?.integration?.submissionEmail || "",
         defaultEmail: isDefaultEmail,
         teamId: teamId,
       }}
       validationSchema={upsertEmailSchema(
         currentEmails || [],
-        initialValues?.submissionEmail,
+        modalState?.integration?.submissionEmail,
       )}
       onSubmit={async (values) => {
         const variables = {
           emails: [
             {
-              id: initialValues?.id,
+              id: modalState?.integration?.id,
               submission_email: values.submissionEmail,
               default_email: values.defaultEmail,
               team_id: teamId,
@@ -69,9 +72,9 @@ export const EmailsUpsertModal = ({
         });
 
         toast.success(
-          `Successfully ${actionType === "add" ? "added" : "updated"} email`,
+          `Successfully ${modalState.actionType === "add" ? "added" : "updated"} email`,
         );
-        setShowModal(false);
+        setModalState(null);
       }}
     >
       {({
@@ -83,10 +86,10 @@ export const EmailsUpsertModal = ({
         errors,
         touched,
       }) => (
-        <Dialog open={showModal || false} onClose={() => setShowModal(false)}>
+        <Dialog open={true} onClose={() => setModalState(null)}>
           <form onSubmit={handleSubmit}>
             <DialogTitle variant="h3" component="h1">
-              {actionType === "add" ? "Add Email" : "Edit Email"}
+              {modalState.actionType === "add" ? "Add Email" : "Edit Email"}
             </DialogTitle>
             <DialogContent dividers>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -124,7 +127,7 @@ export const EmailsUpsertModal = ({
             </DialogContent>
             <DialogActions>
               <Button
-                onClick={() => setShowModal(false)}
+                onClick={() => setModalState(null)}
                 color="secondary"
                 variant="contained"
                 sx={{ backgroundColor: "background.default" }}
@@ -139,7 +142,7 @@ export const EmailsUpsertModal = ({
                   (touched.submissionEmail && !!errors.submissionEmail)
                 }
               >
-                {actionType === "add" ? "Add" : "Update"}
+                {modalState.actionType === "add" ? "Add" : "Update"}
               </Button>
             </DialogActions>
           </form>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -18,14 +18,14 @@ import {
   GET_TEAM_SUBMISSION_INTEGRATIONS,
   UPSERT_TEAM_SUBMISSION_INTEGRATIONS,
 } from "./queries";
-import { UpsertModalProps } from "./types";
+import { EditorModalProps } from "./types";
 
 export const EmailsUpsertModal = ({
   modalState,
   setModalState,
-  refetch,
   currentEmails,
-}: UpsertModalProps) => {
+  refetch,
+}: EditorModalProps) => {
   const teamId = useStore((state) => state.teamId);
   const toast = useToast();
   const [upsertEmail] = useMutation(UPSERT_TEAM_SUBMISSION_INTEGRATIONS);
@@ -74,6 +74,7 @@ export const EmailsUpsertModal = ({
         toast.success(
           `Successfully ${modalState.actionType === "add" ? "added" : "updated"} email`,
         );
+        refetch();
         setModalState(null);
       }}
     >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -18,7 +18,7 @@ import {
   GET_TEAM_SUBMISSION_INTEGRATIONS,
   UPSERT_TEAM_SUBMISSION_INTEGRATIONS,
 } from "./queries";
-import { EditorModalProps } from "./types";
+import { UpsertModalProps } from "./types";
 
 export const EmailsUpsertModal = ({
   setShowModal,
@@ -26,7 +26,7 @@ export const EmailsUpsertModal = ({
   initialValues,
   actionType,
   currentEmails,
-}: EditorModalProps) => {
+}: UpsertModalProps) => {
   const teamId = useStore((state) => state.teamId);
   const toast = useToast();
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -25,8 +25,6 @@ export const RemoveEmailModal = ({
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
 
-  console.log({ initialValues });
-
   const usedFlows = initialValues.flows.map((flow) => ({
     id: flow.id,
     slug: flow.slug,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -25,11 +25,7 @@ export const RemoveEmailModal = ({
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
 
-  const usedFlows = initialValues.flows.map((flow) => ({
-    id: flow.id,
-    slug: flow.slug,
-    name: flow.name,
-  }));
+  const usedFlows = initialValues.flows;
   const { slug: teamSlug } = useStore((state) => state.getTeam());
 
   const deletable = usedFlows.length === 0;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -13,15 +13,14 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import {
-    GET_FLOWS,
-GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
-  DELETE_TEAM_SUBMISSION_INTEGRATIONS
+  DELETE_TEAM_SUBMISSION_INTEGRATIONS,
+  GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
+  GET_FLOWS,
 } from "./queries";
-
 import {
-    GetFlows,
-    GetFlowIdsBySubmissionIntegration,
   EditorModalProps,
+  GetFlowIdsBySubmissionIntegration,
+  GetFlows,
   SubmissionEmailInput,
 } from "./types";
 
@@ -45,10 +44,9 @@ export const RemoveEmailModal = ({
 
   const flowIds = flowIdsData?.flowIds.map((flow) => flow.flowId) || [];
 
-  const { data: flowsData, error: flowsError } =
-    useQuery<GetFlows>(GET_FLOWS, {
-      variables: { emailId, flowIds },
-    });
+  const { data: flowsData, error: flowsError } = useQuery<GetFlows>(GET_FLOWS, {
+    variables: { emailId, flowIds },
+  });
 
   const { slug: teamSlug } = useStore((state) => state.getTeam());
 
@@ -119,7 +117,7 @@ export const RemoveEmailModal = ({
                 </ListItem>
               ))}
               <Typography mt={2}>
-                Please <strong>update your Send component </strong> 
+                Please <strong>update your Send component </strong>
                 to use a different email address before removing this one.
               </Typography>
             </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -1,0 +1,149 @@
+import { useMutation, useQuery } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Link from "@mui/material/Link";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import { useToast } from "hooks/useToast";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+import {
+    GET_FLOWS,
+GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
+  DELETE_TEAM_SUBMISSION_INTEGRATIONS
+} from "./queries";
+
+import {
+    GetFlows,
+    GetFlowIdsBySubmissionIntegration,
+  EditorModalProps,
+  SubmissionEmailInput,
+} from "./types";
+
+export const RemoveEmailModal = ({
+  setShowModal,
+  showModal,
+  actionType,
+  initialValues,
+  refetch,
+}: EditorModalProps) => {
+  const toast = useToast();
+  const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
+  const emailId = initialValues?.id || null;
+  const { data: flowIdsData, error: flowIdsError } =
+    useQuery<GetFlowIdsBySubmissionIntegration>(
+      GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
+      {
+        variables: { emailId },
+      },
+    );
+
+  const flowIds = flowIdsData?.flowIds.map((flow) => flow.flowId) || [];
+
+  const { data: flowsData, error: flowsError } =
+    useQuery<GetFlows>(GET_FLOWS, {
+      variables: { emailId, flowIds },
+    });
+
+  const { slug: teamSlug } = useStore((state) => state.getTeam());
+
+  const usedFlows =
+    flowsData?.flows.map((flow) => ({
+      slug: flow.slug,
+      name: flow.name,
+      flowId: flow.id,
+    })) || [];
+
+  const deletable = usedFlows.length === 0;
+
+  const handleRemoveEmail = async (email: SubmissionEmailInput) => {
+    if (!email?.id) {
+      return;
+    }
+    try {
+      await deleteEmail({
+        variables: { submissionEmailId: email.id },
+        optimisticResponse: {
+          delete_submission_integrations: {
+            returning: [{ ...email }],
+          },
+        },
+      });
+      setShowModal(false);
+      toast.success("Email removed successfully");
+      refetch();
+    } catch (error) {
+      console.error("Error deleting email:", error);
+      toast.error("Failed to remove email");
+    }
+  };
+
+  return (
+    <Dialog
+      aria-labelledby="dialog-heading"
+      data-testid={`modal-${actionType}-email`}
+      open={showModal || false}
+      onClose={() => setShowModal(false)}
+      fullWidth
+    >
+      <DialogTitle variant="h3" component="h1">
+        Remove an email
+      </DialogTitle>
+      <DialogContent>
+        <Box mt={2}>
+          {deletable ? (
+            <Typography mb={2}>
+              Are you sure you want to remove the email address "
+              {initialValues?.submissionEmail}" from receiving submissions?
+            </Typography>
+          ) : (
+            <>
+              <Typography mb={2}>
+                This email address cannot be removed as it is currently used in
+                the following flows:
+              </Typography>
+              {usedFlows.map((flow) => (
+                <ListItem key={flow.name}>
+                  <Link
+                    href={`/app/${teamSlug}/${flow.slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {flow.name}
+                  </Link>
+                </ListItem>
+              ))}
+              <Typography mt={2}>
+                Please <strong>update and republish</strong> the flow settings
+                to use a different email address before removing this one.
+              </Typography>
+            </>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          color="secondary"
+          variant="contained"
+          onClick={() => setShowModal(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => initialValues && handleRemoveEmail(initialValues)}
+          data-testid="confirm-remove-email-button"
+          disabled={!deletable}
+        >
+          Remove Email
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -12,17 +12,8 @@ import { useToast } from "hooks/useToast";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
-import {
-  DELETE_TEAM_SUBMISSION_INTEGRATIONS,
-  GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
-  GET_FLOWS,
-} from "./queries";
-import {
-  EditorModalProps,
-  GetFlowIdsBySubmissionIntegration,
-  GetFlows,
-  SubmissionEmailInput,
-} from "./types";
+import { DELETE_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
+import { RemoveModalProps, SubmissionEmailWithFlows } from "./types";
 
 export const RemoveEmailModal = ({
   setShowModal,
@@ -30,45 +21,33 @@ export const RemoveEmailModal = ({
   actionType,
   initialValues,
   refetch,
-}: EditorModalProps) => {
+}: RemoveModalProps) => {
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
-  const emailId = initialValues?.id || null;
-  const { data: flowIdsData, error: flowIdsError } =
-    useQuery<GetFlowIdsBySubmissionIntegration>(
-      GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION,
-      {
-        variables: { emailId },
-      },
-    );
 
-  const flowIds = flowIdsData?.flowIds.map((flow) => flow.flowId) || [];
+  console.log({ initialValues });
 
-  const { data: flowsData, error: flowsError } = useQuery<GetFlows>(GET_FLOWS, {
-    variables: { emailId, flowIds },
-  });
-
+  const usedFlows = initialValues.flows.map((flow) => ({
+    id: flow.id,
+    slug: flow.slug,
+    name: flow.name,
+  }));
   const { slug: teamSlug } = useStore((state) => state.getTeam());
-
-  const usedFlows =
-    flowsData?.flows.map((flow) => ({
-      slug: flow.slug,
-      name: flow.name,
-      flowId: flow.id,
-    })) || [];
 
   const deletable = usedFlows.length === 0;
 
-  const handleRemoveEmail = async (email: SubmissionEmailInput) => {
-    if (!email?.id) {
+  const handleRemoveEmail = async (
+    submissionIntegration: SubmissionEmailWithFlows,
+  ) => {
+    if (!submissionIntegration?.id) {
       return;
     }
     try {
       await deleteEmail({
-        variables: { submissionEmailId: email.id },
+        variables: { submissionEmailId: submissionIntegration.id },
         optimisticResponse: {
           delete_submission_integrations: {
-            returning: [{ ...email }],
+            returning: [{ ...submissionIntegration }],
           },
         },
       });
@@ -97,7 +76,7 @@ export const RemoveEmailModal = ({
           {deletable ? (
             <Typography mb={2}>
               Are you sure you want to remove the email address "
-              {initialValues?.submissionEmail}" from receiving submissions?
+              {initialValues.submissionEmail}" from receiving submissions?
             </Typography>
           ) : (
             <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -119,7 +119,7 @@ export const RemoveEmailModal = ({
                 </ListItem>
               ))}
               <Typography mt={2}>
-                Please <strong>update and republish</strong> the flow settings
+                Please <strong>update your Send component </strong> 
                 to use a different email address before removing this one.
               </Typography>
             </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/RemoveEmailModal.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -13,21 +13,21 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import { DELETE_TEAM_SUBMISSION_INTEGRATIONS } from "./queries";
-import { RemoveModalProps, SubmissionEmailWithFlows } from "./types";
+import { EditorModalProps, SubmissionEmailWithFlows } from "./types";
 
 export const RemoveEmailModal = ({
-  setShowModal,
-  showModal,
-  actionType,
-  initialValues,
+  modalState,
+  setModalState,
   refetch,
-}: RemoveModalProps) => {
+}: EditorModalProps) => {
   const toast = useToast();
   const [deleteEmail] = useMutation(DELETE_TEAM_SUBMISSION_INTEGRATIONS);
-
-  const usedFlows = initialValues.flows;
   const { slug: teamSlug } = useStore((state) => state.getTeam());
 
+  if (!modalState || modalState.type !== "delete") {
+    throw new Error("RemoveEmailModal requires a delete modalState");
+  }
+  const usedFlows = modalState.integration.flows;
   const deletable = usedFlows.length === 0;
 
   const handleRemoveEmail = async (
@@ -45,7 +45,7 @@ export const RemoveEmailModal = ({
           },
         },
       });
-      setShowModal(false);
+      setModalState(null);
       toast.success("Email removed successfully");
       refetch();
     } catch (error) {
@@ -57,9 +57,9 @@ export const RemoveEmailModal = ({
   return (
     <Dialog
       aria-labelledby="dialog-heading"
-      data-testid={`modal-${actionType}-email`}
-      open={showModal || false}
-      onClose={() => setShowModal(false)}
+      data-testid={`modal-${modalState.type}-email`}
+      open={true}
+      onClose={() => setModalState(null)}
       fullWidth
     >
       <DialogTitle variant="h3" component="h1">
@@ -70,7 +70,8 @@ export const RemoveEmailModal = ({
           {deletable ? (
             <Typography mb={2}>
               Are you sure you want to remove the email address "
-              {initialValues.submissionEmail}" from receiving submissions?
+              {modalState.integration.submissionEmail}" from receiving
+              submissions?
             </Typography>
           ) : (
             <>
@@ -101,14 +102,16 @@ export const RemoveEmailModal = ({
         <Button
           color="secondary"
           variant="contained"
-          onClick={() => setShowModal(false)}
+          onClick={() => setModalState(null)}
         >
           Cancel
         </Button>
         <Button
           variant="contained"
           color="warning"
-          onClick={() => initialValues && handleRemoveEmail(initialValues)}
+          onClick={() =>
+            modalState.integration && handleRemoveEmail(modalState.integration)
+          }
           data-testid="confirm-remove-email-button"
           disabled={!deletable}
         >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -1,15 +1,5 @@
 import { gql } from "@apollo/client";
 
-export const GET_FLOWS = gql`
-  query GetFlows($flowIds: [uuid!]!) {
-    flows(where: { id: { _in: $flowIds } }) {
-      slug
-      name
-      id
-    }
-  }
-`;
-
 export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
   query GetTeamSubmissionIntegrations($teamId: Int!) {
     submissionIntegrations: submission_integrations(
@@ -20,6 +10,11 @@ export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
       id
       submissionEmail: submission_email
       defaultEmail: default_email
+      flows {
+        id
+        name
+        slug
+      }
     }
   }
 `;
@@ -41,14 +36,6 @@ export const UPSERT_TEAM_SUBMISSION_INTEGRATIONS = gql`
         teamId: team_id
         defaultEmail: default_email
       }
-    }
-  }
-`;
-
-export const GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION = gql`
-  query GetFlowIdsBySubmissionIntegration($emailId: uuid!) {
-    flowIds: flows(where: { submission_email_id: { _eq: $emailId } }) {
-      flowId: id
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -1,5 +1,15 @@
 import { gql } from "@apollo/client";
 
+export const GET_FLOWS = gql`
+  query GetFlows($flowIds: [uuid!]!) {
+  flows(where: {id: {_in: $flowIds}}) {
+    slug
+    name
+    id
+  }
+}
+`;
+
 export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
   query GetTeamSubmissionIntegrations($teamId: Int!) {
     submissionIntegrations: submission_integrations(
@@ -29,6 +39,35 @@ export const UPSERT_TEAM_SUBMISSION_INTEGRATIONS = gql`
         id
         submissionEmail: submission_email
         teamId: team_id
+        defaultEmail: default_email
+      }
+    }
+  }
+`;
+
+export const GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION = gql`
+  query GetFlowIdsBySubmissionIntegration($emailId: uuid!) {
+    flowIds: flows(
+      where: { submission_email_id: { _eq: $emailId } }
+    ) {
+      flowId: id
+    }
+  }
+`;
+
+export const DELETE_TEAM_SUBMISSION_INTEGRATIONS = gql`
+  mutation DeleteSubmissionIntegration(
+    $submissionEmailId: uuid!
+  ) {
+    delete_submission_integrations(
+      where: {
+        id: { _eq: $submissionEmailId }
+        default_email: { _eq: false }
+      }
+    ) {
+      returning {
+        teamId: team_id
+        submissionEmail: submission_email
         defaultEmail: default_email
       }
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries.ts
@@ -2,12 +2,12 @@ import { gql } from "@apollo/client";
 
 export const GET_FLOWS = gql`
   query GetFlows($flowIds: [uuid!]!) {
-  flows(where: {id: {_in: $flowIds}}) {
-    slug
-    name
-    id
+    flows(where: { id: { _in: $flowIds } }) {
+      slug
+      name
+      id
+    }
   }
-}
 `;
 
 export const GET_TEAM_SUBMISSION_INTEGRATIONS = gql`
@@ -47,23 +47,16 @@ export const UPSERT_TEAM_SUBMISSION_INTEGRATIONS = gql`
 
 export const GET_FLOW_IDS_BY_SUBMISSION_INTEGRATION = gql`
   query GetFlowIdsBySubmissionIntegration($emailId: uuid!) {
-    flowIds: flows(
-      where: { submission_email_id: { _eq: $emailId } }
-    ) {
+    flowIds: flows(where: { submission_email_id: { _eq: $emailId } }) {
       flowId: id
     }
   }
 `;
 
 export const DELETE_TEAM_SUBMISSION_INTEGRATIONS = gql`
-  mutation DeleteSubmissionIntegration(
-    $submissionEmailId: uuid!
-  ) {
+  mutation DeleteSubmissionIntegration($submissionEmailId: uuid!) {
     delete_submission_integrations(
-      where: {
-        id: { _eq: $submissionEmailId }
-        default_email: { _eq: false }
-      }
+      where: { id: { _eq: $submissionEmailId }, default_email: { _eq: false } }
     ) {
       returning {
         teamId: team_id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/schema.ts
@@ -1,7 +1,5 @@
 import { array, boolean, number, object, string } from "yup";
 
-import { SubmissionEmailValues } from "./types";
-
 export const validationSchema = object().shape({
   submissionIntegrations: array(
     object().shape({
@@ -14,7 +12,3 @@ export const validationSchema = object().shape({
     }),
   ),
 });
-
-export const defaultValues: SubmissionEmailValues = {
-  submissionIntegrations: [],
-};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -32,26 +32,29 @@ export interface UpdateTeamSubmissionIntegrationsVariables {
   emails: SubmissionEmailMutation[];
 }
 
+export type Flow = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
 export type ActionType = "add" | "edit" | "remove"; // TODO: refactor, this is a duplicate from "apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts"
 
 export interface EditorModalProps {
   showModal?: boolean;
   setShowModal: React.Dispatch<SetStateAction<boolean>>;
   initialValues?: SubmissionEmailInput;
-  actionType?: ActionType;
-  previousDefaultEmail?: SubmissionEmailInput;
-  currentEmails?: string[];
-  teamId?: number;
+  actionType: ActionType;
   refetch: (
     variables?: Partial<Record<string, any>>,
   ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
 }
 
-export type Flow = {
-  id: string;
-  slug: string;
-  name: string;
-};
+export interface UpsertModalProps extends EditorModalProps {
+    previousDefaultEmail?: SubmissionEmailInput;
+    currentEmails?: string[];
+    teamId?: number;
+}
 
 export interface RemoveModalProps extends Omit<
   EditorModalProps,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -2,33 +2,29 @@ import { ApolloQueryResult } from "@apollo/client";
 import { SetStateAction } from "react";
 import type { SnakeCasedProperties } from "type-fest";
 
-export interface SubmissionEmailInput {
+export interface SubmissionEmail {
   submissionEmail: string;
   defaultEmail: boolean;
   teamId: number;
+  id: string;
+}
+
+export type SubmissionEmailInput = Omit<SubmissionEmail, "id"> & {
   id?: string;
-}
+};
 
-export interface GetFlows {
-  flows: {
-    slug: string;
-    name: string;
-    id: string;
-  }[];
-}
-
-export interface GetFlowIdsBySubmissionIntegration {
-  flowIds: { flowId: string }[];
+export interface SubmissionEmailWithFlows extends Required<SubmissionEmail> {
+  flows: Flow[] | [];
 }
 
 export interface GetSubmissionEmails {
-  submissionIntegrations: Required<SubmissionEmailInput>[];
+  submissionIntegrations: SubmissionEmailWithFlows[];
 }
 
 export type SubmissionEmailMutation =
   SnakeCasedProperties<SubmissionEmailInput>;
 
-export interface SubmissionEmailValues {
+export interface SubmissionEmailInputs {
   submissionIntegrations: SubmissionEmailInput[];
 }
 
@@ -49,4 +45,17 @@ export interface EditorModalProps {
   refetch: (
     variables?: Partial<Record<string, any>>,
   ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
+}
+
+export type Flow = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export interface RemoveModalProps extends Omit<
+  EditorModalProps,
+  "initialValues"
+> {
+  initialValues: SubmissionEmailWithFlows;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -38,13 +38,21 @@ export type Flow = {
   name: string;
 };
 
-export type ActionType = "add" | "edit" | "remove"; // TODO: refactor, this is a duplicate from "apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts"
+export type ModalState =
+  | {
+      type: "upsert";
+      actionType: "add" | "edit";
+      integration?: SubmissionEmailInput;
+    }
+  | {
+      type: "delete";
+      integration: SubmissionEmailWithFlows;
+    }
+  | null;
 
 export interface EditorModalProps {
-  showModal?: boolean;
-  setShowModal: React.Dispatch<SetStateAction<boolean>>;
-  initialValues?: SubmissionEmailInput;
-  actionType: ActionType;
+  modalState: ModalState;
+  setModalState: React.Dispatch<SetStateAction<ModalState>>;
   refetch: (
     variables?: Partial<Record<string, any>>,
   ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
@@ -53,11 +61,4 @@ export interface EditorModalProps {
 export interface UpsertModalProps extends EditorModalProps {
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
-}
-
-export interface RemoveModalProps extends Omit<
-  EditorModalProps,
-  "initialValues"
-> {
-  initialValues: SubmissionEmailWithFlows;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -1,3 +1,4 @@
+import { ApolloQueryResult } from "@apollo/client";
 import { SetStateAction } from "react";
 import type { SnakeCasedProperties } from "type-fest";
 
@@ -6,6 +7,18 @@ export interface SubmissionEmailInput {
   defaultEmail: boolean;
   teamId: number;
   id?: string;
+}
+
+export interface GetFlows {
+  flows: {
+    slug: string,
+    name: string,
+    id: string
+  }[]
+}
+
+export interface GetFlowIdsBySubmissionIntegration {
+  flowIds: { flowId: string }[];
 }
 
 export interface GetSubmissionEmails {
@@ -32,4 +45,8 @@ export interface EditorModalProps {
   actionType?: ActionType;
   previousDefaultEmail?: SubmissionEmailInput;
   currentEmails?: string[];
+  teamId?: number;
+  refetch: (
+    variables?: Partial<Record<string, any>>,
+  ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -53,12 +53,8 @@ export type ModalState =
 export interface EditorModalProps {
   modalState: ModalState;
   setModalState: React.Dispatch<SetStateAction<ModalState>>;
+  currentEmails?: string[];
   refetch: (
     variables?: Partial<Record<string, any>>,
   ) => Promise<ApolloQueryResult<GetSubmissionEmails>>;
-}
-
-export interface UpsertModalProps extends EditorModalProps {
-  previousDefaultEmail?: SubmissionEmailInput;
-  currentEmails?: string[];
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -11,10 +11,10 @@ export interface SubmissionEmailInput {
 
 export interface GetFlows {
   flows: {
-    slug: string,
-    name: string,
-    id: string
-  }[]
+    slug: string;
+    name: string;
+    id: string;
+  }[];
 }
 
 export interface GetFlowIdsBySubmissionIntegration {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -51,9 +51,8 @@ export interface EditorModalProps {
 }
 
 export interface UpsertModalProps extends EditorModalProps {
-    previousDefaultEmail?: SubmissionEmailInput;
-    currentEmails?: string[];
-    teamId?: number;
+  previousDefaultEmail?: SubmissionEmailInput;
+  currentEmails?: string[];
 }
 
 export interface RemoveModalProps extends Omit<

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_submission_integrations.yaml
@@ -14,6 +14,16 @@ object_relationships:
   - name: team_setting
     using:
       foreign_key_constraint_on: team_id
+array_relationships:
+  - name: flows
+    using:
+      manual_configuration:
+        column_mapping:
+          id: submission_email_id
+        insertion_order: null
+        remote_table:
+          name: flows
+          schema: public
 insert_permissions:
   - role: platformAdmin
     permission:


### PR DESCRIPTION
Re-adds the functionality from #6056 but with the updated data model, as discussed at dev call this week. 

Testing
- Add emails to the Team Settings -> Integrations -> Emails Table
- Delete non-default email
- Go to a submission service for that team and select one of your new emails as the send to email destination in the Send component
- Try to delete the email, you should see a link to the flow in which the email is used and a disabled submit button

<img width="600" alt="Screenshot 2026-03-11 121832" src="https://github.com/user-attachments/assets/c0a97924-8fe6-45c3-ae55-7659e33efc27" />
<img width="600" alt="Screenshot 2026-03-11 121802" src="https://github.com/user-attachments/assets/430de42d-4b3c-43fc-8c56-c96007cdf93e" />
<img width="250" alt="Screenshot 2026-03-11 121836" src="https://github.com/user-attachments/assets/6b8c97cd-45cb-42cb-825f-c8f1270831f1" />
