### PR TITLE
test(hasura): Drop parallelism in order to not ovewherlm GHA runners

### DIFF
--- a/apps/hasura.planx.uk/tests/vitest.config.js
+++ b/apps/hasura.planx.uk/tests/vitest.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.js'],
     deps: {
       inline: ['dotenv']
-    }
+    },
+    fileParallelism: false
   }
 });


### PR DESCRIPTION
## What's the problem?
Our integration tests are [failing ~25% of the time](https://github.com/theopensystemslab/planx-new/actions/metrics/performance?tab=jobs&filters=integration) - the Hasura test step of that is by far the most often to fail (anecdotally). This seem to be on an upward trend. It's frustrating and slow to have to re-run this step in order to get a PR or regression test to pass.

These tests run very quickly locally and we don't hit any timeout issues, it only happens in CI. I believe the issue is that we're overwhelming the GHA runner with a whole bunch of introspection requests too quickly - leading to failures. There's no caching in place here, and each file runs in parallel so we're hitting the GHA runner Hasura instance with ~150-200 requests instantly.

## What's the solution?
I've gone for the easy option here by just dropping the parallelism here ([docs](https://vitest.dev/config/fileparallelism.html)) - these tests will now run one file at time which should resolve this. A more robust solution here could be to - 
 - Implement a very simple cache so that we only make one introspection query per-role (we'll still need to account for Vitest running across multiple threads)
 - Write result of introspection requests to a file, have tests check this

Given the footprint of these tests and likely speed of growth I think the very simplest option is fine here - we can come back to these other options if required. As reference, in parallel these tests completed in [~6s in the previous regression test run this morning](https://github.com/theopensystemslab/planx-new/actions/runs/24230453158/job/70756511793) and took [~10s on this PR](https://github.com/theopensystemslab/planx-new/actions/runs/24237076907/job/70762275927?pr=6444).