### PR TITLE
feat: disable links to archived flows

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -15,7 +15,7 @@ import {
   Card,
   CardBanner,
   CardContent,
-  DashboardLink,
+  FlowCardLink,
   LinkSubText,
 } from "./styles";
 
@@ -107,7 +107,7 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
             </TruncatedText>
           )}
           {showDetails && (
-            <DashboardLink
+            <FlowCardLink
               to="/app/$team/$flow"
               params={{ team: teamSlug, flow: flow.slug }}
               aria-label={flow.name}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
@@ -39,7 +39,7 @@ export const CardContent = styled(Box)(({ theme }) => ({
   width: "100%",
 }));
 
-export const DashboardLink = styled(CustomLink)(() => ({
+export const FlowCardLink = styled(CustomLink)(() => ({
   position: "absolute",
   left: 0,
   top: 0,

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -3,15 +3,11 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import { type LinkOptions, useNavigate } from "@tanstack/react-router";
-import { useRouter } from "@tanstack/react-router";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType } from "ui/editor/FlowTag/types";
 import TruncatedText from "ui/editor/TruncatedText";
-import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 import { useStore } from "../../../FlowEditor/lib/store";
 import FlowMenu from "../FlowMenu";
@@ -19,6 +15,7 @@ import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
 import { useFlowSortDisplay } from "../hooks/useFlowSortDisplay";
+import { FlowRowLink } from "./styles";
 import {
   FlowActionsCell,
   FlowStatusCell,
@@ -87,8 +84,6 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   refreshFlows,
   showDetails,
 }) => {
-  const router = useRouter();
-  const navigate = useNavigate();
   const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
 
   const {
@@ -101,26 +96,8 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
 
   const { displayTimeAgo, displayActor } = useFlowDates(flow);
 
-  const handleRowClick = (e: React.MouseEvent) => {
-    if ((e.target as HTMLElement).closest("a")) return;
-
-    const destination: LinkOptions = {
-      to: "/app/$team/$flow",
-      params: { team: teamSlug, flow: flow.slug },
-    };
-
-    // Allow links to be opened in new tabs
-    if (e.metaKey || e.ctrlKey) {
-      const { href } = router.buildLocation(destination);
-      window.open(href, "_blank");
-      return;
-    }
-
-    navigate(destination);
-  };
-
   return (
-    <StyledTableRow isTemplated={isAnyTemplate} onClick={handleRowClick}>
+    <StyledTableRow isTemplated={isAnyTemplate} clickable={showDetails}>
       <FlowTitleCell>
         <Box>
           {isAnyTemplate && (
@@ -132,24 +109,17 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               />
             </Box>
           )}
-          <CustomLink
-            to="/app/$team/$flow"
-            preload={false}
-            params={{ team: teamSlug, flow: flow.slug }}
-            onClick={(e) => e.stopPropagation()}
-            sx={(theme) => ({
-              textDecoration: "none",
-              color: theme.palette.text.primary,
-              fontWeight: FONT_WEIGHT_SEMI_BOLD,
-              "&:hover": {
-                textDecoration: "underline",
-              },
-            })}
-          >
-            <Typography variant="h4" component="span">
-              {flow.name}
-            </Typography>
-          </CustomLink>
+          <Typography variant="h4" component="span">
+            {flow.name}
+          </Typography>
+          {showDetails && (
+            <FlowRowLink
+              to="/app/$team/$flow"
+              params={{ team: teamSlug, flow: flow.slug }}
+              aria-label={flow.name}
+              preload={false}
+            />
+          )}
           {flow.summary && (
             <TruncatedText
               variant="body2"

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -48,12 +48,8 @@ export const StyledTableRow = styled(TableRow, {
     backgroundColor: isTemplated
       ? theme.palette.template.light
       : theme.palette.background.default,
-    cursor: clickable ? "pointer" : "default",
     "&:hover": {
       backgroundColor: hoverBackground,
-      "& a": {
-        textDecoration: clickable ? "underline" : "none",
-      },
     },
     "& .actions-cell": {
       cursor: "default",
@@ -67,9 +63,6 @@ export const StyledTableRow = styled(TableRow, {
         width: "100%",
         height: "100%",
       },
-    },
-    "&:has(.actions-cell:hover) a": {
-      textDecoration: "none",
     },
   };
 });

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -3,6 +3,9 @@ import Table from "@mui/material/Table";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import { inputFocusStyle } from "theme";
+
+import { CustomLink } from "../../../../ui/shared/CustomLink/CustomLink";
 
 export const StyledTable = styled(Table)(({ theme }) => ({
   marginTop: theme.spacing(2),
@@ -31,38 +34,57 @@ export const StyledTableHead = styled(TableHead)(({ theme }) => ({
 }));
 
 export const StyledTableRow = styled(TableRow, {
-  shouldForwardProp: (prop) => prop !== "isTemplated",
-})<{ isTemplated?: boolean }>(({ theme, isTemplated }) => ({
-  backgroundColor: isTemplated
-    ? theme.palette.template.light
-    : theme.palette.background.default,
-  cursor: "pointer",
-  "&:hover": {
-    backgroundColor: isTemplated
-      ? theme.palette.template.main
-      : theme.palette.background.paper,
-    "& a": {
-      textDecoration: "underline",
-    },
-  },
-  "& .actions-cell": {
-    cursor: "default",
+  shouldForwardProp: (prop) => prop !== "isTemplated" && prop !== "clickable",
+})<{ isTemplated?: boolean; clickable?: boolean }>(({ theme, isTemplated, clickable = true }) => {
+  let hoverBackground: string | undefined;
+  if (clickable && isTemplated) {
+    hoverBackground = theme.palette.template.main;
+  } else if (clickable) {
+    hoverBackground = theme.palette.background.paper;
+  }
+
+  return {
     position: "relative",
-    // Min-height to compensate for padding
-    height: "80px",
-    // Make the entire cell clickable area for the menu button
-    "& > div, & button": {
-      position: "absolute",
-      left: 0,
-      top: 0,
-      width: "100%",
-      height: "100%",
+    backgroundColor: isTemplated
+      ? theme.palette.template.light
+      : theme.palette.background.default,
+    cursor: clickable ? "pointer" : "default",
+    "&:hover": {
+      backgroundColor: hoverBackground,
+      "& a": {
+        textDecoration: clickable ? "underline" : "none",
+      },
     },
+    "& .actions-cell": {
+      cursor: "default",
+      position: "relative",
+      zIndex: 2,
+      height: "80px",
+      "& > div, & button": {
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: "100%",
+        height: "100%",
+      },
+    },
+    "&:has(.actions-cell:hover) a": {
+      textDecoration: "none",
+    },
+  };
+});
+
+export const FlowRowLink = styled(CustomLink)(() => ({
+  position: "absolute",
+  left: 0,
+  top: 0,
+  width: "100%",
+  height: "100%",
+  zIndex: 1,
+  "&:focus": {
+    ...inputFocusStyle,
   },
-  "&:has(.actions-cell:hover) a": {
-    textDecoration: "none",
-  },
-}));
+})) as typeof CustomLink;
 
 export const FlowTitleCell = styled(TableCell)(() => ({
   width: "45%",


### PR DESCRIPTION
Removes flow links from Archive tab table view. They were already disabled for FlowCard Archive view. 

Before:

https://github.com/user-attachments/assets/f9a57285-a181-4a1c-927b-64e0a73d5519

After:

https://github.com/user-attachments/assets/eab49297-7e90-4125-a93b-818b09d1004a
