### PR TITLE
[infra] enforce short maxAge for CORS preflight requests

### DIFF
--- a/apps/api.planx.uk/cors.ts
+++ b/apps/api.planx.uk/cors.ts
@@ -22,6 +22,8 @@ const apiCors = cors({
   credentials: true,
   methods: "*",
   origin: checkAllowedOrigins,
+  // set maxAge to ensure cache for bad preflight requests does not persist for hours
+  maxAge: process.env.APP_ENVIRONMENT == "development" ? 300 : 600,
   allowedHeaders: [
     "Accept",
     "Authorization",


### PR DESCRIPTION
As per title - intended to mitigate the issue @jessicamcinchak had on staging which was resolved by clearing local browser cache. Preflight CORS requests can otherwise be cached for 2-24hrs depending on browser ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Max-Age)).

<img width="1642" height="172" alt="Screenshot from 2026-04-13 07-29-56" src="https://github.com/user-attachments/assets/c34993c1-9bfd-40e0-9b11-05f379c7ccac" />
<br></br>

See [Slack thread](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1776079192164519?thread_ts=1775828142.792299&cid=C01E3AC0C03) for more context.