### PR TITLE
refactor(editor): Implement reducer pattern for complex `FileUploadAndLabel` interactions

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileAccordionCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileAccordionCard.tsx
@@ -36,7 +36,7 @@ interface FileAccordionCardProps {
   onSave: (slotId: string) => void;
   onRemove: (slot: FileUploadSlot) => void;
   fileList: FileList;
-  setFileList: (value: React.SetStateAction<FileList>) => void;
+  setFileList: React.Dispatch<React.SetStateAction<FileList>>;
   error?: string;
   showDrawingNumber?: boolean;
   drawingNumber?: string;

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -22,7 +22,6 @@ import { Dropzone } from "../../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../../shared/PrivateFileUpload/FileStatus";
 import {
   createFileList,
-  FileList,
   FileUploadAndLabel,
   generatePayload,
   getRecoveredData,
@@ -73,27 +72,36 @@ export function FileUploadAndLabelNew(props: Props) {
     [],
   );
 
-  const [fileList, setFileList] = useState<FileList>({
-    required: [],
-    recommended: [],
-    optional: [],
-  });
-
   useEffect(() => {
     const passport = useStore.getState().computePassport();
-    const fileList = createFileList({ passport, fileTypes: props.fileTypes });
-    setFileList(fileList);
+    const initialFileList = createFileList({
+      passport,
+      fileTypes: props.fileTypes,
+    });
 
     if (props.previouslySubmittedData) {
       const recoveredData = getRecoveredData(
         props.previouslySubmittedData,
-        fileList,
+        initialFileList,
       );
-      setSlots(recoveredData.slots);
-      setFileList(recoveredData.fileList);
-      setIsUserReturningToNode(true);
+
+      dispatch({
+        type: "INIT_RECOVERED_DATA",
+        payload: {
+          fileList: recoveredData.fileList,
+          slots: recoveredData.slots,
+        },
+      });
+    } else {
+      dispatch({
+        type: "INIT_RECOVERED_DATA",
+        payload: {
+          fileList: initialFileList,
+          slots: [],
+        },
+      });
     }
-  }, []);
+  }, [props.fileTypes, props.previouslySubmittedData]);
 
   const handleDrawingNumberChange = useCallback(
     (slotId: string, value: string) => {
@@ -105,12 +113,6 @@ export function FileUploadAndLabelNew(props: Props) {
     [],
   );
 
-  // Exit animation
-  const [removingSlotId, setRemovingSlotId] = useState<string | null>(null);
-  const [pendingRemoval, setPendingRemoval] = useState<FileUploadSlot | null>(
-    null,
-  );
-
   // Track number of slots and auto-expand newly uploaded files
   const previousSlotCount = usePrevious(state.slots.length);
   useEffect(() => {
@@ -120,21 +122,23 @@ export function FileUploadAndLabelNew(props: Props) {
     if (isUserReturningToNode) return setIsUserReturningToNode(false);
   }, [state.slots.length]);
 
-  const [fileUploadStatus, setFileUploadStatus] = useState<string | undefined>(
-    undefined,
-  );
-
   const [isUserReturningToNode, setIsUserReturningToNode] =
     useState<boolean>(false);
 
   const validateAndSubmit = () => {
     Promise.all([
-      slotsSchema.validate(state.slots, { context: { fileList } }),
-      fileLabelSchema.validate(fileList, { context: { slots: state.slots } }),
-      fileListSchema.validate(fileList, { context: { slots: state.slots } }),
+      slotsSchema.validate(state.slots, {
+        context: { fileList: state.fileList },
+      }),
+      fileLabelSchema.validate(state.fileList, {
+        context: { slots: state.slots },
+      }),
+      fileListSchema.validate(state.fileList, {
+        context: { slots: state.slots },
+      }),
     ])
       .then(() => {
-        const payload = generatePayload(fileList, state.slots);
+        const payload = generatePayload(state.fileList, state.slots);
         props.handleSubmit?.(payload);
       })
       .catch((err) => {
@@ -174,7 +178,7 @@ export function FileUploadAndLabelNew(props: Props) {
     // Find the next file that has no tags yet
     const nextUntagged = state.slots.find((s, i) => {
       if (i <= currentIndex) return false;
-      const tags = getTagsForSlot(s.id, fileList);
+      const tags = getTagsForSlot(s.id, state.fileList);
       return tags.length === 0;
     });
 
@@ -182,47 +186,25 @@ export function FileUploadAndLabelNew(props: Props) {
     dispatch({ type: "EXPAND_SLOT", payload: { slotId: nextUntagged?.id } });
   };
 
-  const isCategoryVisible = (category: keyof typeof fileList) => {
+  const isCategoryVisible = (category: keyof typeof state.fileList) => {
     if (props.hideDropZone) return true;
 
     switch (category) {
       case "optional":
-        return !fileList["recommended"].length && !fileList["required"].length;
+        return (
+          !state.fileList["recommended"].length &&
+          !state.fileList["required"].length
+        );
       case "required":
       case "recommended":
-        return fileList[category].length > 0;
+        return state.fileList[category].length > 0;
     }
   };
 
-  // Start removal animation, defer actual state update to onExited
-  const initiateRemoveFile = (slot: FileUploadSlot) => {
-    if (state.expandedSlotId === slot.id) {
-      // TODO: removefile action
-      dispatch({ type: "EXPAND_SLOT", payload: { slotId: undefined } });
-    }
-    setPendingRemoval(slot);
-    setRemovingSlotId(slot.id);
-  };
+  const initiateRemoveFile = (slot: FileUploadSlot) =>
+    dispatch({ type: "INIT_REMOVE_FILE", payload: { slot } });
 
-  // Called when the Collapse exit animation completes
-  const completeRemoveFile = () => {
-    if (!pendingRemoval) return;
-
-    const slot = pendingRemoval;
-    setSlots((prev) => prev.filter((s) => s.file !== slot.file));
-    setFileUploadStatus(`${slot.file.path} was deleted`);
-    const updatedFileList = removeSlots(
-      getTagsForSlot(slot.id, fileList),
-      slot,
-      fileList,
-    );
-    setFileList(updatedFileList);
-
-    dispatch({ type: "REMOVE_DRAWING_NUMBER", payload: { slotId: slot.id } });
-
-    setRemovingSlotId(null);
-    setPendingRemoval(null);
-  };
+  const completeRemoveFile = () => dispatch({ type: "COMPLETE_REMOVE_FILE" });
 
   return (
     <Card
@@ -233,7 +215,7 @@ export function FileUploadAndLabelNew(props: Props) {
         <DropzoneContainer>
           {!props.hideDropZone && (
             <>
-              <FileStatus status={fileUploadStatus} />
+              <FileStatus status={state.fileUploadStatus} />
               <ErrorWrapper
                 error={state.dropzoneError}
                 id={`${props.id}-dropzone`}
@@ -247,7 +229,7 @@ export function FileUploadAndLabelNew(props: Props) {
             </>
           )}
           <UploadList disablePadding>
-            {(Object.keys(fileList) as Array<keyof typeof fileList>)
+            {(Object.keys(state.fileList) as Array<keyof typeof state.fileList>)
               .filter(isCategoryVisible)
               .flatMap((fileListCategory) => [
                 <ListSubheader
@@ -264,7 +246,7 @@ export function FileUploadAndLabelNew(props: Props) {
                     {`${capitalize(fileListCategory)} information`}
                   </Typography>
                 </ListSubheader>,
-                fileList[fileListCategory].map((fileType) => (
+                state.fileList[fileListCategory].map((fileType) => (
                   <ListItem key={fileType.name} disablePadding>
                     <InteractiveFileListItem
                       name={fileType.name}
@@ -289,9 +271,11 @@ export function FileUploadAndLabelNew(props: Props) {
               {state.slots.map((slot) => (
                 <Collapse
                   key={slot.id}
-                  in={removingSlotId !== slot.id}
+                  in={state.removingSlotId !== slot.id}
                   onExited={
-                    removingSlotId === slot.id ? completeRemoveFile : undefined
+                    state.removingSlotId === slot.id
+                      ? completeRemoveFile
+                      : undefined
                   }
                 >
                   <FileAccordionCard
@@ -300,7 +284,7 @@ export function FileUploadAndLabelNew(props: Props) {
                     onExpand={handleExpand}
                     onSave={handleSave}
                     onRemove={initiateRemoveFile}
-                    fileList={fileList}
+                    fileList={state.fileList}
                     setFileList={setFileList}
                     error={state.fileLabelErrors?.[slot.id]}
                     showDrawingNumber={props.showDrawingNumber}

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -26,7 +26,6 @@ import {
   generatePayload,
   getRecoveredData,
   getTagsForSlot,
-  removeSlots,
 } from "../model";
 import {
   fileLabelSchema,
@@ -68,6 +67,13 @@ export function FileUploadAndLabelNew(props: Props) {
   const handleSetSlots = useCallback(
     (updater: React.SetStateAction<FileUploadSlot[]>) => {
       dispatch({ type: "SET_SLOTS", payload: updater });
+    },
+    [],
+  );
+
+  const handleSetFileUploadStatus = useCallback(
+    (updater: React.SetStateAction<string | undefined>) => {
+      dispatch({ type: "SET_FILE_UPLOAD_STATUS", payload: updater });
     },
     [],
   );
@@ -223,7 +229,7 @@ export function FileUploadAndLabelNew(props: Props) {
                 <Dropzone
                   slots={state.slots}
                   setSlots={handleSetSlots}
-                  setFileUploadStatus={setFileUploadStatus}
+                  setFileUploadStatus={handleSetFileUploadStatus}
                 />
               </ErrorWrapper>
             </>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -10,7 +10,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { PrintButton } from "components/PrintButton";
 import capitalize from "lodash/capitalize";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useCallback, useEffect, useReducer } from "react";
+import React, { useCallback, useReducer } from "react";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
@@ -35,6 +35,7 @@ import {
 import { FileAccordionCard } from "./FileAccordionCard";
 import {
   fileUploadAndLabelReducer,
+  type FileUploadState,
   initialState,
 } from "./hooks/fileUploadAndLabelReducer";
 import { InteractiveFileListItem } from "./InteractiveFileListItem";
@@ -61,30 +62,7 @@ const UploadList = styled(List)(({ theme }) => ({
 }));
 
 export function FileUploadAndLabelNew(props: Props) {
-  const [state, dispatch] = useReducer(fileUploadAndLabelReducer, initialState);
-
-  const handleSetSlots = useCallback(
-    (updater: React.SetStateAction<FileUploadSlot[]>) => {
-      dispatch({ type: "SET_SLOTS", payload: updater });
-    },
-    [],
-  );
-
-  const handleSetFileUploadStatus = useCallback(
-    (updater: React.SetStateAction<string | undefined>) => {
-      dispatch({ type: "SET_FILE_UPLOAD_STATUS", payload: updater });
-    },
-    [],
-  );
-
-  const handleSetFileList = useCallback(
-    (updater: React.SetStateAction<FileList>) => {
-      dispatch({ type: "SET_FILE_LIST", payload: updater });
-    },
-    [],
-  );
-
-  useEffect(() => {
+  const initState = (props: Props): FileUploadState => {
     const passport = useStore.getState().computePassport();
     const initialFileList = createFileList({
       passport,
@@ -97,33 +75,56 @@ export function FileUploadAndLabelNew(props: Props) {
         initialFileList,
       );
 
-      dispatch({
-        type: "INIT_RECOVERED_DATA",
-        payload: {
-          fileList: recoveredData.fileList,
-          slots: recoveredData.slots,
-        },
-      });
-    } else {
-      dispatch({
-        type: "INIT_RECOVERED_DATA",
-        payload: {
-          fileList: initialFileList,
-          slots: [],
-        },
-      });
+      return {
+        ...initialState,
+        fileList: recoveredData.fileList,
+        slots: recoveredData.slots,
+      };
     }
-  }, [props.fileTypes, props.previouslySubmittedData]);
 
-  const handleDrawingNumberChange = useCallback(
-    (slotId: string, value: string) => {
-      dispatch({
-        type: "UPDATE_DRAWING_NUMBER",
-        payload: { slotId, value },
-      });
-    },
-    [],
+    return {
+      ...initialState,
+      fileList: initialFileList,
+    };
+  };
+
+  const [state, dispatch] = useReducer(
+    fileUploadAndLabelReducer,
+    props,
+    initState,
   );
+
+  const handleSetSlots = (updater: React.SetStateAction<FileUploadSlot[]>) => {
+    dispatch({ type: "SET_SLOTS", payload: updater });
+  };
+
+  const handleSetFileUploadStatus = (
+    updater: React.SetStateAction<string | undefined>,
+  ) => {
+    dispatch({ type: "SET_FILE_UPLOAD_STATUS", payload: updater });
+  };
+
+  const handleSetFileList = (updater: React.SetStateAction<FileList>) => {
+    dispatch({ type: "SET_FILE_LIST", payload: updater });
+  };
+
+  const handleExpand = (slotId: string) =>
+    dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
+
+  const handleSave = (slotId: string) =>
+    dispatch({ type: "SAVE_SLOT", payload: { slotId } });
+
+  const initiateRemoveFile = (slot: FileUploadSlot) =>
+    dispatch({ type: "INIT_REMOVE_FILE", payload: { slot } });
+
+  const completeRemoveFile = () => dispatch({ type: "COMPLETE_REMOVE_FILE" });
+
+  const handleDrawingNumberChange = (slotId: string, value: string) => {
+    dispatch({
+      type: "UPDATE_DRAWING_NUMBER",
+      payload: { slotId, value },
+    });
+  };
 
   const validateAndSubmit = () => {
     Promise.all([
@@ -169,12 +170,6 @@ export function FileUploadAndLabelNew(props: Props) {
       });
   };
 
-  const handleExpand = (slotId: string) =>
-    dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
-
-  const handleSave = (slotId: string) =>
-    dispatch({ type: "SAVE_SLOT", payload: { slotId } });
-
   const isCategoryVisible = (category: keyof typeof state.fileList) => {
     if (props.hideDropZone) return true;
 
@@ -189,11 +184,6 @@ export function FileUploadAndLabelNew(props: Props) {
         return state.fileList[category].length > 0;
     }
   };
-
-  const initiateRemoveFile = (slot: FileUploadSlot) =>
-    dispatch({ type: "INIT_REMOVE_FILE", payload: { slot } });
-
-  const completeRemoveFile = () => dispatch({ type: "COMPLETE_REMOVE_FILE" });
 
   return (
     <Card

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -10,7 +10,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { PrintButton } from "components/PrintButton";
 import capitalize from "lodash/capitalize";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useReducer, useState } from "react";
 import { usePrevious } from "react-use";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -36,6 +36,10 @@ import {
   slotsSchema,
 } from "../schema";
 import { FileAccordionCard } from "./FileAccordionCard";
+import {
+  fileUploadAndLabelReducer,
+  initialState,
+} from "./hooks/fileUploadAndLabelReducer";
 import { InteractiveFileListItem } from "./InteractiveFileListItem";
 
 type Props = PublicProps<FileUploadAndLabel>;
@@ -60,6 +64,8 @@ const UploadList = styled(List)(({ theme }) => ({
 }));
 
 export function FileUploadAndLabelNew(props: Props) {
+  const [state, dispatch] = useReducer(fileUploadAndLabelReducer, initialState);
+
   const [fileList, setFileList] = useState<FileList>({
     required: [],
     recommended: [],
@@ -87,14 +93,12 @@ export function FileUploadAndLabelNew(props: Props) {
   // Accordion state: only one file can be expanded for editing at a time
   const [expandedSlotId, setExpandedSlotId] = useState<string | null>(null);
 
-  // Drawing numbers
-  const [drawingNumbers, setDrawingNumbers] = useState<Record<string, string>>(
-    {},
-  );
-
   const handleDrawingNumberChange = useCallback(
     (slotId: string, value: string) => {
-      setDrawingNumbers((prev) => ({ ...prev, [slotId]: value }));
+      dispatch({
+        type: "UPDATE_DRAWING_NUMBER",
+        payload: { slotId, value },
+      });
     },
     [],
   );
@@ -219,12 +223,7 @@ export function FileUploadAndLabelNew(props: Props) {
     );
     setFileList(updatedFileList);
 
-    // Clean up drawing number for removed file
-    setDrawingNumbers((prev) => {
-      const next = { ...prev };
-      delete next[slot.id];
-      return next;
-    });
+    dispatch({ type: "REMOVE_DRAWING_NUMBER", payload: { slotId: slot.id } });
 
     setRemovingSlotId(null);
     setPendingRemoval(null);
@@ -307,7 +306,7 @@ export function FileUploadAndLabelNew(props: Props) {
                     setFileList={setFileList}
                     error={fileLabelErrors?.[slot.id]}
                     showDrawingNumber={props.showDrawingNumber}
-                    drawingNumber={drawingNumbers[slot.id]}
+                    drawingNumber={state.drawingNumbers[slot.id]}
                     onDrawingNumberChange={(value) =>
                       handleDrawingNumberChange(slot.id, value)
                     }

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -10,8 +10,7 @@ import { PublicProps } from "@planx/components/shared/types";
 import { PrintButton } from "components/PrintButton";
 import capitalize from "lodash/capitalize";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useCallback, useEffect, useReducer, useState } from "react";
-import { usePrevious } from "react-use";
+import React, { useCallback, useEffect, useReducer } from "react";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
@@ -22,10 +21,10 @@ import { Dropzone } from "../../shared/PrivateFileUpload/Dropzone";
 import { FileStatus } from "../../shared/PrivateFileUpload/FileStatus";
 import {
   createFileList,
+  type FileList,
   FileUploadAndLabel,
   generatePayload,
   getRecoveredData,
-  getTagsForSlot,
 } from "../model";
 import {
   fileLabelSchema,
@@ -78,6 +77,13 @@ export function FileUploadAndLabelNew(props: Props) {
     [],
   );
 
+  const handleSetFileList = useCallback(
+    (updater: React.SetStateAction<FileList>) => {
+      dispatch({ type: "SET_FILE_LIST", payload: updater });
+    },
+    [],
+  );
+
   useEffect(() => {
     const passport = useStore.getState().computePassport();
     const initialFileList = createFileList({
@@ -118,18 +124,6 @@ export function FileUploadAndLabelNew(props: Props) {
     },
     [],
   );
-
-  // Track number of slots and auto-expand newly uploaded files
-  const previousSlotCount = usePrevious(state.slots.length);
-  useEffect(() => {
-    if (previousSlotCount === undefined) return;
-
-    // Only stop auto-expand on initial return to node
-    if (isUserReturningToNode) return setIsUserReturningToNode(false);
-  }, [state.slots.length]);
-
-  const [isUserReturningToNode, setIsUserReturningToNode] =
-    useState<boolean>(false);
 
   const validateAndSubmit = () => {
     Promise.all([
@@ -179,7 +173,7 @@ export function FileUploadAndLabelNew(props: Props) {
     dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
 
   const handleSave = (slotId: string) =>
-    dispatch({ type: "SAVE", payload: { slotId } });
+    dispatch({ type: "SAVE_SLOT", payload: { slotId } });
 
   const isCategoryVisible = (category: keyof typeof state.fileList) => {
     if (props.hideDropZone) return true;
@@ -280,7 +274,7 @@ export function FileUploadAndLabelNew(props: Props) {
                     onSave={handleSave}
                     onRemove={initiateRemoveFile}
                     fileList={state.fileList}
-                    setFileList={setFileList}
+                    setFileList={handleSetFileList}
                     error={state.fileLabelErrors?.[slot.id]}
                     showDrawingNumber={props.showDrawingNumber}
                     drawingNumber={state.drawingNumbers[slot.id]}

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -178,19 +178,8 @@ export function FileUploadAndLabelNew(props: Props) {
   const handleExpand = (slotId: string) =>
     dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
 
-  const handleSave = (slotId: string) => {
-    const currentIndex = state.slots.findIndex((s) => s.id === slotId);
-
-    // Find the next file that has no tags yet
-    const nextUntagged = state.slots.find((s, i) => {
-      if (i <= currentIndex) return false;
-      const tags = getTagsForSlot(s.id, state.fileList);
-      return tags.length === 0;
-    });
-
-    // TODO: should this be part of a save "action"?
-    dispatch({ type: "EXPAND_SLOT", payload: { slotId: nextUntagged?.id } });
-  };
+  const handleSave = (slotId: string) =>
+    dispatch({ type: "SAVE", payload: { slotId } });
 
   const isCategoryVisible = (category: keyof typeof state.fileList) => {
     if (props.hideDropZone) return true;

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -66,6 +66,13 @@ const UploadList = styled(List)(({ theme }) => ({
 export function FileUploadAndLabelNew(props: Props) {
   const [state, dispatch] = useReducer(fileUploadAndLabelReducer, initialState);
 
+  const handleSetSlots = useCallback(
+    (updater: React.SetStateAction<FileUploadSlot[]>) => {
+      dispatch({ type: "SET_SLOTS", payload: updater });
+    },
+    [],
+  );
+
   const [fileList, setFileList] = useState<FileList>({
     required: [],
     recommended: [],
@@ -88,8 +95,6 @@ export function FileUploadAndLabelNew(props: Props) {
     }
   }, []);
 
-  const [slots, setSlots] = useState<FileUploadSlot[]>([]);
-
   const handleDrawingNumberChange = useCallback(
     (slotId: string, value: string) => {
       dispatch({
@@ -107,24 +112,13 @@ export function FileUploadAndLabelNew(props: Props) {
   );
 
   // Track number of slots and auto-expand newly uploaded files
-  const previousSlotCount = usePrevious(slots.length);
+  const previousSlotCount = usePrevious(state.slots.length);
   useEffect(() => {
     if (previousSlotCount === undefined) return;
 
     // Only stop auto-expand on initial return to node
     if (isUserReturningToNode) return setIsUserReturningToNode(false);
-
-    // TODO: cleanup elsewhere
-    // Clear errors as files are added/removed
-    // if (slots.length && dropzoneError) setDropzoneError(undefined);
-    // if (!slots.length && fileListError) setFileListError(undefined);
-    // if (!slots.length && fileLabelErrors) setFileLabelErrors(undefined);
-
-    // Auto-expand the most recently uploaded file for tagging
-    if (slots.length > previousSlotCount && slots.length > 0) {
-      dispatch({ type: "EXPAND_SLOT", payload: { slotId: slots[0].id } });
-    }
-  }, [slots.length]);
+  }, [state.slots.length]);
 
   const [fileUploadStatus, setFileUploadStatus] = useState<string | undefined>(
     undefined,
@@ -135,12 +129,12 @@ export function FileUploadAndLabelNew(props: Props) {
 
   const validateAndSubmit = () => {
     Promise.all([
-      slotsSchema.validate(slots, { context: { fileList } }),
-      fileLabelSchema.validate(fileList, { context: { slots } }),
-      fileListSchema.validate(fileList, { context: { slots } }),
+      slotsSchema.validate(state.slots, { context: { fileList } }),
+      fileLabelSchema.validate(fileList, { context: { slots: state.slots } }),
+      fileListSchema.validate(fileList, { context: { slots: state.slots } }),
     ])
       .then(() => {
-        const payload = generatePayload(fileList, slots);
+        const payload = generatePayload(fileList, state.slots);
         props.handleSubmit?.(payload);
       })
       .catch((err) => {
@@ -175,10 +169,10 @@ export function FileUploadAndLabelNew(props: Props) {
     dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
 
   const handleSave = (slotId: string) => {
-    const currentIndex = slots.findIndex((s) => s.id === slotId);
+    const currentIndex = state.slots.findIndex((s) => s.id === slotId);
 
     // Find the next file that has no tags yet
-    const nextUntagged = slots.find((s, i) => {
+    const nextUntagged = state.slots.find((s, i) => {
       if (i <= currentIndex) return false;
       const tags = getTagsForSlot(s.id, fileList);
       return tags.length === 0;
@@ -245,8 +239,8 @@ export function FileUploadAndLabelNew(props: Props) {
                 id={`${props.id}-dropzone`}
               >
                 <Dropzone
-                  slots={slots}
-                  setSlots={setSlots}
+                  slots={state.slots}
+                  setSlots={handleSetSlots}
                   setFileUploadStatus={setFileUploadStatus}
                 />
               </ErrorWrapper>
@@ -286,13 +280,13 @@ export function FileUploadAndLabelNew(props: Props) {
         </DropzoneContainer>
         <ErrorWrapper error={state.fileListError} id={`${props.id}-fileList`}>
           <Box>
-            {Boolean(slots.length) && (
+            {Boolean(state.slots.length) && (
               <Typography variant="h3" mb={2}>
                 Your uploaded files
               </Typography>
             )}
             <Stack spacing={2}>
-              {slots.map((slot) => (
+              {state.slots.map((slot) => (
                 <Collapse
                   key={slot.id}
                   in={removingSlotId !== slot.id}

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/FileUploadAndLabelNew.tsx
@@ -90,9 +90,6 @@ export function FileUploadAndLabelNew(props: Props) {
 
   const [slots, setSlots] = useState<FileUploadSlot[]>([]);
 
-  // Accordion state: only one file can be expanded for editing at a time
-  const [expandedSlotId, setExpandedSlotId] = useState<string | null>(null);
-
   const handleDrawingNumberChange = useCallback(
     (slotId: string, value: string) => {
       dispatch({
@@ -117,14 +114,15 @@ export function FileUploadAndLabelNew(props: Props) {
     // Only stop auto-expand on initial return to node
     if (isUserReturningToNode) return setIsUserReturningToNode(false);
 
+    // TODO: cleanup elsewhere
     // Clear errors as files are added/removed
-    if (slots.length && dropzoneError) setDropzoneError(undefined);
-    if (!slots.length && fileListError) setFileListError(undefined);
-    if (!slots.length && fileLabelErrors) setFileLabelErrors(undefined);
+    // if (slots.length && dropzoneError) setDropzoneError(undefined);
+    // if (!slots.length && fileListError) setFileListError(undefined);
+    // if (!slots.length && fileLabelErrors) setFileLabelErrors(undefined);
 
     // Auto-expand the most recently uploaded file for tagging
     if (slots.length > previousSlotCount && slots.length > 0) {
-      setExpandedSlotId(slots[0].id);
+      dispatch({ type: "EXPAND_SLOT", payload: { slotId: slots[0].id } });
     }
   }, [slots.length]);
 
@@ -132,11 +130,6 @@ export function FileUploadAndLabelNew(props: Props) {
     undefined,
   );
 
-  const [dropzoneError, setDropzoneError] = useState<string | undefined>();
-  const [fileLabelErrors, setFileLabelErrors] = useState<
-    Record<string, string> | undefined
-  >();
-  const [fileListError, setFileListError] = useState<string | undefined>();
   const [isUserReturningToNode, setIsUserReturningToNode] =
     useState<boolean>(false);
 
@@ -154,26 +147,32 @@ export function FileUploadAndLabelNew(props: Props) {
         switch (err?.type) {
           case "minFileUploaded":
           case "nonUploading":
-            setDropzoneError(err?.message);
+            dispatch({
+              type: "SET_DROPZONE_ERROR",
+              payload: { error: err?.message },
+            });
             break;
           case "allFilesTagged": {
             const formattedErrors = formatFileLabelSchemaErrors(err);
-            setFileLabelErrors(formattedErrors);
+            dispatch({
+              type: "SET_FILE_LABEL_ERRORS",
+              payload: { errors: formattedErrors },
+            });
             break;
           }
           case "allRequiredFilesUploaded":
           case "errorStatus":
-            setFileListError(err?.message);
+            dispatch({
+              type: "SET_FILE_LIST_ERROR",
+              payload: { error: err?.message },
+            });
             break;
         }
       });
   };
 
-  const handleExpand = (slotId: string) => {
-    setFileListError(undefined);
-    setFileLabelErrors(undefined);
-    setExpandedSlotId(slotId);
-  };
+  const handleExpand = (slotId: string) =>
+    dispatch({ type: "EXPAND_SLOT", payload: { slotId } });
 
   const handleSave = (slotId: string) => {
     const currentIndex = slots.findIndex((s) => s.id === slotId);
@@ -185,7 +184,8 @@ export function FileUploadAndLabelNew(props: Props) {
       return tags.length === 0;
     });
 
-    setExpandedSlotId(nextUntagged?.id ?? null);
+    // TODO: should this be part of a save "action"?
+    dispatch({ type: "EXPAND_SLOT", payload: { slotId: nextUntagged?.id } });
   };
 
   const isCategoryVisible = (category: keyof typeof fileList) => {
@@ -202,8 +202,9 @@ export function FileUploadAndLabelNew(props: Props) {
 
   // Start removal animation, defer actual state update to onExited
   const initiateRemoveFile = (slot: FileUploadSlot) => {
-    if (expandedSlotId === slot.id) {
-      setExpandedSlotId(null);
+    if (state.expandedSlotId === slot.id) {
+      // TODO: removefile action
+      dispatch({ type: "EXPAND_SLOT", payload: { slotId: undefined } });
     }
     setPendingRemoval(slot);
     setRemovingSlotId(slot.id);
@@ -239,7 +240,10 @@ export function FileUploadAndLabelNew(props: Props) {
           {!props.hideDropZone && (
             <>
               <FileStatus status={fileUploadStatus} />
-              <ErrorWrapper error={dropzoneError} id={`${props.id}-dropzone`}>
+              <ErrorWrapper
+                error={state.dropzoneError}
+                id={`${props.id}-dropzone`}
+              >
                 <Dropzone
                   slots={slots}
                   setSlots={setSlots}
@@ -280,7 +284,7 @@ export function FileUploadAndLabelNew(props: Props) {
               ])}
           </UploadList>
         </DropzoneContainer>
-        <ErrorWrapper error={fileListError} id={`${props.id}-fileList`}>
+        <ErrorWrapper error={state.fileListError} id={`${props.id}-fileList`}>
           <Box>
             {Boolean(slots.length) && (
               <Typography variant="h3" mb={2}>
@@ -298,13 +302,13 @@ export function FileUploadAndLabelNew(props: Props) {
                 >
                   <FileAccordionCard
                     slot={slot}
-                    isExpanded={expandedSlotId === slot.id}
+                    isExpanded={state?.expandedSlotId === slot.id}
                     onExpand={handleExpand}
                     onSave={handleSave}
                     onRemove={initiateRemoveFile}
                     fileList={fileList}
                     setFileList={setFileList}
-                    error={fileLabelErrors?.[slot.id]}
+                    error={state.fileLabelErrors?.[slot.id]}
                     showDrawingNumber={props.showDrawingNumber}
                     drawingNumber={state.drawingNumbers[slot.id]}
                     onDrawingNumberChange={(value) =>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.test.ts
@@ -1,0 +1,210 @@
+import { FileUploadSlot } from "@planx/components/FileUpload/model";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getTagsForSlot, removeSlots } from "../../model";
+import {
+  type FileUploadAction,
+  fileUploadAndLabelReducer,
+  type FileUploadState,
+} from "./fileUploadAndLabelReducer";
+
+vi.mock("../../model", () => ({
+  getTagsForSlot: vi.fn(),
+  removeSlots: vi.fn(),
+}));
+
+const mockFileA = { id: "slot-A", file: { path: "a.pdf" } } as FileUploadSlot;
+const mockFileB = { id: "slot-B", file: { path: "b.pdf" } } as FileUploadSlot;
+const mockFileC = { id: "slot-C", file: { path: "c.pdf" } } as FileUploadSlot;
+
+const baseState: FileUploadState = {
+  slots: [],
+  drawingNumbers: {},
+  fileList: { required: [], recommended: [], optional: [] },
+  pendingRemoval: null,
+  removingSlotId: null,
+};
+
+describe("fileUploadAndLabelReducer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("SET_SLOTS action", () => {
+    it("clears dropzoneError and auto-expands when a new file is added", () => {
+      const state: FileUploadState = {
+        ...baseState,
+        slots: [mockFileA],
+        dropzoneError: "Please upload a file.",
+        expandedSlotId: "slot-A",
+      };
+
+      const action: FileUploadAction = {
+        type: "SET_SLOTS",
+        payload: [mockFileA, mockFileB],
+      };
+
+      const result = fileUploadAndLabelReducer(state, action);
+
+      expect(result.slots).toHaveLength(2);
+      expect(result.dropzoneError).toBeUndefined();
+      expect(result.expandedSlotId).toBe("slot-B");
+    });
+
+    it("does not clear errors or change expansion when an existing file updates (e.g. progress bar update)", () => {
+      const state: FileUploadState = {
+        ...baseState,
+        slots: [mockFileA],
+        dropzoneError: "Some other error",
+        expandedSlotId: "slot-A",
+      };
+
+      const updatedFileA = { ...mockFileA, progress: 50 };
+      const action: FileUploadAction = {
+        type: "SET_SLOTS",
+        payload: [updatedFileA],
+      };
+
+      const result = fileUploadAndLabelReducer(state, action);
+
+      expect(result.dropzoneError).toBe("Some other error");
+      expect(result.expandedSlotId).toBe("slot-A");
+    });
+  });
+
+  describe("SAVE_SLOT action", () => {
+    it("advances expandedSlotId to the next untagged file", () => {
+      const state: FileUploadState = {
+        ...baseState,
+        slots: [mockFileA, mockFileB, mockFileC],
+        expandedSlotId: "slot-A",
+        fileListError: "Missing tags",
+      };
+
+      vi.mocked(getTagsForSlot).mockImplementation((slotId) => {
+        if (slotId === "slot-A") return ["Site Plan"];
+        if (slotId === "slot-B") return ["Elevations"];
+        // Only C is untagged - we should jump to this
+        if (slotId === "slot-C") return [];
+        return [];
+      });
+
+      const action: FileUploadAction = {
+        type: "SAVE_SLOT",
+        payload: { slotId: "slot-A" },
+      };
+      const result = fileUploadAndLabelReducer(state, action);
+
+      expect(result.expandedSlotId).toBe("slot-C");
+      expect(result.fileListError).toBeUndefined();
+    });
+
+    it("sets expandedSlotId to undefined if all subsequent files are fully tagged", () => {
+      const state: FileUploadState = {
+        ...baseState,
+        slots: [mockFileA, mockFileB],
+      };
+
+      vi.mocked(getTagsForSlot).mockReturnValue(["Some Tag"]);
+
+      const action: FileUploadAction = {
+        type: "SAVE_SLOT",
+        payload: { slotId: "slot-A" },
+      };
+      const result = fileUploadAndLabelReducer(state, action);
+
+      // Nothing to tag, no open slots
+      expect(result.expandedSlotId).toBeUndefined();
+    });
+  });
+
+  describe("Two-step file removal", () => {
+    describe("INIT_REMOVE_FILE action", () => {
+      it("queues the file for removal and triggers the animation state without deleting data", () => {
+        const state: FileUploadState = {
+          ...baseState,
+          slots: [mockFileA, mockFileB],
+          expandedSlotId: "slot-A",
+        };
+
+        const action: FileUploadAction = {
+          type: "INIT_REMOVE_FILE",
+          payload: { slot: mockFileA },
+        };
+
+        const result = fileUploadAndLabelReducer(state, action);
+
+        expect(result.slots).toHaveLength(2);
+        expect(result.pendingRemoval).toEqual(mockFileA);
+        expect(result.removingSlotId).toBe("slot-A");
+        expect(result.expandedSlotId).toBeUndefined();
+      });
+    });
+
+    describe("COMPLETE_REMOVE_FILE action", () => {
+      it("deletes the data and resets the animation variables", () => {
+        const state: FileUploadState = {
+          ...baseState,
+          slots: [mockFileA, mockFileB],
+          drawingNumbers: { "slot-A": "123", "slot-B": "456" },
+          pendingRemoval: mockFileA,
+          removingSlotId: "slot-A",
+        };
+
+        const mockUpdatedFileList = {
+          required: [],
+          recommended: [],
+          optional: [],
+        };
+        vi.mocked(removeSlots).mockReturnValue(mockUpdatedFileList);
+
+        const action: FileUploadAction = { type: "COMPLETE_REMOVE_FILE" };
+        const result = fileUploadAndLabelReducer(state, action);
+
+        expect(result.slots).toHaveLength(1);
+        expect(result.slots[0].id).toBe("slot-B");
+        expect(result.drawingNumbers).toEqual({ "slot-B": "456" });
+        expect(result.pendingRemoval).toBeNull();
+        expect(result.removingSlotId).toBeNull();
+        expect(result.fileList).toBe(mockUpdatedFileList);
+      });
+
+      it("clears validation errors when the last file is deleted", () => {
+        const state: FileUploadState = {
+          ...baseState,
+          slots: [mockFileA],
+          pendingRemoval: mockFileA,
+          fileListError: "Error",
+          fileLabelErrors: { "slot-A": "Missing label" },
+        };
+
+        const action: FileUploadAction = { type: "COMPLETE_REMOVE_FILE" };
+        const result = fileUploadAndLabelReducer(state, action);
+
+        expect(result.slots).toHaveLength(0);
+        expect(result.fileListError).toBeUndefined();
+        expect(result.fileLabelErrors).toBeUndefined();
+      });
+    });
+  });
+
+  describe("UI Interactions", () => {
+    it("EXPAND_SLOT action sets the expanded ID and clears validation errors", () => {
+      const state: FileUploadState = {
+        ...baseState,
+        expandedSlotId: "slot-A",
+        fileListError: "Error",
+        fileLabelErrors: { "slot-B": "Error" },
+      };
+
+      const result = fileUploadAndLabelReducer(state, {
+        type: "EXPAND_SLOT",
+        payload: { slotId: "slot-B" },
+      });
+
+      expect(result.expandedSlotId).toBe("slot-B");
+      expect(result.fileListError).toBeUndefined();
+      expect(result.fileLabelErrors).toBeUndefined();
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -58,9 +58,10 @@ export type FileUploadAction =
       payload: SetStateAction<string | undefined>;
     }
   | {
-      type: "SAVE";
+      type: "SAVE_SLOT";
       payload: { slotId: string };
-    };
+    }
+  | { type: "SET_FILE_LIST"; payload: SetStateAction<FileList> };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -209,7 +210,7 @@ export const fileUploadAndLabelReducer = (
       };
     }
 
-    case "SAVE": {
+    case "SAVE_SLOT": {
       const currentIndex = state.slots.findIndex(
         ({ id }) => id === action.payload.slotId,
       );
@@ -224,6 +225,20 @@ export const fileUploadAndLabelReducer = (
       return {
         ...state,
         expandedSlotId: nextUntagged?.id,
+        fileListError: undefined,
+        fileLabelErrors: undefined,
+      };
+    }
+
+    case "SET_FILE_LIST": {
+      const nextFileList =
+        typeof action.payload === "function"
+          ? action.payload(state.fileList)
+          : action.payload;
+
+      return {
+        ...state,
+        fileList: nextFileList,
         fileListError: undefined,
         fileLabelErrors: undefined,
       };

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -6,18 +6,18 @@ import { type FileList, getTagsForSlot, removeSlots } from "../../model";
 
 export interface FileUploadState {
   slots: FileUploadSlot[];
+  fileList: FileList;
   drawingNumbers: Record<string, string>;
   /**
    * Accordion state: only one file can be expanded for editing at a time
    */
   expandedSlotId?: string;
-  fileListError?: string;
-  dropzoneError?: string;
-  fileLabelErrors?: Record<string, string>;
-  fileList: FileList;
   pendingRemoval: FileUploadSlot | null;
   removingSlotId: string | null;
   fileUploadStatus?: string;
+  fileListError?: string;
+  dropzoneError?: string;
+  fileLabelErrors?: Record<string, string>;
 }
 
 export const initialState: FileUploadState = {
@@ -34,30 +34,36 @@ export const initialState: FileUploadState = {
 };
 
 export type FileUploadAction =
+  // Data updates
   | {
       type: "UPDATE_DRAWING_NUMBER";
       payload: { slotId: string; value: string };
     }
   | { type: "REMOVE_DRAWING_NUMBER"; payload: { slotId: string } }
-  | { type: "EXPAND_SLOT"; payload: { slotId: string } }
+
+  // UI interactions
+  | { type: "EXPAND_SLOT"; payload: { slotId?: string } }
+  | { type: "SAVE_SLOT"; payload: { slotId: string } }
+
+  // Validation errors
   | { type: "SET_FILE_LIST_ERROR"; payload: { error: string } }
-  | { type: "SET_DROPZONE_ERROR"; payload: { error: string } }
+  | { type: "SET_DROPZONE_ERROR"; payload: { error?: string } }
   | {
       type: "SET_FILE_LABEL_ERRORS";
       payload: { errors: Record<string, string> };
     }
-  | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> }
+
+  // File removal- Two-step process required to allow UI to animate out before data is deleted
   | { type: "INIT_REMOVE_FILE"; payload: { slot: FileUploadSlot } }
   | { type: "COMPLETE_REMOVE_FILE" }
+
+  // Adapters - allow child components to dispatch updated via setState calls
+  | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> }
+  | { type: "SET_FILE_LIST"; payload: SetStateAction<FileList> }
   | {
       type: "SET_FILE_UPLOAD_STATUS";
       payload: SetStateAction<string | undefined>;
-    }
-  | {
-      type: "SAVE_SLOT";
-      payload: { slotId: string };
-    }
-  | { type: "SET_FILE_LIST"; payload: SetStateAction<FileList> };
+    };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -92,6 +98,26 @@ export const fileUploadAndLabelReducer = (
       };
     }
 
+    case "SAVE_SLOT": {
+      const currentIndex = state.slots.findIndex(
+        ({ id }) => id === action.payload.slotId,
+      );
+
+      // Find the next file that has no tags yet
+      const nextUntagged = state.slots.find((s, i) => {
+        if (i <= currentIndex) return false;
+        const tags = getTagsForSlot(s.id, state.fileList);
+        return tags.length === 0;
+      });
+
+      return {
+        ...state,
+        expandedSlotId: nextUntagged?.id,
+        fileListError: undefined,
+        fileLabelErrors: undefined,
+      };
+    }
+
     case "SET_FILE_LIST_ERROR": {
       return {
         ...state,
@@ -113,28 +139,6 @@ export const fileUploadAndLabelReducer = (
       };
     }
 
-    case "SET_SLOTS": {
-      const nextSlots =
-        typeof action.payload === "function"
-          ? action.payload(state.slots)
-          : action.payload;
-
-      const isNewFileAdded = nextSlots.length > state.slots.length;
-      const newlyAddedSlotId = isNewFileAdded
-        ? nextSlots[state.slots.length].id
-        : state.expandedSlotId;
-
-      return {
-        ...state,
-        slots: nextSlots,
-        // Clear error on new upload
-        dropzoneError: isNewFileAdded ? undefined : state.dropzoneError,
-        // Auto-expand if a new file was just added
-        expandedSlotId: newlyAddedSlotId,
-      };
-    }
-
-    // Start removal animation, defer actual state update to COMPLETE_REMOVE_FILE
     case "INIT_REMOVE_FILE": {
       return {
         ...state,
@@ -143,6 +147,7 @@ export const fileUploadAndLabelReducer = (
           state.expandedSlotId === action.payload.slot.id
             ? undefined
             : state.expandedSlotId,
+        // Queue the file for deletion and trigger the UI exit animation
         pendingRemoval: action.payload.slot,
         removingSlotId: action.payload.slot.id,
       };
@@ -186,6 +191,27 @@ export const fileUploadAndLabelReducer = (
       };
     }
 
+    case "SET_SLOTS": {
+      const nextSlots =
+        typeof action.payload === "function"
+          ? action.payload(state.slots)
+          : action.payload;
+
+      const isNewFileAdded = nextSlots.length > state.slots.length;
+      const newlyAddedSlotId = isNewFileAdded
+        ? nextSlots[state.slots.length].id
+        : state.expandedSlotId;
+
+      return {
+        ...state,
+        slots: nextSlots,
+        // Clear error on new upload
+        dropzoneError: isNewFileAdded ? undefined : state.dropzoneError,
+        // Auto-expand if a new file was just added
+        expandedSlotId: newlyAddedSlotId,
+      };
+    }
+
     case "SET_FILE_UPLOAD_STATUS": {
       const nextStatus =
         typeof action.payload === "function"
@@ -195,26 +221,6 @@ export const fileUploadAndLabelReducer = (
       return {
         ...state,
         fileUploadStatus: nextStatus,
-      };
-    }
-
-    case "SAVE_SLOT": {
-      const currentIndex = state.slots.findIndex(
-        ({ id }) => id === action.payload.slotId,
-      );
-
-      // Find the next file that has no tags yet
-      const nextUntagged = state.slots.find((s, i) => {
-        if (i <= currentIndex) return false;
-        const tags = getTagsForSlot(s.id, state.fileList);
-        return tags.length === 0;
-      });
-
-      return {
-        ...state,
-        expandedSlotId: nextUntagged?.id,
-        fileListError: undefined,
-        fileLabelErrors: undefined,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -35,10 +35,6 @@ export const initialState: FileUploadState = {
 
 export type FileUploadAction =
   | {
-      type: "INIT_RECOVERED_DATA";
-      payload: { fileList: FileList; slots: FileUploadSlot[] };
-    }
-  | {
       type: "UPDATE_DRAWING_NUMBER";
       payload: { slotId: string; value: string };
     }
@@ -135,14 +131,6 @@ export const fileUploadAndLabelReducer = (
         dropzoneError: isNewFileAdded ? undefined : state.dropzoneError,
         // Auto-expand if a new file was just added
         expandedSlotId: newlyAddedSlotId,
-      };
-    }
-
-    case "INIT_RECOVERED_DATA": {
-      return {
-        ...state,
-        fileList: action.payload.fileList,
-        slots: action.payload.slots,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -2,6 +2,13 @@ import { exhaustiveCheck } from "utils";
 
 export interface FileUploadState {
   drawingNumbers: Record<string, string>;
+  /**
+   * Accordion state: only one file can be expanded for editing at a time
+   */
+  expandedSlotId?: string;
+  fileListError?: string;
+  dropzoneError?: string;
+  fileLabelErrors?: Record<string, string>;
 }
 
 export const initialState: FileUploadState = {
@@ -13,7 +20,14 @@ export type FileUploadAction =
       type: "UPDATE_DRAWING_NUMBER";
       payload: { slotId: string; value: string };
     }
-  | { type: "REMOVE_DRAWING_NUMBER"; payload: { slotId: string } };
+  | { type: "REMOVE_DRAWING_NUMBER"; payload: { slotId: string } }
+  | { type: "EXPAND_SLOT"; payload: { slotId: string } }
+  | { type: "SET_FILE_LIST_ERROR"; payload: { error: string } }
+  | { type: "SET_DROPZONE_ERROR"; payload: { error: string } }
+  | {
+      type: "SET_FILE_LABEL_ERRORS";
+      payload: { errors: Record<string, string> };
+    };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -36,6 +50,36 @@ export const fileUploadAndLabelReducer = (
       return {
         ...state,
         drawingNumbers: newDrawingNumbers,
+      };
+    }
+
+    case "EXPAND_SLOT": {
+      return {
+        ...state,
+        expandedSlotId: action.payload.slotId,
+        fileListError: undefined,
+        fileLabelErrors: undefined,
+      };
+    }
+
+    case "SET_FILE_LIST_ERROR": {
+      return {
+        ...state,
+        fileListError: action.payload.error,
+      };
+    }
+
+    case "SET_DROPZONE_ERROR": {
+      return {
+        ...state,
+        dropzoneError: action.payload.error,
+      };
+    }
+
+    case "SET_FILE_LABEL_ERRORS": {
+      return {
+        ...state,
+        fileLabelErrors: action.payload.errors,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -56,6 +56,10 @@ export type FileUploadAction =
   | {
       type: "SET_FILE_UPLOAD_STATUS";
       payload: SetStateAction<string | undefined>;
+    }
+  | {
+      type: "SAVE";
+      payload: { slotId: string };
     };
 
 export const fileUploadAndLabelReducer = (
@@ -202,6 +206,26 @@ export const fileUploadAndLabelReducer = (
       return {
         ...state,
         fileUploadStatus: nextStatus,
+      };
+    }
+
+    case "SAVE": {
+      const currentIndex = state.slots.findIndex(
+        ({ id }) => id === action.payload.slotId,
+      );
+
+      // Find the next file that has no tags yet
+      const nextUntagged = state.slots.find((s, i) => {
+        if (i <= currentIndex) return false;
+        const tags = getTagsForSlot(s.id, state.fileList);
+        return tags.length === 0;
+      });
+
+      return {
+        ...state,
+        expandedSlotId: nextUntagged?.id,
+        fileListError: undefined,
+        fileLabelErrors: undefined,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -1,0 +1,45 @@
+import { exhaustiveCheck } from "utils";
+
+export interface FileUploadState {
+  drawingNumbers: Record<string, string>;
+}
+
+export const initialState: FileUploadState = {
+  drawingNumbers: {},
+};
+
+export type FileUploadAction =
+  | {
+      type: "UPDATE_DRAWING_NUMBER";
+      payload: { slotId: string; value: string };
+    }
+  | { type: "REMOVE_DRAWING_NUMBER"; payload: { slotId: string } };
+
+export const fileUploadAndLabelReducer = (
+  state: FileUploadState,
+  action: FileUploadAction,
+): FileUploadState => {
+  switch (action.type) {
+    case "UPDATE_DRAWING_NUMBER":
+      return {
+        ...state,
+        drawingNumbers: {
+          ...state.drawingNumbers,
+          [action.payload.slotId]: action.payload.value,
+        },
+      };
+
+    case "REMOVE_DRAWING_NUMBER": {
+      const newDrawingNumbers = { ...state.drawingNumbers };
+      delete newDrawingNumbers[action.payload.slotId];
+
+      return {
+        ...state,
+        drawingNumbers: newDrawingNumbers,
+      };
+    }
+
+    default:
+      return exhaustiveCheck(action);
+  }
+};

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -2,6 +2,8 @@ import type { FileUploadSlot } from "@planx/components/FileUpload/model";
 import type { SetStateAction } from "react";
 import { exhaustiveCheck } from "utils";
 
+import { type FileList, getTagsForSlot, removeSlots } from "../../model";
+
 export interface FileUploadState {
   slots: FileUploadSlot[];
   drawingNumbers: Record<string, string>;
@@ -12,14 +14,30 @@ export interface FileUploadState {
   fileListError?: string;
   dropzoneError?: string;
   fileLabelErrors?: Record<string, string>;
+  fileList: FileList;
+  pendingRemoval: FileUploadSlot | null;
+  removingSlotId: string | null;
+  fileUploadStatus?: string;
 }
 
 export const initialState: FileUploadState = {
   slots: [],
   drawingNumbers: {},
+  fileList: {
+    required: [],
+    recommended: [],
+    optional: [],
+  },
+  pendingRemoval: null,
+  removingSlotId: null,
+  fileUploadStatus: undefined,
 };
 
 export type FileUploadAction =
+  | {
+      type: "INIT_RECOVERED_DATA";
+      payload: { fileList: FileList; slots: FileUploadSlot[] };
+    }
   | {
       type: "UPDATE_DRAWING_NUMBER";
       payload: { slotId: string; value: string };
@@ -32,7 +50,9 @@ export type FileUploadAction =
       type: "SET_FILE_LABEL_ERRORS";
       payload: { errors: Record<string, string> };
     }
-  | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> };
+  | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> }
+  | { type: "INIT_REMOVE_FILE"; payload: { slot: FileUploadSlot } }
+  | { type: "COMPLETE_REMOVE_FILE" };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -106,6 +126,66 @@ export const fileUploadAndLabelReducer = (
         dropzoneError: isNewFileAdded ? undefined : state.dropzoneError,
         // Auto-expand if a new file was just added
         expandedSlotId: newlyAddedSlotId,
+      };
+    }
+
+    case "INIT_RECOVERED_DATA": {
+      return {
+        ...state,
+        fileList: action.payload.fileList,
+        slots: action.payload.slots,
+      };
+    }
+
+    // Start removal animation, defer actual state update to COMPLETE_REMOVE_FILE
+    case "INIT_REMOVE_FILE": {
+      return {
+        ...state,
+        // Close the accordion if the one they are deleting is currently open
+        expandedSlotId:
+          state.expandedSlotId === action.payload.slot.id
+            ? undefined
+            : state.expandedSlotId,
+        pendingRemoval: action.payload.slot,
+        removingSlotId: action.payload.slot.id,
+      };
+    }
+
+    case "COMPLETE_REMOVE_FILE": {
+      if (!state.pendingRemoval) return state;
+      const slot = state.pendingRemoval;
+
+      // Remove from slots array
+      const newSlots = state.slots.filter((s) => s.id !== slot.id);
+
+      // Remove from fileList object
+      // TODO: Single source of truth, no need to sync this
+      const updatedFileList = removeSlots(
+        getTagsForSlot(slot.id, state.fileList),
+        slot,
+        state.fileList,
+      );
+
+      // Clean up drawing numbers
+      // TODO: Make this a property of slots
+      const newDrawingNumbers = { ...state.drawingNumbers };
+      delete newDrawingNumbers[slot.id];
+
+      return {
+        ...state,
+        slots: newSlots,
+        fileList: updatedFileList,
+        drawingNumbers: newDrawingNumbers,
+        fileUploadStatus: `${slot.file.path} was deleted`,
+
+        // Reset animation states
+        removingSlotId: null,
+        pendingRemoval: null,
+
+        // Clear errors if they deleted the last file
+        fileListError: newSlots.length === 0 ? undefined : state.fileListError,
+        fileLabelErrors:
+          newSlots.length === 0 ? undefined : state.fileLabelErrors,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -52,7 +52,11 @@ export type FileUploadAction =
     }
   | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> }
   | { type: "INIT_REMOVE_FILE"; payload: { slot: FileUploadSlot } }
-  | { type: "COMPLETE_REMOVE_FILE" };
+  | { type: "COMPLETE_REMOVE_FILE" }
+  | {
+      type: "SET_FILE_UPLOAD_STATUS";
+      payload: SetStateAction<string | undefined>;
+    };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -186,6 +190,18 @@ export const fileUploadAndLabelReducer = (
         fileListError: newSlots.length === 0 ? undefined : state.fileListError,
         fileLabelErrors:
           newSlots.length === 0 ? undefined : state.fileLabelErrors,
+      };
+    }
+
+    case "SET_FILE_UPLOAD_STATUS": {
+      const nextStatus =
+        typeof action.payload === "function"
+          ? action.payload(state.fileUploadStatus)
+          : action.payload;
+
+      return {
+        ...state,
+        fileUploadStatus: nextStatus,
       };
     }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/hooks/fileUploadAndLabelReducer.tsx
@@ -1,6 +1,9 @@
+import type { FileUploadSlot } from "@planx/components/FileUpload/model";
+import type { SetStateAction } from "react";
 import { exhaustiveCheck } from "utils";
 
 export interface FileUploadState {
+  slots: FileUploadSlot[];
   drawingNumbers: Record<string, string>;
   /**
    * Accordion state: only one file can be expanded for editing at a time
@@ -12,6 +15,7 @@ export interface FileUploadState {
 }
 
 export const initialState: FileUploadState = {
+  slots: [],
   drawingNumbers: {},
 };
 
@@ -27,7 +31,8 @@ export type FileUploadAction =
   | {
       type: "SET_FILE_LABEL_ERRORS";
       payload: { errors: Record<string, string> };
-    };
+    }
+  | { type: "SET_SLOTS"; payload: SetStateAction<FileUploadSlot[]> };
 
 export const fileUploadAndLabelReducer = (
   state: FileUploadState,
@@ -80,6 +85,27 @@ export const fileUploadAndLabelReducer = (
       return {
         ...state,
         fileLabelErrors: action.payload.errors,
+      };
+    }
+
+    case "SET_SLOTS": {
+      const nextSlots =
+        typeof action.payload === "function"
+          ? action.payload(state.slots)
+          : action.payload;
+
+      const isNewFileAdded = nextSlots.length > state.slots.length;
+      const newlyAddedSlotId = isNewFileAdded
+        ? nextSlots[state.slots.length].id
+        : state.expandedSlotId;
+
+      return {
+        ...state,
+        slots: nextSlots,
+        // Clear error on new upload
+        dropzoneError: isNewFileAdded ? undefined : state.dropzoneError,
+        // Auto-expand if a new file was just added
+        expandedSlotId: newlyAddedSlotId,
       };
     }
 


### PR DESCRIPTION
## What does this PR do?
Refactors `FileUploadAndLabel` to use a reducer pattern ([docs](https://react.dev/reference/react/useReducer)). This will allow us to more easily scale and maintain this component. This follows on from [#6416](https://github.com/theopensystemslab/planx-new/pull/6416) and has been a bit of tech debt I've been very keen to address - as the complexity here has grown we've simply continued to manage state in-line which is proving tricky to manage.

This PR does not introduce new functionality, and is simply a refactor of the existing `FileUploadAndLabel` component.

## Why this pattern?
Previously, we relied here on multiple `useState()` hooks paired with reactive `useEffects()` - this is tricky to read and understand, and will be very challenging to integrate the following upcoming features (imho!)
 - Drawing numbers
 - `slots` as a single source of truth (see #6416)
 - Persist data mid-component (e.g. on upload, on tag), not just on "Continue"
 - AI classification and validation (?)

Switching to a pattern using `useReducer()` allows to to understand the component a series of "actions" which the user can trigger. This makes the UI dumber, and the state management is handled centrally by the reducer - this means we don't need to manage cascading updates and effects.

## Testing
In order to test this you'll need the `UPLOAD_LABEL_REBUILD` feature flag enabled. 

## Next steps...
Please see #6416 for more detail - the next step here is to make `slots` a single source of truth.