### PR TITLE
[infra] break redirect loop by forwarding traffic from http listener

### DIFF
--- a/infrastructure/application/utils/setupService.ts
+++ b/infrastructure/application/utils/setupService.ts
@@ -75,17 +75,14 @@ export const setupLoadBalancer = async ({
           targetGroupArn: targetGroup.arn,
         }],
       },
-      // force http connections to upgrade to https
+      // don't force http to https, to avoid ALB <-> Cloudflare redirect loop during deploy
+      // TODO: after Cloudflare SSL mode successfully upgraded to 'Full (Strict)', delete this listener
       {
         port: 80,
         protocol: "HTTP",
         defaultActions: [{
-          type: "redirect",
-          redirect: {
-            port: "443",
-            protocol: "HTTPS",
-            statusCode: "HTTP_301",
-          },
+          type: "forward",
+          targetGroupArn: targetGroup.arn,
         }],
       },
     ],


### PR DESCRIPTION
A small addendum to #6430, relating to [this ticket](https://trello.com/c/rTdHv3A0).

I decided that we don't need to accept unnecessary downtime on production. We should engineer that out of the deployment as much as possible. So here we make a change so that http traffic from Cloudflare to our load balancers is forwarded on, rather than redirected to the https address. More context [here](https://github.com/theopensystemslab/planx-new/pull/6430#issuecomment-4224488533).

There may still be a moment of downtime if we do need to manually destroy the LBs before `pulumi up`, but that may no longer be necessary.