### PR TITLE
fix: clear auth cookies on failed login to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ planx-new is a monorepo containing our full application stack. Here's a quick su
 5. Move into the hasura directory `cd ../apps/hasura.planx.uk` and install dependencies `pnpm i`.
 
 6. Open [Hasura's](https://hasura.io/) web console (`cd apps/hasura.planx.uk` then `pnpm start`) and check that your Google email address is in the `users` table, if not then add it. This will eventually allow you to authenticate into the application as an admin.
+  - In order to sign in to the editor, you will need to either set the `is_platform_admin` boolean on your user, or add your user to a `team` via the `team_members` join table, setting their role to `teamEditor`
 
 7. Move into the editor directory `cd ../apps/editor.planx.uk` & install dependencies `pnpm i`.
 

--- a/apps/editor.planx.uk/src/lib/api/auth/requests.ts
+++ b/apps/editor.planx.uk/src/lib/api/auth/requests.ts
@@ -8,4 +8,7 @@ export const getUser = async () => {
   return data;
 };
 
-export const logout = async () => await apiClient.post("auth/logout");
+export const logout = async () =>
+  await apiClient.post("auth/logout", undefined, {
+    withCredentials: true,
+  });

--- a/apps/editor.planx.uk/src/routes/(auth)/logout.tsx
+++ b/apps/editor.planx.uk/src/routes/(auth)/logout.tsx
@@ -25,9 +25,8 @@ export const Route = createFileRoute("/(auth)/logout")({
     // Clear cookies
     clearCookie("auth");
     clearCookie("jwt");
-
-    // Clear localStorage
-    localStorage.removeItem("jwt");
+    clearCookie("session");
+    clearCookie("session.sig");
 
     // Must throw redirect to trigger navigation
     throw redirect({ to: "/login", search: {}, replace: true });

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
@@ -67,10 +67,7 @@ export const Route = createFileRoute("/_authenticated/app")({
       if (isRedirect(error)) throw error;
 
       throw redirect({
-        to: "/login",
-        search: {
-          redirectTo: pathname !== "/app" ? pathname : undefined,
-        },
+        to: "/logout",
       });
     }
   },


### PR DESCRIPTION
Fixes a couple of small issues I noticed when getting set up for the first time, and adjusts README accordingly.

- when trying to log in to the editor as a user who exists, but does not have proper permissions set, I was getting bounced back to the /login page but kept in a 'logged in' state, as the auth cookies were still set. This broken state made it impossible to properly sign in after permissions were correctly added
    - a more complete fix might be to add a 'permission denied' screen - this would cover the state accurately i.e. authenticated but not authorized. This PR just makes that state impossible to reach, which i think is fine for now
- achieved this by redirecting through the `/logout` route which already handles clearing of cookies. I tidied up the cookie clearing in this route to match what I was seeing also
- added a note to the README regarding permissions required for new dev users