### PR TITLE
fix(editor): Simplify auth process by centralising within an `AuthStore`

### DIFF
--- a/apps/api.planx.uk/modules/auth/controller.ts
+++ b/apps/api.planx.uk/modules/auth/controller.ts
@@ -6,8 +6,7 @@ import {
   isTokenRevoked,
   revokeToken,
 } from "./service/logout/revokeToken.js";
-import { getToken, userContext } from "./middleware.js";
-import { ServerError } from "../../errors/serverError.js";
+import { getToken } from "./middleware.js";
 
 export const failedLogin: RequestHandler = (_req, _res, next) =>
   next({
@@ -83,27 +82,42 @@ function setJWTSearchParams(returnTo: string, res: Response, req: Request) {
  * Revokes a user's JWT on logout
  * TODO: We check if a JWT is revoked when authenticating requests via the API and Hasura
  */
-export const logout: RequestHandler = async (_req, res, next) => {
-  const { jwt, sub: userId } = userContext.getStore()?.user || {};
-
-  if (!jwt) {
-    return next(
-      new ServerError({
-        message: `JWT missing from logout request, no token to revoke for user ${userId}`,
-      }),
-    );
+export const logout: RequestHandler = async (req, res) => {
+  // If a token was provided, try to revoke
+  const token = getToken(req);
+  if (token) {
+    try {
+      await revokeToken(token);
+    } catch (error) {
+      console.warn(`Failed to revoke token during logout: ${error}`);
+    }
   }
 
-  try {
-    await revokeToken(jwt);
-    return res.status(200).send();
-  } catch (error) {
-    return next(
-      new ServerError({
-        message: `Failed to logout successfully. Error: ${error}`,
-      }),
-    );
+  // Always clear cookies, even if we didn't get passed a JWT or the above failed
+  const origin = req.headers.origin || req.headers.referer;
+  let cookieDomain: string | undefined = undefined;
+
+  if (origin) {
+    try {
+      cookieDomain = `.${new URL(origin).host}`;
+    } catch (e) {
+      console.warn(
+        "Could not parse origin to set cookie domain during logout:",
+        origin,
+      );
+    }
   }
+
+  const baseCookieOptions: CookieOptions = {
+    domain: cookieDomain,
+    sameSite: "none",
+    secure: true,
+  };
+
+  res.clearCookie("jwt", { ...baseCookieOptions, httpOnly: true });
+  res.clearCookie("auth", { ...baseCookieOptions, httpOnly: false });
+
+  return res.status(200).send();
 };
 
 export const isJWTRevoked: RequestHandler = async (req, res) => {

--- a/apps/api.planx.uk/modules/auth/routes.ts
+++ b/apps/api.planx.uk/modules/auth/routes.ts
@@ -7,11 +7,7 @@ export default (passport: Authenticator): Router => {
   const router = Router();
 
   router.get("/auth/login/failed", Controller.failedLogin);
-  router.post(
-    "/auth/logout",
-    Middleware.useLoggedInUserAuth,
-    Controller.logout,
-  );
+  router.post("/auth/logout", Controller.logout);
 
   router.get("/auth/google", Middleware.getGoogleAuthHandler(passport));
   router.get(

--- a/apps/api.planx.uk/modules/auth/service/logout/logout.test.ts
+++ b/apps/api.planx.uk/modules/auth/service/logout/logout.test.ts
@@ -1,49 +1,17 @@
 import supertest from "supertest";
 import app from "../../../../server.js";
-import { authHeader, expiredAuthHeader } from "../../../../tests/mockJWT.js";
+import { authHeader } from "../../../../tests/mockJWT.js";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
 
 const ENDPOINT = "/auth/logout";
 
 afterEach(() => queryMock.reset());
 
-test("requests without a JWT will be rejected", async () => {
-  await supertest(app)
-    .post(ENDPOINT)
-    .expect(401)
-    .then((res) => {
-      expect(res.body).toEqual({
-        error: "No authorization token was found",
-      });
-    });
+test("logout succeeds even without a JWT", async () => {
+  await supertest(app).post(ENDPOINT).expect(200);
 });
 
-test("invalid tokens will be rejected", async () => {
-  await supertest(app)
-    .post(ENDPOINT)
-    .set({ authorization: "Bearer INVALID_JWT" })
-    .expect(401)
-    .then((res) => {
-      expect(res.body).toEqual({
-        error: "jwt malformed",
-      });
-    });
-});
-
-test("expired tokens will be rejected", async () => {
-  const auth = expiredAuthHeader({ role: "teamEditor" });
-
-  await supertest(app)
-    .post(ENDPOINT)
-    .set(auth)
-    .expect(302)
-    .then((res) => {
-      expect(res.redirect).toBe(true);
-      expect(res.header.location).toMatch(/logout/);
-    });
-});
-
-test("errors thrown whilst checking if a token is revoked are handled", async () => {
+test("logout succeeds even if token revocation check fails", async () => {
   const auth = authHeader({ role: "teamEditor" });
 
   // Throw an error whilst calling IsTokenRevoked query
@@ -54,24 +22,12 @@ test("errors thrown whilst checking if a token is revoked are handled", async ()
     matchOnVariables: false,
   });
 
-  await supertest(app)
-    .post(ENDPOINT)
-    .set(auth)
-    .expect(500)
-    .then((res) => {
-      const error = JSON.stringify(res.error);
-
-      expect(error).toMatch(/Failed to check if token is already revoked/);
-
-      // Don't log potentially sensitive information
-      expect(error).not.toMatch(/Something went wrong with Hasura/);
-    });
+  await supertest(app).post(ENDPOINT).set(auth).expect(200);
 });
 
-test("revoked tokens cannot get re-revoked", async () => {
+test("logout succeeds even if token is already revoked", async () => {
   const auth = authHeader({ role: "teamEditor" });
 
-  // Mock an already revoked token
   queryMock.mockQuery({
     name: "IsTokenRevoked",
     matchOnVariables: false,
@@ -82,24 +38,17 @@ test("revoked tokens cannot get re-revoked", async () => {
     },
   });
 
-  await supertest(app)
-    .post(ENDPOINT)
-    .set(auth)
-    .expect(401)
-    .then((res) => expect(res.text).toMatch(/The token has been revoked/));
+  await supertest(app).post(ENDPOINT).set(auth).expect(200);
 });
 
-test("errors thrown whilst revoking a token are handled", async () => {
+test("logout succeeds even if writing to revoked_tokens fails", async () => {
   const auth = authHeader({ role: "teamEditor" });
 
-  // Mock a token which is not yet revoked
   queryMock.mockQuery({
     name: "IsTokenRevoked",
     matchOnVariables: false,
     data: {
-      revokedToken: {
-        revokedAt: null,
-      },
+      revokedToken: { revokedAt: null },
     },
   });
 
@@ -110,33 +59,16 @@ test("errors thrown whilst revoking a token are handled", async () => {
     matchOnVariables: false,
   });
 
-  await supertest(app)
-    .post(ENDPOINT)
-    .set(auth)
-    .expect(500)
-    .then((res) => {
-      const error = JSON.stringify(res.error);
-
-      expect(error).toMatch(/Failed to logout successfully/);
-      expect(error).toMatch(/Failed to add token to revoked list/);
-
-      // Don't log potentially sensitive information
-      expect(error).not.toMatch(/Something went wrong with Hasura/);
-    });
+  await supertest(app).post(ENDPOINT).set(auth).expect(200);
 });
 
-test("valid tokens will be written to the revoked_tokens table", async () => {
+test("valid tokens are written to the revoked_tokens table", async () => {
   const auth = authHeader({ role: "teamEditor" });
 
-  // Mock a token which is not yet revoked
   queryMock.mockQuery({
     name: "IsTokenRevoked",
     matchOnVariables: false,
-    data: {
-      revokedToken: {
-        revokedAt: null,
-      },
-    },
+    data: { revokedToken: { revokedAt: null } },
   });
 
   // Insert revoked_tokens record
@@ -154,6 +86,16 @@ test("valid tokens will be written to the revoked_tokens table", async () => {
   await supertest(app).post(ENDPOINT).set(auth).expect(200);
 });
 
-// Awaiting implementation
+test("cookies are cleared on logout regardless of token state", async () => {
+  await supertest(app)
+    .post(ENDPOINT)
+    .expect(200)
+    .then((res) => {
+      const cookies = res.headers["set-cookie"] as unknown as string[];
+      expect(cookies.some((c) => c.startsWith("jwt=;"))).toBe(true);
+      expect(cookies.some((c) => c.startsWith("auth=;"))).toBe(true);
+    });
+});
+
 test.todo("revoked tokens cannot access the REST API");
 test.todo("revoked tokens cannot access the GraphQL API");

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -14,20 +14,22 @@ import { vi } from "vitest";
 import { ChecklistEditor } from "./Editor";
 import { Checklist } from "./model";
 
-const { getState } = useStore;
+const { setState } = useStore;
 
 describe("Checklist editor component", () => {
   beforeEach(() => {
-    getState().setUser({
-      id: 1,
-      firstName: "Editor",
-      lastName: "Test",
-      isPlatformAdmin: true,
-      isAnalyst: true,
-      email: "test@test.com",
-      teams: [],
+    setState({
+      user: {
+        id: 1,
+        firstName: "Editor",
+        lastName: "Test",
+        isPlatformAdmin: true,
+        isAnalyst: true,
+        email: "test@test.com",
+        teams: [],
+        defaultTeamId: null,
+      },
       jwt: "x.y.z",
-      defaultTeamId: null,
     });
   });
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
@@ -7,21 +7,23 @@ import { setup } from "testUtils";
 
 import FileUploadAndLabelComponent from "./Editor";
 
-const { getState } = useStore;
+const { setState } = useStore;
 
 describe("FileUploadAndLabel - Editor Modal", () => {
   // TODO correctly mock an authenticated Platform Admin user so 'add' button is enabled in final test
   beforeEach(() => {
-    getState().setUser({
-      id: 1,
-      firstName: "Editor",
-      lastName: "Test",
-      isPlatformAdmin: true,
-      isAnalyst: false,
-      email: "test@test.com",
-      teams: [],
+    setState({
+      user: {
+        id: 1,
+        firstName: "Editor",
+        lastName: "Test",
+        isPlatformAdmin: true,
+        isAnalyst: false,
+        email: "test@test.com",
+        teams: [],
+        defaultTeamId: null,
+      },
       jwt: "x.y.z",
-      defaultTeamId: null,
     });
   });
 

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -15,20 +15,22 @@ import { Condition } from "../shared/RuleBuilder/types";
 import ResponsiveChecklistEditor from "./Editor";
 import { ResponsiveChecklist } from "./model";
 
-const { getState } = useStore;
+const { setState } = useStore;
 
 describe("Responsive Checklist editor component", async () => {
   beforeEach(() => {
-    getState().setUser({
-      id: 1,
-      firstName: "Editor",
-      lastName: "Test",
-      isPlatformAdmin: true,
-      isAnalyst: true,
-      email: "test@test.com",
-      teams: [],
+    setState({
+      user: {
+        id: 1,
+        firstName: "Editor",
+        lastName: "Test",
+        isPlatformAdmin: true,
+        isAnalyst: true,
+        email: "test@test.com",
+        teams: [],
+        defaultTeamId: null,
+      },
       jwt: "x.y.z",
-      defaultTeamId: null,
     });
   });
 

--- a/apps/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Sections/NavBar.tsx
@@ -34,10 +34,11 @@ export const SectionNavBar: React.FC = () => {
   const matches = useMatches();
   const isContentPage = matches.some(
     (match) =>
-      "isContentPage" in match.context && match.context.isContentPage === true,
+      match?.context && "isContentPage" in match.context && match.context.isContentPage === true,
   );
   const isViewApplicationPage = matches.some(
     (match) =>
+      match?.context && 
       "isViewApplicationPage" in match.context &&
       match.context.isViewApplicationPage === true,
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/index.test.tsx
@@ -61,7 +61,7 @@ describe("About flow page", () => {
   beforeAll(() => (initialState = getState()));
 
   beforeEach(() => {
-    getState().setUser(platformAdminUser);
+    setState({ user: platformAdminUser });
     server.use(...handlers);
   });
 
@@ -152,7 +152,7 @@ describe("About flow page", () => {
 
   it("is not editable if the user has the teamViewer role", async () => {
     const teamViewerUser = { ...platformAdminUser, isPlatformAdmin: false };
-    getState().setUser(teamViewerUser);
+    setState({ user: teamViewerUser });
 
     await setup(<About />);
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/auth.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/auth.ts
@@ -1,0 +1,94 @@
+import { CoreDomainClient } from "@opensystemslab/planx-core";
+import type { User } from "@opensystemslab/planx-core/types";
+import { getUser, logout } from "lib/api/auth/requests";
+import { clearCookie, setCookie } from "lib/cookie";
+import { client } from "lib/graphql";
+import { disconnectShareDB } from "pages/FlowEditor/lib/sharedb";
+import { type StateCreator } from "zustand";
+
+import type { SharedStore } from "./shared";
+
+export interface AuthStore {
+  authStatus: "idle" | "loading" | "authenticated" | "unauthenticated";
+  user: User | null;
+  jwt: string | null;
+
+  initAuthStore: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const authStore: StateCreator<
+  AuthStore & SharedStore,
+  [],
+  [],
+  AuthStore
+> = (set, get) => ({
+  authStatus: "idle",
+  user: null,
+  jwt: null,
+
+  initAuthStore: async () => {
+    if (get().authStatus === "authenticated") return;
+    if (get().authStatus === "loading") return;
+
+    set({ authStatus: "loading" });
+
+    // On local and Pizza environments, JWT is stored as a URL param due to restrictions on
+    // cross-domain cookies (we auth via planx.dev). On staging and production these cookies 
+    // are set via response headers from the API.
+    const url = new URL(window.location.href);
+    const jwtParam = url.searchParams.get("jwt");
+
+    if (jwtParam) {
+      setCookie("jwt", jwtParam);
+      setCookie("auth", JSON.stringify({ loggedIn: true }));
+
+      url.searchParams.delete("jwt");
+      window.history.replaceState({}, document.title, url.pathname + url.search);
+    }
+
+    try {
+      const result = await getUser();
+
+      if (!result) {
+        set({ authStatus: "unauthenticated", user: null, jwt: null });
+        return;
+      }
+
+      const { jwt, ...user } = result;
+      set({
+        authStatus: "authenticated",
+        user,
+        jwt,
+        $client: new CoreDomainClient({
+          targetURL: import.meta.env.VITE_APP_HASURA_URL!,
+          auth: { jwt },
+        }),
+      });
+    } catch (err) {
+      set({ authStatus: "unauthenticated", user: null, jwt: null });
+    }
+  },
+
+  logout: async () => {
+    await logout()
+
+    // Clean up client connections
+    disconnectShareDB();
+    await client.resetStore();
+
+    // Clear all client-side auth tokens
+    clearCookie("auth");
+    clearCookie("jwt");
+    localStorage.removeItem("jwt");
+
+    set({
+      authStatus: "unauthenticated",
+      user: null,
+      jwt: null,
+      $client: new CoreDomainClient({
+        targetURL: import.meta.env.VITE_APP_HASURA_URL!,
+      }),
+    });
+  },
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -39,7 +39,6 @@ import { getFlowDoc, subscribeToDoc } from "./../sharedb";
 import { type Store } from ".";
 import { NavigationStore } from "./navigation";
 import type { SharedStore } from "./shared";
-import { UserStore } from "./user";
 
 let doc: Doc;
 
@@ -325,7 +324,7 @@ export interface EditorStore extends Store.Store {
 }
 
 export const editorStore: StateCreator<
-  SharedStore & EditorStore & UserStore & NavigationStore,
+  SharedStore & EditorStore & NavigationStore,
   [],
   [],
   EditorStore

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -7,6 +7,7 @@ import {
 import { isPreviewOnlyDomain } from "utils/routeUtils/utils";
 import { create, StoreApi, UseBoundStore } from "zustand";
 
+import { AuthStore, authStore } from "./auth";
 import type { EditorStore, EditorUIStore } from "./editor";
 import { editorStore, editorUIStore } from "./editor";
 import type { NavigationStore } from "./navigation";
@@ -60,7 +61,7 @@ export type PublicStore = SharedStore &
   SettingsStore &
   TeamStore;
 
-export type FullStore = PublicStore & EditorStore & EditorUIStore & UserStore;
+export type FullStore = PublicStore & EditorStore & EditorUIStore & UserStore & AuthStore;
 
 /**
  * If accessing the public preview, don't load editor store files
@@ -88,6 +89,7 @@ const createFullStore = () => {
     ...settingsStore(...args),
     ...teamStore(...args),
     ...userStore(...args),
+    ...authStore(...args),
   }));
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -1,9 +1,7 @@
-import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { Role, Team, User, UserTeams } from "@opensystemslab/planx-core/types";
-import { getUser } from "lib/api/auth/requests";
 import type { StateCreator } from "zustand";
 
-import { EditorStore } from "./editor";
+import type { AuthStore } from "./auth";
 import { TeamStore } from "./team";
 
 export const getDisplayRole = (user: User): string => {
@@ -13,31 +11,17 @@ export const getDisplayRole = (user: User): string => {
 };
 
 export interface UserStore {
-  user?: User;
-  jwt?: string;
-
-  setUser: (user: User & { jwt: string }) => void;
   canUserEditTeam: (teamSlug: Team["slug"]) => boolean;
-  initUserStore: () => Promise<User>;
   getUserRoleForCurrentTeam: () => Role | undefined;
   getUserRole: () => string | undefined;
 }
 
 export const userStore: StateCreator<
-  UserStore & EditorStore & TeamStore,
+  UserStore & TeamStore & AuthStore,
   [],
   [],
   UserStore
-> = (set, get) => ({
-  setUser: ({ jwt, ...user }) => {
-    const authenticatedClient = new CoreDomainClient({
-      targetURL: import.meta.env.VITE_APP_HASURA_URL!,
-      auth: { jwt },
-    });
-    set({ $client: authenticatedClient });
-    set({ jwt, user });
-  },
-
+> = (_set, get) => ({
   canUserEditTeam(teamSlug) {
     const user = get().user;
     if (!user) return false;
@@ -46,19 +30,6 @@ export const userStore: StateCreator<
       team.role !== "teamViewer" && team.team.slug === teamSlug;
 
     return user.isPlatformAdmin || user.teams.some(canEditTeam);
-  },
-
-  async initUserStore() {
-    const { user, setUser } = get();
-    if (user) return user;
-
-    try {
-      const user = await getUser();
-      setUser(user);
-      return user;
-    } catch (error) {
-      throw Error("Failed to fetch user matching JWT cookie");
-    }
   },
 
   getUserRoleForCurrentTeam: () => {

--- a/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.tsx
@@ -108,10 +108,13 @@ const SaveAndReturn: React.FC<PropsWithChildren> = ({ children }) => {
   const matches = useMatches();
   const isContentPage = matches.some(
     (match) =>
-      "isContentPage" in match.context && match.context.isContentPage === true,
+      match?.context &&
+      "isContentPage" in match.context && 
+      match.context.isContentPage === true,
   );
   const isViewApplicationPage = matches.some(
     (match) =>
+      match?.context &&
       "isViewApplicationPage" in match.context &&
       match.context.isViewApplicationPage === true,
   );

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as authLogoutRouteImport } from './routes/(auth)/logout'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as PublicCustomDomainRouteRouteImport } from './routes/_public/_customDomain/route'
@@ -103,6 +104,11 @@ const SplatRoute = SplatRouteImport.update({
 } as any)
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authLogoutRoute = authLogoutRouteImport.update({
@@ -609,7 +615,7 @@ const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRoute =
   )
 
 export interface FileRoutesByFullPath {
-  '/': typeof PublicCustomDomainRouteRouteWithChildren
+  '/': typeof IndexRoute
   '/$': typeof SplatRoute
   '/app': typeof AuthenticatedAppRouteRouteWithChildren
   '/login': typeof authLoginRoute
@@ -695,7 +701,7 @@ export interface FileRoutesByFullPath {
   '/app/$team/$flow/nodes/$parent/nodes/$id/edit/$before': typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof PublicCustomDomainRouteRouteWithChildren
+  '/': typeof IndexRoute
   '/$': typeof SplatRoute
   '/login': typeof authLoginRoute
   '/logout': typeof authLogoutRoute
@@ -770,6 +776,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/$': typeof SplatRoute
   '/_authenticated/app': typeof AuthenticatedAppRouteRouteWithChildren
@@ -1020,6 +1027,7 @@ export interface FileRouteTypes {
     | '/app/$team/$flow/nodes/$parent/nodes/$id/edit/$before'
   id:
     | '__root__'
+    | '/'
     | '/_authenticated'
     | '/$'
     | '/_authenticated/app'
@@ -1109,6 +1117,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   SplatRoute: typeof SplatRoute
   PublicCustomDomainRouteRoute: typeof PublicCustomDomainRouteRouteWithChildren
@@ -1132,6 +1141,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(auth)/logout': {
@@ -2157,6 +2173,7 @@ const PublicPlanXDomainTeamFlowRouteRouteWithChildren =
   )
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   SplatRoute: SplatRoute,
   PublicCustomDomainRouteRoute: PublicCustomDomainRouteRouteWithChildren,

--- a/apps/editor.planx.uk/src/router.ts
+++ b/apps/editor.planx.uk/src/router.ts
@@ -1,34 +1,9 @@
 import { createRouter } from "@tanstack/react-router";
-import { getCookie, setCookie } from "lib/cookie";
 
 import { routeTree } from "./routeTree.gen";
 
-const hasJWT = (): boolean | void => {
-  // This cookie indicates the presence of the secure httpOnly "jwt" cookie
-  const authCookie = getCookie("auth");
-  if (authCookie) return true;
-
-  // If JWT not set via cookie, check search params
-  const jwtSearchParams = new URLSearchParams(window.location.search).get(
-    "jwt",
-  );
-  if (!jwtSearchParams) return false;
-
-  // Remove JWT from URL, and re-run this function
-  setCookie("jwt", jwtSearchParams);
-  setCookie("auth", JSON.stringify({ loggedIn: true }));
-  // Remove the jwt param from the URL
-  const url = new URL(window.location.href);
-  url.searchParams.delete("jwt");
-  window.history.replaceState({}, document.title, url.pathname + url.search);
-
-  // Return true to indicate authenticated state
-  return true;
-};
-
 export const router = createRouter({
   routeTree,
-  context: { currentUser: hasJWT() },
   scrollRestoration: true,
   defaultPendingMs: 0,
 });

--- a/apps/editor.planx.uk/src/routes/(auth)/logout.tsx
+++ b/apps/editor.planx.uk/src/routes/(auth)/logout.tsx
@@ -1,35 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { logout } from "lib/api/auth/requests";
-import { clearCookie } from "lib/cookie";
-import { disconnectShareDB } from "pages/FlowEditor/lib/sharedb";
-
-import { client } from "../../lib/graphql";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 export const Route = createFileRoute("/(auth)/logout")({
   beforeLoad: async () => {
-    try {
-      await logout();
-    } catch (error) {
-      // Non-blocking - API may fail due to expired tokens, still need to proceed to local cleanup
-      console.warn("Logout API call failed:", error);
-    }
-
-    // Clean up client-side state
-    try {
-      disconnectShareDB();
-      await client.resetStore();
-    } catch (err) {
-      console.error("Failed to cleanup client state:", err);
-    }
-
-    // Clear cookies
-    clearCookie("auth");
-    clearCookie("jwt");
-
-    // Clear localStorage
-    localStorage.removeItem("jwt");
-
-    // Must throw redirect to trigger navigation
+    await useStore.getState().logout();
     throw redirect({ to: "/login", search: {}, replace: true });
   },
 });

--- a/apps/editor.planx.uk/src/routes/__root.tsx
+++ b/apps/editor.planx.uk/src/routes/__root.tsx
@@ -1,14 +1,11 @@
-import { User } from "@opensystemslab/planx-core/types";
 import {
   createRootRouteWithContext,
   HeadContent,
   Outlet,
-  redirect,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { zodValidator } from "@tanstack/zod-adapter";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import ErrorFallback from "components/Error/ErrorFallback";
 import ErrorPage from "pages/ErrorPage/ErrorPage";
 import React from "react";
 import { createPortal } from "react-dom";
@@ -16,29 +13,15 @@ import { z } from "zod";
 
 import { CatchAllComponent } from "./$";
 
-interface RouterContext {
-  currentUser?: boolean | void;
-  user?: User;
-}
-
 // Search params schema for error handling and redirects
 const rootSearchSchema = z.object({
   error: z.string().optional(),
   redirectTo: z.string().optional(),
 });
 
-export const Route = createRootRouteWithContext<RouterContext>()({
+export const Route = createRootRouteWithContext()({
   validateSearch: zodValidator(rootSearchSchema),
   pendingComponent: DelayedLoadingIndicator,
-
-  beforeLoad: async ({ location }) => {
-    // Redirect authenticated users to the /app base route
-    if (location.pathname === "/") {
-      throw redirect({
-        to: "/app",
-      });
-    }
-  },
   errorComponent: ({ error }) => {
     if (
       error?.message?.includes("not found") ||

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
@@ -44,35 +44,23 @@ export const Route = createFileRoute("/_authenticated/app")({
   beforeLoad: async ({ location: { pathname } }) => {
     useStore.getState().setPreviewEnvironment("editor");
 
-    const isInitialSessionLoad = !useStore.getState().user;
+    const user = useStore.getState().user;
 
-    try {
-      const user = await useStore.getState().initUserStore();
+    // Handle default team redirect for initial session load
+    if (pathname === "/app" && user?.defaultTeamId) {
+      const defaultTeam = user.teams.find(
+        (t) => t.team.id === user.defaultTeamId,
+      );
 
-      if (isInitialSessionLoad && pathname === "/app" && user.defaultTeamId) {
-        const defaultTeam = user.teams.find(
-          (t) => t.team.id === user.defaultTeamId,
-        );
-
-        if (defaultTeam) {
-          throw redirect({
-            to: "/app/$team",
-            params: { team: defaultTeam.team.slug },
-          });
-        }
+      if (defaultTeam) {
+        throw redirect({
+          to: "/app/$team",
+          params: { team: defaultTeam.team.slug },
+        });
       }
-
-      return { user, isPublicRoute: false };
-    } catch (error) {
-      if (isRedirect(error)) throw error;
-
-      throw redirect({
-        to: "/login",
-        search: {
-          redirectTo: pathname !== "/app" ? pathname : undefined,
-        },
-      });
     }
+
+    return { user, isPublicRoute: false };
   },
   component: () => (
     <AuthenticatedLayout>

--- a/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
@@ -1,9 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 import { validateDomain } from "./-loader";
 
 export const Route = createFileRoute("/_authenticated")({
-  beforeLoad: validateDomain,
+  beforeLoad: async ({ location }) => {
+    validateDomain();
+
+    const { authStatus, initAuthStore } = useStore.getState();
+
+    if (authStatus === "idle") {
+      await initAuthStore();
+    }
+
+    if (useStore.getState().authStatus !== "authenticated") {
+      throw redirect({
+        to: "/login",
+        search: { redirectTo: location.pathname },
+        replace: true,
+      });
+    }
+  },
   head: () => ({
     meta: [
       {

--- a/apps/editor.planx.uk/src/routes/index.tsx
+++ b/apps/editor.planx.uk/src/routes/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, redirect } from "@tanstack/react-router"
+
+// Redirect authenticated users to the /app base route
+export const Route = createFileRoute("/")({
+  beforeLoad: () => {
+    throw redirect({
+      to: "/app",
+      replace: true,
+    })
+  },
+})


### PR DESCRIPTION
## What's the problem?
Auth state within the app is split across multiple sources truth. We're currently tracking and managing this in the following locations - 

- `UserStore` — we hold `user` and `jwt` properties which where initialised via `initUserStore()`
- `/_authenticated` route — this initUserStore() as its auth guard, via a domain validation loader
- `/logout` route — this directly called the API request `logout()`, cleared cookies, disconnected ShareDB, reset Apollo, then redirected 
- `hasJWT()` - helper function passed invoked as router context - the output of this is unused, but triggering it sets cookies and clears URL

This makes following (and fixing!) the auth lifecycle pretty challenging. The following two issues are the motivating factor behind this PR, and the catalyst to rationalise this code just now.

### Bug: logout produced a white screen after the TanStack Router migration
The logout route was protected by useLoggedInUserAuth middleware, which rejected expired tokens with a redirect. Expired tokens are a normal logout scenario — blocking them meant logout was broken for any user whose session had already expired.

### Bug: `httpOnly` JWT cookie not cleared client-side on logout
The JWT `httpOnly` cookie set by the API on login was never explicitly cleared on logout. We cleared auth and localStorage, but the `httpOnly` cookie persisted, leaving a revoked token in the browser. This isn't a security issue per-se as the partner `auth` cookie was removed (blocking the app from authenticating), and the JWT is block-listed on the DB, but it's better that we're removing this and following out the intent in the code.

## How did we get here?
Slowly I guess..! I think this has honestly accumulated over many PRs - originally this mostly lived within `App.tsx` as `hasJWT()` and as we've needed various features (expiry, logout, auth guards, JWT for new clients) it's spread and gotten a bit messy. The recent refactor to Tanstack Router has fragmented this even further.

## What's the solution?
All auth lifecycle logic has been moved into a single `authStore` Zustand slice, merged into the main store alongside the existing slices.

We now use a single `authStatus` variable (`"idle" | "loading" | "authenticated" | "unauthenticated"`) which can be referenced at any time - we don't need to infer this from the presence of a JWT, `User`, or failed `/user/me` request.

This should solve the issues listed above - auth state is clear and centralised, and the above bugs are resolved.

## Prior art
 - https://github.com/theopensystemslab/planx-new/pull/6448
 - https://github.com/theopensystemslab/planx-new/pull/6415