### PR TITLE
chore: fetch archived flows in Archive component

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Constraints/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Constraints/index.tsx
@@ -2,12 +2,12 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-
 import { Switch } from "ui/shared/Switch";
+
 import SettingsFormContainer from "../../../shared/SettingsForm";
-import { GetTeamConstraintsData, TeamConstraintsFormValues, UpdateTeamConstraintsVariables } from "./types";
 import { GET_TEAM_CONSTRAINTS, UPDATE_TEAM_CONSTRAINTS } from "./queries";
 import { defaultValues, validationSchema } from "./schema";
+import { GetTeamConstraintsData, TeamConstraintsFormValues, UpdateTeamConstraintsVariables } from "./types";
 
 const Constraints: React.FC = () => {
   const [teamId] = useStore((state) => [

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -3,12 +3,13 @@ import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Box from "@mui/material/Box";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
-import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 import { FlowCardView } from "../../FlowEditor/lib/store/editor";
 import { FlowTable } from "../components/FlowTable";
 import { ShowingServicesHeader } from "../components/ShowingServicesHeader";
+import { useGetArchivedFlows } from "../helpers/useGetArchivedFlows";
 import { DashboardList } from "./DashboardList";
 import FlowCard from "./FlowCard";
 import { StyledToggleButton } from "./StyledToggleButton"
@@ -19,7 +20,6 @@ type Props = {
     _event: React.MouseEvent<HTMLElement>,
     newView: FlowCardView | null,
   ) => void;
-  archivedFlows: FlowSummary[] | null;
   teamId: number;
   slug: string;
   fetchFlows: () => void;
@@ -28,11 +28,34 @@ type Props = {
 const Archive: React.FC<Props> = ({
   flowCardView,
   handleViewChange,
-  archivedFlows,
   teamId,
   slug,
   fetchFlows,
 }) => {
+  const { data: archivedFlowsData, loading, error } = useGetArchivedFlows(teamId);
+  const archivedFlows = archivedFlowsData?.flows ?? null;
+
+  if (error) {
+      console.log(error.message);
+      return null;
+    }
+
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          pt: 2,
+          display: "flex",
+          justifyContent: "flex-start",
+          alignItems: "center",
+          gap: 2,
+          minHeight: "50px",
+        }}
+      >
+        <Typography>Loading...</Typography>
+      </Box>
+    );
+  }
   return (
     <>
       <Box
@@ -45,6 +68,7 @@ const Archive: React.FC<Props> = ({
       >
         <Box
           sx={{
+            pt: 2,
             display: "flex",
             justifyContent: "flex-start",
             alignItems: "center",

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -5,6 +5,7 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { FlowCardView } from "../../FlowEditor/lib/store/editor";
 import { FlowTable } from "../components/FlowTable";
@@ -13,7 +14,6 @@ import { useGetArchivedFlows } from "../helpers/useGetArchivedFlows";
 import { DashboardList } from "./DashboardList";
 import FlowCard from "./FlowCard";
 import { StyledToggleButton } from "./StyledToggleButton"
-
 type Props = {
   flowCardView: FlowCardView;
   handleViewChange: (
@@ -34,11 +34,14 @@ const Archive: React.FC<Props> = ({
 }) => {
   const { data: archivedFlowsData, loading, error } = useGetArchivedFlows(teamId);
   const archivedFlows = archivedFlowsData?.flows ?? null;
-
+  
   if (error) {
-      console.log(error.message);
-      return null;
-    }
+    return (
+      <Box sx={{pt: 2}}>
+        <ErrorSummary message={error.message} />
+      </Box>
+    )
+  }
 
   if (loading) {
     return (

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowMenu.tsx
@@ -56,17 +56,19 @@ const FlowMenu: React.FC<Props> = ({
     refreshFlows();
   };
 
-  const handleArchive = async () => {
-    try {
-      await archiveFlow(flow);
-      setOpenDialog(null);
-      toast.success("Archived flow");
-    } catch (error) {
-      toast.error(
-        "We are unable to archive this flow, refesh and try again or contact an admin",
-      );
-    }
-  };
+const handleArchive = async () => {
+  try {
+    await archiveFlow(flow);
+    refreshFlows();
+    toast.success("Archived flow");
+  } catch (error) {
+    toast.error(
+      "We are unable to archive this flow, refesh and try again or contact an admin",
+    );
+  } finally {
+    setOpenDialog(null);
+  }
+};
 
   const menuItems = [
     {

--- a/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/helpers/useGetArchivedFlows.tsx
@@ -9,4 +9,5 @@ import {
 export const useGetArchivedFlows = (teamId: number) =>
   useQuery<GetArchivedFlowsQuery, GetArchivedFlowsVars>(GET_ARCHIVED_FLOWS, {
     variables: { teamId },
+    fetchPolicy: "cache-and-network",
   });

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -16,7 +16,6 @@ import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
-import { useGetArchivedFlows } from "./helpers/useGetArchivedFlows";
 import TeamLayout from "./TeamLayout";
 
 export type FlowView = "flows" | "archive";
@@ -56,8 +55,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
 
   const [flows, setFlows] = useState<FlowSummary[] | null>(initialFlows);
   const [flowView, setFlowView] = useState<FlowView>("flows");
-  const { data: archivedFlowsData } = useGetArchivedFlows(teamId);
-  const archivedFlows = archivedFlowsData?.flows ?? null;
 
   const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(
     null,
@@ -214,7 +211,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
           <Archive
             flowCardView={flowCardView}
             handleViewChange={handleViewChange}
-            archivedFlows={archivedFlows}
             teamId={teamId}
             slug={slug}
             fetchFlows={fetchFlows}


### PR DESCRIPTION
This PR:
- Moves archived flows fetch into Archive component to speed up initial load time (as per [Daf's suggestion](https://github.com/theopensystemslab/planx-new/pull/6435#pullrequestreview-4088298478))
- Ensures that Flows UI updates on archive
- Uses `cache-and-network` fetch policy on archived flows to speed up load / ensure list updates with newly archived flows too