### PR TITLE
refactor: Add a second step for modifying project descriptions

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -26,11 +26,11 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
   const showError = Boolean(errors.userInput);
 
   return (
-    <Box mb={2}>
-      <Typography variant="h2" component="h1" mb={1}>
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="h2" component="h1" sx={{ mb: 1 }}>
         Confirm your project description
       </Typography>
-      <Typography variant="subtitle1" component="p" mb={2}>
+      <Typography variant="subtitle1" component="p" sx={{ mb: 2 }}>
         Edit the description below, or continue to submit it as shown.
       </Typography>
       <InputRow>

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -1,0 +1,69 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import {
+  DESCRIPTION_TEXT,
+  ERROR_MESSAGE,
+} from "@planx/components/shared/constants";
+import type { PublicProps } from "@planx/components/shared/types";
+import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
+import { useFormikContext } from "formik";
+import React from "react";
+import InputLabel from "ui/public/InputLabel";
+import { CharacterCounter } from "ui/shared/CharacterCounter";
+import Input from "ui/shared/Input/Input";
+import InputRow from "ui/shared/InputRow";
+
+import type { EnhancedTextInput } from "../types";
+import type { FormValues } from "./types";
+
+const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
+  const { values, errors, setFieldValue } = useFormikContext<FormValues>();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFieldValue("userInput", event.target.value);
+  };
+
+  const showError = Boolean(errors.userInput);
+
+  return (
+    <Box mb={2}>
+      <Typography variant="h2" component="h1" mb={1}>
+        Confirm your project description
+      </Typography>
+      <Typography variant="subtitle1" component="p" mb={2}>
+        Edit the description below, or continue to submit it as shown.
+      </Typography>
+      <InputRow>
+        <InputLabel label="Project description" htmlFor={props.id} hidden>
+          <Input
+            type="text"
+            multiline
+            rows={5}
+            name="userInput"
+            value={values.userInput}
+            bordered
+            onChange={handleChange}
+            errorMessage={showError ? (errors.userInput as string) : undefined}
+            id={props.id}
+            inputProps={{
+              "aria-describedby": [
+                props.description ? DESCRIPTION_TEXT : "",
+                "character-hint",
+                showError ? `${ERROR_MESSAGE}-${props.id}` : "",
+              ]
+                .filter(Boolean)
+                .join(" "),
+            }}
+          />
+          <CharacterCounter
+            limit={TEXT_LIMITS[TextInputType.Long]}
+            count={values.userInput.length}
+            error={showError}
+          />
+        </InputLabel>
+      </InputRow>
+    </Box>
+  );
+};
+
+export default ModifyUserInput;

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -145,6 +145,63 @@ describe("Passport generation", () => {
     );
   });
 
+  test("writing a new description", async () => {
+    const handleSubmit = vi.fn();
+
+    const { user } = await setup(
+      <EnhancedTextInputComponent
+        id="testId"
+        title="test"
+        task={"projectDescription"}
+        handleSubmit={handleSubmit}
+        {...taskDefaults.projectDescription}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Wait for next screen
+    expect(
+      screen.getByText(taskDefaults.projectDescription.revisionTitle),
+    ).toBeVisible();
+
+    // Select "Write a new description" and type a custom value
+    await user.click(
+      screen.getByRole("radio", { name: /Write a new description/i }),
+    );
+    const customInput = screen.getByRole("textbox", {
+      name: /Enter your project description/i,
+    });
+    await user.type(customInput, "my custom description");
+
+    // Continuing submits directly without a modification step
+    await user.click(screen.getByTestId("continue-button"));
+    expect(
+      screen.queryByRole("heading", {
+        name: /Do you want to modify this description/i,
+        level: 1,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Breadcrumb formatted as expected
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          "proposal.description": "my custom description",
+          "enhancedTextInput.proposal.description.action":
+            "Re-wrote their description after AI feedback",
+          _enhancements: {
+            "proposal.description": {
+              original: ORIGINAL,
+              enhanced: ENHANCED,
+            },
+          },
+        },
+      }),
+    );
+  });
+
   test("modifying a description", async () => {
     const handleSubmit = vi.fn();
 
@@ -428,6 +485,9 @@ describe("basic layout and behaviour", () => {
     expect(
       screen.getByRole("radio", { name: /Use your original description/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /Write a new description/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText(ENHANCED)).toBeVisible();
     expect(screen.getByText(ORIGINAL)).toBeVisible();
   });
@@ -502,6 +562,42 @@ describe("basic layout and behaviour", () => {
     expect(
       screen.getByRole("textbox", { name: /Project description/i }),
     ).toHaveValue(ORIGINAL);
+  });
+
+  it("selecting 'Write a new description' reveals a text input", async () => {
+    const { user } = await setup(
+      <EnhancedTextInputComponent
+        id="testId"
+        title="test"
+        task={"projectDescription"}
+        {...taskDefaults.projectDescription}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Wait for next screen
+    expect(
+      screen.getByText(taskDefaults.projectDescription.revisionTitle),
+    ).toBeVisible();
+
+    // No text input visible before selecting the option
+    expect(
+      screen.queryByRole("textbox", {
+        name: /Enter your project description/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Selecting the option reveals the text input
+    await user.click(
+      screen.getByRole("radio", { name: /Write a new description/i }),
+    );
+    expect(
+      screen.getByRole("textbox", {
+        name: /Enter your project description/i,
+      }),
+    ).toBeVisible();
   });
 
   it("displays additional information to the user on the 'task' step", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -67,7 +67,7 @@ describe("Passport generation", () => {
     // Modification step: continue without changes
     expect(
       screen.getByRole("heading", {
-        name: /Do you want to modify this description/i,
+        name: /Confirm your project description/i,
         level: 1,
       }),
     ).toBeVisible();
@@ -121,7 +121,7 @@ describe("Passport generation", () => {
     // Modification step: continue without changes
     expect(
       screen.getByRole("heading", {
-        name: /Do you want to modify this description/i,
+        name: /Confirm your project description/i,
         level: 1,
       }),
     ).toBeVisible();
@@ -179,7 +179,7 @@ describe("Passport generation", () => {
     await user.click(screen.getByTestId("continue-button"));
     expect(
       screen.queryByRole("heading", {
-        name: /Do you want to modify this description/i,
+        name: /Confirm your project description/i,
         level: 1,
       }),
     ).not.toBeInTheDocument();
@@ -555,7 +555,7 @@ describe("basic layout and behaviour", () => {
     await user.click(screen.getByTestId("continue-button"));
     expect(
       screen.getByRole("heading", {
-        name: /Do you want to modify this description/i,
+        name: /Confirm your project description/i,
         level: 1,
       }),
     ).toBeVisible();
@@ -681,7 +681,7 @@ describe("basic layout and behaviour", () => {
     await user.click(screen.getByTestId("continue-button"));
     expect(
       screen.getByRole("heading", {
-        name: /Do you want to modify this description/i,
+        name: /Confirm your project description/i,
         level: 1,
       }),
     ).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -163,7 +163,7 @@ describe("Passport generation", () => {
 
     // Wait for next screen
     expect(
-      screen.getByText(taskDefaults.projectDescription.revisionTitle),
+      await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
     // Select "Write a new description" and type a custom value
@@ -579,7 +579,7 @@ describe("basic layout and behaviour", () => {
 
     // Wait for next screen
     expect(
-      screen.getByText(taskDefaults.projectDescription.revisionTitle),
+      await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
     // No text input visible before selecting the option
@@ -673,6 +673,11 @@ describe("basic layout and behaviour", () => {
 
     await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
+
+    // Wait for API response before interacting with selection step
+    expect(
+      await screen.findByText(taskDefaults.projectDescription.revisionTitle),
+    ).toBeVisible();
 
     // Advance to modification step
     await user.click(

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -58,10 +58,19 @@ describe("Passport generation", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select suggested description and submit
+    // Select suggested description and advance to modification step
     await user.click(
       screen.getByRole("radio", { name: /Use suggested description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Modification step: continue without changes
+    expect(
+      screen.getByRole("heading", {
+        name: /Do you want to modify this description/i,
+        level: 1,
+      }),
+    ).toBeVisible();
     await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
@@ -103,10 +112,19 @@ describe("Passport generation", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select original description and submit
+    // Select original description and advance to modification step
     await user.click(
       screen.getByRole("radio", { name: /Use your original description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Modification step: continue without changes
+    expect(
+      screen.getByRole("heading", {
+        name: /Do you want to modify this description/i,
+        level: 1,
+      }),
+    ).toBeVisible();
     await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
@@ -127,7 +145,7 @@ describe("Passport generation", () => {
     );
   });
 
-  test("using a hybrid value", async () => {
+  test("modifying a description", async () => {
     const handleSubmit = vi.fn();
 
     const { user } = await setup(
@@ -148,16 +166,19 @@ describe("Passport generation", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select "Write a new description" to reveal the text input
+    // Select suggested description and advance to modification step
     await user.click(
-      screen.getByRole("radio", { name: /Write a new description/i }),
+      screen.getByRole("radio", { name: /Use suggested description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
 
-    // Enter a custom description
-    await user.type(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
-      "a new description",
-    );
+    // Modification step: clear pre-filled text and enter a custom description
+    const textarea = screen.getByRole("textbox", {
+      name: /Project description/i,
+    });
+    expect(textarea).toHaveValue(ENHANCED);
+    await user.clear(textarea);
+    await user.type(textarea, "a new description");
     await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
@@ -292,10 +313,13 @@ describe("navigating back to the EnhancedTextInput component", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select suggested description and submit
+    // Select suggested description and advance to modification step
     await user.click(
       screen.getByRole("radio", { name: /Use suggested description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Modification step: continue without changes
     await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected - action and values updated
@@ -404,9 +428,6 @@ describe("basic layout and behaviour", () => {
     expect(
       screen.getByRole("radio", { name: /Use your original description/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("radio", { name: /Write a new description/i }),
-    ).toBeInTheDocument();
     expect(screen.getByText(ENHANCED)).toBeVisible();
     expect(screen.getByText(ORIGINAL)).toBeVisible();
   });
@@ -433,7 +454,7 @@ describe("basic layout and behaviour", () => {
     expect(results).toHaveNoViolations();
   });
 
-  it("allows the user to select between the enhanced, original, or custom description", async () => {
+  it("allows the user to select between the enhanced and original description", async () => {
     const { user } = await setup(
       <EnhancedTextInputComponent
         id="testId"
@@ -451,7 +472,7 @@ describe("basic layout and behaviour", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // No option selected by default, custom textarea not visible
+    // No option selected by default, no textarea visible
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
     // User can select suggested description
@@ -470,25 +491,17 @@ describe("basic layout and behaviour", () => {
       screen.getByRole("radio", { name: /Use your original description/i }),
     ).toBeChecked();
 
-    // User can select to write a new description - textarea appears
-    await user.click(
-      screen.getByRole("radio", { name: /Write a new description/i }),
-    );
+    // Continuing advances to the modification step with the selected description pre-filled
+    await user.click(screen.getByTestId("continue-button"));
     expect(
-      screen.getByRole("radio", { name: /Write a new description/i }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
+      screen.getByRole("heading", {
+        name: /Do you want to modify this description/i,
+        level: 1,
+      }),
     ).toBeVisible();
-
-    // User can type their own custom description
-    await user.type(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
-      "Something unique",
-    );
     expect(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
-    ).toHaveValue("Something unique");
+      screen.getByRole("textbox", { name: /Project description/i }),
+    ).toHaveValue(ORIGINAL);
   });
 
   it("displays additional information to the user on the 'task' step", async () => {
@@ -550,6 +563,41 @@ describe("basic layout and behaviour", () => {
 
     // Exit sidebar
     await user.keyboard("{Esc}");
+  });
+
+  test("users can navigate 'back' from the modification step to the selection step", async () => {
+    const { user } = await setup(
+      <EnhancedTextInputComponent
+        id="testId"
+        title="test"
+        task={"projectDescription"}
+        {...taskDefaults.projectDescription}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByTestId("continue-button"));
+
+    // Advance to modification step
+    await user.click(
+      screen.getByRole("radio", { name: /Use suggested description/i }),
+    );
+    await user.click(screen.getByTestId("continue-button"));
+    expect(
+      screen.getByRole("heading", {
+        name: /Do you want to modify this description/i,
+        level: 1,
+      }),
+    ).toBeVisible();
+
+    // Back returns to selection step
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(
+      screen.getByText(taskDefaults.projectDescription.revisionTitle),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("radio", { name: /Use suggested description/i }),
+    ).toBeInTheDocument();
   });
 
   test("users can navigate 'back' to the input step", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -65,7 +65,11 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
       showBorder={recommended}
     >
       {recommended && <RecommendedTag>Recommended</RecommendedTag>}
-      <Radio value={id} onChange={onChange} />
+      <Radio
+        value={id}
+        onChange={onChange}
+        inputProps={{ "aria-label": title }}
+      />
       <Box sx={{ position: "relative" }}>
         <Typography color="text.primary" variant="body1" sx={{ pt: 0.95 }}>
           {title}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -3,10 +3,6 @@ import Box from "@mui/material/Box";
 import Radio from "@mui/material/Radio";
 import RadioGroup, { useRadioGroup } from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
-import {
-  DESCRIPTION_TEXT,
-  ERROR_MESSAGE,
-} from "@planx/components/shared/constants";
 import { HelpButton } from "@planx/components/shared/Preview/CardHeader/styled";
 import MoreInfo from "@planx/components/shared/Preview/MoreInfo";
 import MoreInfoSection from "@planx/components/shared/Preview/MoreInfoSection";
@@ -94,7 +90,16 @@ const ProjectDescription: React.FC<Props> = (props) => {
     useFormikContext<FormValues>();
   const [open, setOpen] = useState(false);
 
-  const initialValueRef = useRef(values.userInput);
+  const initialValueRef = useRef(
+    (() => {
+      if (values.status !== "success") return values.userInput;
+      // If userInput matches a previously-processed value, use the cached original
+      const isPreviouslyProcessed =
+        values.userInput === values.original ||
+        values.userInput === values.enhanced;
+      return isPreviouslyProcessed ? values.original : values.userInput;
+    })(),
+  );
 
   const { isPending, data, error, isSuccess } = useQuery<
     EnhanceResponse,
@@ -115,6 +120,8 @@ const ProjectDescription: React.FC<Props> = (props) => {
       initialValueRef.current,
     ],
     retry: 0,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
 
   useEffect(() => {
@@ -157,7 +164,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
         case "retainedOriginal":
           setFieldValue("userInput", data.original);
           break;
-        case "hybrid":
+        case "new":
           setFieldValue("userInput", values.customDescription);
           break;
       }
@@ -167,14 +174,11 @@ const ProjectDescription: React.FC<Props> = (props) => {
   const handleCustomDescriptionChange = (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const value = event.target.value;
-    setFieldValue("customDescription", value);
-    setFieldValue("userInput", value);
+    setFieldValue("customDescription", event.target.value);
+    setFieldValue("userInput", event.target.value);
   };
 
   const showRadioError = !values.selectedOption && Boolean(errors.userInput);
-  const showCustomInputError =
-    values.selectedOption === "hybrid" && Boolean(errors.userInput);
 
   const LOADING_STAGES = [
     "Analysing your project description",
@@ -233,8 +237,8 @@ const ProjectDescription: React.FC<Props> = (props) => {
         <Typography variant="h2" component="h1" sx={{ mb: 1 }}>
           {props.revisionTitle}
         </Typography>
-        <Typography variant="subtitle1" component="p">
-          {props.revisionDescription}
+        <Typography variant="subtitle1" component="div">
+          <ReactMarkdownOrHtml source={props.revisionDescription} />
         </Typography>
         <Typography variant="subtitle1" component="div">
           <HelpButton
@@ -272,20 +276,18 @@ const ProjectDescription: React.FC<Props> = (props) => {
                 title="Use your original description"
                 description={data.original}
               />
-
               <Box sx={{ width: 68, my: 1 }}>
                 <Typography align="center">or</Typography>
               </Box>
-
               <DescriptionRadio
-                id="hybrid"
+                id="new"
                 onChange={handleOptionChange}
                 title="Write a new description"
               />
             </RadioGroup>
           </ErrorWrapper>
 
-          {values.selectedOption === "hybrid" && (
+          {values.selectedOption === "new" && (
             <RevealedContent>
               <InputRow>
                 <InputLabel
@@ -296,32 +298,16 @@ const ProjectDescription: React.FC<Props> = (props) => {
                     type="text"
                     multiline
                     rows={5}
-                    name="userInput"
+                    name="customDescription"
                     value={values.customDescription}
                     bordered
                     onChange={handleCustomDescriptionChange}
-                    errorMessage={
-                      showCustomInputError
-                        ? (errors.userInput as string)
-                        : undefined
-                    }
                     id={props.id}
-                    inputProps={{
-                      "aria-describedby": [
-                        props.description ? DESCRIPTION_TEXT : "",
-                        "character-hint",
-                        showCustomInputError
-                          ? `${ERROR_MESSAGE}-${props.id}`
-                          : "",
-                      ]
-                        .filter(Boolean)
-                        .join(" "),
-                    }}
                   />
                   <CharacterCounter
                     limit={TEXT_LIMITS[TextInputType.Long]}
                     count={values.customDescription.length}
-                    error={showCustomInputError}
+                    error={false}
                   />
                 </InputLabel>
               </InputRow>

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -68,7 +68,7 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
       <Radio
         value={id}
         onChange={onChange}
-        inputProps={{ "aria-label": title }}
+        slotProps={{ input: { "aria-label": title } }}
       />
       <Box sx={{ position: "relative" }}>
         <Typography color="text.primary" variant="body1" sx={{ pt: 0.95 }}>

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -234,7 +234,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
   return (
     <>
       <Box sx={{ my: 2 }}>
-        <Typography variant="h2" component="h1" sx={{ mb: 1 }}>
+        <Typography variant="h2" component="h1">
           {props.revisionTitle}
         </Typography>
         <Typography variant="subtitle1" component="div">

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -18,6 +18,9 @@ const taskComponents: TaskComponentMap = {
 const EnhancedTextInputComponent = (props: Props) => {
   const previous = getPreviouslySubmittedData(props);
   const [step, setStep] = useState<"input" | "task">("input");
+  const [taskSubStep, setTaskSubStep] = useState<"selection" | "modification">(
+    "selection",
+  );
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
   const initialValues: FormValues = previous
@@ -50,8 +53,10 @@ const EnhancedTextInputComponent = (props: Props) => {
 
     if (step === "input") return setStep("task");
 
-    if (step === "task")
+    if (step === "task") {
+      if (taskSubStep === "selection") return setTaskSubStep("modification");
       props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
+    }
   };
 
   const TaskComponent = taskComponents[props.task];
@@ -59,7 +64,18 @@ const EnhancedTextInputComponent = (props: Props) => {
 
   const validationSchema = getValidationSchema(props);
 
-  const handleBack = step === "task" ? () => setStep("input") : undefined;
+  const handleBack = (() => {
+    if (step === "task" && taskSubStep === "modification") {
+      return () => setTaskSubStep("selection");
+    }
+    if (step === "task") {
+      return () => {
+        setStep("input");
+        setTaskSubStep("selection");
+      };
+    }
+    return undefined;
+  })();
 
   return (
     <Formik<FormValues>
@@ -91,7 +107,10 @@ const EnhancedTextInputComponent = (props: Props) => {
               />
             )}
             {step === "input" && <InitialUserInput {...props} />}
-            {step === "task" && <TaskComponent {...props} />}
+            {step === "task" && (
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              <TaskComponent {...(props as any)} taskSubStep={taskSubStep} />
+            )}
           </Card>
         );
       }}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -54,7 +54,8 @@ const EnhancedTextInputComponent = (props: Props) => {
     if (step === "input") return setStep("task");
 
     if (step === "task") {
-      if (taskSubStep === "selection") return setTaskSubStep("modification");
+      if (taskSubStep === "selection" && values.selectedOption !== "new")
+        return setTaskSubStep("modification");
       props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
     }
   };

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -85,6 +85,7 @@ const EnhancedTextInputComponent = (props: Props) => {
 
         const handleBack = (() => {
           if (step === "modification") return () => setStep("selection");
+          // Repopulate field with user's original input
           if (step === "selection" && !isRunningTask)
             return () => {
               if (values.status === "success") {
@@ -114,10 +115,7 @@ const EnhancedTextInputComponent = (props: Props) => {
             )}
             {step === "input" && <InitialUserInput {...props} />}
             {step === "modification" && <ModifyUserInput {...props} />}
-            {step === "selection" && (
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              <TaskComponent {...(props as any)} />
-            )}
+            {step === "selection" && <TaskComponent {...props} />}
           </Card>
         );
       }}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -68,12 +68,6 @@ const EnhancedTextInputComponent = (props: Props) => {
 
   const validationSchema = getValidationSchema(props);
 
-  const handleBack = (() => {
-    if (step === "modification") return () => setStep("selection");
-    if (step === "selection") return () => setStep("input");
-    return undefined;
-  })();
-
   return (
     <Formik<FormValues>
       initialValues={initialValues}
@@ -83,8 +77,23 @@ const EnhancedTextInputComponent = (props: Props) => {
       validateOnChange={false}
       validationSchema={validationSchema}
     >
-      {({ submitForm, values }) => {
-        const showCardHeader = step === "input" || values.status !== "success";
+      {({ submitForm, values, setFieldValue }) => {
+        const showCardHeader =
+          step === "input" ||
+          values.status !== "success" ||
+          Boolean(isRunningTask);
+
+        const handleBack = (() => {
+          if (step === "modification") return () => setStep("selection");
+          if (step === "selection" && !isRunningTask)
+            return () => {
+              if (values.status === "success") {
+                setFieldValue("userInput", values.original);
+              }
+              setStep("input");
+            };
+          return undefined;
+        })();
 
         return (
           <Card

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -7,6 +7,7 @@ import React, { useState } from "react";
 
 import type { TaskComponentMap } from "../types";
 import InitialUserInput from "./InitialUserInput";
+import ModifyUserInput from "./ModifyUserInput";
 import ProjectDescription from "./Tasks/ProjectDescription";
 import type { FormValues, Props } from "./types";
 import { getValidationSchema, makeBreadcrumb } from "./utils";
@@ -17,9 +18,8 @@ const taskComponents: TaskComponentMap = {
 
 const EnhancedTextInputComponent = (props: Props) => {
   const previous = getPreviouslySubmittedData(props);
-  const [step, setStep] = useState<"input" | "task">("input");
-  const [taskSubStep, setTaskSubStep] = useState<"selection" | "modification">(
-    "selection",
+  const [step, setStep] = useState<"input" | "selection" | "modification">(
+    "input",
   );
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
@@ -51,11 +51,14 @@ const EnhancedTextInputComponent = (props: Props) => {
       return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
     }
 
-    if (step === "input") return setStep("task");
+    if (step === "input") return setStep("selection");
 
-    if (step === "task") {
-      if (taskSubStep === "selection" && values.selectedOption !== "new")
-        return setTaskSubStep("modification");
+    if (step === "selection") {
+      if (values.selectedOption !== "new") return setStep("modification");
+      return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
+    }
+
+    if (step === "modification") {
       props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
     }
   };
@@ -66,15 +69,8 @@ const EnhancedTextInputComponent = (props: Props) => {
   const validationSchema = getValidationSchema(props);
 
   const handleBack = (() => {
-    if (step === "task" && taskSubStep === "modification") {
-      return () => setTaskSubStep("selection");
-    }
-    if (step === "task") {
-      return () => {
-        setStep("input");
-        setTaskSubStep("selection");
-      };
-    }
+    if (step === "modification") return () => setStep("selection");
+    if (step === "selection") return () => setStep("input");
     return undefined;
   })();
 
@@ -108,9 +104,10 @@ const EnhancedTextInputComponent = (props: Props) => {
               />
             )}
             {step === "input" && <InitialUserInput {...props} />}
-            {step === "task" && (
+            {step === "modification" && <ModifyUserInput {...props} />}
+            {step === "selection" && (
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              <TaskComponent {...(props as any)} taskSubStep={taskSubStep} />
+              <TaskComponent {...(props as any)} />
             )}
           </Card>
         );

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
@@ -18,7 +18,7 @@ export const getAction = (values: FormValues): TaskActionDescription => {
 
   if (userInput === original) return TaskActionMap.retainedOriginal;
   if (userInput === enhanced) return TaskActionMap.acceptedEnhanced;
-  return TaskActionMap.hybrid;
+  return TaskActionMap.new;
 };
 
 export const makeBreadcrumb = (

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/content.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/content.ts
@@ -1,5 +1,5 @@
 export const HOW_DOES_THIS_WORK = `
-  We use AI to review your project description and suggest improvements that may help your planning application be accepted more quickly.
+  We use AI to review your project description and suggest improvements that may help your planning application be validated more quickly.
 
   The AI checks your description for - 
   - Clear explanations of what you want to build

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/model.ts
@@ -19,6 +19,17 @@ export const taskDefaults: TaskDefaults = {
   },
 };
 
+const initialScreenDefaults: Record<
+  Task,
+  { title: string; description: string }
+> = {
+  projectDescription: {
+    title: "Describe the project",
+    description:
+      "<p>Write a brief description of the changes using two sentences or fewer.</p><p>Your description will be checked for likelihood of validity using an AI model, and you'll have the opportunity to review and modify any changes.</p>",
+  },
+};
+
 export const parseEnhancedTextInput = (
   data: Partial<EnhancedTextInput> | undefined,
 ): EnhancedTextInput => {
@@ -26,8 +37,8 @@ export const parseEnhancedTextInput = (
 
   return {
     task,
-    title: data?.title || "",
-    description: data?.description,
+    title: initialScreenDefaults[task].title,
+    description: initialScreenDefaults[task].description,
     ...parseBaseNodeData(data),
     ...taskDefaults[task],
     ...(data || {}),

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/model.ts
@@ -15,7 +15,7 @@ export const taskDefaults: TaskDefaults = {
     fn: "proposal.description",
     revisionTitle: "We suggest revising your project description",
     revisionDescription:
-      "The suggested description uses planning terminology that planning officers expect, reducing the chance of a delay to your application.",
+      "<p>The suggested description uses planning terminology that planning officers expect, reducing the chance of a delay to your application.</p><p>You will be able to modify either of the selected descriptions at the next step.</p>",
   },
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
@@ -12,7 +12,7 @@ export interface EnhancementData {
 export const TaskActionMap = {
   retainedOriginal: "Retained their original description",
   acceptedEnhanced: "Accepted the AI-enhanced description",
-  hybrid: "Re-wrote their description after AI feedback",
+  new: "Re-wrote their description after AI feedback",
 } as const;
 
 /**

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -160,7 +160,7 @@ const TextInputToggle: React.FC<{
         label={
           <>
             <AutoAwesomeIcon sx={{ mr: 1 }} />
-            AI enhanced (testing only)
+            AI enhanced
           </>
         }
         onChange={toggleTextInput}


### PR DESCRIPTION
#### Iteration of enhanced project descriptions

## Options for accepting or modifying descriptions in second step

- First step prompts for a user to choose between suggested or original
- User is advised `You will be able to modify either of the selected descriptions at the next step.`
- Second step allows user to modify selected description

<img width="827" height="625" alt="image" src="https://github.com/user-attachments/assets/8b873049-0d16-44b3-956b-2bc9ffa8e346" />

<img width="827" height="843" alt="image" src="https://github.com/user-attachments/assets/c9775970-86c8-4131-b694-2b07edd6fa68" />

<img width="827" height="489" alt="image" src="https://github.com/user-attachments/assets/9d119424-0596-4585-a549-fc16661a5eea" />
