### PR TITLE
feat: Add 'Open in Editor' button to /draft links

### DIFF
--- a/apps/editor.planx.uk/src/components/OpenInEditorButton.tsx
+++ b/apps/editor.planx.uk/src/components/OpenInEditorButton.tsx
@@ -12,6 +12,7 @@ const StyledFab = styled(Fab)(() => ({
   zIndex: 9999,
   backgroundColor: "#2c2c2c",
   color: "#fff",
+  border: "1px solid #ffffff",
   "&:hover": {
     backgroundColor: "#444",
   },
@@ -26,16 +27,11 @@ const StyledFab = styled(Fab)(() => ({
  * On click, opens the corresponding node in the PlanX Editor in a new tab.
  */
 const OpenInEditorButton: React.FC = () => {
-  const getEditorURLForCurrentCard = useStore(
-    (state) => state.getEditorURLForCurrentCard,
-  );
-
-  const isDraft = window.location.pathname.includes("/draft");
-  if (!isDraft) return null;
+  const currentCardURL = useStore((state) => state.currentCardURL);
 
   const handleClick = () => {
     try {
-      const url = getEditorURLForCurrentCard();
+      const url = currentCardURL();
       if (url) {
         window.open(url, "_blank");
       }

--- a/apps/editor.planx.uk/src/components/OpenInEditorButton.tsx
+++ b/apps/editor.planx.uk/src/components/OpenInEditorButton.tsx
@@ -1,0 +1,62 @@
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import Fab from "@mui/material/Fab";
+import { styled } from "@mui/material/styles";
+import Tooltip from "@mui/material/Tooltip";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+const StyledFab = styled(Fab)(() => ({
+  position: "fixed",
+  bottom: 20,
+  left: 20,
+  zIndex: 9999,
+  backgroundColor: "#2c2c2c",
+  color: "#fff",
+  "&:hover": {
+    backgroundColor: "#444",
+  },
+  textTransform: "none",
+  fontFamily: "sans-serif",
+  fontSize: "0.8125rem",
+  gap: 6,
+}));
+
+/**
+ * Renders an "Open in Editor" button when the current URL is a /draft preview.
+ * On click, opens the corresponding node in the PlanX Editor in a new tab.
+ */
+const OpenInEditorButton: React.FC = () => {
+  const getEditorURLForCurrentCard = useStore(
+    (state) => state.getEditorURLForCurrentCard,
+  );
+
+  const isDraft = window.location.pathname.includes("/draft");
+  if (!isDraft) return null;
+
+  const handleClick = () => {
+    try {
+      const url = getEditorURLForCurrentCard();
+      if (url) {
+        window.open(url, "_blank");
+      }
+    } catch (error) {
+      console.error("Failed to generate editor URL:", error);
+    }
+  };
+
+  return (
+    <Tooltip title="Open this node in the PlanX Editor" placement="right">
+      <StyledFab
+        variant="extended"
+        size="small"
+        onClick={handleClick}
+        data-testid="open-in-editor-button"
+      >
+        <OpenInNewIcon fontSize="small" />
+        Open in Editor
+      </StyledFab>
+    </Tooltip>
+  );
+};
+
+export default OpenInEditorButton;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -1,7 +1,9 @@
+import { getPathForNode, sortFlow } from "@opensystemslab/planx-core";
 import type {
   Address,
   Flag,
   FlagSet,
+  FlowGraph,
   GovUKPayment,
   Node,
   NodeId,
@@ -117,6 +119,7 @@ export interface PreviewStore extends Store.Store {
   autoAnswerableFlag: (filterId: NodeId) => NodeId | undefined;
   hasAcknowledgedWarning: boolean;
   setHasAcknowledgedWarning: () => void;
+  getEditorURLForCurrentCard: () => string | null;
 }
 
 export const previewStore: StateCreator<
@@ -863,6 +866,67 @@ export const previewStore: StateCreator<
 
   hasAcknowledgedWarning: false,
   setHasAcknowledgedWarning: () => set({ hasAcknowledgedWarning: true }),
+
+  getEditorURLForCurrentCard: () => {
+    const { currentCard, flow, flowSlug, teamSlug } = get();
+    if (!currentCard?.id) return null;
+
+    const orderedFlow = sortFlow(flow as FlowGraph);
+    const path = getPathForNode({ nodeId: currentCard.id, flow: orderedFlow });
+    if (!path || path.length === 0) return null;
+
+    let basePath = `${teamSlug}/${flowSlug}`;
+    const internalPortals: typeof path = [];
+    let externalPortalId: string | null = null;
+
+    // Walk node to root and check for nested flows
+    for (let i = 0; i < path.length; i++) {
+      const pNode = path[i];
+
+      if (pNode.type === TYPES.InternalPortal) {
+        const orderedNode = orderedFlow.find((n) => n.id === pNode.id);
+        const nodeData = orderedNode?.data || {};
+
+        if (nodeData.flattenedFromExternalPortal) {
+          if (nodeData.text) {
+            basePath = String(nodeData.text);
+            externalPortalId = pNode.id;
+            break;
+          }
+        } else {
+          internalPortals.push(pNode);
+        }
+      }
+    }
+
+    const [node, parent, grandparent] = path;
+
+    // Folder (internal portal) segments
+    const portalPath = internalPortals.length
+      ? "," +
+        internalPortals
+          .reverse()
+          .map(({ id }) => id)
+          .join(",")
+      : "";
+
+    // Swap nested flow ID for _root
+    const getCleanId = (pathNode: (typeof path)[0] | undefined) => {
+      if (!pathNode) return "_root";
+      if (pathNode.id === externalPortalId) return "_root";
+      return pathNode.id;
+    };
+
+    const cleanParentId = getCleanId(parent);
+    const cleanGrandparentId = getCleanId(grandparent);
+
+    const nodePath =
+      node?.type === TYPES.Answer
+        ? `nodes/${cleanGrandparentId}/nodes/${cleanParentId}/edit#${node.id}`
+        : `nodes/${cleanParentId}/nodes/${node?.id}/edit`;
+
+    return `${window.location.origin}/app/${basePath}${portalPath}/${nodePath}`;
+  },
 });
 
 interface RemoveOrphansFromBreadcrumbsProps {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -119,7 +119,7 @@ export interface PreviewStore extends Store.Store {
   autoAnswerableFlag: (filterId: NodeId) => NodeId | undefined;
   hasAcknowledgedWarning: boolean;
   setHasAcknowledgedWarning: () => void;
-  getEditorURLForCurrentCard: () => string | null;
+  currentCardURL: () => string | null;
 }
 
 export const previewStore: StateCreator<
@@ -867,7 +867,7 @@ export const previewStore: StateCreator<
   hasAcknowledgedWarning: false,
   setHasAcknowledgedWarning: () => set({ hasAcknowledgedWarning: true }),
 
-  getEditorURLForCurrentCard: () => {
+  currentCardURL: () => {
     const { currentCard, flow, flowSlug, teamSlug } = get();
     if (!currentCard?.id) return null;
 

--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -21,6 +21,7 @@ import { ApplicationPath, Session } from "types";
 import Main from "ui/shared/Main";
 
 import ErrorFallback from "../../components/Error/ErrorFallback";
+import OpenInEditorButton from "../../components/OpenInEditorButton";
 import { useStore } from "../FlowEditor/lib/store";
 import Node, { HandleSubmit } from "./Node";
 
@@ -257,6 +258,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
           </ErrorBoundary>
         </Main>
       )}
+      <OpenInEditorButton />
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -81,6 +81,9 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.sectionProgress,
   ]);
   const isStandalone = previewEnvironment === "standalone";
+  const isDraft =
+    typeof window !== "undefined" &&
+    window.location.pathname.endsWith("/draft");
   const { createAnalytics, trackEvent } = useAnalyticsTracking();
   const [gotFlow, setGotFlow] = useState(false);
   const isUsingLocalStorage =
@@ -258,7 +261,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
           </ErrorBoundary>
         </Main>
       )}
-      <OpenInEditorButton />
+      {isDraft && <OpenInEditorButton />}
     </Box>
   );
 };


### PR DESCRIPTION
This PR adds a button to /draft links that opens a link to the node of the active card in the PlanX Editor of its respective environment.

Currently uses a Floating Action Button, the first one in the codebase as far as I can see? Idea was that it's nicely detached, highly visible, and the sole action that will take you out of the /draft tab. Happy to replace with a different component, as it may compete too much with the 'Continue' button as the primary action on the screen.