### PR TITLE
refactor(api): Move 'welcome' template from codebase to Resend

### DIFF
--- a/apps/api.planx.uk/lib/resend/index.ts
+++ b/apps/api.planx.uk/lib/resend/index.ts
@@ -1,36 +1,23 @@
 import { Resend } from "resend";
-import {
-  templateRegistry,
-  type ResendTemplate,
-  type TemplateParams,
-} from "./templates/index.js";
+import type { ResendTemplate, TemplateRegistry } from "./templates/index.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const FROM_ADDRESS =
   process.env.RESEND_FROM_ADDRESS || "PlanX <no-reply@opensystemslab.io>";
 
-export const sendEmail = async (
-  payload: TemplateParams & { template: ResendTemplate },
+export const sendEmail = async <T extends ResendTemplate>(
+  templateName: T,
+  to: string,
+  variables: TemplateRegistry[T]["variables"],
 ): Promise<{ message: string }> => {
-  const {
-    template: templateName,
-    email,
-    firstName,
-    lastName,
-    isTrial,
-  } = payload;
-  const template = templateRegistry[templateName];
-
-  if (!template) {
-    throw new Error(`Undefined email template: ${templateName}`);
-  }
-
   const { error } = await resend.emails.send({
     from: FROM_ADDRESS,
-    to: email,
-    subject: template.subject,
-    html: template.html({ firstName, lastName, email, isTrial }),
+    to,
+    template: {
+      id: templateName,
+      variables,
+    },
   });
 
   if (error) {

--- a/apps/api.planx.uk/lib/resend/templates/index.ts
+++ b/apps/api.planx.uk/lib/resend/templates/index.ts
@@ -1,19 +1,15 @@
-import { welcomeTemplate } from "./welcome.js";
+import type { WelcomeTemplate } from "./welcome.js";
 
-export interface TemplateParams {
-  firstName: string;
-  lastName: string;
-  email: string;
-  isTrial?: boolean;
+export type EmailTemplate<
+  TTemplateName extends string,
+  TVariables extends Record<string, string | number>,
+> = {
+  id: TTemplateName;
+  variables: TVariables;
+};
+
+export interface TemplateRegistry {
+  welcome: WelcomeTemplate;
 }
 
-export interface EmailTemplate {
-  subject: string;
-  html: (params: TemplateParams) => string;
-}
-
-export const templateRegistry = {
-  welcome: welcomeTemplate,
-} as const satisfies Record<string, EmailTemplate>;
-
-export type ResendTemplate = keyof typeof templateRegistry;
+export type ResendTemplate = keyof TemplateRegistry;

--- a/apps/api.planx.uk/lib/resend/templates/welcome.ts
+++ b/apps/api.planx.uk/lib/resend/templates/welcome.ts
@@ -1,46 +1,9 @@
 import type { EmailTemplate } from "./index.js";
 
-export const welcomeTemplate: EmailTemplate = {
-  subject: "Welcome to PlanX",
-  html: ({ firstName, isTrial }) => `
-    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 16px; color: #37352f; font-size: 15px; line-height: 1.6;">
-      <h1>Welcome to the PlanX Editor, ${firstName}!</h1>
-      <p><strong>Subscription Status: ${isTrial ? "Trial" : "Active"}</strong></p>
-      <p>We're excited to have you on board!</p>
-      <p>This is where you can build, customise and manage your local digital services, receive submissions, and view analytics for your services.</p>
-
-      <h2>A few key things to know before you get started:</h2>
-
-      <ul style="padding-left: 16px;">
-        <li>
-          <strong>Staging vs Production:</strong> PlanX has two environments. Use <strong>Production</strong> (<a href="https://editor.planx.uk">editor.planx.uk</a>) to create and edit any content you want to keep. Use <strong>Staging</strong> (<a href="https://editor.planx.dev">editor.planx.dev</a>) to test services and integrations. <strong>Important:</strong> new content on staging is overwritten nightly with what's in production, so don't make lasting changes directly in staging or you will lose them overnight!
-        </li>
-        <li>
-          <strong>Resources:</strong> You can access guidance on creating, customising and managing your services directly from the Editor – under <strong>Resources</strong> – as well as on our <a href="https://www.notion.so/Plan-Resources-6b896f88be4c4b4c8ec8474a34c70d7c">Resources pages</a>.
-        </li>
-        <li>
-          <strong>Training:</strong> We run regular PlanX Academy Day sessions (both online and in person) on how to make the most of the PlanX Editor. Let us know if you'd like to join the next one.
-        </li>
-        <li>
-          <strong>Community &amp; Support:</strong> Connect with us on the ODP Slack:
-          <ul style="padding-left: 16px;">
-            <li><code>#planx-council-forum</code> – Your one stop shop for everything PlanX, general updates and community discussion</li>
-            <li><code>#help-issues-odp-products</code> – Ask questions, request help and report bugs</li>
-            <li><code>#planx-product-group</code> – Get access to early feature testing and input on the PlanX roadmap</li>
-            <li><code>#planx-services-group</code> – Collaborate with LPAs and our service design team on improving our service offering</li>
-          </ul>
-        </li>
-        <li>
-          <strong>Subscription Status:</strong> If your council is still going through PlanX procurement, your account will be on a trial. Trial accounts have access to all PlanX features but cannot turn services online. Full functionality is enabled once a contract is in place.
-        </li>
-      </ul>
-
-      <p>For any questions, you can always contact <a href="mailto:alkiviadis@opensystemslab.io">alkiviadis@opensystemslab.io</a> or <a href="mailto:silvia@opensystemslab.io">silvia@opensystemslab.io</a>.</p>
-
-      <p>Looking forward to working with you!</p>
-
-      <hr style="border: none; border-top: 1px solid #e3e2e0; margin: 20px 0;" />
-      <p style="color: #9b9a97; font-size: 13px;">Open Systems Lab</p>
-    </div>
-  `,
-};
+export type WelcomeTemplate = EmailTemplate<
+  "welcome",
+  {
+    firstName: string;
+    subscriptionStatus: "Active" | "Trial";
+  }
+>;

--- a/apps/api.planx.uk/modules/sendEmail/controller.ts
+++ b/apps/api.planx.uk/modules/sendEmail/controller.ts
@@ -14,6 +14,7 @@ import type {
 import { sendEmail } from "../../lib/resend/index.js";
 import { $api } from "../../client/index.js";
 import { gql } from "graphql-request";
+import type { TemplateRegistry } from "../../lib/resend/templates/index.js";
 
 export const singleApplicationEmailController: SingleApplicationEmail = async (
   _req,
@@ -92,9 +93,15 @@ export const resendEmailController: ResendEmail = async (_req, res, next) => {
       message: `Skipping ${template} email: APP_ENVIRONMENT is not production or test`,
     });
   }
+
   try {
     const isTrial = await getTeamIsTrial(payload.defaultTeamId);
-    const response = await sendEmail({ ...payload, template, isTrial });
+    const variables: TemplateRegistry["welcome"]["variables"] = {
+      firstName: payload.firstName,
+      subscriptionStatus: isTrial ? "Trial" : "Active",
+    };
+
+    const response = await sendEmail("welcome", payload.email, variables);
     return res.status(200).send(response);
   } catch (error) {
     return next(


### PR DESCRIPTION
## What does this PR do?
Currently, the "welcome" template lives as a HTML string within a `.ts` file within the codebase. If we need to make any changes, we need to get it through the local → pizza → staging → production pipeline.

This PR moves it to be a Resend-managed template - we can now update via the Resend web GUI (as we do with Notify).

## Motivation
I'm picking this up before https://github.com/theopensystemslab/planx-new/pull/6458 which adds a new template. This sets up some of the groundwork around types etc to make these easier to manage. This largely copies the current Notify `TemplateRegistry` pattern we already have in place.