### PR TITLE
refactor: Allow modifying of project descriptions

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -154,12 +154,11 @@ describe("Passport generation", () => {
     );
 
     // Enter a custom description
-    await user.type(
-      screen.getByRole("textbox", {
-        name: /Modify the suggested description below/i,
-      }),
-      "a new description",
-    );
+    const modifyTextbox = screen.getByRole("textbox", {
+      name: /Modify the suggested description below/i,
+    });
+    await user.clear(modifyTextbox);
+    await user.type(modifyTextbox, "a new description");
     await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
@@ -486,17 +485,12 @@ describe("basic layout and behaviour", () => {
     ).toBeVisible();
 
     // User can type their own custom description
-    await user.type(
-      screen.getByRole("textbox", {
-        name: /Modify the suggested description below/i,
-      }),
-      "Something unique",
-    );
-    expect(
-      screen.getByRole("textbox", {
-        name: /Modify the suggested description below/i,
-      }),
-    ).toHaveValue("Something unique");
+    const customTextbox = screen.getByRole("textbox", {
+      name: /Modify the suggested description below/i,
+    });
+    await user.clear(customTextbox);
+    await user.type(customTextbox, "Something unique");
+    expect(customTextbox).toHaveValue("Something unique");
   });
 
   it("displays additional information to the user on the 'task' step", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -148,14 +148,16 @@ describe("Passport generation", () => {
       screen.getByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select "Write a new description" to reveal the text input
+    // Select "Modify suggested description" to reveal the text input
     await user.click(
-      screen.getByRole("radio", { name: /Write a new description/i }),
+      screen.getByRole("radio", { name: /Modify suggested description/i }),
     );
 
     // Enter a custom description
     await user.type(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
+      screen.getByRole("textbox", {
+        name: /Modify the suggested description below/i,
+      }),
       "a new description",
     );
     await user.click(screen.getByTestId("continue-button"));
@@ -405,7 +407,7 @@ describe("basic layout and behaviour", () => {
       screen.getByRole("radio", { name: /Use your original description/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("radio", { name: /Write a new description/i }),
+      screen.getByRole("radio", { name: /Modify suggested description/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(ENHANCED)).toBeVisible();
     expect(screen.getByText(ORIGINAL)).toBeVisible();
@@ -470,24 +472,30 @@ describe("basic layout and behaviour", () => {
       screen.getByRole("radio", { name: /Use your original description/i }),
     ).toBeChecked();
 
-    // User can select to write a new description - textarea appears
+    // User can select to modify the suggested description - textarea appears
     await user.click(
-      screen.getByRole("radio", { name: /Write a new description/i }),
+      screen.getByRole("radio", { name: /Modify suggested description/i }),
     );
     expect(
-      screen.getByRole("radio", { name: /Write a new description/i }),
+      screen.getByRole("radio", { name: /Modify suggested description/i }),
     ).toBeChecked();
     expect(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
+      screen.getByRole("textbox", {
+        name: /Modify the suggested description below/i,
+      }),
     ).toBeVisible();
 
     // User can type their own custom description
     await user.type(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
+      screen.getByRole("textbox", {
+        name: /Modify the suggested description below/i,
+      }),
       "Something unique",
     );
     expect(
-      screen.getByRole("textbox", { name: /Enter your project description/i }),
+      screen.getByRole("textbox", {
+        name: /Modify the suggested description below/i,
+      }),
     ).toHaveValue("Something unique");
   });
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -127,7 +127,7 @@ describe("Passport generation", () => {
     );
   });
 
-  test("using a hybrid value", async () => {
+  test("using a modifiedEnhanced value", async () => {
     const handleSubmit = vi.fn();
 
     const { user } = await setup(

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -127,6 +127,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
         error: null,
         selectedOption: null,
         customDescription: "",
+        customOriginalDescription: "",
       });
     }
   }, [isSuccess, data, setValues]);
@@ -141,6 +142,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
         userInput: initialValueRef.current,
         selectedOption: null,
         customDescription: "",
+        customOriginalDescription: "",
       });
     }
   }, [error, setValues]);
@@ -157,9 +159,18 @@ const ProjectDescription: React.FC<Props> = (props) => {
         case "retainedOriginal":
           setFieldValue("userInput", data.original);
           break;
-        case "hybrid":
-          setFieldValue("userInput", values.customDescription);
+        case "modifiedEnhanced": {
+          const prefill = values.customDescription || data.enhanced;
+          setFieldValue("customDescription", prefill);
+          setFieldValue("userInput", prefill);
           break;
+        }
+        case "modifiedOriginal": {
+          const prefill = values.customOriginalDescription || data.original;
+          setFieldValue("customOriginalDescription", prefill);
+          setFieldValue("userInput", prefill);
+          break;
+        }
       }
     }
   };
@@ -172,9 +183,19 @@ const ProjectDescription: React.FC<Props> = (props) => {
     setFieldValue("userInput", value);
   };
 
+  const handleCustomOriginalDescriptionChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = event.target.value;
+    setFieldValue("customOriginalDescription", value);
+    setFieldValue("userInput", value);
+  };
+
   const showRadioError = !values.selectedOption && Boolean(errors.userInput);
   const showCustomInputError =
-    values.selectedOption === "hybrid" && Boolean(errors.userInput);
+    (values.selectedOption === "modifiedEnhanced" ||
+      values.selectedOption === "modifiedOriginal") &&
+    Boolean(errors.userInput);
 
   const LOADING_STAGES = [
     "Analysing your project description",
@@ -267,66 +288,109 @@ const ProjectDescription: React.FC<Props> = (props) => {
                 recommended
               />
               <DescriptionRadio
+                id="modifiedEnhanced"
+                onChange={handleOptionChange}
+                title="Modify suggested description"
+              />
+              {values.selectedOption === "modifiedEnhanced" && (
+                <RevealedContent>
+                  <InputRow>
+                    <InputLabel
+                      label="Modify the suggested description below."
+                      htmlFor={props.id}
+                      hidden={true}
+                    >
+                      <Input
+                        type="text"
+                        multiline
+                        rows={5}
+                        name="userInput"
+                        value={values.customDescription}
+                        bordered
+                        onChange={handleCustomDescriptionChange}
+                        errorMessage={
+                          showCustomInputError
+                            ? (errors.userInput as string)
+                            : undefined
+                        }
+                        id={props.id}
+                        inputProps={{
+                          "aria-describedby": [
+                            props.description ? DESCRIPTION_TEXT : "",
+                            "character-hint",
+                            showCustomInputError
+                              ? `${ERROR_MESSAGE}-${props.id}`
+                              : "",
+                          ]
+                            .filter(Boolean)
+                            .join(" "),
+                        }}
+                      />
+                      <CharacterCounter
+                        limit={TEXT_LIMITS[TextInputType.Long]}
+                        count={values.customDescription.length}
+                        error={showCustomInputError}
+                      />
+                    </InputLabel>
+                  </InputRow>
+                </RevealedContent>
+              )}
+              <DescriptionRadio
                 id="retainedOriginal"
                 onChange={handleOptionChange}
                 title="Use your original description"
                 description={data.original}
               />
-
-              <Box width={68} my={1}>
-                <Typography align="center">or</Typography>
-              </Box>
-
               <DescriptionRadio
-                id="hybrid"
+                id="modifiedOriginal"
                 onChange={handleOptionChange}
-                title="Write a new description"
+                title="Modify your original description"
               />
+              {values.selectedOption === "modifiedOriginal" && (
+                <RevealedContent>
+                  <InputRow>
+                    <InputLabel
+                      label="Modify your original description below."
+                      htmlFor={props.id}
+                      hidden={true}
+                    >
+                      <Input
+                        type="text"
+                        multiline
+                        rows={5}
+                        name="userInput"
+                        value={values.customOriginalDescription}
+                        bordered
+                        onChange={handleCustomOriginalDescriptionChange}
+                        errorMessage={
+                          showCustomInputError
+                            ? (errors.userInput as string)
+                            : undefined
+                        }
+                        id={props.id}
+                        inputProps={{
+                          "aria-describedby": [
+                            props.description ? DESCRIPTION_TEXT : "",
+                            "character-hint",
+                            showCustomInputError
+                              ? `${ERROR_MESSAGE}-${props.id}`
+                              : "",
+                          ]
+                            .filter(Boolean)
+                            .join(" "),
+                        }}
+                      />
+                      <CharacterCounter
+                        limit={TEXT_LIMITS[TextInputType.Long]}
+                        count={values.customOriginalDescription.length}
+                        error={showCustomInputError}
+                      />
+                    </InputLabel>
+                  </InputRow>
+                </RevealedContent>
+              )}
             </RadioGroup>
           </ErrorWrapper>
-
-          {values.selectedOption === "hybrid" && (
-            <RevealedContent>
-              <InputRow>
-                <InputLabel
-                  label="Enter your project description. This will not be checked for suggested improvements."
-                  htmlFor={props.id}
-                >
-                  <Input
-                    type="text"
-                    multiline
-                    rows={5}
-                    name="userInput"
-                    value={values.customDescription}
-                    bordered
-                    onChange={handleCustomDescriptionChange}
-                    errorMessage={
-                      showCustomInputError
-                        ? (errors.userInput as string)
-                        : undefined
-                    }
-                    id={props.id}
-                    inputProps={{
-                      "aria-describedby": [
-                        props.description ? DESCRIPTION_TEXT : "",
-                        "character-hint",
-                        showCustomInputError
-                          ? `${ERROR_MESSAGE}-${props.id}`
-                          : "",
-                      ]
-                        .filter(Boolean)
-                        .join(" "),
-                    }}
-                  />
-                  <CharacterCounter
-                    limit={TEXT_LIMITS[TextInputType.Long]}
-                    count={values.customDescription.length}
-                    error={showCustomInputError}
-                  />
-                </InputLabel>
-              </InputRow>
-            </RevealedContent>
-          )}
         </Box>
       )}
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
@@ -48,6 +48,7 @@ export const RevealedContent = styled(Box)(({ theme }) => ({
   paddingLeft: theme.spacing(3.45),
   marginLeft: theme.spacing(3.2),
   paddingTop: theme.spacing(1),
+  marginBottom: theme.spacing(2),
 }));
 
 export const QuotedText = styled(Typography)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -31,6 +31,7 @@ const EnhancedTextInputComponent = (props: Props) => {
         error: null,
         selectedOption: null,
         customDescription: "",
+        customOriginalDescription: "",
       }
     : {
         userInput: "",
@@ -39,6 +40,7 @@ const EnhancedTextInputComponent = (props: Props) => {
         error: null,
         selectedOption: null,
         customDescription: "",
+        customOriginalDescription: "",
       };
 
   const nextStep = (values: FormValues) => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
@@ -8,6 +8,7 @@ interface FormValuesBase {
   userInput: string;
   selectedOption: TaskAction | null;
   customDescription: string;
+  customOriginalDescription: string;
 }
 
 interface FormValuesIdle extends FormValuesBase {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
@@ -18,7 +18,7 @@ export const getAction = (values: FormValues): TaskActionDescription => {
 
   if (userInput === original) return TaskActionMap.retainedOriginal;
   if (userInput === enhanced) return TaskActionMap.acceptedEnhanced;
-  return TaskActionMap.hybrid;
+  return TaskActionMap.modifiedEnhanced;
 };
 
 export const makeBreadcrumb = (

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
@@ -12,7 +12,8 @@ export interface EnhancementData {
 export const TaskActionMap = {
   retainedOriginal: "Retained their original description",
   acceptedEnhanced: "Accepted the AI-enhanced description",
-  hybrid: "Re-wrote their description after AI feedback",
+  modifiedEnhanced: "Re-wrote their description after AI feedback",
+  modifiedOriginal: "Modified their original description",
 } as const;
 
 /**


### PR DESCRIPTION
#### Iteration of enhanced project descriptions

## Options for accepting or modifying descriptions in same screen

- "Add a new description" is replaced with ability to modify either suggested or original descriptions

<img width="834" height="855" alt="image" src="https://github.com/user-attachments/assets/469856a2-aed7-4c20-ab59-09434e875a06" />
