### PR TITLE
feat: write new emails from Send

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -23,19 +23,23 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
 import { Switch } from "ui/shared/Switch";
+import { ValidationError } from "yup";
 
 import { ICONS } from "../shared/icons";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { EditorProps } from "../shared/types";
 import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
+import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
 import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
 import { parseSend, Send, validationSchema } from "./model";
 import {
   EmailEmptyStateProps,
   EmailSelectionProps,
-  GetFlowEmailIdQuery,
+  GetFlowEmailIdQuery
 } from "./types";
+import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
+import { useState } from "react";
 
 const EmailLoadingState: React.FC = () => (
   <Typography variant="body2">Loading email options...</Typography>
@@ -70,9 +74,14 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   teamSlug,
   emailOptions,
   currentEmail,
+  newEmail,
   submissionEmailId,
+  isNewEmailSelected,
   handleSelectChange,
   disabled,
+  newEmailError,
+  setFieldValue,
+  setNewEmail
 }) => (
   <>
     <InputRow>
@@ -92,7 +101,11 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
     <InputRow>
       <SelectInput
         name="submissionEmail"
-        value={submissionEmailId || currentEmail?.id || ""}
+        value={
+          isNewEmailSelected
+            ? "new-email"
+            : submissionEmailId
+        }
         onChange={handleSelectChange}
         bordered
         disabled={disabled}
@@ -102,28 +115,72 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
             {email.submissionEmail}
           </MenuItem>
         ))}
+        <MenuItem value="new-email">
+          New email...
+        </MenuItem>
       </SelectInput>
     </InputRow>
+        {isNewEmailSelected && (
+          <Input
+            name="newEmail"
+            value={newEmail}
+            placeholder="Enter new email"
+            onChange={(e) => {
+              setNewEmail(e.target.value);
+              setFieldValue("newEmail", e.target.value);
+            }}
+            disabled={disabled}
+            errorMessage={newEmailError}
+          />
+        )}
   </>
 );
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
 const SendComponent: React.FC<Props> = (props) => {
+  const [isNewEmailSelected, setIsNewEmailSelected] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
   const formik = useFormikWithRef<Send>(
     {
       initialValues: parseSend(props.node?.data),
       onSubmit: async (newValues) => {
         try {
           if (props.handleSubmit) {
-            await handleUpdate(newValues, existingEmailId, id, refetchFlowData);
+            const updatedEmailId = await handleInsertOrUpdate(
+              teamId,
+              newValues,
+              existingEmailId,
+              insertNewDefaultEmail,
+              newEmail,
+              id
+            );
+
+            if (updatedEmailId) {
+              newValues.submissionEmailId = updatedEmailId;
+            }
+
             props.handleSubmit({ type: TYPES.Send, data: newValues });
           }
         } catch (error) {
           formik.setFieldError("submissionEmailId", (error as Error).message);
         }
       },
-      validationSchema,
+      validate: async (values) => {
+        try {
+          await validationSchema.validate(values, {
+            context: {
+              existingEmails: emailOptions.map(
+                (email: SubmissionEmailInput) => email.submissionEmail,
+              ),
+            },
+          });
+        } catch (error) {
+          if (error instanceof ValidationError) {
+            return { [error.path || "unknown"]: error.message };
+          }
+        }
+      },
     },
     props.formikRef,
   );
@@ -141,46 +198,81 @@ const SendComponent: React.FC<Props> = (props) => {
     error: flowError,
     refetch: refetchFlowData,
   } = useFlowEmailId(id);
-  const existingEmailId = flowData?.flows?.[0]?.submissionEmailId;
+  const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
 
   const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
   const emailOptions = data?.submissionIntegrations || [];
   const defaultEmail = emailOptions.find(
     (email) => email.defaultEmail === true,
   );
+  const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
 
+  const [insertSubmissionIntegration] = useInsertSubmissionIntegration(newEmail, insertNewDefaultEmail, teamId);
   const [updateFlowSubmissionEmail] = useUpdateFlowSubmissionEmail();
 
-  const handleUpdate = async (
+  const handleInsertOrUpdate = async (
+    teamId: number,
     newValues: Send,
     existingEmailId: string | undefined,
+    insertNewDefaultEmail: boolean,
+    newSubmissionEmail: string,
     id: string,
-    refetchFlowData: () => Promise<ApolloQueryResult<GetFlowEmailIdQuery>>,
   ) => {
     const selectedEmailId = newValues.submissionEmailId;
+    const newEmail = newValues.newEmail;
 
-    if (newValues.submissionEmailId && existingEmailId !== selectedEmailId) {
+    // if there is no existing email, write a new one and then update the flows record
+    if (selectedEmailId === "new-email" && newEmail) {
+      const { data } = await insertSubmissionIntegration({
+        variables: {
+          submissionEmail: newSubmissionEmail,
+          defaultEmail: insertNewDefaultEmail,
+          teamId,
+        }
+      })
+      const submissionEmailId = data?.insert_submission_integrations_one?.id;      
+      if (!submissionEmailId) {
+        throw new Error("No submission email ID was returned");
+      }
+
+      // after we add the new record to submission_integrations, we need to update the flows record too
       await updateFlowSubmissionEmail({
         variables: {
           flowId: id,
-          submissionEmailId: newValues.submissionEmailId,
+          submissionEmailId,
         },
       });
-
-      await refetchFlowData();
-      return;
+      return submissionEmailId;
+    }
+    // if a new email is selected
+    if (selectedEmailId && existingEmailId !== selectedEmailId) {
+      await updateFlowSubmissionEmail({
+        variables: {
+          flowId: id,
+          submissionEmailId: selectedEmailId,
+        },
+      });
+      return selectedEmailId;
     }
   };
 
   useEffect(() => {
-    if (!formik.values.submissionEmailId && defaultEmail?.id) {
-      formik.setFieldValue("submissionEmailId", defaultEmail.id);
+    if (flowData) {
+      const existingEmailId = flowData.flowsByPK?.submissionEmailId;
+      if (!formik.values.submissionEmailId && existingEmailId) {
+        formik.setFieldValue("submissionEmailId", existingEmailId);
+      } else if (!formik.values.submissionEmailId && defaultEmail?.id) {
+        formik.setFieldValue("submissionEmailId", defaultEmail.id);
+      }
     }
-  }, [defaultEmail?.id, formik]);
+  }, [flowData, defaultEmail?.id, formik]);
 
   const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
     const selectedValue = event.target.value as string;
     formik.setFieldValue("submissionEmailId", selectedValue);
+
+    setIsNewEmailSelected(selectedValue === "new-email");
+
   };
 
   const currentEmail = emailOptions.find(
@@ -218,9 +310,14 @@ const SendComponent: React.FC<Props> = (props) => {
           teamSlug={teamSlug}
           emailOptions={emailOptions}
           currentEmail={currentEmail}
+          newEmail={newEmail}
           submissionEmailId={formik.values.submissionEmailId}
+          isNewEmailSelected={isNewEmailSelected}
           handleSelectChange={handleSelectChange}
           disabled={props.disabled}
+          newEmailError={formik.errors.newEmail}
+          setFieldValue={formik.setFieldValue}
+          setNewEmail={setNewEmail}
         />
       );
   };

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -1,9 +1,6 @@
-import { ApolloQueryResult } from "@apollo/client/core/types";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
-import MenuItem from "@mui/material/MenuItem";
-import { SelectChangeEvent } from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
 import {
   ComponentType as TYPES,
@@ -14,7 +11,6 @@ import { getIn } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { useEffect } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -22,108 +18,19 @@ import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
-import SelectInput from "ui/shared/SelectInput/SelectInput";
+import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
+import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
 import { Switch } from "ui/shared/Switch";
 import { ValidationError } from "yup";
+import EmailSection from "./EmailSection"
 
 import { ICONS } from "../shared/icons";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { EditorProps } from "../shared/types";
+import { parseSend, Send, validationSchema } from "./model";
+
 import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
-import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
-import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
-import { parseSend, Send, validationSchema } from "./model";
-import {
-  EmailEmptyStateProps,
-  EmailSelectionProps,
-} from "./types";
-
-const EmailLoadingState: React.FC = () => (
-  <Typography variant="body2">Loading email options...</Typography>
-);
-
-const EmailErrorState: React.FC = () => (
-  <Typography variant="body2" color="error">
-    Failed to load email options.
-  </Typography>
-);
-
-const EmailEmptyState: React.FC<EmailEmptyStateProps> = ({
-  teamSlug,
-  error,
-}) => (
-  <ErrorWrapper error={error}>
-    <Typography variant="body2">
-      You do not have a submission email configured. Please add one in your{" "}
-      <Link
-        href={`/app/${teamSlug}/settings/integrations`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        team settings
-      </Link>
-      .
-    </Typography>
-  </ErrorWrapper>
-);
-
-const EmailSelection: React.FC<EmailSelectionProps> = ({
-  teamSlug,
-  emailOptions,
-  newEmail,
-  submissionEmailId,
-  isNewEmailSelected,
-  handleSelectChange,
-  disabled,
-  newEmailError,
-  setFieldValue,
-}) => (
-  <>
-    <InputRow>
-      <Typography variant="body2" mb={2}>
-        Select a submission email for this service. To add or update submission
-        emails, please visit your{" "}
-        <Link
-          href={`/app/${teamSlug}/settings/integrations`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          team settings
-        </Link>{" "}
-        page.
-      </Typography>
-    </InputRow>
-    <InputRow>
-      <SelectInput
-        name="submissionEmail"
-        value={isNewEmailSelected ? "new-email" : submissionEmailId}
-        onChange={handleSelectChange}
-        bordered
-        disabled={disabled}
-      >
-        {emailOptions.map((email) => (
-          <MenuItem key={email.id} value={email.id}>
-            {email.submissionEmail}
-          </MenuItem>
-        ))}
-        <MenuItem value="new-email">New email...</MenuItem>
-      </SelectInput>
-    </InputRow>
-    {isNewEmailSelected && (
-      <Input
-        name="newEmail"
-        value={newEmail}
-        placeholder="Enter new email"
-        onChange={(e) => {
-            setFieldValue("newEmail", e.target.value);
-          }}
-        disabled={disabled}
-        errorMessage={newEmailError}
-      />
-    )}
-  </>
-);
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
@@ -176,20 +83,15 @@ const SendComponent: React.FC<Props> = (props) => {
     state.id,
   ]);
 
-  const {
-    data: flowData,
-    loading: flowLoading,
-    error: flowError,
-    refetch: refetchFlowData,
-  } = useFlowEmailId(id);
+  const { data: flowData } = useFlowEmailId(id);
   const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
 
-  const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
+  const { data } = useTeamSubmissionIntegrations(teamId);
   const emailOptions = data?.submissionIntegrations || [];
   const defaultEmail = emailOptions.find(
-    (email) => email.defaultEmail === true,
+    (email: SubmissionEmailInput) => email.defaultEmail === true,
   );
-  const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
+  const insertNewDefaultEmail = defaultEmail ? false : true;
 
   const [insertSubmissionIntegration] = useInsertSubmissionIntegration();
   const [updateFlowSubmissionEmail] = useUpdateFlowSubmissionEmail();
@@ -201,6 +103,8 @@ const SendComponent: React.FC<Props> = (props) => {
   ): Promise<string | undefined> => {
     const selectedEmailId = newValues.submissionEmailId;
     const newEmail = newValues.newEmail;
+
+
 
     if (selectedEmailId === "new-email" && newEmail) {
       const { data } = await insertSubmissionIntegration({
@@ -234,28 +138,6 @@ const SendComponent: React.FC<Props> = (props) => {
     }
   };
 
-  const isNewEmailSelected = formik.values.submissionEmailId === "new-email";
-
-  useEffect(() => {
-    if (flowData) {
-      const existingEmailId = flowData.flowsByPK?.submissionEmailId;
-      if (!formik.values.submissionEmailId && existingEmailId) {
-        formik.setFieldValue("submissionEmailId", existingEmailId);
-      } else if (!formik.values.submissionEmailId && defaultEmail?.id) {
-        formik.setFieldValue("submissionEmailId", defaultEmail.id);
-      }
-    }
-  }, [flowData, defaultEmail?.id, formik.values.submissionEmailId]);
-
-  const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
-    const selectedValue = event.target.value as string;
-    formik.setFieldValue("submissionEmailId", selectedValue);
-  };
-
-  const currentEmail = emailOptions.find(
-    (email) => email.id === existingEmailId,
-  );
-
   const toggleSwitch = (value: SendIntegration) => {
     let newCheckedValues: SendIntegration[];
 
@@ -267,35 +149,6 @@ const SendComponent: React.FC<Props> = (props) => {
     }
 
     formik.setFieldValue("destinations", newCheckedValues.sort());
-  };
-
-  const renderEmailContent = () => {
-    if (loading || flowLoading) {
-      return <EmailLoadingState />;
-    } else if (error || flowError) {
-      return <EmailErrorState />;
-    } else if (emailOptions.length === 0) {
-      return (
-        <EmailEmptyState
-          teamSlug={teamSlug}
-          error={getIn(formik.errors, "submissionEmailId")}
-        />
-      );
-    } else
-      return (
-        <EmailSelection
-          teamSlug={teamSlug}
-          emailOptions={emailOptions}
-          currentEmail={currentEmail}
-          newEmail={formik.values.newEmail}
-          submissionEmailId={formik.values.submissionEmailId}
-          isNewEmailSelected={isNewEmailSelected}
-          handleSelectChange={handleSelectChange}
-          disabled={props.disabled}
-          newEmailError={formik.errors.newEmail}
-          setFieldValue={formik.setFieldValue}
-        />
-      );
   };
 
   return (
@@ -340,20 +193,13 @@ const SendComponent: React.FC<Props> = (props) => {
               </InputRow>
             </ModalSectionContent>
             <Divider />
-            <ModalSectionContent title={"Email"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("email")}
-                  onChange={() => toggleSwitch("email")}
-                  label={`Send to email`}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-              <>
-                {formik.values.destinations.includes("email") &&
-                  renderEmailContent()}
-              </>
-            </ModalSectionContent>
+            <EmailSection 
+              id={id}
+              teamId={teamId}
+              teamSlug={teamSlug}
+              toggleSwitch={toggleSwitch}
+              disabled={props.disabled}
+              />
             <Divider />
             <ModalSectionContent title={"Microsoft SharePoint"}>
               <InputRow>

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -7,7 +7,7 @@ import {
   SendIntegration,
 } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import { getIn } from "formik";
+import { Formik, getIn } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -35,47 +35,6 @@ import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionInteg
 export type Props = EditorProps<TYPES.Send, Send>;
 
 const SendComponent: React.FC<Props> = (props) => {
-  const formik = useFormikWithRef<Send>(
-    {
-      initialValues: parseSend(props.node?.data),
-      onSubmit: async (newValues) => {
-        try {
-          if (props.handleSubmit) {
-            const updatedEmailId = await handleInsertOrUpdate(
-              newValues,
-              existingEmailId,
-              insertNewDefaultEmail,
-            );
-
-            if (updatedEmailId) {
-              newValues.submissionEmailId = updatedEmailId;
-            }
-
-            props.handleSubmit({ type: TYPES.Send, data: newValues });
-          }
-        } catch (error) {
-          formik.setFieldError("submissionEmailId", (error as Error).message);
-        }
-      },
-      validate: async (values) => {
-        try {
-          await validationSchema.validate(values, {
-            context: {
-              existingEmails: emailOptions.map(
-                (email: SubmissionEmailInput) => email.submissionEmail,
-              ),
-            },
-          });
-        } catch (error) {
-          if (error instanceof ValidationError) {
-            return { [error.path || "unknown"]: error.message };
-          }
-        }
-      },
-    },
-    props.formikRef,
-  );
-
   const [teamSlug, teamId, flowSlug, id] = useStore((state) => [
     state.teamSlug,
     state.teamId,
@@ -138,156 +97,184 @@ const SendComponent: React.FC<Props> = (props) => {
     }
   };
 
-  const toggleSwitch = (value: SendIntegration) => {
-    let newCheckedValues: SendIntegration[];
-
-    // Remove or append this value from the existing array of destinations
-    if (formik.values.destinations.includes(value)) {
-      newCheckedValues = formik.values.destinations.filter((x) => x !== value);
-    } else {
-      newCheckedValues = [...formik.values.destinations, value];
-    }
-
-    formik.setFieldValue("destinations", newCheckedValues.sort());
-  };
-
   return (
-    <form onSubmit={formik.handleSubmit} id="modal">
-      <TemplatedNodeInstructions
-        isTemplatedNode={formik.values.isTemplatedNode}
-        templatedNodeInstructions={formik.values.templatedNodeInstructions}
-        areTemplatedNodeInstructionsRequired={
-          formik.values.areTemplatedNodeInstructionsRequired
+    <Formik<Send>
+      initialValues={parseSend(props.node?.data)}
+      onSubmit={async (newValues, formikHelpers) => {
+        try {
+          if (props.handleSubmit) {
+            const updatedEmailId = await handleInsertOrUpdate(
+              newValues,
+              existingEmailId,
+              insertNewDefaultEmail,
+            );
+
+            if (updatedEmailId) {
+              newValues.submissionEmailId = updatedEmailId;
+            }
+
+            props.handleSubmit({ type: TYPES.Send, data: newValues });
+          }
+        } catch (error) {
+          formikHelpers.setFieldError("submissionEmailId", (error as Error).message);
         }
-      />
-      <ModalSection>
-        <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
-          <InputRow>
-            <Input
-              format="large"
-              name="title"
-              value={formik.values.title}
-              placeholder="Editor title"
-              onChange={formik.handleChange}
-              disabled={props.disabled}
-              errorMessage={formik.errors.title}
-            />
-          </InputRow>
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalSection>
-        <ErrorWrapper error={getIn(formik.errors, "destinations")}>
-          <>
-            <ModalSectionContent title={"Back Office Planning System"}>
+      }}
+    >
+
+      {(formik) => {
+        const toggleSwitch = (value: SendIntegration) => {
+          let newCheckedValues: SendIntegration[];
+
+          // Remove or append this value from the existing array of destinations
+          if (formik.values.destinations.includes(value)) {
+            newCheckedValues = formik.values.destinations.filter((x) => x !== value);
+          } else {
+            newCheckedValues = [...formik.values.destinations, value];
+          }
+
+          formik.setFieldValue("destinations", newCheckedValues.sort());
+        };
+
+      return (
+        <form onSubmit={formik.handleSubmit} id="modal">
+          <TemplatedNodeInstructions
+            isTemplatedNode={formik.values.isTemplatedNode}
+            templatedNodeInstructions={formik.values.templatedNodeInstructions}
+            areTemplatedNodeInstructionsRequired={
+              formik.values.areTemplatedNodeInstructionsRequired
+            }
+          />
+          <ModalSection>
+            <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
               <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("bops")}
-                  onChange={() => toggleSwitch("bops")}
-                  label={`Send to BOPS ${
-                    import.meta.env.VITE_APP_ENV === "production"
-                      ? "production"
-                      : "staging"
-                  }`}
+                <Input
+                  format="large"
+                  name="title"
+                  value={formik.values.title}
+                  placeholder="Editor title"
+                  onChange={formik.handleChange}
                   disabled={props.disabled}
+                  errorMessage={formik.errors.title}
                 />
               </InputRow>
             </ModalSectionContent>
-            <Divider />
-            <EmailSection 
-              id={id}
-              teamId={teamId}
-              teamSlug={teamSlug}
-              toggleSwitch={toggleSwitch}
-              disabled={props.disabled}
-              />
-            <Divider />
-            <ModalSectionContent title={"Microsoft SharePoint"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("s3")}
-                  onChange={() => toggleSwitch("s3")}
-                  label="Send to Microsoft SharePoint"
+          </ModalSection>
+          <ModalSection>
+            <ErrorWrapper error={getIn(formik.errors, "destinations")}>
+              <>
+                <ModalSectionContent title={"Back Office Planning System"}>
+                  <InputRow>
+                    <Switch
+                      checked={formik.values.destinations.includes("bops")}
+                      onChange={() => toggleSwitch("bops")}
+                      label={`Send to BOPS ${
+                        import.meta.env.VITE_APP_ENV === "production"
+                          ? "production"
+                          : "staging"
+                      }`}
+                      disabled={props.disabled}
+                    />
+                  </InputRow>
+                </ModalSectionContent>
+                <Divider />
+                <EmailSection 
+                  id={id}
+                  teamId={teamId}
+                  teamSlug={teamSlug}
+                  toggleSwitch={toggleSwitch}
                   disabled={props.disabled}
-                />
-              </InputRow>
-              <Typography variant="body2">
-                Receive submissions in MS SharePoint via a Power Automate
-                workflow. This option requires you to host a Power Automate
-                webhook that can receive notifications of new submissions in
-                real-time. Learn more about this option in our{" "}
-                <Link
-                  href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  resources
-                </Link>
-                .
-              </Typography>
+                  />
+                <Divider />
+                <ModalSectionContent title={"Microsoft SharePoint"}>
+                  <InputRow>
+                    <Switch
+                      checked={formik.values.destinations.includes("s3")}
+                      onChange={() => toggleSwitch("s3")}
+                      label="Send to Microsoft SharePoint"
+                      disabled={props.disabled}
+                    />
+                  </InputRow>
+                  <Typography variant="body2">
+                    Receive submissions in MS SharePoint via a Power Automate
+                    workflow. This option requires you to host a Power Automate
+                    webhook that can receive notifications of new submissions in
+                    real-time. Learn more about this option in our{" "}
+                    <Link
+                      href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      resources
+                    </Link>
+                    .
+                  </Typography>
+                </ModalSectionContent>
+                <Divider />
+                <ModalSectionContent title={"FME Workbench"}>
+                  <InputRow>
+                    <Switch
+                      checked={formik.values.destinations.includes("fme")}
+                      onChange={() => toggleSwitch("fme")}
+                      label="Retrieve using FME Workbench"
+                      disabled={props.disabled}
+                    />
+                  </InputRow>
+                  <Typography variant="body2">
+                    Retrieve submissions using FME Workbench to download to your
+                    local network. This option requires you to setup a workflow
+                    which polls for new submissions on a schedule of your choice.
+                  </Typography>
+                </ModalSectionContent>
+                <Divider />
+                <ModalSectionContent title={"Uniform"}>
+                  <InputRow>
+                    <Switch
+                      checked={formik.values.destinations.includes("uniform")}
+                      onChange={() => toggleSwitch("uniform")}
+                      label={`Send to Uniform ${
+                        import.meta.env.VITE_APP_ENV === "production"
+                          ? "production"
+                          : "staging"
+                      }`}
+                      disabled={
+                        props.disabled ||
+                        !["buckinghamshire", "lambeth", "southwark"].includes(
+                          teamSlug,
+                        )
+                      }
+                    />
+                  </InputRow>
+                  <Typography variant="body2">
+                    This is a legacy integration with limited support. It is only
+                    available for specific councils and suitable for use with Lawful
+                    Development Certificate applications (existing and proposed).
+                  </Typography>
+                </ModalSectionContent>
+              </>
+            </ErrorWrapper>
+            <ModalSectionContent>
+              <WarningContainer>
+                <FactCheckIcon />
+                <Typography variant="body2" ml={2}>
+                  Records of submissions can be viewed in the{" "}
+                  <Link
+                    href={`/${teamSlug}/${flowSlug}/submissions`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Submissions
+                  </Link>{" "}
+                  log in the left-hand menu. Editors can download successful
+                  submissions within 28 days from receipt.
+                </Typography>
+              </WarningContainer>
             </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"FME Workbench"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("fme")}
-                  onChange={() => toggleSwitch("fme")}
-                  label="Retrieve using FME Workbench"
-                  disabled={props.disabled}
-                />
-              </InputRow>
-              <Typography variant="body2">
-                Retrieve submissions using FME Workbench to download to your
-                local network. This option requires you to setup a workflow
-                which polls for new submissions on a schedule of your choice.
-              </Typography>
-            </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"Uniform"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("uniform")}
-                  onChange={() => toggleSwitch("uniform")}
-                  label={`Send to Uniform ${
-                    import.meta.env.VITE_APP_ENV === "production"
-                      ? "production"
-                      : "staging"
-                  }`}
-                  disabled={
-                    props.disabled ||
-                    !["buckinghamshire", "lambeth", "southwark"].includes(
-                      teamSlug,
-                    )
-                  }
-                />
-              </InputRow>
-              <Typography variant="body2">
-                This is a legacy integration with limited support. It is only
-                available for specific councils and suitable for use with Lawful
-                Development Certificate applications (existing and proposed).
-              </Typography>
-            </ModalSectionContent>
-          </>
-        </ErrorWrapper>
-        <ModalSectionContent>
-          <WarningContainer>
-            <FactCheckIcon />
-            <Typography variant="body2" ml={2}>
-              Records of submissions can be viewed in the{" "}
-              <Link
-                href={`/${teamSlug}/${flowSlug}/submissions`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Submissions
-              </Link>{" "}
-              log in the left-hand menu. Editors can download successful
-              submissions within 28 days from receipt.
-            </Typography>
-          </WarningContainer>
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
-    </form>
+          </ModalSection>
+          <ModalFooter formik={formik} showMoreInformation={false} />
+        </form>
+        );
+      }}
+    </Formik>
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -18,7 +18,6 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
-import { ValidationError } from "yup";
 
 import { ICONS } from "../shared/icons";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
@@ -185,7 +184,6 @@ const SendComponent: React.FC<Props> = (props) => {
                   </ModalSectionContent>
                   <Divider />
                   <EmailSection
-                    id={id}
                     teamId={teamId}
                     teamSlug={teamSlug}
                     toggleSwitch={toggleSwitch}

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -11,9 +11,11 @@ import {
 } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import { getIn } from "formik";
+import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useEffect } from "react";
+import { useState } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -36,10 +38,8 @@ import { parseSend, Send, validationSchema } from "./model";
 import {
   EmailEmptyStateProps,
   EmailSelectionProps,
-  GetFlowEmailIdQuery
+  GetFlowEmailIdQuery,
 } from "./types";
-import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
-import { useState } from "react";
 
 const EmailLoadingState: React.FC = () => (
   <Typography variant="body2">Loading email options...</Typography>
@@ -81,7 +81,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   disabled,
   newEmailError,
   setFieldValue,
-  setNewEmail
+  setNewEmail,
 }) => (
   <>
     <InputRow>
@@ -101,11 +101,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
     <InputRow>
       <SelectInput
         name="submissionEmail"
-        value={
-          isNewEmailSelected
-            ? "new-email"
-            : submissionEmailId
-        }
+        value={isNewEmailSelected ? "new-email" : submissionEmailId}
         onChange={handleSelectChange}
         bordered
         disabled={disabled}
@@ -115,24 +111,22 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
             {email.submissionEmail}
           </MenuItem>
         ))}
-        <MenuItem value="new-email">
-          New email...
-        </MenuItem>
+        <MenuItem value="new-email">New email...</MenuItem>
       </SelectInput>
     </InputRow>
-        {isNewEmailSelected && (
-          <Input
-            name="newEmail"
-            value={newEmail}
-            placeholder="Enter new email"
-            onChange={(e) => {
-              setNewEmail(e.target.value);
-              setFieldValue("newEmail", e.target.value);
-            }}
-            disabled={disabled}
-            errorMessage={newEmailError}
-          />
-        )}
+    {isNewEmailSelected && (
+      <Input
+        name="newEmail"
+        value={newEmail}
+        placeholder="Enter new email"
+        onChange={(e) => {
+          setNewEmail(e.target.value);
+          setFieldValue("newEmail", e.target.value);
+        }}
+        disabled={disabled}
+        errorMessage={newEmailError}
+      />
+    )}
   </>
 );
 
@@ -153,7 +147,7 @@ const SendComponent: React.FC<Props> = (props) => {
               existingEmailId,
               insertNewDefaultEmail,
               newEmail,
-              id
+              id,
             );
 
             if (updatedEmailId) {
@@ -207,7 +201,11 @@ const SendComponent: React.FC<Props> = (props) => {
   );
   const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
 
-  const [insertSubmissionIntegration] = useInsertSubmissionIntegration(newEmail, insertNewDefaultEmail, teamId);
+  const [insertSubmissionIntegration] = useInsertSubmissionIntegration(
+    newEmail,
+    insertNewDefaultEmail,
+    teamId,
+  );
   const [updateFlowSubmissionEmail] = useUpdateFlowSubmissionEmail();
 
   const handleInsertOrUpdate = async (
@@ -228,9 +226,9 @@ const SendComponent: React.FC<Props> = (props) => {
           submissionEmail: newSubmissionEmail,
           defaultEmail: insertNewDefaultEmail,
           teamId,
-        }
-      })
-      const submissionEmailId = data?.insert_submission_integrations_one?.id;      
+        },
+      });
+      const submissionEmailId = data?.insert_submission_integrations_one?.id;
       if (!submissionEmailId) {
         throw new Error("No submission email ID was returned");
       }
@@ -272,7 +270,6 @@ const SendComponent: React.FC<Props> = (props) => {
     formik.setFieldValue("submissionEmailId", selectedValue);
 
     setIsNewEmailSelected(selectedValue === "new-email");
-
   };
 
   const currentEmail = emailOptions.find(

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -49,7 +49,7 @@ const SendComponent: React.FC<Props> = (props) => {
   const defaultEmail = emailOptions.find(
     (email: SubmissionEmailInput) => email.defaultEmail === true,
   );
-  const insertNewDefaultEmail = defaultEmail ? false : true;
+  const insertNewDefaultEmail = !defaultEmail;
 
   const [insertSubmissionIntegration] = useInsertSubmissionIntegration();
   const [updateFlowSubmissionEmail] = useUpdateFlowSubmissionEmail();
@@ -119,6 +119,7 @@ const SendComponent: React.FC<Props> = (props) => {
           );
         }
       }}
+      enableReinitialize={true}
     >
       {(formik) => {
         const toggleSwitch = (value: SendIntegration) => {

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -6,7 +6,6 @@ import {
   ComponentType as TYPES,
   SendIntegration,
 } from "@opensystemslab/planx-core/types";
-import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import { Formik, getIn } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -29,7 +28,7 @@ import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
 import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
 import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
-import { parseSend, Send, validationSchema } from "./model";
+import { parseSend, Send, validateSchema } from "./model";
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
@@ -119,6 +118,11 @@ const SendComponent: React.FC<Props> = (props) => {
           );
         }
       }}
+      validationSchema={validateSchema(
+        emailOptions.map(
+          (email: SubmissionEmailInput) => email.submissionEmail,
+        ),
+      )}
       enableReinitialize={true}
     >
       {(formik) => {

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -18,19 +18,18 @@ import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
-import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
-import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
 import { Switch } from "ui/shared/Switch";
 import { ValidationError } from "yup";
-import EmailSection from "./EmailSection"
 
 import { ICONS } from "../shared/icons";
 import { WarningContainer } from "../shared/Preview/WarningContainer";
 import { EditorProps } from "../shared/types";
-import { parseSend, Send, validationSchema } from "./model";
-
+import EmailSection from "./EmailSection";
 import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
+import { useInsertSubmissionIntegration } from "./hooks/useInsertSubmissionIntegration";
+import { useUpdateFlowSubmissionEmail } from "./hooks/useUpdateFlowSubmissionEmail";
+import { parseSend, Send, validationSchema } from "./model";
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
@@ -62,8 +61,6 @@ const SendComponent: React.FC<Props> = (props) => {
   ): Promise<string | undefined> => {
     const selectedEmailId = newValues.submissionEmailId;
     const newEmail = newValues.newEmail;
-
-
 
     if (selectedEmailId === "new-email" && newEmail) {
       const { data } = await insertSubmissionIntegration({
@@ -116,18 +113,22 @@ const SendComponent: React.FC<Props> = (props) => {
             props.handleSubmit({ type: TYPES.Send, data: newValues });
           }
         } catch (error) {
-          formikHelpers.setFieldError("submissionEmailId", (error as Error).message);
+          formikHelpers.setFieldError(
+            "submissionEmailId",
+            (error as Error).message,
+          );
         }
       }}
     >
-
       {(formik) => {
         const toggleSwitch = (value: SendIntegration) => {
           let newCheckedValues: SendIntegration[];
 
           // Remove or append this value from the existing array of destinations
           if (formik.values.destinations.includes(value)) {
-            newCheckedValues = formik.values.destinations.filter((x) => x !== value);
+            newCheckedValues = formik.values.destinations.filter(
+              (x) => x !== value,
+            );
           } else {
             newCheckedValues = [...formik.values.destinations, value];
           }
@@ -135,143 +136,148 @@ const SendComponent: React.FC<Props> = (props) => {
           formik.setFieldValue("destinations", newCheckedValues.sort());
         };
 
-      return (
-        <form onSubmit={formik.handleSubmit} id="modal">
-          <TemplatedNodeInstructions
-            isTemplatedNode={formik.values.isTemplatedNode}
-            templatedNodeInstructions={formik.values.templatedNodeInstructions}
-            areTemplatedNodeInstructionsRequired={
-              formik.values.areTemplatedNodeInstructionsRequired
-            }
-          />
-          <ModalSection>
-            <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
-              <InputRow>
-                <Input
-                  format="large"
-                  name="title"
-                  value={formik.values.title}
-                  placeholder="Editor title"
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.title}
-                />
-              </InputRow>
-            </ModalSectionContent>
-          </ModalSection>
-          <ModalSection>
-            <ErrorWrapper error={getIn(formik.errors, "destinations")}>
-              <>
-                <ModalSectionContent title={"Back Office Planning System"}>
-                  <InputRow>
-                    <Switch
-                      checked={formik.values.destinations.includes("bops")}
-                      onChange={() => toggleSwitch("bops")}
-                      label={`Send to BOPS ${
-                        import.meta.env.VITE_APP_ENV === "production"
-                          ? "production"
-                          : "staging"
-                      }`}
-                      disabled={props.disabled}
-                    />
-                  </InputRow>
-                </ModalSectionContent>
-                <Divider />
-                <EmailSection 
-                  id={id}
-                  teamId={teamId}
-                  teamSlug={teamSlug}
-                  toggleSwitch={toggleSwitch}
-                  disabled={props.disabled}
+        return (
+          <form onSubmit={formik.handleSubmit} id="modal">
+            <TemplatedNodeInstructions
+              isTemplatedNode={formik.values.isTemplatedNode}
+              templatedNodeInstructions={
+                formik.values.templatedNodeInstructions
+              }
+              areTemplatedNodeInstructionsRequired={
+                formik.values.areTemplatedNodeInstructionsRequired
+              }
+            />
+            <ModalSection>
+              <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
+                <InputRow>
+                  <Input
+                    format="large"
+                    name="title"
+                    value={formik.values.title}
+                    placeholder="Editor title"
+                    onChange={formik.handleChange}
+                    disabled={props.disabled}
+                    errorMessage={formik.errors.title}
                   />
-                <Divider />
-                <ModalSectionContent title={"Microsoft SharePoint"}>
-                  <InputRow>
-                    <Switch
-                      checked={formik.values.destinations.includes("s3")}
-                      onChange={() => toggleSwitch("s3")}
-                      label="Send to Microsoft SharePoint"
-                      disabled={props.disabled}
-                    />
-                  </InputRow>
-                  <Typography variant="body2">
-                    Receive submissions in MS SharePoint via a Power Automate
-                    workflow. This option requires you to host a Power Automate
-                    webhook that can receive notifications of new submissions in
-                    real-time. Learn more about this option in our{" "}
+                </InputRow>
+              </ModalSectionContent>
+            </ModalSection>
+            <ModalSection>
+              <ErrorWrapper error={getIn(formik.errors, "destinations")}>
+                <>
+                  <ModalSectionContent title={"Back Office Planning System"}>
+                    <InputRow>
+                      <Switch
+                        checked={formik.values.destinations.includes("bops")}
+                        onChange={() => toggleSwitch("bops")}
+                        label={`Send to BOPS ${
+                          import.meta.env.VITE_APP_ENV === "production"
+                            ? "production"
+                            : "staging"
+                        }`}
+                        disabled={props.disabled}
+                      />
+                    </InputRow>
+                  </ModalSectionContent>
+                  <Divider />
+                  <EmailSection
+                    id={id}
+                    teamId={teamId}
+                    teamSlug={teamSlug}
+                    toggleSwitch={toggleSwitch}
+                    disabled={props.disabled}
+                  />
+                  <Divider />
+                  <ModalSectionContent title={"Microsoft SharePoint"}>
+                    <InputRow>
+                      <Switch
+                        checked={formik.values.destinations.includes("s3")}
+                        onChange={() => toggleSwitch("s3")}
+                        label="Send to Microsoft SharePoint"
+                        disabled={props.disabled}
+                      />
+                    </InputRow>
+                    <Typography variant="body2">
+                      Receive submissions in MS SharePoint via a Power Automate
+                      workflow. This option requires you to host a Power
+                      Automate webhook that can receive notifications of new
+                      submissions in real-time. Learn more about this option in
+                      our{" "}
+                      <Link
+                        href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        resources
+                      </Link>
+                      .
+                    </Typography>
+                  </ModalSectionContent>
+                  <Divider />
+                  <ModalSectionContent title={"FME Workbench"}>
+                    <InputRow>
+                      <Switch
+                        checked={formik.values.destinations.includes("fme")}
+                        onChange={() => toggleSwitch("fme")}
+                        label="Retrieve using FME Workbench"
+                        disabled={props.disabled}
+                      />
+                    </InputRow>
+                    <Typography variant="body2">
+                      Retrieve submissions using FME Workbench to download to
+                      your local network. This option requires you to setup a
+                      workflow which polls for new submissions on a schedule of
+                      your choice.
+                    </Typography>
+                  </ModalSectionContent>
+                  <Divider />
+                  <ModalSectionContent title={"Uniform"}>
+                    <InputRow>
+                      <Switch
+                        checked={formik.values.destinations.includes("uniform")}
+                        onChange={() => toggleSwitch("uniform")}
+                        label={`Send to Uniform ${
+                          import.meta.env.VITE_APP_ENV === "production"
+                            ? "production"
+                            : "staging"
+                        }`}
+                        disabled={
+                          props.disabled ||
+                          !["buckinghamshire", "lambeth", "southwark"].includes(
+                            teamSlug,
+                          )
+                        }
+                      />
+                    </InputRow>
+                    <Typography variant="body2">
+                      This is a legacy integration with limited support. It is
+                      only available for specific councils and suitable for use
+                      with Lawful Development Certificate applications (existing
+                      and proposed).
+                    </Typography>
+                  </ModalSectionContent>
+                </>
+              </ErrorWrapper>
+              <ModalSectionContent>
+                <WarningContainer>
+                  <FactCheckIcon />
+                  <Typography variant="body2" ml={2}>
+                    Records of submissions can be viewed in the{" "}
                     <Link
-                      href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
+                      href={`/${teamSlug}/${flowSlug}/submissions`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      resources
-                    </Link>
-                    .
+                      Submissions
+                    </Link>{" "}
+                    log in the left-hand menu. Editors can download successful
+                    submissions within 28 days from receipt.
                   </Typography>
-                </ModalSectionContent>
-                <Divider />
-                <ModalSectionContent title={"FME Workbench"}>
-                  <InputRow>
-                    <Switch
-                      checked={formik.values.destinations.includes("fme")}
-                      onChange={() => toggleSwitch("fme")}
-                      label="Retrieve using FME Workbench"
-                      disabled={props.disabled}
-                    />
-                  </InputRow>
-                  <Typography variant="body2">
-                    Retrieve submissions using FME Workbench to download to your
-                    local network. This option requires you to setup a workflow
-                    which polls for new submissions on a schedule of your choice.
-                  </Typography>
-                </ModalSectionContent>
-                <Divider />
-                <ModalSectionContent title={"Uniform"}>
-                  <InputRow>
-                    <Switch
-                      checked={formik.values.destinations.includes("uniform")}
-                      onChange={() => toggleSwitch("uniform")}
-                      label={`Send to Uniform ${
-                        import.meta.env.VITE_APP_ENV === "production"
-                          ? "production"
-                          : "staging"
-                      }`}
-                      disabled={
-                        props.disabled ||
-                        !["buckinghamshire", "lambeth", "southwark"].includes(
-                          teamSlug,
-                        )
-                      }
-                    />
-                  </InputRow>
-                  <Typography variant="body2">
-                    This is a legacy integration with limited support. It is only
-                    available for specific councils and suitable for use with Lawful
-                    Development Certificate applications (existing and proposed).
-                  </Typography>
-                </ModalSectionContent>
-              </>
-            </ErrorWrapper>
-            <ModalSectionContent>
-              <WarningContainer>
-                <FactCheckIcon />
-                <Typography variant="body2" ml={2}>
-                  Records of submissions can be viewed in the{" "}
-                  <Link
-                    href={`/${teamSlug}/${flowSlug}/submissions`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Submissions
-                  </Link>{" "}
-                  log in the left-hand menu. Editors can download successful
-                  submissions within 28 days from receipt.
-                </Typography>
-              </WarningContainer>
-            </ModalSectionContent>
-          </ModalSection>
-          <ModalFooter formik={formik} showMoreInformation={false} />
-        </form>
+                </WarningContainer>
+              </ModalSectionContent>
+            </ModalSection>
+            <ModalFooter formik={formik} showMoreInformation={false} />
+          </form>
         );
       }}
     </Formik>

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -6,10 +6,10 @@ import {
   ComponentType as TYPES,
   SendIntegration,
 } from "@opensystemslab/planx-core/types";
-import { Formik, getIn } from "formik";
+import { Formik, getIn, useFormikContext } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useCallback } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -31,13 +31,186 @@ import { parseSend, Send, validateSchema } from "./model";
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
-const SendComponent: React.FC<Props> = (props) => {
-  const [teamSlug, teamId, flowSlug, id] = useStore((state) => [
+interface SendFormProps {
+  disabled?: boolean;
+}
+
+const SendForm: React.FC<SendFormProps> = ({ disabled }) => {
+  const [teamSlug, teamId, flowSlug] = useStore((state) => [
     state.teamSlug,
     state.teamId,
     state.flowSlug,
-    state.id,
   ]);
+
+  const formik = useFormikContext<Send>();
+
+  const toggleSwitch = useCallback(
+    (value: SendIntegration) => {
+      let newCheckedValues: SendIntegration[];
+
+      if (formik.values.destinations.includes(value)) {
+        newCheckedValues = formik.values.destinations.filter(
+          (x) => x !== value,
+        );
+      } else {
+        newCheckedValues = [...formik.values.destinations, value];
+      }
+
+      formik.setFieldValue("destinations", newCheckedValues.sort());
+    },
+    [formik],
+  );
+
+  return (
+    <form onSubmit={formik.handleSubmit} id="modal">
+      <TemplatedNodeInstructions
+        isTemplatedNode={formik.values.isTemplatedNode}
+        templatedNodeInstructions={formik.values.templatedNodeInstructions}
+        areTemplatedNodeInstructionsRequired={
+          formik.values.areTemplatedNodeInstructionsRequired
+        }
+      />
+      <ModalSection>
+        <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
+          <InputRow>
+            <Input
+              format="large"
+              name="title"
+              value={formik.values.title}
+              placeholder="Editor title"
+              onChange={formik.handleChange}
+              disabled={disabled}
+              errorMessage={formik.errors.title}
+            />
+          </InputRow>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalSection>
+        <ErrorWrapper error={getIn(formik.errors, "destinations")}>
+          <>
+            <ModalSectionContent title={"Back Office Planning System"}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.destinations.includes("bops")}
+                  onChange={() => toggleSwitch("bops")}
+                  label={`Send to BOPS ${
+                    import.meta.env.VITE_APP_ENV === "production"
+                      ? "production"
+                      : "staging"
+                  }`}
+                  disabled={disabled}
+                />
+              </InputRow>
+            </ModalSectionContent>
+            <Divider />
+            <ModalSectionContent title={"Email"}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.destinations.includes("email")}
+                  onChange={() => toggleSwitch("email")}
+                  label={`Send to email`}
+                  disabled={disabled}
+                />
+              </InputRow>
+              {formik.values.destinations.includes("email") ? (
+                <EmailSection teamId={teamId} teamSlug={teamSlug} />
+              ) : (
+                <></>
+              )}
+            </ModalSectionContent>
+            <Divider />
+            <ModalSectionContent title={"Microsoft SharePoint"}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.destinations.includes("s3")}
+                  onChange={() => toggleSwitch("s3")}
+                  label="Send to Microsoft SharePoint"
+                  disabled={disabled}
+                />
+              </InputRow>
+              <Typography variant="body2">
+                Receive submissions in MS SharePoint via a Power Automate
+                workflow. This option requires you to host a Power Automate
+                webhook that can receive notifications of new submissions in
+                real-time. Learn more about this option in our{" "}
+                <Link
+                  href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  resources
+                </Link>
+                .
+              </Typography>
+            </ModalSectionContent>
+            <Divider />
+            <ModalSectionContent title={"FME Workbench"}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.destinations.includes("fme")}
+                  onChange={() => toggleSwitch("fme")}
+                  label="Retrieve using FME Workbench"
+                  disabled={disabled}
+                />
+              </InputRow>
+              <Typography variant="body2">
+                Retrieve submissions using FME Workbench to download to your
+                local network. This option requires you to setup a workflow
+                which polls for new submissions on a schedule of your choice.
+              </Typography>
+            </ModalSectionContent>
+            <Divider />
+            <ModalSectionContent title={"Uniform"}>
+              <InputRow>
+                <Switch
+                  checked={formik.values.destinations.includes("uniform")}
+                  onChange={() => toggleSwitch("uniform")}
+                  label={`Send to Uniform ${
+                    import.meta.env.VITE_APP_ENV === "production"
+                      ? "production"
+                      : "staging"
+                  }`}
+                  disabled={
+                    disabled ||
+                    !["buckinghamshire", "lambeth", "southwark"].includes(
+                      teamSlug,
+                    )
+                  }
+                />
+              </InputRow>
+              <Typography variant="body2">
+                This is a legacy integration with limited support. It is only
+                available for specific councils and suitable for use with Lawful
+                Development Certificate applications (existing and proposed).
+              </Typography>
+            </ModalSectionContent>
+          </>
+        </ErrorWrapper>
+        <ModalSectionContent>
+          <WarningContainer>
+            <FactCheckIcon />
+            <Typography variant="body2" ml={2}>
+              Records of submissions can be viewed in the{" "}
+              <Link
+                href={`/${teamSlug}/${flowSlug}/submissions`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Submissions
+              </Link>{" "}
+              log in the left-hand menu. Editors can download successful
+              submissions within 28 days from receipt.
+            </Typography>
+          </WarningContainer>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalFooter formik={formik} showMoreInformation={false} />
+    </form>
+  );
+};
+
+const SendComponent: React.FC<Props> = (props) => {
+  const [teamId, id] = useStore((state) => [state.teamId, state.id]);
 
   const { data: flowData } = useFlowEmailId(id);
   const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
@@ -123,165 +296,7 @@ const SendComponent: React.FC<Props> = (props) => {
         ),
       )}
     >
-      {(formik) => {
-        const toggleSwitch = (value: SendIntegration) => {
-          let newCheckedValues: SendIntegration[];
-
-          // Remove or append this value from the existing array of destinations
-          if (formik.values.destinations.includes(value)) {
-            newCheckedValues = formik.values.destinations.filter(
-              (x) => x !== value,
-            );
-          } else {
-            newCheckedValues = [...formik.values.destinations, value];
-          }
-
-          formik.setFieldValue("destinations", newCheckedValues.sort());
-        };
-
-        return (
-          <form onSubmit={formik.handleSubmit} id="modal">
-            <TemplatedNodeInstructions
-              isTemplatedNode={formik.values.isTemplatedNode}
-              templatedNodeInstructions={
-                formik.values.templatedNodeInstructions
-              }
-              areTemplatedNodeInstructionsRequired={
-                formik.values.areTemplatedNodeInstructionsRequired
-              }
-            />
-            <ModalSection>
-              <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
-                <InputRow>
-                  <Input
-                    format="large"
-                    name="title"
-                    value={formik.values.title}
-                    placeholder="Editor title"
-                    onChange={formik.handleChange}
-                    disabled={props.disabled}
-                    errorMessage={formik.errors.title}
-                  />
-                </InputRow>
-              </ModalSectionContent>
-            </ModalSection>
-            <ModalSection>
-              <ErrorWrapper error={getIn(formik.errors, "destinations")}>
-                <>
-                  <ModalSectionContent title={"Back Office Planning System"}>
-                    <InputRow>
-                      <Switch
-                        checked={formik.values.destinations.includes("bops")}
-                        onChange={() => toggleSwitch("bops")}
-                        label={`Send to BOPS ${
-                          import.meta.env.VITE_APP_ENV === "production"
-                            ? "production"
-                            : "staging"
-                        }`}
-                        disabled={props.disabled}
-                      />
-                    </InputRow>
-                  </ModalSectionContent>
-                  <Divider />
-                  <EmailSection
-                    teamId={teamId}
-                    teamSlug={teamSlug}
-                    toggleSwitch={toggleSwitch}
-                    disabled={props.disabled}
-                  />
-                  <Divider />
-                  <ModalSectionContent title={"Microsoft SharePoint"}>
-                    <InputRow>
-                      <Switch
-                        checked={formik.values.destinations.includes("s3")}
-                        onChange={() => toggleSwitch("s3")}
-                        label="Send to Microsoft SharePoint"
-                        disabled={props.disabled}
-                      />
-                    </InputRow>
-                    <Typography variant="body2">
-                      Receive submissions in MS SharePoint via a Power Automate
-                      workflow. This option requires you to host a Power
-                      Automate webhook that can receive notifications of new
-                      submissions in real-time. Learn more about this option in
-                      our{" "}
-                      <Link
-                        href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        resources
-                      </Link>
-                      .
-                    </Typography>
-                  </ModalSectionContent>
-                  <Divider />
-                  <ModalSectionContent title={"FME Workbench"}>
-                    <InputRow>
-                      <Switch
-                        checked={formik.values.destinations.includes("fme")}
-                        onChange={() => toggleSwitch("fme")}
-                        label="Retrieve using FME Workbench"
-                        disabled={props.disabled}
-                      />
-                    </InputRow>
-                    <Typography variant="body2">
-                      Retrieve submissions using FME Workbench to download to
-                      your local network. This option requires you to setup a
-                      workflow which polls for new submissions on a schedule of
-                      your choice.
-                    </Typography>
-                  </ModalSectionContent>
-                  <Divider />
-                  <ModalSectionContent title={"Uniform"}>
-                    <InputRow>
-                      <Switch
-                        checked={formik.values.destinations.includes("uniform")}
-                        onChange={() => toggleSwitch("uniform")}
-                        label={`Send to Uniform ${
-                          import.meta.env.VITE_APP_ENV === "production"
-                            ? "production"
-                            : "staging"
-                        }`}
-                        disabled={
-                          props.disabled ||
-                          !["buckinghamshire", "lambeth", "southwark"].includes(
-                            teamSlug,
-                          )
-                        }
-                      />
-                    </InputRow>
-                    <Typography variant="body2">
-                      This is a legacy integration with limited support. It is
-                      only available for specific councils and suitable for use
-                      with Lawful Development Certificate applications (existing
-                      and proposed).
-                    </Typography>
-                  </ModalSectionContent>
-                </>
-              </ErrorWrapper>
-              <ModalSectionContent>
-                <WarningContainer>
-                  <FactCheckIcon />
-                  <Typography variant="body2" ml={2}>
-                    Records of submissions can be viewed in the{" "}
-                    <Link
-                      href={`/${teamSlug}/${flowSlug}/submissions`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Submissions
-                    </Link>{" "}
-                    log in the left-hand menu. Editors can download successful
-                    submissions within 28 days from receipt.
-                  </Typography>
-                </WarningContainer>
-              </ModalSectionContent>
-            </ModalSection>
-            <ModalFooter formik={formik} showMoreInformation={false} />
-          </form>
-        );
-      }}
+      <SendForm />
     </Formik>
   );
 };

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -123,7 +123,6 @@ const SendComponent: React.FC<Props> = (props) => {
           (email: SubmissionEmailInput) => email.submissionEmail,
         ),
       )}
-      enableReinitialize={true}
     >
       {(formik) => {
         const toggleSwitch = (value: SendIntegration) => {

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -15,7 +15,6 @@ import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useEffect } from "react";
-import { useState } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
@@ -38,7 +37,6 @@ import { parseSend, Send, validationSchema } from "./model";
 import {
   EmailEmptyStateProps,
   EmailSelectionProps,
-  GetFlowEmailIdQuery,
 } from "./types";
 
 const EmailLoadingState: React.FC = () => (
@@ -73,7 +71,6 @@ const EmailEmptyState: React.FC<EmailEmptyStateProps> = ({
 const EmailSelection: React.FC<EmailSelectionProps> = ({
   teamSlug,
   emailOptions,
-  currentEmail,
   newEmail,
   submissionEmailId,
   isNewEmailSelected,
@@ -81,7 +78,6 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   disabled,
   newEmailError,
   setFieldValue,
-  setNewEmail,
 }) => (
   <>
     <InputRow>
@@ -120,9 +116,8 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
         value={newEmail}
         placeholder="Enter new email"
         onChange={(e) => {
-          setNewEmail(e.target.value);
-          setFieldValue("newEmail", e.target.value);
-        }}
+            setFieldValue("newEmail", e.target.value);
+          }}
         disabled={disabled}
         errorMessage={newEmailError}
       />
@@ -133,8 +128,6 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
 export type Props = EditorProps<TYPES.Send, Send>;
 
 const SendComponent: React.FC<Props> = (props) => {
-  const [isNewEmailSelected, setIsNewEmailSelected] = useState(false);
-  const [newEmail, setNewEmail] = useState("");
   const formik = useFormikWithRef<Send>(
     {
       initialValues: parseSend(props.node?.data),
@@ -142,12 +135,9 @@ const SendComponent: React.FC<Props> = (props) => {
         try {
           if (props.handleSubmit) {
             const updatedEmailId = await handleInsertOrUpdate(
-              teamId,
               newValues,
               existingEmailId,
               insertNewDefaultEmail,
-              newEmail,
-              id,
             );
 
             if (updatedEmailId) {
@@ -201,39 +191,29 @@ const SendComponent: React.FC<Props> = (props) => {
   );
   const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
 
-  const [insertSubmissionIntegration] = useInsertSubmissionIntegration(
-    newEmail,
-    insertNewDefaultEmail,
-    teamId,
-  );
+  const [insertSubmissionIntegration] = useInsertSubmissionIntegration();
   const [updateFlowSubmissionEmail] = useUpdateFlowSubmissionEmail();
 
   const handleInsertOrUpdate = async (
-    teamId: number,
     newValues: Send,
     existingEmailId: string | undefined,
     insertNewDefaultEmail: boolean,
-    newSubmissionEmail: string,
-    id: string,
-  ) => {
+  ): Promise<string | undefined> => {
     const selectedEmailId = newValues.submissionEmailId;
     const newEmail = newValues.newEmail;
 
-    // if there is no existing email, write a new one and then update the flows record
     if (selectedEmailId === "new-email" && newEmail) {
       const { data } = await insertSubmissionIntegration({
         variables: {
-          submissionEmail: newSubmissionEmail,
+          submissionEmail: newEmail,
           defaultEmail: insertNewDefaultEmail,
           teamId,
         },
       });
-      const submissionEmailId = data?.insert_submission_integrations_one?.id;
+      const submissionEmailId = data?.insertSubmissionIntegrationsOne?.id;
       if (!submissionEmailId) {
         throw new Error("No submission email ID was returned");
       }
-
-      // after we add the new record to submission_integrations, we need to update the flows record too
       await updateFlowSubmissionEmail({
         variables: {
           flowId: id,
@@ -242,7 +222,7 @@ const SendComponent: React.FC<Props> = (props) => {
       });
       return submissionEmailId;
     }
-    // if a new email is selected
+
     if (selectedEmailId && existingEmailId !== selectedEmailId) {
       await updateFlowSubmissionEmail({
         variables: {
@@ -254,6 +234,8 @@ const SendComponent: React.FC<Props> = (props) => {
     }
   };
 
+  const isNewEmailSelected = formik.values.submissionEmailId === "new-email";
+
   useEffect(() => {
     if (flowData) {
       const existingEmailId = flowData.flowsByPK?.submissionEmailId;
@@ -263,13 +245,11 @@ const SendComponent: React.FC<Props> = (props) => {
         formik.setFieldValue("submissionEmailId", defaultEmail.id);
       }
     }
-  }, [flowData, defaultEmail?.id, formik]);
+  }, [flowData, defaultEmail?.id, formik.values.submissionEmailId]);
 
   const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
     const selectedValue = event.target.value as string;
     formik.setFieldValue("submissionEmailId", selectedValue);
-
-    setIsNewEmailSelected(selectedValue === "new-email");
   };
 
   const currentEmail = emailOptions.find(
@@ -307,14 +287,13 @@ const SendComponent: React.FC<Props> = (props) => {
           teamSlug={teamSlug}
           emailOptions={emailOptions}
           currentEmail={currentEmail}
-          newEmail={newEmail}
+          newEmail={formik.values.newEmail}
           submissionEmailId={formik.values.submissionEmailId}
           isNewEmailSelected={isNewEmailSelected}
           handleSelectChange={handleSelectChange}
           disabled={props.disabled}
           newEmailError={formik.errors.newEmail}
           setFieldValue={formik.setFieldValue}
-          setNewEmail={setNewEmail}
         />
       );
   };

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -14,12 +14,10 @@ import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
 import { Switch } from "ui/shared/Switch";
 
-import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
 import { EmailSelectionProps } from "./types";
 
 interface EmailSectionProps {
-  id: string;
   teamId: number;
   teamSlug: string;
   toggleSwitch: (value: SendIntegration) => void;
@@ -31,7 +29,6 @@ interface EmailContentProps {
   error: ApolloError | undefined;
   teamSlug: string;
   emailOptions: Required<SubmissionEmailInput>[];
-  currentEmail: Required<SubmissionEmailInput> | undefined;
   submissionEmailId: string | undefined;
   handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;
@@ -118,21 +115,12 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
 };
 
 const EmailSection: React.FC<EmailSectionProps> = ({
-  id,
   teamId,
   teamSlug,
   toggleSwitch,
   disabled,
 }) => {
   const { values, setFieldValue } = useFormikContext<Send>();
-
-  const {
-    data: flowData,
-    loading: flowLoading,
-    error: flowError,
-  } = useFlowEmailId(id);
-
-  const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
 
   const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
   const emailOptions = data?.submissionIntegrations || [];
@@ -144,10 +132,6 @@ const EmailSection: React.FC<EmailSectionProps> = ({
     const selectedValue = event.target.value as string;
     setFieldValue("submissionEmailId", selectedValue);
   };
-
-  const currentEmail = emailOptions.find(
-    (email) => email.id === existingEmailId,
-  );
 
   useEffect(() => {
     if (!values.submissionEmailId && defaultEmail) {
@@ -166,11 +150,10 @@ const EmailSection: React.FC<EmailSectionProps> = ({
         />
       </InputRow>
       <EmailContent
-        loading={loading || flowLoading}
-        error={error || flowError}
+        loading={loading}
+        error={error}
         teamSlug={teamSlug}
         emailOptions={emailOptions}
-        currentEmail={currentEmail}
         submissionEmailId={values.submissionEmailId}
         handleSelectChange={handleSelectChange}
       />
@@ -183,7 +166,6 @@ const EmailContent: React.FC<EmailContentProps> = ({
   error,
   teamSlug,
   emailOptions,
-  currentEmail,
   submissionEmailId,
   handleSelectChange,
 }) => {
@@ -194,7 +176,6 @@ const EmailContent: React.FC<EmailContentProps> = ({
     <EmailSelection
       teamSlug={teamSlug}
       emailOptions={emailOptions}
-      currentEmail={currentEmail}
       submissionEmailId={submissionEmailId}
       handleSelectChange={handleSelectChange}
     />

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -6,7 +6,7 @@ import { SendIntegration } from "@opensystemslab/planx-core/types";
 import { Send } from "@planx/components/Send/model";
 import { getIn } from "formik";
 import { useFormikContext } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
@@ -146,6 +146,12 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   const currentEmail = emailOptions.find(
     (email) => email.id === existingEmailId,
   );
+
+  useEffect(() => {
+    if (!values.submissionEmailId && defaultEmail) {
+      setFieldValue("submissionEmailId", defaultEmail.id);
+    }
+  }, [defaultEmail?.id]);
 
   const renderEmailContent = () => {
     if (loading || flowLoading) {

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -5,12 +5,10 @@ import { SelectChangeEvent } from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
 import { SendIntegration } from "@opensystemslab/planx-core/types";
 import { Send } from "@planx/components/Send/model";
-import { getIn } from "formik";
 import { useFormikContext } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import React, { useEffect } from "react";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
-import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
@@ -67,7 +65,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
     if (emailOptions.length === 0 && values.submissionEmailId !== "new-email") {
       setFieldValue("submissionEmailId", "new-email");
     }
-  }, [emailOptions.length]);
+  }, [emailOptions.length, setFieldValue, values.submissionEmailId]);
 
   return (
     <>
@@ -126,7 +124,7 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   toggleSwitch,
   disabled,
 }) => {
-  const { values, setFieldValue, errors } = useFormikContext<Send>();
+  const { values, setFieldValue } = useFormikContext<Send>();
 
   const {
     data: flowData,
@@ -142,8 +140,6 @@ const EmailSection: React.FC<EmailSectionProps> = ({
     (email) => email.defaultEmail === true,
   );
 
-  const isNewEmailSelected = values.submissionEmailId === "new-email";
-
   const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
     const selectedValue = event.target.value as string;
     setFieldValue("submissionEmailId", selectedValue);
@@ -157,7 +153,7 @@ const EmailSection: React.FC<EmailSectionProps> = ({
     if (!values.submissionEmailId && defaultEmail) {
       setFieldValue("submissionEmailId", defaultEmail.id);
     }
-  }, [defaultEmail?.id]);
+  }, [defaultEmail?.id, defaultEmail, setFieldValue, values.submissionEmailId]);
 
   return (
     <ModalSectionContent title={"Email"}>
@@ -170,8 +166,8 @@ const EmailSection: React.FC<EmailSectionProps> = ({
         />
       </InputRow>
       <EmailContent
-        loading={loading}
-        error={error}
+        loading={loading || flowLoading}
+        error={error || flowError}
         teamSlug={teamSlug}
         emailOptions={emailOptions}
         currentEmail={currentEmail}

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -1,34 +1,30 @@
+import Link from "@mui/material/Link";
+import MenuItem from "@mui/material/MenuItem";
+import { SelectChangeEvent } from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import { SendIntegration } from "@opensystemslab/planx-core/types";
+import { Send } from "@planx/components/Send/model";
+import { getIn } from "formik";
+import { useFormikContext } from "formik";
+import { useEffect } from "react";
+import React from "react";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
-import MenuItem from "@mui/material/MenuItem";
-import Link from "@mui/material/Link";
-import { SelectChangeEvent } from "@mui/material/Select";
-import Typography from "@mui/material/Typography";
-import { getIn } from "formik";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
 import { Switch } from "ui/shared/Switch";
-import { SendIntegration } from "@opensystemslab/planx-core/types";
-import { useEffect } from "react";
-import { useFormikContext } from "formik";
-import { Send } from "@planx/components/Send/model";
 
 import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
-
-import {
-  EmailEmptyStateProps,
-  EmailSelectionProps,
-} from "./types";
-import React from "react";
+import { EmailEmptyStateProps, EmailSelectionProps } from "./types";
 
 interface EmailSectionProps {
-    id: string;
-    teamId: number;
-    teamSlug: string;
-    toggleSwitch: (value: SendIntegration) => void;
-    disabled?: boolean;
+  id: string;
+  teamId: number;
+  teamSlug: string;
+  toggleSwitch: (value: SendIntegration) => void;
+  disabled?: boolean;
 }
 
 const EmailLoadingState: React.FC = () => (
@@ -108,8 +104,8 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
         value={newEmail}
         placeholder="Enter new email"
         onChange={(e) => {
-            setFieldValue("newEmail", e.target.value);
-          }}
+          setFieldValue("newEmail", e.target.value);
+        }}
         disabled={disabled}
         errorMessage={newEmailError}
       />
@@ -118,97 +114,94 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
 );
 
 const EmailSection: React.FC<EmailSectionProps> = ({
-    id,
-    teamId,
-    teamSlug,
-    toggleSwitch,
-    disabled,
+  id,
+  teamId,
+  teamSlug,
+  toggleSwitch,
+  disabled,
 }) => {
-    const { values, setFieldValue, errors } = useFormikContext<Send>();
+  const { values, setFieldValue, errors } = useFormikContext<Send>();
 
-    const {
-        data: flowData,
-        loading: flowLoading,
-        error: flowError,
-        refetch: refetchFlowData,
-    } = useFlowEmailId(id);
+  const {
+    data: flowData,
+    loading: flowLoading,
+    error: flowError,
+    refetch: refetchFlowData,
+  } = useFlowEmailId(id);
 
-    const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
+  const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
 
-    const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
-    const emailOptions = data?.submissionIntegrations || [];
-    const defaultEmail = emailOptions.find(
+  const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
+  const emailOptions = data?.submissionIntegrations || [];
+  const defaultEmail = emailOptions.find(
     (email) => email.defaultEmail === true,
-    );
-    const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
-    
-    const isNewEmailSelected = values.submissionEmailId === "new-email";
-    
-    useEffect(() => {
-        if (flowData) {
-            const existingEmailId = flowData.flowsByPK?.submissionEmailId;
-            if (!values.submissionEmailId && existingEmailId) {
-            setFieldValue("submissionEmailId", existingEmailId);
-            } else if (!values.submissionEmailId && defaultEmail?.id) {
-            setFieldValue("submissionEmailId", defaultEmail.id);
-            }
-        }
-        }, [flowData, defaultEmail?.id, values.submissionEmailId]);
-    
-      const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
-        const selectedValue = event.target.value as string;
-        setFieldValue("submissionEmailId", selectedValue);
-      };
-    
-      const currentEmail = emailOptions.find(
-        (email) => email.id === existingEmailId,
+  );
+  const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
+
+  const isNewEmailSelected = values.submissionEmailId === "new-email";
+
+  useEffect(() => {
+    if (flowData) {
+      const existingEmailId = flowData.flowsByPK?.submissionEmailId;
+      if (!values.submissionEmailId && existingEmailId) {
+        setFieldValue("submissionEmailId", existingEmailId);
+      } else if (!values.submissionEmailId && defaultEmail?.id) {
+        setFieldValue("submissionEmailId", defaultEmail.id);
+      }
+    }
+  }, [flowData, defaultEmail?.id, values.submissionEmailId]);
+
+  const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
+    const selectedValue = event.target.value as string;
+    setFieldValue("submissionEmailId", selectedValue);
+  };
+
+  const currentEmail = emailOptions.find(
+    (email) => email.id === existingEmailId,
+  );
+
+  const renderEmailContent = () => {
+    if (loading || flowLoading) {
+      return <EmailLoadingState />;
+    } else if (error || flowError) {
+      return <EmailErrorState />;
+    } else if (emailOptions.length === 0) {
+      return (
+        <EmailEmptyState
+          teamSlug={teamSlug}
+          error={getIn(errors, "submissionEmailId")}
+        />
       );
+    } else
+      return (
+        <EmailSelection
+          teamSlug={teamSlug}
+          emailOptions={emailOptions}
+          currentEmail={currentEmail}
+          newEmail={values.newEmail}
+          submissionEmailId={values.submissionEmailId}
+          isNewEmailSelected={isNewEmailSelected}
+          handleSelectChange={handleSelectChange}
+          disabled={disabled}
+          newEmailError={errors.newEmail}
+          setFieldValue={setFieldValue}
+        />
+      );
+  };
 
-    const renderEmailContent = () => {
-        if (loading || flowLoading) {
-          return <EmailLoadingState />;
-        } else if (error || flowError) {
-          return <EmailErrorState />;
-        } else if (emailOptions.length === 0) {
-          return (
-            <EmailEmptyState
-              teamSlug={teamSlug}
-              error={getIn(errors, "submissionEmailId")}
-            />
-          );
-        } else
-          return (
-            <EmailSelection
-              teamSlug={teamSlug}
-              emailOptions={emailOptions}
-              currentEmail={currentEmail}
-              newEmail={values.newEmail}
-              submissionEmailId={values.submissionEmailId}
-              isNewEmailSelected={isNewEmailSelected}
-              handleSelectChange={handleSelectChange}
-              disabled={disabled}
-              newEmailError={errors.newEmail}
-              setFieldValue={setFieldValue}
-            />
-          );
-      };
-
-    return ( 
-        <ModalSectionContent title={"Email"}>
-            <InputRow>
-            <Switch
-                checked={values.destinations.includes("email")}
-                onChange={() => toggleSwitch("email")}
-                label={`Send to email`}
-                disabled={disabled}
-            />
-            </InputRow>
-            <>
-            {values.destinations.includes("email") &&
-                renderEmailContent()}
-            </>
-        </ModalSectionContent>
-    )
+  return (
+    <ModalSectionContent title={"Email"}>
+      <InputRow>
+        <Switch
+          checked={values.destinations.includes("email")}
+          onChange={() => toggleSwitch("email")}
+          label={`Send to email`}
+          disabled={disabled}
+        />
+      </InputRow>
+      <>{values.destinations.includes("email") && renderEmailContent()}</>
+    </ModalSectionContent>
+  );
 };
 
 export default EmailSection;

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -58,60 +58,63 @@ const EmailEmptyState: React.FC<EmailEmptyStateProps> = ({
 const EmailSelection: React.FC<EmailSelectionProps> = ({
   teamSlug,
   emailOptions,
-  newEmail,
   submissionEmailId,
-  isNewEmailSelected,
   handleSelectChange,
   disabled,
-  newEmailError,
-  setFieldValue,
-  touched,
-}) => (
-  <>
-    <InputRow>
-      <Typography variant="body2" mb={2}>
-        Select a submission email for this service. To add or update submission
-        emails, please visit your{" "}
-        <Link
-          href={`/app/${teamSlug}/settings/integrations`}
-          target="_blank"
-          rel="noopener noreferrer"
+}) => {
+  const { values, setFieldValue, touched, errors } = useFormikContext<Send>();
+
+  const newEmail = values.newEmail;
+  const isNewEmailSelected = values.submissionEmailId === "new-email";
+  const newEmailError = errors.newEmail;
+
+  return (
+    <>
+      <InputRow>
+        <Typography variant="body2" mb={2}>
+          Select a submission email for this service. To add or update
+          submission emails, please visit your{" "}
+          <Link
+            href={`/app/${teamSlug}/settings/integrations`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            team settings
+          </Link>{" "}
+          page.
+        </Typography>
+      </InputRow>
+      <InputRow>
+        <SelectInput
+          name="submissionEmail"
+          value={isNewEmailSelected ? "new-email" : submissionEmailId}
+          onChange={handleSelectChange}
+          bordered
+          disabled={disabled}
         >
-          team settings
-        </Link>{" "}
-        page.
-      </Typography>
-    </InputRow>
-    <InputRow>
-      <SelectInput
-        name="submissionEmail"
-        value={isNewEmailSelected ? "new-email" : submissionEmailId}
-        onChange={handleSelectChange}
-        bordered
-        disabled={disabled}
-      >
-        {emailOptions.map((email) => (
-          <MenuItem key={email.id} value={email.id}>
-            {email.submissionEmail}
-          </MenuItem>
-        ))}
-        <MenuItem value="new-email">New email...</MenuItem>
-      </SelectInput>
-    </InputRow>
-    {isNewEmailSelected && (
-      <Input
-        name="newEmail"
-        value={newEmail}
-        placeholder="Enter new email"
-        onChange={(e) => {
-          setFieldValue("newEmail", e.target.value);
-        }}
-        disabled={disabled}
-        errorMessage={touched.newEmail ? newEmailError : undefined}
-      />
-    )}
-  </>
-);
+          {emailOptions.map((email) => (
+            <MenuItem key={email.id} value={email.id}>
+              {email.submissionEmail}
+            </MenuItem>
+          ))}
+          <MenuItem value="new-email">New email...</MenuItem>
+        </SelectInput>
+      </InputRow>
+      {isNewEmailSelected && (
+        <Input
+          name="newEmail"
+          value={newEmail}
+          placeholder="Enter new email"
+          onChange={(e) => {
+            setFieldValue("newEmail", e.target.value);
+          }}
+          disabled={disabled}
+          errorMessage={touched.newEmail ? newEmailError : undefined}
+        />
+      )}
+    </>
+  );
+};
 
 const EmailSection: React.FC<EmailSectionProps> = ({
   id,
@@ -120,7 +123,7 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   toggleSwitch,
   disabled,
 }) => {
-  const { values, setFieldValue, errors, touched } = useFormikContext<Send>();
+  const { values, setFieldValue, errors } = useFormikContext<Send>();
 
   const {
     data: flowData,
@@ -171,14 +174,9 @@ const EmailSection: React.FC<EmailSectionProps> = ({
           teamSlug={teamSlug}
           emailOptions={emailOptions}
           currentEmail={currentEmail}
-          newEmail={values.newEmail}
           submissionEmailId={values.submissionEmailId || defaultEmail?.id}
-          isNewEmailSelected={isNewEmailSelected}
           handleSelectChange={handleSelectChange}
           disabled={disabled}
-          newEmailError={errors.newEmail}
-          setFieldValue={setFieldValue}
-          touched={touched}
         />
       );
   };

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -6,7 +6,6 @@ import { SendIntegration } from "@opensystemslab/planx-core/types";
 import { Send } from "@planx/components/Send/model";
 import { getIn } from "formik";
 import { useFormikContext } from "formik";
-import { useEffect } from "react";
 import React from "react";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -66,6 +65,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   disabled,
   newEmailError,
   setFieldValue,
+  touched,
 }) => (
   <>
     <InputRow>
@@ -107,7 +107,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
           setFieldValue("newEmail", e.target.value);
         }}
         disabled={disabled}
-        errorMessage={newEmailError}
+        errorMessage={touched.newEmail ? newEmailError : undefined}
       />
     )}
   </>
@@ -120,7 +120,7 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   toggleSwitch,
   disabled,
 }) => {
-  const { values, setFieldValue, errors } = useFormikContext<Send>();
+  const { values, setFieldValue, errors, touched } = useFormikContext<Send>();
 
   const {
     data: flowData,
@@ -166,12 +166,13 @@ const EmailSection: React.FC<EmailSectionProps> = ({
           emailOptions={emailOptions}
           currentEmail={currentEmail}
           newEmail={values.newEmail}
-          submissionEmailId={values.submissionEmailId}
+          submissionEmailId={values.submissionEmailId || defaultEmail?.id}
           isNewEmailSelected={isNewEmailSelected}
           handleSelectChange={handleSelectChange}
           disabled={disabled}
           newEmailError={errors.newEmail}
           setFieldValue={setFieldValue}
+          touched={touched}
         />
       );
   };

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -3,16 +3,13 @@ import Link from "@mui/material/Link";
 import MenuItem from "@mui/material/MenuItem";
 import { SelectChangeEvent } from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
-import { SendIntegration } from "@opensystemslab/planx-core/types";
 import { Send } from "@planx/components/Send/model";
 import { useFormikContext } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import React, { useEffect } from "react";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
-import { Switch } from "ui/shared/Switch";
 
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
 import { EmailSelectionProps } from "./types";
@@ -20,8 +17,6 @@ import { EmailSelectionProps } from "./types";
 interface EmailSectionProps {
   teamId: number;
   teamSlug: string;
-  toggleSwitch: (value: SendIntegration) => void;
-  disabled?: boolean;
 }
 
 interface EmailContentProps {
@@ -114,12 +109,7 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   );
 };
 
-const EmailSection: React.FC<EmailSectionProps> = ({
-  teamId,
-  teamSlug,
-  toggleSwitch,
-  disabled,
-}) => {
+const EmailSection: React.FC<EmailSectionProps> = ({ teamId, teamSlug }) => {
   const { values, setFieldValue } = useFormikContext<Send>();
 
   const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
@@ -140,24 +130,14 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   }, [defaultEmail?.id, defaultEmail, setFieldValue, values.submissionEmailId]);
 
   return (
-    <ModalSectionContent title={"Email"}>
-      <InputRow>
-        <Switch
-          checked={values.destinations.includes("email")}
-          onChange={() => toggleSwitch("email")}
-          label={`Send to email`}
-          disabled={disabled}
-        />
-      </InputRow>
-      <EmailContent
-        loading={loading}
-        error={error}
-        teamSlug={teamSlug}
-        emailOptions={emailOptions}
-        submissionEmailId={values.submissionEmailId}
-        handleSelectChange={handleSelectChange}
-      />
-    </ModalSectionContent>
+    <EmailContent
+      loading={loading}
+      error={error}
+      teamSlug={teamSlug}
+      emailOptions={emailOptions}
+      submissionEmailId={values.submissionEmailId}
+      handleSelectChange={handleSelectChange}
+    />
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -126,7 +126,6 @@ const EmailSection: React.FC<EmailSectionProps> = ({
     data: flowData,
     loading: flowLoading,
     error: flowError,
-    refetch: refetchFlowData,
   } = useFlowEmailId(id);
 
   const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
@@ -136,20 +135,8 @@ const EmailSection: React.FC<EmailSectionProps> = ({
   const defaultEmail = emailOptions.find(
     (email) => email.defaultEmail === true,
   );
-  const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
 
   const isNewEmailSelected = values.submissionEmailId === "new-email";
-
-  useEffect(() => {
-    if (flowData) {
-      const existingEmailId = flowData.flowsByPK?.submissionEmailId;
-      if (!values.submissionEmailId && existingEmailId) {
-        setFieldValue("submissionEmailId", existingEmailId);
-      } else if (!values.submissionEmailId && defaultEmail?.id) {
-        setFieldValue("submissionEmailId", defaultEmail.id);
-      }
-    }
-  }, [flowData, defaultEmail?.id, values.submissionEmailId]);
 
   const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
     const selectedValue = event.target.value as string;

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -1,3 +1,4 @@
+import { ApolloError } from "@apollo/client";
 import Link from "@mui/material/Link";
 import MenuItem from "@mui/material/MenuItem";
 import { SelectChangeEvent } from "@mui/material/Select";
@@ -6,6 +7,7 @@ import { SendIntegration } from "@opensystemslab/planx-core/types";
 import { Send } from "@planx/components/Send/model";
 import { getIn } from "formik";
 import { useFormikContext } from "formik";
+import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import React, { useEffect } from "react";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -16,13 +18,24 @@ import { Switch } from "ui/shared/Switch";
 
 import { useFlowEmailId } from "./hooks/useFlowEmailId";
 import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
-import { EmailEmptyStateProps, EmailSelectionProps } from "./types";
+import { EmailSelectionProps } from "./types";
 
 interface EmailSectionProps {
   id: string;
   teamId: number;
   teamSlug: string;
   toggleSwitch: (value: SendIntegration) => void;
+  disabled?: boolean;
+}
+
+interface EmailContentProps {
+  loading: boolean;
+  error: ApolloError | undefined;
+  teamSlug: string;
+  emailOptions: Required<SubmissionEmailInput>[];
+  currentEmail: Required<SubmissionEmailInput> | undefined;
+  submissionEmailId: string | undefined;
+  handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;
 }
 
@@ -36,25 +49,6 @@ const EmailErrorState: React.FC = () => (
   </Typography>
 );
 
-const EmailEmptyState: React.FC<EmailEmptyStateProps> = ({
-  teamSlug,
-  error,
-}) => (
-  <ErrorWrapper error={error}>
-    <Typography variant="body2">
-      You do not have a submission email configured. Please add one in your{" "}
-      <Link
-        href={`/app/${teamSlug}/settings/integrations`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        team settings
-      </Link>
-      .
-    </Typography>
-  </ErrorWrapper>
-);
-
 const EmailSelection: React.FC<EmailSelectionProps> = ({
   teamSlug,
   emailOptions,
@@ -65,15 +59,22 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
   const { values, setFieldValue, touched, errors } = useFormikContext<Send>();
 
   const newEmail = values.newEmail;
-  const isNewEmailSelected = values.submissionEmailId === "new-email";
+  const isNewEmailSelected =
+    emailOptions.length === 0 ? true : values.submissionEmailId === "new-email";
   const newEmailError = errors.newEmail;
+
+  useEffect(() => {
+    if (emailOptions.length === 0 && values.submissionEmailId !== "new-email") {
+      setFieldValue("submissionEmailId", "new-email");
+    }
+  }, [emailOptions.length]);
 
   return (
     <>
       <InputRow>
         <Typography variant="body2" mb={2}>
-          Select a submission email for this service. To add or update
-          submission emails, please visit your{" "}
+          Add or select a submission email address for this service. To edit or
+          delete submission emails, please visit your{" "}
           <Link
             href={`/app/${teamSlug}/settings/integrations`}
             target="_blank"
@@ -84,22 +85,24 @@ const EmailSelection: React.FC<EmailSelectionProps> = ({
           page.
         </Typography>
       </InputRow>
-      <InputRow>
-        <SelectInput
-          name="submissionEmail"
-          value={isNewEmailSelected ? "new-email" : submissionEmailId}
-          onChange={handleSelectChange}
-          bordered
-          disabled={disabled}
-        >
-          {emailOptions.map((email) => (
-            <MenuItem key={email.id} value={email.id}>
-              {email.submissionEmail}
-            </MenuItem>
-          ))}
-          <MenuItem value="new-email">New email...</MenuItem>
-        </SelectInput>
-      </InputRow>
+      {emailOptions.length > 0 && (
+        <InputRow>
+          <SelectInput
+            name="submissionEmail"
+            value={isNewEmailSelected ? "new-email" : submissionEmailId}
+            onChange={handleSelectChange}
+            bordered
+            disabled={disabled}
+          >
+            {emailOptions.map((email) => (
+              <MenuItem key={email.id} value={email.id}>
+                {email.submissionEmail}
+              </MenuItem>
+            ))}
+            <MenuItem value="new-email">New email...</MenuItem>
+          </SelectInput>
+        </InputRow>
+      )}
       {isNewEmailSelected && (
         <Input
           name="newEmail"
@@ -156,31 +159,6 @@ const EmailSection: React.FC<EmailSectionProps> = ({
     }
   }, [defaultEmail?.id]);
 
-  const renderEmailContent = () => {
-    if (loading || flowLoading) {
-      return <EmailLoadingState />;
-    } else if (error || flowError) {
-      return <EmailErrorState />;
-    } else if (emailOptions.length === 0) {
-      return (
-        <EmailEmptyState
-          teamSlug={teamSlug}
-          error={getIn(errors, "submissionEmailId")}
-        />
-      );
-    } else
-      return (
-        <EmailSelection
-          teamSlug={teamSlug}
-          emailOptions={emailOptions}
-          currentEmail={currentEmail}
-          submissionEmailId={values.submissionEmailId || defaultEmail?.id}
-          handleSelectChange={handleSelectChange}
-          disabled={disabled}
-        />
-      );
-  };
-
   return (
     <ModalSectionContent title={"Email"}>
       <InputRow>
@@ -191,8 +169,39 @@ const EmailSection: React.FC<EmailSectionProps> = ({
           disabled={disabled}
         />
       </InputRow>
-      <>{values.destinations.includes("email") && renderEmailContent()}</>
+      <EmailContent
+        loading={loading}
+        error={error}
+        teamSlug={teamSlug}
+        emailOptions={emailOptions}
+        currentEmail={currentEmail}
+        submissionEmailId={values.submissionEmailId}
+        handleSelectChange={handleSelectChange}
+      />
     </ModalSectionContent>
+  );
+};
+
+const EmailContent: React.FC<EmailContentProps> = ({
+  loading,
+  error,
+  teamSlug,
+  emailOptions,
+  currentEmail,
+  submissionEmailId,
+  handleSelectChange,
+}) => {
+  if (loading) return <EmailLoadingState />;
+  if (error) return <EmailErrorState />;
+
+  return (
+    <EmailSelection
+      teamSlug={teamSlug}
+      emailOptions={emailOptions}
+      currentEmail={currentEmail}
+      submissionEmailId={submissionEmailId}
+      handleSelectChange={handleSelectChange}
+    />
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/EmailSection.tsx
@@ -1,0 +1,214 @@
+import ErrorWrapper from "ui/shared/ErrorWrapper";
+import Input from "ui/shared/Input/Input";
+import InputRow from "ui/shared/InputRow";
+import SelectInput from "ui/shared/SelectInput/SelectInput";
+import MenuItem from "@mui/material/MenuItem";
+import Link from "@mui/material/Link";
+import { SelectChangeEvent } from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import { getIn } from "formik";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
+import { Switch } from "ui/shared/Switch";
+import { SendIntegration } from "@opensystemslab/planx-core/types";
+import { useEffect } from "react";
+import { useFormikContext } from "formik";
+import { Send } from "@planx/components/Send/model";
+
+import { useFlowEmailId } from "./hooks/useFlowEmailId";
+import { useTeamSubmissionIntegrations } from "./hooks/useGetTeamSubmissionIntegrations";
+
+import {
+  EmailEmptyStateProps,
+  EmailSelectionProps,
+} from "./types";
+import React from "react";
+
+interface EmailSectionProps {
+    id: string;
+    teamId: number;
+    teamSlug: string;
+    toggleSwitch: (value: SendIntegration) => void;
+    disabled?: boolean;
+}
+
+const EmailLoadingState: React.FC = () => (
+  <Typography variant="body2">Loading email options...</Typography>
+);
+
+const EmailErrorState: React.FC = () => (
+  <Typography variant="body2" color="error">
+    Failed to load email options.
+  </Typography>
+);
+
+const EmailEmptyState: React.FC<EmailEmptyStateProps> = ({
+  teamSlug,
+  error,
+}) => (
+  <ErrorWrapper error={error}>
+    <Typography variant="body2">
+      You do not have a submission email configured. Please add one in your{" "}
+      <Link
+        href={`/app/${teamSlug}/settings/integrations`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        team settings
+      </Link>
+      .
+    </Typography>
+  </ErrorWrapper>
+);
+
+const EmailSelection: React.FC<EmailSelectionProps> = ({
+  teamSlug,
+  emailOptions,
+  newEmail,
+  submissionEmailId,
+  isNewEmailSelected,
+  handleSelectChange,
+  disabled,
+  newEmailError,
+  setFieldValue,
+}) => (
+  <>
+    <InputRow>
+      <Typography variant="body2" mb={2}>
+        Select a submission email for this service. To add or update submission
+        emails, please visit your{" "}
+        <Link
+          href={`/app/${teamSlug}/settings/integrations`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          team settings
+        </Link>{" "}
+        page.
+      </Typography>
+    </InputRow>
+    <InputRow>
+      <SelectInput
+        name="submissionEmail"
+        value={isNewEmailSelected ? "new-email" : submissionEmailId}
+        onChange={handleSelectChange}
+        bordered
+        disabled={disabled}
+      >
+        {emailOptions.map((email) => (
+          <MenuItem key={email.id} value={email.id}>
+            {email.submissionEmail}
+          </MenuItem>
+        ))}
+        <MenuItem value="new-email">New email...</MenuItem>
+      </SelectInput>
+    </InputRow>
+    {isNewEmailSelected && (
+      <Input
+        name="newEmail"
+        value={newEmail}
+        placeholder="Enter new email"
+        onChange={(e) => {
+            setFieldValue("newEmail", e.target.value);
+          }}
+        disabled={disabled}
+        errorMessage={newEmailError}
+      />
+    )}
+  </>
+);
+
+const EmailSection: React.FC<EmailSectionProps> = ({
+    id,
+    teamId,
+    teamSlug,
+    toggleSwitch,
+    disabled,
+}) => {
+    const { values, setFieldValue, errors } = useFormikContext<Send>();
+
+    const {
+        data: flowData,
+        loading: flowLoading,
+        error: flowError,
+        refetch: refetchFlowData,
+    } = useFlowEmailId(id);
+
+    const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
+
+    const { data, loading, error } = useTeamSubmissionIntegrations(teamId);
+    const emailOptions = data?.submissionIntegrations || [];
+    const defaultEmail = emailOptions.find(
+    (email) => email.defaultEmail === true,
+    );
+    const insertNewDefaultEmail = defaultEmail ? false : true; // if an existing defaultEmail is set, the newly added one is not default
+    
+    const isNewEmailSelected = values.submissionEmailId === "new-email";
+    
+    useEffect(() => {
+        if (flowData) {
+            const existingEmailId = flowData.flowsByPK?.submissionEmailId;
+            if (!values.submissionEmailId && existingEmailId) {
+            setFieldValue("submissionEmailId", existingEmailId);
+            } else if (!values.submissionEmailId && defaultEmail?.id) {
+            setFieldValue("submissionEmailId", defaultEmail.id);
+            }
+        }
+        }, [flowData, defaultEmail?.id, values.submissionEmailId]);
+    
+      const handleSelectChange = (event: SelectChangeEvent<unknown>) => {
+        const selectedValue = event.target.value as string;
+        setFieldValue("submissionEmailId", selectedValue);
+      };
+    
+      const currentEmail = emailOptions.find(
+        (email) => email.id === existingEmailId,
+      );
+
+    const renderEmailContent = () => {
+        if (loading || flowLoading) {
+          return <EmailLoadingState />;
+        } else if (error || flowError) {
+          return <EmailErrorState />;
+        } else if (emailOptions.length === 0) {
+          return (
+            <EmailEmptyState
+              teamSlug={teamSlug}
+              error={getIn(errors, "submissionEmailId")}
+            />
+          );
+        } else
+          return (
+            <EmailSelection
+              teamSlug={teamSlug}
+              emailOptions={emailOptions}
+              currentEmail={currentEmail}
+              newEmail={values.newEmail}
+              submissionEmailId={values.submissionEmailId}
+              isNewEmailSelected={isNewEmailSelected}
+              handleSelectChange={handleSelectChange}
+              disabled={disabled}
+              newEmailError={errors.newEmail}
+              setFieldValue={setFieldValue}
+            />
+          );
+      };
+
+    return ( 
+        <ModalSectionContent title={"Email"}>
+            <InputRow>
+            <Switch
+                checked={values.destinations.includes("email")}
+                onChange={() => toggleSwitch("email")}
+                label={`Send to email`}
+                disabled={disabled}
+            />
+            </InputRow>
+            <>
+            {values.destinations.includes("email") &&
+                renderEmailContent()}
+            </>
+        </ModalSectionContent>
+    )
+};
+
+export default EmailSection;

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useFlowEmailId.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useFlowEmailId.tsx
@@ -8,6 +8,7 @@ export const useFlowEmailId = (flowId: string) => {
     GET_FLOW_EMAIL_ID,
     {
       variables: { flowId },
+      fetchPolicy: "network-only",
     },
   );
 

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useFlowEmailId.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useFlowEmailId.tsx
@@ -8,7 +8,6 @@ export const useFlowEmailId = (flowId: string) => {
     GET_FLOW_EMAIL_ID,
     {
       variables: { flowId },
-      fetchPolicy: "network-only",
     },
   );
 

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useGetTeamSubmissionIntegrations.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useGetTeamSubmissionIntegrations.tsx
@@ -10,6 +10,7 @@ export const useTeamSubmissionIntegrations = (teamId: number) => {
     GetTeamSubmissionIntegrationsQueryVariables
   >(GET_TEAM_SUBMISSION_INTEGRATIONS, {
     variables: { teamId },
+    fetchPolicy: "network-only",
   });
 
   return query;

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
@@ -1,21 +1,12 @@
 import { useMutation } from "@apollo/client";
-import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries";
+import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "../queries";
 import {
   SubmissionEmailInput,
   SubmissionEmailMutation,
 } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 
-export const useInsertSubmissionIntegration = (
-  submissionEmail: string,
-  defaultEmail: boolean,
-  teamId: number,
-) => {
-  const query = useMutation<SubmissionEmailMutation, SubmissionEmailInput>(
-    INSERT_TEAM_SUBMISSION_INTEGRATION,
-    {
-      variables: { teamId, submissionEmail, defaultEmail },
-    },
+export const useInsertSubmissionIntegration = () => {
+  return useMutation<SubmissionEmailMutation, SubmissionEmailInput>(
+    INSERT_TEAM_SUBMISSION_INTEGRATION
   );
-
-  return query;
 };

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
@@ -1,14 +1,21 @@
 import { useMutation } from "@apollo/client";
 import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries";
-import { SubmissionEmailMutation, SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
+import {
+  SubmissionEmailInput,
+  SubmissionEmailMutation,
+} from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 
-export const useInsertSubmissionIntegration = (submissionEmail: string, defaultEmail: boolean, teamId: number) => {
-  const query = useMutation<
-    SubmissionEmailMutation,
-    SubmissionEmailInput
-  >(INSERT_TEAM_SUBMISSION_INTEGRATION, {
-    variables: { teamId, submissionEmail, defaultEmail },
-  });
+export const useInsertSubmissionIntegration = (
+  submissionEmail: string,
+  defaultEmail: boolean,
+  teamId: number,
+) => {
+  const query = useMutation<SubmissionEmailMutation, SubmissionEmailInput>(
+    INSERT_TEAM_SUBMISSION_INTEGRATION,
+    {
+      variables: { teamId, submissionEmail, defaultEmail },
+    },
+  );
 
   return query;
 };

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
@@ -1,0 +1,14 @@
+import { useMutation } from "@apollo/client";
+import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/queries";
+import { SubmissionEmailMutation, SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
+
+export const useInsertSubmissionIntegration = (submissionEmail: string, defaultEmail: boolean, teamId: number) => {
+  const query = useMutation<
+    SubmissionEmailMutation,
+    SubmissionEmailInput
+  >(INSERT_TEAM_SUBMISSION_INTEGRATION, {
+    variables: { teamId, submissionEmail, defaultEmail },
+  });
+
+  return query;
+};

--- a/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/hooks/useInsertSubmissionIntegration.tsx
@@ -1,12 +1,13 @@
 import { useMutation } from "@apollo/client";
-import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "../queries";
 import {
   SubmissionEmailInput,
   SubmissionEmailMutation,
 } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 
+import { INSERT_TEAM_SUBMISSION_INTEGRATION } from "../queries";
+
 export const useInsertSubmissionIntegration = () => {
   return useMutation<SubmissionEmailMutation, SubmissionEmailInput>(
-    INSERT_TEAM_SUBMISSION_INTEGRATION
+    INSERT_TEAM_SUBMISSION_INTEGRATION,
   );
 };

--- a/apps/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -47,7 +47,7 @@ export function getCombinedEventsPayload({
   return payload;
 }
 
-export const validationSchema: SchemaOf<Send> =
+export const validateSchema = (existingEmails: string[]) =>
   baseNodeDataValidationSchema.concat(
     object({
       title: string().required(),
@@ -69,14 +69,8 @@ export const validationSchema: SchemaOf<Send> =
             .test(
               "is-unique",
               "Please enter a unique email address.",
-              async function (value) {
+              function (value) {
                 if (!value) return true;
-                const { existingEmails } = this.options.context || {};
-                if (!existingEmails || !Array.isArray(existingEmails)) {
-                  throw new Error(
-                    "Validation context is missing existing emails.",
-                  );
-                }
                 return !existingEmails.includes(value);
               },
             ),

--- a/apps/editor.planx.uk/src/@planx/components/Send/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Send/model.ts
@@ -12,6 +12,7 @@ export interface Send extends BaseNodeData {
   title: string;
   destinations: SendIntegration[];
   submissionEmailId?: string;
+  newEmail?: string;
 }
 
 export const DEFAULT_TITLE = "Send";
@@ -59,5 +60,26 @@ export const validationSchema: SchemaOf<Send> =
           "Submission email is required when 'send to email' is selected.",
         ),
       }),
+      newEmail: string()
+        .email("Please enter a valid email address.")
+        .when("submissionEmailId", {
+          is: (submissionEmailId: string) => submissionEmailId === "new-email",
+          then: string()
+            .required("Please enter a new submission email.")
+            .test(
+              "is-unique",
+              "Please enter a unique email address.",
+              async function (value) {
+                if (!value) return true;
+                const { existingEmails } = this.options.context || {};
+                if (!existingEmails || !Array.isArray(existingEmails)) {
+                  throw new Error(
+                    "Validation context is missing existing emails.",
+                  );
+                }
+                return !existingEmails.includes(value);
+              },
+            ),
+        }),
     }),
   );

--- a/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
@@ -29,11 +29,17 @@ export const INSERT_TEAM_SUBMISSION_INTEGRATION = gql`
     $teamId: Int!
     $defaultEmail: Boolean!
   ) {
-  insertSubmissionIntegrationsOne: insert_submission_integrations_one(object: {default_email: $defaultEmail, submission_email: $submissionEmail, team_id: $teamId}) {
-    default_email
-    id
-    submission_email
-    team_id
+    insertSubmissionIntegrationsOne: insert_submission_integrations_one(
+      object: {
+        default_email: $defaultEmail
+        submission_email: $submissionEmail
+        team_id: $teamId
+      }
+    ) {
+      default_email
+      id
+      submission_email
+      team_id
+    }
   }
-}
-`
+`;

--- a/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
@@ -2,18 +2,23 @@ import { gql } from "@apollo/client";
 
 export const GET_FLOW_EMAIL_ID = gql`
   query GetFlowEmailId($flowId: uuid!) {
-    flows(where: { id: { _eq: $flowId } }) {
+    flowsByPK: flows_by_pk(id: $flowId) {
       submissionEmailId: submission_email_id
     }
   }
 `;
 
 export const UPDATE_FLOW_SUBMISSION_EMAIL_ID = gql`
-  mutation UpdateFlowSubmissionEmailId($flowId: uuid!, $submissionEmailId: uuid!) {
-    update_flows(where: {id: {_eq: $flowId}}, _set: {submission_email_id: $submissionEmailId}) {
-      returning {
-        submission_email_id
-      }
-    }
+  mutation UpdateFlowSubmissionEmailId(
+  $flowId: uuid!
+  $submissionEmailId: uuid!
+) {
+  update_flows_by_pk(
+    pk_columns: { id: $flowId }
+    _set: { submission_email_id: $submissionEmailId }
+  ) {
+    id
+    submission_email_id
   }
+}
 `;

--- a/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
@@ -10,15 +10,15 @@ export const GET_FLOW_EMAIL_ID = gql`
 
 export const UPDATE_FLOW_SUBMISSION_EMAIL_ID = gql`
   mutation UpdateFlowSubmissionEmailId(
-  $flowId: uuid!
-  $submissionEmailId: uuid!
-) {
-  update_flows_by_pk(
-    pk_columns: { id: $flowId }
-    _set: { submission_email_id: $submissionEmailId }
+    $flowId: uuid!
+    $submissionEmailId: uuid!
   ) {
-    id
-    submission_email_id
+    update_flows_by_pk(
+      pk_columns: { id: $flowId }
+      _set: { submission_email_id: $submissionEmailId }
+    ) {
+      id
+      submission_email_id
+    }
   }
-}
 `;

--- a/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/queries.tsx
@@ -22,3 +22,18 @@ export const UPDATE_FLOW_SUBMISSION_EMAIL_ID = gql`
     }
   }
 `;
+
+export const INSERT_TEAM_SUBMISSION_INTEGRATION = gql`
+  mutation InsertSubmissionIntegration(
+    $submissionEmail: String!
+    $teamId: Int!
+    $defaultEmail: Boolean!
+  ) {
+  insertSubmissionIntegrationsOne: insert_submission_integrations_one(object: {default_email: $defaultEmail, submission_email: $submissionEmail, team_id: $teamId}) {
+    default_email
+    id
+    submission_email
+    team_id
+  }
+}
+`

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -60,5 +60,4 @@ export interface EmailSelectionProps {
   disabled?: boolean;
   newEmailError?: FormikErrors<string>;
   setFieldValue: FormikHelpers<any>["setFieldValue"];
-  setNewEmail: (value: string) => void;
 }

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -55,12 +55,7 @@ export interface EmailSelectionProps {
   teamSlug: string;
   emailOptions: Required<SubmissionEmailInput>[];
   currentEmail: Required<SubmissionEmailInput> | undefined;
-  newEmail: string | undefined;
   submissionEmailId: string | undefined;
-  isNewEmailSelected: boolean;
   handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;
-  newEmailError?: FormikErrors<string>;
-  setFieldValue: FormikHelpers<any>["setFieldValue"];
-  touched: FormikTouched<Send>;
 }

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -46,11 +46,6 @@ export interface InsertSubmissionEmailMutation {
   };
 }
 
-export interface EmailEmptyStateProps {
-  teamSlug: string;
-  error?: string;
-}
-
 export interface EmailSelectionProps {
   teamSlug: string;
   emailOptions: Required<SubmissionEmailInput>[];

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -1,8 +1,5 @@
 import { SelectChangeEvent } from "@mui/material/Select";
-import { FormikErrors, FormikHelpers, FormikTouched } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
-
-import { Send } from "./model";
 
 export interface GetFlowEmailIdQuery {
   flowsByPK: {
@@ -49,7 +46,6 @@ export interface InsertSubmissionEmailMutation {
 export interface EmailSelectionProps {
   teamSlug: string;
   emailOptions: Required<SubmissionEmailInput>[];
-  currentEmail: Required<SubmissionEmailInput> | undefined;
   submissionEmailId: string | undefined;
   handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -41,7 +41,7 @@ export interface InsertSubmissionEmailMutation {
     email: string;
     teamId: number;
     defaultEmail: boolean;
-  }
+  };
 }
 
 export interface EmailEmptyStateProps {
@@ -59,6 +59,6 @@ export interface EmailSelectionProps {
   handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;
   newEmailError?: FormikErrors<string>;
-  setFieldValue: FormikHelpers<any>['setFieldValue'];
+  setFieldValue: FormikHelpers<any>["setFieldValue"];
   setNewEmail: (value: string) => void;
 }

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -1,10 +1,11 @@
 import { SelectChangeEvent } from "@mui/material/Select";
+import { FormikErrors, FormikHelpers } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 
 export interface GetFlowEmailIdQuery {
-  flows: Array<{
+  flows_by_pk: {
     submissionEmailId: string;
-  }>;
+  };
 }
 
 export interface GetFlowEmailIdQueryVariables {
@@ -34,6 +35,15 @@ export interface GetTeamSubmissionIntegrationsQueryVariables {
   teamId: number;
 }
 
+export interface InsertSubmissionEmailMutation {
+  submissionIntegrations: {
+    id: string;
+    email: string;
+    teamId: number;
+    defaultEmail: boolean;
+  }
+}
+
 export interface EmailEmptyStateProps {
   teamSlug: string;
   error?: string;
@@ -43,7 +53,12 @@ export interface EmailSelectionProps {
   teamSlug: string;
   emailOptions: Required<SubmissionEmailInput>[];
   currentEmail: Required<SubmissionEmailInput> | undefined;
+  newEmail: string | undefined;
   submissionEmailId: string | undefined;
+  isNewEmailSelected: boolean;
   handleSelectChange: (event: SelectChangeEvent<unknown>) => void;
   disabled?: boolean;
+  newEmailError?: FormikErrors<string>;
+  setFieldValue: FormikHelpers<any>['setFieldValue'];
+  setNewEmail: (value: string) => void;
 }

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -3,7 +3,7 @@ import { FormikErrors, FormikHelpers } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 
 export interface GetFlowEmailIdQuery {
-  flows_by_pk: {
+  flowsByPK: {
     submissionEmailId: string;
   };
 }

--- a/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/types.tsx
@@ -1,6 +1,8 @@
 import { SelectChangeEvent } from "@mui/material/Select";
-import { FormikErrors, FormikHelpers } from "formik";
+import { FormikErrors, FormikHelpers, FormikTouched } from "formik";
 import { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
+
+import { Send } from "./model";
 
 export interface GetFlowEmailIdQuery {
   flowsByPK: {
@@ -60,4 +62,5 @@ export interface EmailSelectionProps {
   disabled?: boolean;
   newEmailError?: FormikErrors<string>;
   setFieldValue: FormikHelpers<any>["setFieldValue"];
+  touched: FormikTouched<Send>;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types.ts
@@ -12,8 +12,9 @@ export interface GetSubmissionEmails {
   submissionIntegrations: Required<SubmissionEmailInput>[];
 }
 
-export type SubmissionEmailMutation =
-  SnakeCasedProperties<SubmissionEmailInput>;
+export type SubmissionEmailMutation = {
+  insertSubmissionIntegrationsOne: SnakeCasedProperties<SubmissionEmailInput>;
+};
 
 export interface SubmissionEmailValues {
   submissionIntegrations: SubmissionEmailInput[];


### PR DESCRIPTION
Enables new emails to be written to `submission_integrations` from Send using new `useInsertSubmissionIntegration` hook. 

I wonder if it's worth refactoring this into a separate `SendToEmail` component? `Send` is getting quite complicated, but I wasn't sure as this didn't seem to be a pattern used in other components when I checked. 