### PR TITLE
feat: archived flows view

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -1,0 +1,105 @@
+import TableRowsIcon from "@mui/icons-material/TableRows";
+import ViewModuleIcon from "@mui/icons-material/ViewModule";
+import Box from "@mui/material/Box";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Tooltip from "@mui/material/Tooltip";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import React from "react";
+
+import { FlowCardView } from "../../FlowEditor/lib/store/editor";
+import { FlowTable } from "../components/FlowTable";
+import { ShowingServicesHeader } from "../components/ShowingServicesHeader";
+import { DashboardList } from "./DashboardList";
+import FlowCard from "./FlowCard";
+import { StyledToggleButton } from "./StyledToggleButton"
+
+type Props = {
+  flowCardView: FlowCardView;
+  handleViewChange: (
+    _event: React.MouseEvent<HTMLElement>,
+    newView: FlowCardView | null,
+  ) => void;
+  archivedFlows: FlowSummary[] | null;
+  teamId: number;
+  slug: string;
+  fetchFlows: () => void;
+};
+
+const Archive: React.FC<Props> = ({
+  flowCardView,
+  handleViewChange,
+  archivedFlows,
+  teamId,
+  slug,
+  fetchFlows,
+}) => {
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-start",
+            alignItems: "center",
+            gap: 2,
+            minHeight: "50px",
+          }}
+        >
+          <ShowingServicesHeader
+            matchedFlowsCount={archivedFlows?.length || 0}
+          />
+        </Box>
+        <ToggleButtonGroup
+          value={flowCardView}
+          exclusive
+          onChange={handleViewChange}
+          size="small"
+        >
+          <Tooltip title="Card view" placement="bottom">
+            <StyledToggleButton value="grid" disableRipple>
+              <ViewModuleIcon />
+            </StyledToggleButton>
+          </Tooltip>
+          <Tooltip title="Table view" placement="bottom">
+            <StyledToggleButton value="row" disableRipple>
+              <TableRowsIcon />
+            </StyledToggleButton>
+          </Tooltip>
+        </ToggleButtonGroup>
+      </Box>
+      {archivedFlows && (
+        <>
+          {flowCardView === "grid" ? (
+            <DashboardList>
+              {archivedFlows.map((flow) => (
+                <FlowCard
+                  flow={flow}
+                  flows={archivedFlows}
+                  key={flow.slug}
+                  refreshFlows={fetchFlows}
+                  showDetails={false}
+                />
+              ))}
+            </DashboardList>
+          ) : (
+            <FlowTable
+              flows={archivedFlows}
+              teamId={teamId}
+              teamSlug={slug}
+              refreshFlows={fetchFlows}
+              showDetails={false}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+};
+export default Archive;

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -55,9 +55,6 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
     },
   ];
 
-  const editPermissions = canUserEditTeam(teamSlug);
-  console.log({ showDetails, editPermissions });
-
   return (
     <Card>
       <Box

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -23,9 +23,10 @@ interface Props {
   flow: FlowSummary;
   flows: FlowSummary[];
   refreshFlows: () => void;
+  showDetails: boolean;
 }
 
-const FlowCard: React.FC<Props> = ({ flow, refreshFlows }) => {
+const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
   const [canUserEditTeam, teamSlug] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
@@ -54,6 +55,9 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows }) => {
     },
   ];
 
+  const editPermissions = canUserEditTeam(teamSlug);
+  console.log({ showDetails, editPermissions });
+
   return (
     <Card>
       <Box
@@ -80,19 +84,21 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows }) => {
             </Typography>
             <LinkSubText>{displayFormatted}</LinkSubText>
           </Box>
-          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-            {displayTags
-              .filter((tag) => tag.shouldAddTag)
-              .map((tag) => (
-                <FlowTag
-                  key={`${tag.displayName}-flowtag`}
-                  tagType={tag.type}
-                  statusVariant={statusVariant}
-                >
-                  {tag.displayName}
-                </FlowTag>
-              ))}
-          </Box>
+          {showDetails && (
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {displayTags
+                .filter((tag) => tag.shouldAddTag)
+                .map((tag) => (
+                  <FlowTag
+                    key={`${tag.displayName}-flowtag`}
+                    tagType={tag.type}
+                    statusVariant={statusVariant}
+                  >
+                    {tag.displayName}
+                  </FlowTag>
+                ))}
+            </Box>
+          )}
           {flow.summary && (
             <TruncatedText
               variant="body2"
@@ -103,15 +109,17 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows }) => {
               {flow.summary}
             </TruncatedText>
           )}
-          <DashboardLink
-            to="/app/$team/$flow"
-            params={{ team: teamSlug, flow: flow.slug }}
-            aria-label={flow.name}
-            preload={false}
-          />
+          {showDetails && (
+            <DashboardLink
+              to="/app/$team/$flow"
+              params={{ team: teamSlug, flow: flow.slug }}
+              aria-label={flow.name}
+              preload={false}
+            />
+          )}
         </CardContent>
       </Box>
-      {canUserEditTeam(teamSlug) && (
+      {canUserEditTeam(teamSlug) && showDetails && (
         <FlowMenu
           flow={flow}
           refreshFlows={refreshFlows}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -33,12 +33,14 @@ interface FlowTableProps {
   teamId: number;
   teamSlug: string;
   refreshFlows: () => void;
+  showDetails: boolean;
 }
 
 export const FlowTable: React.FC<FlowTableProps> = ({
   flows,
   teamSlug,
   refreshFlows,
+  showDetails,
 }) => {
   const { headerText } = useFlowSortDisplay();
 
@@ -47,10 +49,14 @@ export const FlowTable: React.FC<FlowTableProps> = ({
       <StyledTableHead>
         <TableRow>
           <FlowTitleCell>Flow title</FlowTitleCell>
-          <FlowStatusCell>Online status</FlowStatusCell>
-          <FlowStatusCell>Flow type</FlowStatusCell>
-          <TableCell>{headerText}</TableCell>
-          <FlowActionsCell align="center">Actions</FlowActionsCell>
+          {showDetails && (
+            <>
+              <FlowStatusCell>Online status</FlowStatusCell>
+              <FlowStatusCell>Flow type</FlowStatusCell>
+              <TableCell>{headerText}</TableCell>
+              <FlowActionsCell align="center">Actions</FlowActionsCell>
+            </>
+          )}
         </TableRow>
       </StyledTableHead>
       <TableBody>
@@ -60,6 +66,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
             flow={flow}
             teamSlug={teamSlug}
             refreshFlows={refreshFlows}
+            showDetails={showDetails}
           />
         ))}
       </TableBody>
@@ -71,12 +78,14 @@ interface FlowTableRowProps {
   flow: FlowSummary;
   teamSlug: string;
   refreshFlows: () => void;
+  showDetails: boolean;
 }
 
 const FlowTableRow: React.FC<FlowTableRowProps> = ({
   flow,
   teamSlug,
   refreshFlows,
+  showDetails,
 }) => {
   const router = useRouter();
   const navigate = useNavigate();
@@ -153,44 +162,52 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           )}
         </Box>
       </FlowTitleCell>
-      <FlowStatusCell>
-        <Box sx={{ display: "inline-flex" }}>
-          <FlowTag tagType={FlowTagType.Status} statusVariant={statusVariant}>
-            {statusVariant}
-          </FlowTag>
-        </Box>
-      </FlowStatusCell>
-      <FlowStatusCell>
-        {isSubmissionService && (
-          <Box sx={{ display: "inline-flex" }}>
-            <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
-          </Box>
-        )}
-      </FlowStatusCell>
-      <TableCell>
-        <Box>
-          <Typography variant="body2">{displayTimeAgo}</Typography>
-          {displayActor && (
-            <Typography variant="body2" color="textSecondary">
-              by {displayActor}
-            </Typography>
-          )}
-        </Box>
-      </TableCell>
-      <FlowActionsCell
-        className="actions-cell"
-        align="center"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {canUserEditTeam(teamSlug) && (
-          <FlowMenu
-            flow={flow}
-            refreshFlows={refreshFlows}
-            isAnyTemplate={isAnyTemplate}
-            variant="table"
-          />
-        )}
-      </FlowActionsCell>
+      {showDetails && (
+        <>
+          <FlowStatusCell>
+            <Box sx={{ display: "inline-flex" }}>
+              <FlowTag
+                tagType={FlowTagType.Status}
+                statusVariant={statusVariant}
+              >
+                {statusVariant}
+              </FlowTag>
+            </Box>
+          </FlowStatusCell>
+          <FlowStatusCell>
+            {isSubmissionService && (
+              <Box sx={{ display: "inline-flex" }}>
+                <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+              </Box>
+            )}
+          </FlowStatusCell>
+
+          <TableCell>
+            <Box>
+              <Typography variant="body2">{displayTimeAgo}</Typography>
+              {displayActor && (
+                <Typography variant="body2" color="textSecondary">
+                  by {displayActor}
+                </Typography>
+              )}
+            </Box>
+          </TableCell>
+          <FlowActionsCell
+            className="actions-cell"
+            align="center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {canUserEditTeam(teamSlug) && (
+              <FlowMenu
+                flow={flow}
+                refreshFlows={refreshFlows}
+                isAnyTemplate={isAnyTemplate}
+                variant="table"
+              />
+            )}
+          </FlowActionsCell>
+        </>
+      )}
     </StyledTableRow>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -153,6 +153,7 @@ const Flows: React.FC<Props> = ({
                     flows={sortedFlows}
                     key={flow.slug}
                     refreshFlows={fetchFlows}
+                    showDetails={true}
                   />
                 ))}
               </DashboardList>
@@ -162,6 +163,7 @@ const Flows: React.FC<Props> = ({
                 teamId={teamId}
                 teamSlug={slug}
                 refreshFlows={fetchFlows}
+                showDetails={true}
               />
             )}
           </>

--- a/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
@@ -1,6 +1,10 @@
 import { useQuery } from "@apollo/client";
 
-import { GET_ARCHIVED_FLOWS, GetArchivedFlowsQuery, GetArchivedFlowsVars } from "../queries";
+import {
+  GET_ARCHIVED_FLOWS,
+  GetArchivedFlowsQuery,
+  GetArchivedFlowsVars,
+} from "../queries";
 
 export const useArchivedFlows = (teamId: number) =>
   useQuery<GetArchivedFlowsQuery, GetArchivedFlowsVars>(GET_ARCHIVED_FLOWS, {

--- a/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
@@ -6,7 +6,7 @@ import {
   GetArchivedFlowsVars,
 } from "../queries";
 
-export const useArchivedFlows = (teamId: number) =>
+export const useGetArchivedFlows = (teamId: number) =>
   useQuery<GetArchivedFlowsQuery, GetArchivedFlowsVars>(GET_ARCHIVED_FLOWS, {
     variables: { teamId },
   });

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -1,8 +1,7 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useSearch } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { isEmpty, orderBy } from "lodash";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -12,27 +11,15 @@ import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 import { useStore } from "../FlowEditor/lib/store";
 import { FlowCardView, FlowSummary } from "../FlowEditor/lib/store/editor";
 import { AddFlow } from "./components/AddFlow";
+import Archive from "./components/Archive";
 import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
+import { useArchivedFlows } from "./helpers/useGetArchivedFlows";
 import TeamLayout from "./TeamLayout";
 
 export type FlowView = "flows" | "archive";
-
-export const FiltersContainer = styled(Box)(({ theme }) => ({
-  width: "100%",
-  margin: theme.spacing(1, 0, 2),
-  padding: theme.spacing(1.5, 0),
-  display: "flex",
-  flexDirection: "row",
-  flexWrap: "wrap",
-  alignItems: "center",
-  justifyContent: "space-between",
-  gap: theme.spacing(1),
-  borderTop: `1px solid ${theme.palette.border.light}`,
-  borderBottom: `1px solid ${theme.palette.border.light}`,
-}));
 
 const GetStarted: React.FC = () => (
   <DashboardList sx={{ paddingTop: 2 }}>
@@ -68,14 +55,16 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
   ]);
 
   const [flows, setFlows] = useState<FlowSummary[] | null>(initialFlows);
+  const [flowView, setFlowView] = useState<FlowView>("flows");
+  const { data: archivedFlowsData } = useArchivedFlows(teamId);
+  const archivedFlows = archivedFlowsData?.flows ?? null;
+
   const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(
     null,
   );
-  const [flowView, setFlowView] = useState<FlowView>("flows");
   const [shouldClearSearch, setShouldClearSearch] = useState<boolean>(false);
   const searchParams = useSearch({ from: "/_authenticated/app/$team/" });
-  const navigate = useNavigate();
-  
+
   const sortedFlows = useMemo(() => {
     // Use searchedFlows if available (from SearchBox), otherwise use all flows
     const sourceFlows = searchedFlows || flows;
@@ -155,12 +144,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
   }, [teamId, setFlows, getFlows]);
 
   useEffect(() => {
-    if (initialFlows) {
-      setFlows(initialFlows);
-    }
-  }, [initialFlows]);
-
-  useEffect(() => {
     if (shouldClearSearch) {
       setShouldClearSearch(false);
     }
@@ -211,7 +194,9 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             <TeamLayout flowView={flowView} setFlowView={setFlowView} />
           )}
         </Box>
-        <Flows
+
+        {flowView === "flows" && (
+          <Flows
             flowsHaveBeenFiltered={flowsHaveBeenFiltered}
             setSearchedFlows={setSearchedFlows}
             setShouldClearSearch={setShouldClearSearch}
@@ -224,6 +209,18 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             handleViewChange={handleViewChange}
             slug={slug}
           />
+        )}
+        {flowView === "archive" && (
+          <Archive
+            flowCardView={flowCardView}
+            handleViewChange={handleViewChange}
+            archivedFlows={archivedFlows}
+            teamId={teamId}
+            slug={slug}
+            fetchFlows={fetchFlows}
+          />
+        )}
+
         {flows && !flows.length && <GetStarted />}
       </Container>
     </Box>

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -16,7 +16,7 @@ import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
-import { useArchivedFlows } from "./helpers/useGetArchivedFlows";
+import { useGetArchivedFlows } from "./helpers/useGetArchivedFlows";
 import TeamLayout from "./TeamLayout";
 
 export type FlowView = "flows" | "archive";
@@ -56,7 +56,7 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
 
   const [flows, setFlows] = useState<FlowSummary[] | null>(initialFlows);
   const [flowView, setFlowView] = useState<FlowView>("flows");
-  const { data: archivedFlowsData } = useArchivedFlows(teamId);
+  const { data: archivedFlowsData } = useGetArchivedFlows(teamId);
   const archivedFlows = archivedFlowsData?.flows ?? null;
 
   const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(

--- a/apps/editor.planx.uk/src/pages/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/queries.ts
@@ -31,11 +31,23 @@ export const GET_ARCHIVED_FLOWS = gql`
           name
         }
       }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        publishedAt: created_at
+        hasSendComponent: has_send_component
+        hasVisiblePayComponent: has_pay_component
+        hasEnabledServiceCharge: service_charge_enabled
+      }
     }
   }
 `;
 
-export type GetArchivedFlowsQuery = FlowSummary[]
+export type GetArchivedFlowsQuery = {
+  flows: FlowSummary[];
+};
+
 export type GetArchivedFlowsVars = {
   teamId: number;
-}
+};


### PR DESCRIPTION
Still behind a feature flag!

# What does this PR do?
- Create a new `Archive` component to show archived flows
- New `showDetails` prop in components to conditionally render flow info (eg we want to show status and service type for live flows, but not for archived ones)
- Hook `TeamLayout` component up to `Flows` and `Archive` components to conditionally render view depending on `flowView` state

# Testing
- Go to the Pizza and run `window.featureFlags.toggle("ARCHIVE_VIEW")`
- Navigate to the Teams page and toggle between Archive and Flows view (features missing include Actions tooltip on archived flows, removing links to archived flows, etc.)
<img width="700" alt="Screenshot 2026-04-09 160653" src="https://github.com/user-attachments/assets/df32e976-f5c9-4582-99e7-decbe9194300" />

<img width="700" alt="Screenshot 2026-04-09 160659" src="https://github.com/user-attachments/assets/48cb1eae-e956-493c-8885-11b6cc5fb5f1" />
