### PR TITLE
feat: user pinned flows - editor frontend 

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -234,6 +234,7 @@ export interface FlowSummary {
   templatedFrom: string | null;
   isTemplate: boolean;
   isListedOnLPS: boolean;
+  pinnedFlows: { flowId: string }[];
   template: {
     team: {
       name: string;
@@ -554,6 +555,9 @@ export const editorStore: StateCreator<
               hasSendComponent: has_send_component
               hasVisiblePayComponent: has_pay_component
               hasEnabledServiceCharge: service_charge_enabled
+            }
+            pinnedFlows: user_pinned_flows {
+              flowId: flow_id
             }
           }
         }

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -13,7 +13,7 @@ import { ShowingServicesHeader } from "../components/ShowingServicesHeader";
 import { useGetArchivedFlows } from "../helpers/useGetArchivedFlows";
 import { DashboardList } from "./DashboardList";
 import FlowCard from "./FlowCard";
-import { StyledToggleButton } from "./StyledToggleButton"
+import { StyledToggleButton } from "./StyledToggleButton";
 type Props = {
   flowCardView: FlowCardView;
   handleViewChange: (
@@ -32,15 +32,19 @@ const Archive: React.FC<Props> = ({
   slug,
   fetchFlows,
 }) => {
-  const { data: archivedFlowsData, loading, error } = useGetArchivedFlows(teamId);
+  const {
+    data: archivedFlowsData,
+    loading,
+    error,
+  } = useGetArchivedFlows(teamId);
   const archivedFlows = archivedFlowsData?.flows ?? null;
-  
+
   if (error) {
     return (
-      <Box sx={{pt: 2}}>
+      <Box sx={{ pt: 2 }}>
         <ErrorSummary message={error.message} />
       </Box>
-    )
+    );
   }
 
   if (loading) {
@@ -108,7 +112,6 @@ const Archive: React.FC<Props> = ({
               {archivedFlows.map((flow) => (
                 <FlowCard
                   flow={flow}
-                  flows={archivedFlows}
                   key={flow.slug}
                   refreshFlows={fetchFlows}
                   showDetails={false}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -1,11 +1,5 @@
-import { useMutation } from "@apollo/client/react";
-import StarIcon from "@mui/icons-material/Star";
-import StarOutlineIcon from "@mui/icons-material/StarOutline";
 import Box from "@mui/material/Box";
-import CircularProgress from "@mui/material/CircularProgress";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
@@ -15,10 +9,10 @@ import TruncatedText from "ui/editor/TruncatedText";
 import { useStore } from "../../../FlowEditor/lib/store";
 import { FlowSummary } from "../../../FlowEditor/lib/store/editor";
 import FlowMenu from "../FlowMenu";
+import { FlowPinButton } from "../FlowPinButton";
 import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
-import { PIN_FLOW, UNPIN_FLOW } from "./queries";
 import {
   Card,
   CardBanner,
@@ -35,10 +29,9 @@ interface Props {
 }
 
 const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow }) => {
-  const [canUserEditTeam, teamSlug, user] = useStore((state) => [
+  const [canUserEditTeam, teamSlug] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
-    state.user,
   ]);
 
   const {
@@ -50,14 +43,6 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
   } = useFlowMetadata(flow);
 
   const { displayFormatted } = useFlowDates(flow);
-
-  const [pinFlow, { loading: isPinLoading }] = useMutation<{
-    insert_user_pinned_flows_one: { flow: FlowSummary };
-  }>(PIN_FLOW);
-
-  const [unpinFlow, { loading: isUnpinLoading }] = useMutation<{
-    delete_user_pinned_flows: { returning: { flow: FlowSummary }[] };
-  }>(UNPIN_FLOW);
 
   const displayTags = [
     {
@@ -71,23 +56,6 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
       shouldAddTag: isSubmissionService,
     },
   ];
-
-  const handlePinFlow = async () => {
-    if (!user) return;
-
-    const result = await pinFlow({
-      variables: { flowId: flow.id, userId: user.id },
-    });
-    const updatedFlow = result.data?.insert_user_pinned_flows_one?.flow;
-    if (updatedFlow) updateFlow(updatedFlow);
-  };
-
-  const handleUnpinFlow = async () => {
-    const result = await unpinFlow({ variables: { flowId: flow.id } });
-    const updatedFlow =
-      result.data?.delete_user_pinned_flows?.returning?.[0]?.flow;
-    if (updatedFlow) updateFlow(updatedFlow);
-  };
 
   const isPinnedByCurrentUser = flow.pinnedFlows.some(
     (f) => f.flowId === flow.id,
@@ -126,45 +94,11 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
               <LinkSubText>{displayFormatted}</LinkSubText>
             </Stack>
 
-            <Box sx={{ position: "relative", zIndex: 2 }}>
-              {(isPinLoading || isUnpinLoading) && (
-                <CircularProgress
-                  size={34}
-                  disableShrink
-                  thickness={1}
-                  sx={{
-                    position: "absolute",
-                    top: 0,
-                    right: 0,
-                    animationDuration: "700ms",
-                  }}
-                />
-              )}
-              {isPinnedByCurrentUser ? (
-                <Tooltip title="Unpin flow">
-                  <IconButton
-                    size="small"
-                    onClick={handleUnpinFlow}
-                    aria-label="Unpin flow"
-                    sx={{ borderRadius: "50%" }}
-                  >
-                    <StarIcon sx={{ fontSize: 24 }} />
-                  </IconButton>
-                </Tooltip>
-              ) : (
-                <Tooltip title="Pin flow">
-                  <IconButton
-                    size="small"
-                    onClick={handlePinFlow}
-                    aria-label="Pin flow"
-                    disabled={!user}
-                    sx={{ borderRadius: "50%" }}
-                  >
-                    <StarOutlineIcon sx={{ fontSize: 24 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </Box>
+            <FlowPinButton
+              isPinnedByCurrentUser={isPinnedByCurrentUser}
+              flowId={flow.id}
+              updateFlow={updateFlow}
+            />
           </Stack>
           {showDetails && (
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -25,10 +25,15 @@ interface Props {
   flow: FlowSummary;
   refreshFlows: () => void;
   showDetails: boolean;
-  updateFlow: (updatedFlow: FlowSummary) => void;
+  updateFlow?: (updatedFlow: FlowSummary) => void;
 }
 
-const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow }) => {
+const FlowCard: React.FC<Props> = ({
+  flow,
+  refreshFlows,
+  showDetails,
+  updateFlow,
+}) => {
   const [canUserEditTeam, teamSlug, userId] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
@@ -94,7 +99,7 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
               </Typography>
               <LinkSubText>{displayFormatted}</LinkSubText>
             </Stack>
-            {userId && (
+            {userId && updateFlow && (
               <FlowPinButton
                 flowId={flow.id}
                 userId={userId}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -1,4 +1,10 @@
+import { useMutation } from "@apollo/client/react";
+import StarIcon from "@mui/icons-material/Star";
+import StarOutlineIcon from "@mui/icons-material/StarOutline";
 import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
@@ -11,6 +17,7 @@ import FlowMenu from "../FlowMenu";
 import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
+import { PIN_FLOW, UNPIN_FLOW } from "./queries";
 import {
   Card,
   CardBanner,
@@ -21,15 +28,16 @@ import {
 
 interface Props {
   flow: FlowSummary;
-  flows: FlowSummary[];
   refreshFlows: () => void;
   showDetails: boolean;
+  updateFlow: (updatedFlow: FlowSummary) => void;
 }
 
-const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
-  const [canUserEditTeam, teamSlug] = useStore((state) => [
+const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow }) => {
+  const [canUserEditTeam, teamSlug, user] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
+    state.user,
   ]);
 
   const {
@@ -41,6 +49,14 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
   } = useFlowMetadata(flow);
 
   const { displayFormatted } = useFlowDates(flow);
+
+  const [pinFlow, { loading: isPinLoading }] = useMutation<{
+    insert_user_pinned_flows_one: { flow: FlowSummary };
+  }>(PIN_FLOW);
+
+  const [unpinFlow, { loading: isUnpinLoading }] = useMutation<{
+    delete_user_pinned_flows: { returning: { flow: FlowSummary }[] };
+  }>(UNPIN_FLOW);
 
   const displayTags = [
     {
@@ -54,6 +70,27 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
       shouldAddTag: isSubmissionService,
     },
   ];
+
+  const handlePinFlow = async () => {
+    if (!user) return;
+
+    const result = await pinFlow({
+      variables: { flowId: flow.id, userId: user.id },
+    });
+    const updatedFlow = result.data?.insert_user_pinned_flows_one?.flow;
+    if (updatedFlow) updateFlow(updatedFlow);
+  };
+
+  const handleUnpinFlow = async () => {
+    const result = await unpinFlow({ variables: { flowId: flow.id } });
+    const updatedFlow =
+      result.data?.delete_user_pinned_flows?.returning?.[0]?.flow;
+    if (updatedFlow) updateFlow(updatedFlow);
+  };
+
+  const isPinnedByCurrentUser = flow.pinnedFlows.some(
+    (f) => f.flowId === flow.id,
+  );
 
   return (
     <Card>
@@ -75,12 +112,54 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
           </CardBanner>
         )}
         <CardContent>
-          <Box>
-            <Typography variant="h3" component="h2">
-              {flow.name}
-            </Typography>
-            <LinkSubText>{displayFormatted}</LinkSubText>
-          </Box>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="flex-start"
+          >
+            <Stack direction="column" alignItems="flex-start">
+              <Typography variant="h3" component="h2">
+                {flow.name}
+              </Typography>
+              <LinkSubText>{displayFormatted}</LinkSubText>
+            </Stack>
+
+            <Box sx={{ position: "relative", zIndex: 2 }}>
+              {(isPinLoading || isUnpinLoading) && (
+                <CircularProgress
+                  size={34}
+                  disableShrink
+                  thickness={1}
+                  sx={{
+                    position: "absolute",
+                    top: 0,
+                    right: 0,
+                    animationDuration: "700ms",
+                  }}
+                />
+              )}
+              {isPinnedByCurrentUser ? (
+                <IconButton
+                  size="small"
+                  onClick={handleUnpinFlow}
+                  aria-label="Unpin flow"
+                  sx={{ borderRadius: "50%" }}
+                >
+                  <StarIcon sx={{ fontSize: 24 }} />
+                </IconButton>
+              ) : (
+                <IconButton
+                  size="small"
+                  onClick={handlePinFlow}
+                  aria-label="Pin flow"
+                  disabled={!user}
+                  sx={{ borderRadius: "50%" }}
+                >
+                  <StarOutlineIcon sx={{ fontSize: 24 }} />
+                </IconButton>
+              )}
+            </Box>
+          </Stack>
           {showDetails && (
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
               {displayTags

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -5,6 +5,7 @@ import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
@@ -116,6 +117,7 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
             direction="row"
             justifyContent="space-between"
             alignItems="flex-start"
+            width="100%"
           >
             <Stack direction="column" alignItems="flex-start">
               <Typography variant="h3" component="h2">
@@ -139,24 +141,28 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
                 />
               )}
               {isPinnedByCurrentUser ? (
-                <IconButton
-                  size="small"
-                  onClick={handleUnpinFlow}
-                  aria-label="Unpin flow"
-                  sx={{ borderRadius: "50%" }}
-                >
-                  <StarIcon sx={{ fontSize: 24 }} />
-                </IconButton>
+                <Tooltip title="Unpin flow">
+                  <IconButton
+                    size="small"
+                    onClick={handleUnpinFlow}
+                    aria-label="Unpin flow"
+                    sx={{ borderRadius: "50%" }}
+                  >
+                    <StarIcon sx={{ fontSize: 24 }} />
+                  </IconButton>
+                </Tooltip>
               ) : (
-                <IconButton
-                  size="small"
-                  onClick={handlePinFlow}
-                  aria-label="Pin flow"
-                  disabled={!user}
-                  sx={{ borderRadius: "50%" }}
-                >
-                  <StarOutlineIcon sx={{ fontSize: 24 }} />
-                </IconButton>
+                <Tooltip title="Pin flow">
+                  <IconButton
+                    size="small"
+                    onClick={handlePinFlow}
+                    aria-label="Pin flow"
+                    disabled={!user}
+                    sx={{ borderRadius: "50%" }}
+                  >
+                    <StarOutlineIcon sx={{ fontSize: 24 }} />
+                  </IconButton>
+                </Tooltip>
               )}
             </Box>
           </Stack>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -29,9 +29,10 @@ interface Props {
 }
 
 const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow }) => {
-  const [canUserEditTeam, teamSlug] = useStore((state) => [
+  const [canUserEditTeam, teamSlug, userId] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
+    state.user?.id,
   ]);
 
   const {
@@ -93,12 +94,14 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails, updateFlow
               </Typography>
               <LinkSubText>{displayFormatted}</LinkSubText>
             </Stack>
-
-            <FlowPinButton
-              isPinnedByCurrentUser={isPinnedByCurrentUser}
-              flowId={flow.id}
-              updateFlow={updateFlow}
-            />
+            {userId && (
+              <FlowPinButton
+                flowId={flow.id}
+                userId={userId}
+                isPinnedByCurrentUser={isPinnedByCurrentUser}
+                updateFlow={updateFlow}
+              />
+            )}
           </Stack>
           {showDetails && (
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/queries.ts
@@ -1,4 +1,6 @@
-import { gql } from "@apollo/client";
+import { useMutation } from "@apollo/client";
+import gql from "graphql-tag";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 
 // this is copied from the getFlows query in FlowEditor/lib/store/editor.ts - might be worth re-using the fragment there as well?
 const FLOW_SUMMARY_FIELDS = gql`
@@ -63,3 +65,30 @@ export const UNPIN_FLOW = gql`
     }
   }
 `;
+
+interface PinFlowMutation {
+  insert_user_pinned_flows_one: { flow: FlowSummary };
+}
+
+interface UnpinFlowMutation {
+  delete_user_pinned_flows: { returning: { flow: FlowSummary }[] };
+}
+
+interface PinFlowVars {
+  flowId: string;
+  userId: number;
+}
+
+interface UnpinFlowVars {
+  flowId: string;
+}
+
+export const usePinFlow = (variables: PinFlowVars) =>
+  useMutation<PinFlowMutation, PinFlowVars>(PIN_FLOW, {
+    variables,
+  });
+
+export const useUnpinFlow = (variables: UnpinFlowVars) =>
+  useMutation<UnpinFlowMutation, UnpinFlowVars>(UNPIN_FLOW, {
+    variables,
+  });

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/queries.ts
@@ -1,0 +1,65 @@
+import { gql } from "@apollo/client";
+
+// this is copied from the getFlows query in FlowEditor/lib/store/editor.ts - might be worth re-using the fragment there as well?
+const FLOW_SUMMARY_FIELDS = gql`
+  fragment FlowSummaryFields on flows {
+    id
+    name
+    slug
+    status
+    summary
+    updatedAt: updated_at
+    isListedOnLPS: is_listed_on_lps
+    operations(limit: 1, order_by: { created_at: desc }) {
+      createdAt: created_at
+      actor {
+        firstName: first_name
+        lastName: last_name
+      }
+    }
+    templatedFrom: templated_from
+    isTemplate: is_template
+    template {
+      team {
+        id
+        name
+      }
+    }
+    publishedFlows: published_flows(order_by: { created_at: desc }, limit: 1) {
+      publishedAt: created_at
+      hasSendComponent: has_send_component
+      hasVisiblePayComponent: has_pay_component
+      hasEnabledServiceCharge: service_charge_enabled
+    }
+    pinnedFlows: user_pinned_flows {
+      flowId: flow_id
+    }
+  }
+`;
+
+export const PIN_FLOW = gql`
+  ${FLOW_SUMMARY_FIELDS}
+  mutation PinFlow($flowId: uuid!, $userId: Int!) {
+    insert_user_pinned_flows_one(
+      object: { flow_id: $flowId, user_id: $userId }
+    ) {
+      flow {
+        ...FlowSummaryFields
+      }
+    }
+  }
+`;
+
+// userId not required as a variable, as it is pulled from the jwt by the hasura middleware, and used to restrict operations
+export const UNPIN_FLOW = gql`
+  ${FLOW_SUMMARY_FIELDS}
+  mutation UnpinFlow($flowId: uuid!) {
+    delete_user_pinned_flows(where: { flow_id: { _eq: $flowId } }) {
+      returning {
+        flow {
+          ...FlowSummaryFields
+        }
+      }
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
@@ -1,0 +1,115 @@
+import { useMutation } from "@apollo/client";
+import StarIcon from "@mui/icons-material/Star";
+import StarOutlineIcon from "@mui/icons-material/StarOutline";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import React, { useState } from "react";
+
+import { useStore } from "../../FlowEditor/lib/store";
+import { PIN_FLOW, UNPIN_FLOW } from "./FlowCard/queries";
+
+interface Props {
+  flowId: string;
+  isPinnedByCurrentUser: boolean;
+  updateFlow: (flow: FlowSummary) => void;
+}
+
+export const FlowPinButton = ({
+  flowId,
+  isPinnedByCurrentUser,
+  updateFlow,
+}: Props) => {
+  const user = useStore((state) => state.user);
+
+  const [pinFlow, { loading: isPinLoading }] = useMutation<{
+    insert_user_pinned_flows_one: { flow: FlowSummary };
+  }>(PIN_FLOW);
+
+  const [unpinFlow, { loading: isUnpinLoading }] = useMutation<{
+    delete_user_pinned_flows: { returning: { flow: FlowSummary }[] };
+  }>(UNPIN_FLOW);
+
+  const handlePinFlow = async (flowId: string) => {
+    if (!user) {
+      return;
+    }
+
+    const result = await pinFlow({
+      variables: { flowId, userId: user.id },
+    });
+    const updatedFlow = result.data?.insert_user_pinned_flows_one?.flow;
+    if (updatedFlow) {
+      setTooltipOpen(false);
+      updateFlow(updatedFlow);
+    }
+  };
+
+  const handleUnpinFlow = async (flowId: string) => {
+    const result = await unpinFlow({ variables: { flowId } });
+    const updatedFlow =
+      result.data?.delete_user_pinned_flows?.returning?.[0]?.flow;
+
+    if (updatedFlow) {
+      setTooltipOpen(false);
+      updateFlow(updatedFlow);
+    }
+  };
+
+  const isLoading = isPinLoading || isUnpinLoading;
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  return (
+    <Box sx={{ position: "relative", zIndex: 2, display: "inline-flex" }}>
+      {isLoading && (
+        <CircularProgress
+          size={34}
+          disableShrink
+          thickness={1}
+          sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            animationDuration: "700ms",
+          }}
+        />
+      )}
+      {isPinnedByCurrentUser ? (
+        <Tooltip
+          title="Unpin flow"
+          open={tooltipOpen}
+          onOpen={() => setTooltipOpen(true)}
+          onClose={() => setTooltipOpen(false)}
+        >
+          <IconButton
+            size="small"
+            onClick={() => handleUnpinFlow(flowId)}
+            aria-label="Unpin flow"
+            sx={{ borderRadius: "50%" }}
+          >
+            <StarIcon sx={{ fontSize: 24 }} />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip
+          title="Pin flow"
+          open={tooltipOpen}
+          onOpen={() => setTooltipOpen(true)}
+          onClose={() => setTooltipOpen(false)}
+        >
+          <IconButton
+            size="small"
+            onClick={() => handlePinFlow(flowId)}
+            aria-label="Pin flow"
+            disabled={!user}
+            sx={{ borderRadius: "50%" }}
+          >
+            <StarOutlineIcon sx={{ fontSize: 24 }} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@apollo/client";
-import StarIcon from "@mui/icons-material/Star";
-import StarOutlineIcon from "@mui/icons-material/StarOutline";
+import PushPinIcon from "@mui/icons-material/PushPin";
+import PushPinOutlineIcon from "@mui/icons-material/PushPinOutlined";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
@@ -89,7 +89,7 @@ export const FlowPinButton = ({
             aria-label="Unpin flow"
             sx={{ borderRadius: "50%" }}
           >
-            <StarIcon sx={{ fontSize: 24 }} />
+            <PushPinIcon sx={{ fontSize: 24, transform: "translateY(2px)" }} />
           </IconButton>
         </Tooltip>
       ) : (
@@ -106,7 +106,9 @@ export const FlowPinButton = ({
             disabled={!user}
             sx={{ borderRadius: "50%" }}
           >
-            <StarOutlineIcon sx={{ fontSize: 24 }} />
+            <PushPinOutlineIcon
+              sx={{ fontSize: 24, transform: "translateY(2px)" }}
+            />
           </IconButton>
         </Tooltip>
       )}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from "@apollo/client";
 import PushPinIcon from "@mui/icons-material/PushPin";
 import PushPinOutlineIcon from "@mui/icons-material/PushPinOutlined";
 import Box from "@mui/material/Box";
@@ -9,7 +8,7 @@ import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { useState } from "react";
 
 import { useStore } from "../../FlowEditor/lib/store";
-import { PIN_FLOW, UNPIN_FLOW } from "./FlowCard/queries";
+import { usePinFlow, useUnpinFlow } from "./FlowCard/queries";
 
 interface Props {
   flowId: string;
@@ -24,22 +23,20 @@ export const FlowPinButton = ({
 }: Props) => {
   const user = useStore((state) => state.user);
 
-  const [pinFlow, { loading: isPinLoading }] = useMutation<{
-    insert_user_pinned_flows_one: { flow: FlowSummary };
-  }>(PIN_FLOW);
+  const [pinFlow, { loading: isPinLoading }] = usePinFlow({
+    flowId,
+    userId: user?.id,
+  });
+  const [unpinFlow, { loading: isUnpinLoading }] = useUnpinFlow({
+    flowId,
+  });
 
-  const [unpinFlow, { loading: isUnpinLoading }] = useMutation<{
-    delete_user_pinned_flows: { returning: { flow: FlowSummary }[] };
-  }>(UNPIN_FLOW);
-
-  const handlePinFlow = async (flowId: string) => {
+  const handlePinFlow = async () => {
     if (!user) {
       return;
     }
 
-    const result = await pinFlow({
-      variables: { flowId, userId: user.id },
-    });
+    const result = await pinFlow();
     const updatedFlow = result.data?.insert_user_pinned_flows_one?.flow;
     if (updatedFlow) {
       setTooltipOpen(false);
@@ -47,8 +44,8 @@ export const FlowPinButton = ({
     }
   };
 
-  const handleUnpinFlow = async (flowId: string) => {
-    const result = await unpinFlow({ variables: { flowId } });
+  const handleUnpinFlow = async () => {
+    const result = await unpinFlow();
     const updatedFlow =
       result.data?.delete_user_pinned_flows?.returning?.[0]?.flow;
 
@@ -85,7 +82,7 @@ export const FlowPinButton = ({
         >
           <IconButton
             size="small"
-            onClick={() => handleUnpinFlow(flowId)}
+            onClick={handleUnpinFlow}
             aria-label="Unpin flow"
             sx={{ borderRadius: "50%" }}
           >
@@ -101,7 +98,7 @@ export const FlowPinButton = ({
         >
           <IconButton
             size="small"
-            onClick={() => handlePinFlow(flowId)}
+            onClick={handlePinFlow}
             aria-label="Pin flow"
             disabled={!user}
             sx={{ borderRadius: "50%" }}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowPinButton.tsx
@@ -7,35 +7,30 @@ import Tooltip from "@mui/material/Tooltip";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { useState } from "react";
 
-import { useStore } from "../../FlowEditor/lib/store";
 import { usePinFlow, useUnpinFlow } from "./FlowCard/queries";
 
 interface Props {
   flowId: string;
+  userId: number;
   isPinnedByCurrentUser: boolean;
   updateFlow: (flow: FlowSummary) => void;
 }
 
 export const FlowPinButton = ({
   flowId,
+  userId,
   isPinnedByCurrentUser,
   updateFlow,
 }: Props) => {
-  const user = useStore((state) => state.user);
-
   const [pinFlow, { loading: isPinLoading }] = usePinFlow({
     flowId,
-    userId: user?.id,
+    userId,
   });
   const [unpinFlow, { loading: isUnpinLoading }] = useUnpinFlow({
     flowId,
   });
 
   const handlePinFlow = async () => {
-    if (!user) {
-      return;
-    }
-
     const result = await pinFlow();
     const updatedFlow = result.data?.insert_user_pinned_flows_one?.flow;
     if (updatedFlow) {
@@ -100,7 +95,6 @@ export const FlowPinButton = ({
             size="small"
             onClick={handlePinFlow}
             aria-label="Pin flow"
-            disabled={!user}
             sx={{ borderRadius: "50%" }}
           >
             <PushPinOutlineIcon

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -91,7 +91,10 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   showDetails,
   updateFlow,
 }) => {
-  const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
+  const [canUserEditTeam, userId] = useStore((state) => [
+    state.canUserEditTeam,
+    state.user?.id,
+  ]);
 
   const {
     isSubmissionService,
@@ -170,11 +173,14 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           </TableCell>
           <TableCell>
             <Box onClick={(e) => e.stopPropagation()}>
-              <FlowPinButton
-                flowId={flow.id}
-                isPinnedByCurrentUser={flow.pinnedFlows.length > 0}
-                updateFlow={updateFlow}
-              />
+              {userId && (
+                <FlowPinButton
+                  flowId={flow.id}
+                  userId={userId}
+                  isPinnedByCurrentUser={flow.pinnedFlows.length > 0}
+                  updateFlow={updateFlow}
+                />
+              )}
             </Box>
           </TableCell>
           <FlowActionsCell

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -32,7 +32,7 @@ interface FlowTableProps {
   teamSlug: string;
   refreshFlows: () => void;
   showDetails: boolean;
-  updateFlow: (flow: FlowSummary) => void;
+  updateFlow?: (flow: FlowSummary) => void;
 }
 
 export const FlowTable: React.FC<FlowTableProps> = ({
@@ -42,7 +42,10 @@ export const FlowTable: React.FC<FlowTableProps> = ({
   showDetails,
   updateFlow,
 }) => {
+  const [userId] = useStore((state) => [state.user?.id]);
   const { headerText } = useFlowSortDisplay();
+
+  const showPinnedColumn = updateFlow && userId;
 
   return (
     <StyledTable>
@@ -54,7 +57,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
               <FlowStatusCell>Online status</FlowStatusCell>
               <FlowStatusCell>Flow type</FlowStatusCell>
               <TableCell>{headerText}</TableCell>
-              <TableCell>Pinned</TableCell>
+              {showPinnedColumn && <TableCell>Pinned</TableCell>}
               <FlowActionsCell align="center">Actions</FlowActionsCell>
             </>
           )}
@@ -81,7 +84,7 @@ interface FlowTableRowProps {
   teamSlug: string;
   refreshFlows: () => void;
   showDetails: boolean;
-  updateFlow: (flow: FlowSummary) => void;
+  updateFlow?: (flow: FlowSummary) => void;
 }
 
 const FlowTableRow: React.FC<FlowTableRowProps> = ({
@@ -105,6 +108,8 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   } = useFlowMetadata(flow);
 
   const { displayTimeAgo, displayActor } = useFlowDates(flow);
+
+  const showPinnedColumn = updateFlow && userId;
 
   return (
     <StyledTableRow isTemplated={isAnyTemplate} clickable={showDetails}>
@@ -171,18 +176,20 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               )}
             </Box>
           </TableCell>
-          <TableCell>
-            <Box onClick={(e) => e.stopPropagation()}>
-              {userId && (
-                <FlowPinButton
-                  flowId={flow.id}
-                  userId={userId}
-                  isPinnedByCurrentUser={flow.pinnedFlows.length > 0}
-                  updateFlow={updateFlow}
-                />
-              )}
-            </Box>
-          </TableCell>
+          {showPinnedColumn && (
+            <TableCell>
+              <Box onClick={(e) => e.stopPropagation()}>
+                {userId && updateFlow && (
+                  <FlowPinButton
+                    flowId={flow.id}
+                    userId={userId}
+                    isPinnedByCurrentUser={flow.pinnedFlows.length > 0}
+                    updateFlow={updateFlow}
+                  />
+                )}
+              </Box>
+            </TableCell>
+          )}
           <FlowActionsCell
             className="actions-cell"
             align="center"

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -11,6 +11,7 @@ import TruncatedText from "ui/editor/TruncatedText";
 
 import { useStore } from "../../../FlowEditor/lib/store";
 import FlowMenu from "../FlowMenu";
+import { FlowPinButton } from "../FlowPinButton";
 import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
@@ -31,6 +32,7 @@ interface FlowTableProps {
   teamSlug: string;
   refreshFlows: () => void;
   showDetails: boolean;
+  updateFlow: (flow: FlowSummary) => void;
 }
 
 export const FlowTable: React.FC<FlowTableProps> = ({
@@ -38,6 +40,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
   teamSlug,
   refreshFlows,
   showDetails,
+  updateFlow,
 }) => {
   const { headerText } = useFlowSortDisplay();
 
@@ -51,6 +54,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
               <FlowStatusCell>Online status</FlowStatusCell>
               <FlowStatusCell>Flow type</FlowStatusCell>
               <TableCell>{headerText}</TableCell>
+              <TableCell>Pinned</TableCell>
               <FlowActionsCell align="center">Actions</FlowActionsCell>
             </>
           )}
@@ -64,6 +68,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
             teamSlug={teamSlug}
             refreshFlows={refreshFlows}
             showDetails={showDetails}
+            updateFlow={updateFlow}
           />
         ))}
       </TableBody>
@@ -76,6 +81,7 @@ interface FlowTableRowProps {
   teamSlug: string;
   refreshFlows: () => void;
   showDetails: boolean;
+  updateFlow: (flow: FlowSummary) => void;
 }
 
 const FlowTableRow: React.FC<FlowTableRowProps> = ({
@@ -83,6 +89,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   teamSlug,
   refreshFlows,
   showDetails,
+  updateFlow,
 }) => {
   const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
 
@@ -151,7 +158,6 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               </Box>
             )}
           </FlowStatusCell>
-
           <TableCell>
             <Box>
               <Typography variant="body2">{displayTimeAgo}</Typography>
@@ -160,6 +166,15 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
                   by {displayActor}
                 </Typography>
               )}
+            </Box>
+          </TableCell>
+          <TableCell>
+            <Box onClick={(e) => e.stopPropagation()}>
+              <FlowPinButton
+                flowId={flow.id}
+                isPinnedByCurrentUser={flow.pinnedFlows.length > 0}
+                updateFlow={updateFlow}
+              />
             </Box>
           </TableCell>
           <FlowActionsCell

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -9,6 +9,7 @@ import { CustomLink } from "../../../../ui/shared/CustomLink/CustomLink";
 
 export const StyledTable = styled(Table)(({ theme }) => ({
   marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2),
   zIndex: 1,
   position: "relative",
   border: `1px solid ${theme.palette.border.main}`,

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -46,6 +46,7 @@ type Props = {
   teamId: number;
   flows: FlowSummary[] | null;
   pinnedFlows: FlowSummary[];
+  unpinnedFlows: FlowSummary[];
   handleViewChange: (
     _event: React.MouseEvent<HTMLElement>,
     newView: FlowCardView | null,
@@ -64,12 +65,16 @@ const Flows: React.FC<Props> = ({
   fetchFlows,
   teamId,
   pinnedFlows,
+  unpinnedFlows,
   handleViewChange,
   slug,
   updateFlow,
 }) => {
   const teamHasFlows = sortedFlows ? true : false;
   const navigate = useNavigate();
+
+  const showPinnedFlows = pinnedFlows.length > 0 && !flowsHaveBeenFiltered;
+  const remainingFlows = showPinnedFlows ? unpinnedFlows : sortedFlows;
 
   return (
     teamHasFlows && (
@@ -178,11 +183,11 @@ const Flows: React.FC<Props> = ({
             )}
           </Box>
         </Box>
-        {sortedFlows && (
+        {remainingFlows && (
           <>
             {flowCardView === "grid" ? (
               <DashboardList>
-                {sortedFlows.map((flow) => (
+                {remainingFlows.map((flow) => (
                   <FlowCard
                     flow={flow}
                     key={flow.slug}
@@ -194,7 +199,7 @@ const Flows: React.FC<Props> = ({
               </DashboardList>
             ) : (
               <FlowTable
-                flows={sortedFlows}
+                flows={remainingFlows}
                 teamId={teamId}
                 teamSlug={slug}
                 refreshFlows={fetchFlows}

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -109,10 +109,14 @@ const Flows: React.FC<Props> = ({
         </FiltersContainer>
         {pinnedFlows.length > 0 && !flowsHaveBeenFiltered && (
           <Box>
-            <ShowingServicesHeader
-              matchedFlowsCount={pinnedFlows?.length || 0}
-              isPinnedFlows={true}
-            />
+            <Box
+              sx={{ minHeight: "50px", display: "flex", alignItems: "center" }}
+            >
+              <ShowingServicesHeader
+                matchedFlowsCount={pinnedFlows?.length || 0}
+                isPinnedFlows={true}
+              />
+            </Box>
             {flowCardView === "grid" ? (
               <DashboardList>
                 {pinnedFlows.map((flow) => (

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -126,6 +126,7 @@ const Flows: React.FC<Props> = ({
                 teamId={teamId}
                 teamSlug={slug}
                 refreshFlows={fetchFlows}
+                updateFlow={updateFlow}
                 showDetails={true}
               />
             )}
@@ -198,6 +199,7 @@ const Flows: React.FC<Props> = ({
                 teamSlug={slug}
                 refreshFlows={fetchFlows}
                 showDetails={true}
+                updateFlow={updateFlow}
               />
             )}
           </>

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -74,7 +74,12 @@ const Flows: React.FC<Props> = ({
   const navigate = useNavigate();
 
   const showPinnedFlows = pinnedFlows.length > 0 && !flowsHaveBeenFiltered;
-  const remainingFlows = showPinnedFlows ? unpinnedFlows : sortedFlows;
+  const sortedPinnedFlows = showPinnedFlows
+    ? (sortedFlows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [])
+    : [];
+  const remainingFlows = showPinnedFlows
+    ? (sortedFlows?.filter((flow) => flow.pinnedFlows.length === 0) ?? null)
+    : sortedFlows;
 
   return (
     teamHasFlows && (
@@ -107,19 +112,19 @@ const Flows: React.FC<Props> = ({
             </Tooltip>
           </ToggleButtonGroup>
         </FiltersContainer>
-        {pinnedFlows.length > 0 && !flowsHaveBeenFiltered && (
+        {sortedPinnedFlows.length > 0 && (
           <Box>
             <Box
               sx={{ minHeight: "50px", display: "flex", alignItems: "center" }}
             >
               <ShowingServicesHeader
-                matchedFlowsCount={pinnedFlows?.length || 0}
+                matchedFlowsCount={sortedPinnedFlows.length}
                 isPinnedFlows={true}
               />
             </Box>
             {flowCardView === "grid" ? (
               <DashboardList>
-                {pinnedFlows.map((flow) => (
+                {sortedPinnedFlows.map((flow) => (
                   <FlowCard
                     flow={flow}
                     key={flow.slug}
@@ -131,7 +136,7 @@ const Flows: React.FC<Props> = ({
               </DashboardList>
             ) : (
               <FlowTable
-                flows={pinnedFlows}
+                flows={sortedPinnedFlows}
                 teamId={teamId}
                 teamSlug={slug}
                 refreshFlows={fetchFlows}

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -45,11 +45,13 @@ type Props = {
   fetchFlows: () => void;
   teamId: number;
   flows: FlowSummary[] | null;
+  pinnedFlows: FlowSummary[];
   handleViewChange: (
     _event: React.MouseEvent<HTMLElement>,
     newView: FlowCardView | null,
   ) => void;
   slug: string;
+  updateFlow: (updatedFlow: FlowSummary) => void;
 };
 
 const Flows: React.FC<Props> = ({
@@ -61,8 +63,10 @@ const Flows: React.FC<Props> = ({
   flowCardView,
   fetchFlows,
   teamId,
+  pinnedFlows,
   handleViewChange,
   slug,
+  updateFlow,
 }) => {
   const teamHasFlows = sortedFlows ? true : false;
   const navigate = useNavigate();
@@ -80,11 +84,57 @@ const Flows: React.FC<Props> = ({
               <SortControl<FlowSummary> sortOptions={sortOptions} />
             </Box>
           )}
+          <ToggleButtonGroup
+            value={flowCardView}
+            exclusive
+            onChange={handleViewChange}
+            size="small"
+          >
+            <Tooltip title="Card view" placement="bottom">
+              <StyledToggleButton value="grid" disableRipple>
+                <ViewModuleIcon />
+              </StyledToggleButton>
+            </Tooltip>
+            <Tooltip title="Table view" placement="bottom">
+              <StyledToggleButton value="row" disableRipple>
+                <TableRowsIcon />
+              </StyledToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
         </FiltersContainer>
+        {pinnedFlows.length > 0 && !flowsHaveBeenFiltered && (
+          <Box>
+            <ShowingServicesHeader
+              matchedFlowsCount={pinnedFlows?.length || 0}
+              isPinnedFlows={true}
+            />
+            {flowCardView === "grid" ? (
+              <DashboardList>
+                {pinnedFlows.map((flow) => (
+                  <FlowCard
+                    flow={flow}
+                    key={flow.slug}
+                    refreshFlows={fetchFlows}
+                    showDetails={true}
+                    updateFlow={updateFlow}
+                  />
+                ))}
+              </DashboardList>
+            ) : (
+              <FlowTable
+                flows={pinnedFlows}
+                teamId={teamId}
+                teamSlug={slug}
+                refreshFlows={fetchFlows}
+                showDetails={true}
+              />
+            )}
+          </Box>
+        )}
         <Box
           sx={{
             display: "flex",
-            justifyContent: "space-between",
+            flexDirection: "row",
             alignItems: "center",
             gap: 2,
           }}
@@ -100,6 +150,7 @@ const Flows: React.FC<Props> = ({
           >
             <ShowingServicesHeader
               matchedFlowsCount={sortedFlows?.length || 0}
+              isFiltered={flowsHaveBeenFiltered}
             />
             {flowsHaveBeenFiltered && (
               <Button
@@ -125,23 +176,6 @@ const Flows: React.FC<Props> = ({
               </Button>
             )}
           </Box>
-          <ToggleButtonGroup
-            value={flowCardView}
-            exclusive
-            onChange={handleViewChange}
-            size="small"
-          >
-            <Tooltip title="Card view" placement="bottom">
-              <StyledToggleButton value="grid" disableRipple>
-                <ViewModuleIcon />
-              </StyledToggleButton>
-            </Tooltip>
-            <Tooltip title="Table view" placement="bottom">
-              <StyledToggleButton value="row" disableRipple>
-                <TableRowsIcon />
-              </StyledToggleButton>
-            </Tooltip>
-          </ToggleButtonGroup>
         </Box>
         {sortedFlows && (
           <>
@@ -150,10 +184,10 @@ const Flows: React.FC<Props> = ({
                 {sortedFlows.map((flow) => (
                   <FlowCard
                     flow={flow}
-                    flows={sortedFlows}
                     key={flow.slug}
                     refreshFlows={fetchFlows}
                     showDetails={true}
+                    updateFlow={updateFlow}
                   />
                 ))}
               </DashboardList>
@@ -172,4 +206,5 @@ const Flows: React.FC<Props> = ({
     )
   );
 };
+
 export default Flows;

--- a/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -3,17 +3,35 @@ import React from "react";
 
 export const ShowingServicesHeader = ({
   matchedFlowsCount,
+  isFiltered = false,
+  isPinnedFlows = false,
 }: {
   matchedFlowsCount: number;
+  isFiltered?: boolean;
+  isPinnedFlows?: boolean;
 }) => {
-  const showingServicesMessage =
+  let message =
     matchedFlowsCount !== 1
       ? `Showing ${matchedFlowsCount} flows`
       : `Showing ${matchedFlowsCount} flow`;
 
+  if (isFiltered) {
+    message =
+      matchedFlowsCount !== 1
+        ? `Showing ${matchedFlowsCount} filtered flows`
+        : `Showing ${matchedFlowsCount} filtered flow`;
+  }
+
+  if (isPinnedFlows) {
+    message =
+      matchedFlowsCount !== 1
+        ? `Showing ${matchedFlowsCount} pinned flows`
+        : `Showing ${matchedFlowsCount} pinned flow`;
+  }
+
   return (
     <Typography variant="h4" component="h2">
-      {showingServicesMessage}
+      {message}
     </Typography>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -194,20 +194,19 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
               {isTrial && <InfoChip label="Trial account" />}
               {showAddFlowButton && <AddFlow />}
             </Box>
+            {teamHasFlows && (
+              <SearchBox<FlowSummary>
+                records={flows}
+                setRecords={setSearchedFlows}
+                searchKey={["name", "slug"]}
+                clearSearch={shouldClearSearch}
+              />
+            )}
           </Box>
-          {teamHasFlows && (
-            <SearchBox<FlowSummary>
-              records={flows}
-              setRecords={setSearchedFlows}
-              searchKey={["name", "slug"]}
-              clearSearch={shouldClearSearch}
-            />
+          {hasFeatureFlag("ARCHIVE_VIEW") && (
+            <TeamLayout flowView={flowView} setFlowView={setFlowView} />
           )}
         </Box>
-
-        {hasFeatureFlag("ARCHIVE_VIEW") && (
-          <TeamLayout flowView={flowView} setFlowView={setFlowView} />
-        )}
 
         {flowView === "flows" && (
           <Flows

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -17,6 +17,8 @@ import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
+import FlowCard from "./components/FlowCard";
+import { FlowTable } from "./components/FlowTable";
 
 export type FlowView = "flows" | "archive";
 
@@ -140,6 +142,14 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
     });
   }, [teamId, setFlows, getFlows]);
 
+  const updateFlow = useCallback((updatedFlow: FlowSummary) => {
+    const updateSingleFlow = (prev: FlowSummary[] | null) =>
+      prev?.map((f) => (f.id === updatedFlow.id ? updatedFlow : f)) ?? prev;
+
+    setFlows(updateSingleFlow(flows));
+    setSearchedFlows(updateSingleFlow);
+  }, []);
+
   useEffect(() => {
     if (shouldClearSearch) {
       setShouldClearSearch(false);
@@ -185,6 +195,30 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
                 searchKey={["name", "slug"]}
                 clearSearch={shouldClearSearch}
               />
+            )}
+            {sortedFlows && (
+              <>
+                {flowCardView === "grid" ? (
+                  <DashboardList>
+                    {sortedFlows.map((flow) => (
+                      <FlowCard
+                        flow={flow}
+                        key={flow.slug}
+                        refreshFlows={fetchFlows}
+                        showDetails={true}
+                        updateFlow={updateFlow}
+                      />
+                    ))}
+                  </DashboardList>
+                ) : (
+                  <FlowTable
+                    flows={sortedFlows}
+                    teamId={teamId}
+                    teamSlug={slug}
+                    refreshFlows={fetchFlows}
+                  />
+                )}
+              </>
             )}
           </Box>
           {hasFeatureFlag("ARCHIVE_VIEW") && (

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -66,6 +66,10 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
     return flows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [];
   }, [flows]);
 
+  const unpinnedFlows = useMemo(() => {
+    return flows?.filter((flow) => flow.pinnedFlows.length === 0) ?? [];
+  }, [flows]);
+
   const sortedFlows = useMemo(() => {
     // Use searchedFlows if available (from SearchBox), otherwise use all flows
     const sourceFlows = searchedFlows || flows;
@@ -217,6 +221,7 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             teamId={teamId}
             flows={flows}
             pinnedFlows={pinnedFlows}
+            unpinnedFlows={unpinnedFlows}
             handleViewChange={handleViewChange}
             slug={slug}
             updateFlow={updateFlow}

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -17,8 +17,6 @@ import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
-import FlowCard from "./components/FlowCard";
-import { FlowTable } from "./components/FlowTable";
 
 export type FlowView = "flows" | "archive";
 
@@ -63,6 +61,10 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
   );
   const [shouldClearSearch, setShouldClearSearch] = useState<boolean>(false);
   const searchParams = useSearch({ from: "/_authenticated/app/$team/" });
+
+  const pinnedFlows = useMemo(() => {
+    return flows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [];
+  }, [flows]);
 
   const sortedFlows = useMemo(() => {
     // Use searchedFlows if available (from SearchBox), otherwise use all flows
@@ -146,7 +148,7 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
     const updateSingleFlow = (prev: FlowSummary[] | null) =>
       prev?.map((f) => (f.id === updatedFlow.id ? updatedFlow : f)) ?? prev;
 
-    setFlows(updateSingleFlow(flows));
+    setFlows(updateSingleFlow);
     setSearchedFlows(updateSingleFlow);
   }, []);
 
@@ -188,43 +190,20 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
               {isTrial && <InfoChip label="Trial account" />}
               {showAddFlowButton && <AddFlow />}
             </Box>
-            {teamHasFlows && (
-              <SearchBox<FlowSummary>
-                records={flows}
-                setRecords={setSearchedFlows}
-                searchKey={["name", "slug"]}
-                clearSearch={shouldClearSearch}
-              />
-            )}
-            {sortedFlows && (
-              <>
-                {flowCardView === "grid" ? (
-                  <DashboardList>
-                    {sortedFlows.map((flow) => (
-                      <FlowCard
-                        flow={flow}
-                        key={flow.slug}
-                        refreshFlows={fetchFlows}
-                        showDetails={true}
-                        updateFlow={updateFlow}
-                      />
-                    ))}
-                  </DashboardList>
-                ) : (
-                  <FlowTable
-                    flows={sortedFlows}
-                    teamId={teamId}
-                    teamSlug={slug}
-                    refreshFlows={fetchFlows}
-                  />
-                )}
-              </>
-            )}
           </Box>
-          {hasFeatureFlag("ARCHIVE_VIEW") && (
-            <TeamLayout flowView={flowView} setFlowView={setFlowView} />
+          {teamHasFlows && (
+            <SearchBox<FlowSummary>
+              records={flows}
+              setRecords={setSearchedFlows}
+              searchKey={["name", "slug"]}
+              clearSearch={shouldClearSearch}
+            />
           )}
         </Box>
+
+        {hasFeatureFlag("ARCHIVE_VIEW") && (
+          <TeamLayout flowView={flowView} setFlowView={setFlowView} />
+        )}
 
         {flowView === "flows" && (
           <Flows
@@ -237,8 +216,10 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             fetchFlows={fetchFlows}
             teamId={teamId}
             flows={flows}
+            pinnedFlows={pinnedFlows}
             handleViewChange={handleViewChange}
             slug={slug}
+            updateFlow={updateFlow}
           />
         )}
         {flowView === "archive" && (


### PR DESCRIPTION

### What's in this PR?
Editor frontend changes to display and manage pinned flows

### Design & implementation details / decisions
- used a star icon for the pin/unpin icon
- little loading animation whilst the mutation is being applied
- moved the grid/table toggle into the filters & sort section 
- pinned flows are not included in the regular flow list
- graphql mutation returns the full modified flow, and the frontend partially updates its `flows` state - this way you avoid refetching and rendering all the flows, but you also ensure that the browser reflects DB state directly rather than tracking its own state