### PR TITLE
feat: unarchive flow functionality

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -267,9 +267,6 @@ export interface EditorStore extends Store.Store {
   cutNode: (id: NodeId, parent: NodeId) => void;
   getCutNode: () => CutPayload | null;
   addNode: (node: any, relationships?: Relationships) => void;
-  archiveFlow: (
-    flow: FlowSummary,
-  ) => Promise<{ id: string; name: string } | void>;
   connect: (src: NodeId, tgt: NodeId, object?: any) => void;
   connectToFlow: (id: NodeId) => Promise<void>;
   disconnectFromFlow: () => void;
@@ -338,34 +335,6 @@ export const editorStore: StateCreator<
       { children, parent, before },
     )(get().flow);
     send(ops);
-  },
-
-  archiveFlow: async ({ id, slug }) => {
-    try {
-      const { data } = await client.mutate<{
-        flow: { id: string; name: string };
-      }>({
-        mutation: gql`
-          mutation updateFlow($id: uuid!, $slug: String!) {
-            flow: update_flows_by_pk(
-              pk_columns: { id: $id }
-              _set: { archived_at: "now()", status: offline, slug: $slug }
-            ) {
-              id
-              name
-            }
-          }
-        `,
-        variables: {
-          id,
-          slug: `${slug}-archived`,
-        },
-      });
-
-      return data?.flow;
-    } catch (error) {
-      throw Error("Failed to archive flow", { cause: error });
-    }
   },
 
   connect: (src, tgt, { before = undefined } = {}) => {

--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -14,25 +14,23 @@ import { FlowMenuProps, StyledSimpleMenu } from "./StyledSimpleMenu";
 
 const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
   flow,
-  refreshFlows,
   isAnyTemplate,
   variant = "card",
+  teamId, 
 }) => {
   type OpenFlowDialog = "archive" | "copy" | "rename" | "move";
   const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(null);
-  const [archiveFlow] = useArchiveFlow(flow.id, flow.slug);
+  const [archiveFlow] = useArchiveFlow(flow.id, flow.slug, teamId);
 
   const toast = useToast();
 
   const handleClose = () => {
     setOpenFlowDialog(null);
-    refreshFlows();
   };
 
 const handleArchive = async () => {
   try {
     await archiveFlow();
-    refreshFlows();
     toast.success("Archived flow");
   } catch (error) {
     toast.error(

--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -1,64 +1,37 @@
 import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import Box from "@mui/material/Box";
-import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useToast } from "hooks/useToast";
-import { useStore } from "pages/FlowEditor/lib/store";
-import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { useState } from "react";
 import SimpleMenu from "ui/editor/SimpleMenu";
 
 import { ArchiveDialog } from "./ArchiveDialog";
 import { CopyDialog } from "./CopyDialog";
+import { useArchiveFlow } from "./hooks/useArchiveFlow";
 import { MoveDialog } from "./MoveDialog";
 import { RenameDialog } from "./RenameDialog";
+import { FlowMenuProps, StyledSimpleMenu } from "./StyledSimpleMenu";
 
-export const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
-  display: "flex",
-  marginTop: "auto",
-  borderTop: `1px solid ${theme.palette.border.light}`,
-  backgroundColor: theme.palette.background.paper,
-  overflow: "hidden",
-  borderRadius: "0px 0px 4px 4px",
-  maxHeight: "35px",
-  "& > button": {
-    padding: theme.spacing(0.25, 1),
-    width: "100%",
-    justifyContent: "flex-start",
-    "& > svg": {
-      display: "none",
-    },
-  },
-}));
-
-interface Props {
-  flow: FlowSummary;
-  refreshFlows: () => void;
-  isAnyTemplate: boolean;
-  variant?: "card" | "table";
-}
-
-const FlowMenu: React.FC<Props> = ({
+const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
   flow,
   refreshFlows,
   isAnyTemplate,
   variant = "card",
 }) => {
-  type OpenDialog = "archive" | "copy" | "rename" | "move";
-  const [openDialog, setOpenDialog] = useState<OpenDialog | null>(null);
-
-  const archiveFlow = useStore((state) => state.archiveFlow);
+  type OpenFlowDialog = "archive" | "copy" | "rename" | "move";
+  const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(null);
+  const [archiveFlow] = useArchiveFlow(flow.id, flow.slug);
 
   const toast = useToast();
 
   const handleClose = () => {
-    setOpenDialog(null);
+    setOpenFlowDialog(null);
     refreshFlows();
   };
 
 const handleArchive = async () => {
   try {
-    await archiveFlow(flow);
+    await archiveFlow();
     refreshFlows();
     toast.success("Archived flow");
   } catch (error) {
@@ -66,45 +39,45 @@ const handleArchive = async () => {
       "We are unable to archive this flow, refesh and try again or contact an admin",
     );
   } finally {
-    setOpenDialog(null);
+    setOpenFlowDialog(null);
   }
 };
 
   const menuItems = [
     {
       label: "Rename",
-      onClick: () => setOpenDialog("rename"),
+      onClick: () => setOpenFlowDialog("rename"),
     },
     {
       label: "Make a copy",
-      onClick: () => setOpenDialog("copy"),
+      onClick: () => setOpenFlowDialog("copy"),
       disabled: isAnyTemplate,
     },
     {
       label: "Move",
-      onClick: () => setOpenDialog("move"),
+      onClick: () => setOpenFlowDialog("move"),
     },
     {
       label: "Archive",
-      onClick: () => setOpenDialog("archive"),
+      onClick: () => setOpenFlowDialog("archive"),
     },
   ];
 
   return (
     <>
-      {openDialog === "archive" && (
+      {openFlowDialog === "archive" && (
         <ArchiveDialog
           title={`Archive "${flow.name}"`}
-          open={openDialog === "archive"}
-          content={`Are you sure you want to archive "${flow.name}"? Once archived, a flow is no longer able to be viewed in the editor and can only be restored by a developer.`}
+          open={openFlowDialog === "archive"}
+          content={`Are you sure you want to archive "${flow.name}"? Once archived, a flow is no longer able to be viewed in the editor.`}
           handleClose={handleClose}
           onConfirm={handleArchive}
           submitLabel="Archive this flow"
         />
       )}
-      {openDialog === "copy" && (
+      {openFlowDialog === "copy" && (
         <CopyDialog
-          isDialogOpen={openDialog === "copy"}
+          isDialogOpen={openFlowDialog === "copy"}
           handleClose={handleClose}
           sourceFlow={{
             name: flow.name,
@@ -113,9 +86,9 @@ const handleArchive = async () => {
           }}
         />
       )}
-      {openDialog === "rename" && (
+      {openFlowDialog === "rename" && (
         <RenameDialog
-          isDialogOpen={openDialog === "rename"}
+          isDialogOpen={openFlowDialog === "rename"}
           handleClose={handleClose}
           flow={{
             name: flow.name,
@@ -124,9 +97,9 @@ const handleArchive = async () => {
           }}
         />
       )}
-      {openDialog === "move" && (
+      {openFlowDialog === "move" && (
         <MoveDialog
-          isDialogOpen={openDialog === "move"}
+          isDialogOpen={openFlowDialog === "move"}
           handleClose={handleClose}
           sourceFlow={{
             name: flow.name,
@@ -152,4 +125,4 @@ const handleArchive = async () => {
   );
 };
 
-export default FlowMenu;
+export default ActiveFlowMenu;

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -23,7 +23,6 @@ type Props = {
   ) => void;
   teamId: number;
   slug: string;
-  fetchFlows: () => void;
 };
 
 const Archive: React.FC<Props> = ({
@@ -31,7 +30,6 @@ const Archive: React.FC<Props> = ({
   handleViewChange,
   teamId,
   slug,
-  fetchFlows,
 }) => {
   const { data: archivedFlowsData, loading, error } = useGetArchivedFlows(teamId);
   const archivedFlows = archivedFlowsData?.flows ?? null;
@@ -111,7 +109,6 @@ const Archive: React.FC<Props> = ({
                   flow={flow}
                   flows={archivedFlows}
                   key={flow.slug}
-                  refreshFlows={fetchFlows}
                   view={"archive"}
                 />
               ))}
@@ -121,7 +118,6 @@ const Archive: React.FC<Props> = ({
               flows={archivedFlows}
               teamId={teamId}
               teamSlug={slug}
-              refreshFlows={fetchFlows}
               view={"archive"}
             />
           )}

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -10,10 +10,11 @@ import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 import { FlowCardView } from "../../FlowEditor/lib/store/editor";
 import { FlowTable } from "../components/FlowTable";
 import { ShowingServicesHeader } from "../components/ShowingServicesHeader";
-import { useGetArchivedFlows } from "../helpers/useGetArchivedFlows";
 import { DashboardList } from "./DashboardList";
 import FlowCard from "./FlowCard";
-import { StyledToggleButton } from "./StyledToggleButton"
+import { useGetArchivedFlows } from "./hooks/useGetArchivedFlows";
+import { StyledToggleButton } from "./StyledToggleButton";
+
 type Props = {
   flowCardView: FlowCardView;
   handleViewChange: (
@@ -111,7 +112,7 @@ const Archive: React.FC<Props> = ({
                   flows={archivedFlows}
                   key={flow.slug}
                   refreshFlows={fetchFlows}
-                  showDetails={false}
+                  view={"archive"}
                 />
               ))}
             </DashboardList>
@@ -121,7 +122,7 @@ const Archive: React.FC<Props> = ({
               teamId={teamId}
               teamSlug={slug}
               refreshFlows={fetchFlows}
-              showDetails={false}
+              view={"archive"}
             />
           )}
         </>

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -1,0 +1,79 @@
+import MoreHoriz from "@mui/icons-material/MoreHoriz";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { useToast } from "hooks/useToast";
+import React, { useState } from "react";
+import SimpleMenu from "ui/editor/SimpleMenu";
+
+import { ArchiveDialog } from "./ArchiveDialog";
+import { useUnarchiveFlow } from "./hooks/useUnarchiveFlow";
+import { FlowMenuProps } from "./StyledSimpleMenu";
+import { StyledSimpleMenu } from "./StyledSimpleMenu";
+
+const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
+    flow,
+    refreshFlows,
+    variant = "card",
+}) => {
+    type OpenFlowDialog = "unarchive";
+    const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(null);
+    const unarchivedSlug = flow.slug.replace("-archive", "");
+    const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug);
+
+    const toast = useToast();
+
+    const handleClose = () => {
+        setOpenFlowDialog(null);
+        refreshFlows();
+        }; // TODO: this is repetitive, refactor? 
+
+    const handleUnarchive = async () => {
+        try {
+            await unarchiveFlow();
+            refreshFlows();
+            toast.success("Unarchived flow");
+        } catch (error) {
+            toast.error(
+            "We are unable to unarchive this flow, refesh and try again or contact an admin",
+            );
+        } finally {
+            setOpenFlowDialog(null);
+        }
+        };
+
+    const menuItems = [
+        {
+        label: "Unarchive",
+        onClick: () => setOpenFlowDialog("unarchive"),
+        },
+    ];
+
+return (
+    <>
+      {openFlowDialog === "unarchive" && (
+        <ArchiveDialog
+          title={`Unarchive "${flow.name}"`}
+          open={openFlowDialog === "unarchive"}
+          content={`Are you sure you want to unarchive "${flow.name}"?`}
+          handleClose={handleClose}
+          onConfirm={handleUnarchive}
+          submitLabel="Unarchive this flow"
+        />
+      )}
+
+      {variant === "card" ? (
+        <StyledSimpleMenu items={menuItems}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.2 }}>
+            <MoreHoriz sx={{ fontSize: "1.4em" }} />
+            <Typography variant="body2" fontSize="small">
+              <strong>Menu</strong>
+            </Typography>
+          </Box>
+        </StyledSimpleMenu>
+      ) : (
+        <SimpleMenu items={menuItems} />
+      )}
+    </>
+)};
+
+export default ArchivedFlowMenu;

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -24,7 +24,7 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
 
     const handleClose = () => {
         setOpenFlowDialog(null);
-        }; // TODO: this is repetitive, refactor? 
+        };
 
     const handleUnarchive = async () => {
         try {

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -12,25 +12,23 @@ import { StyledSimpleMenu } from "./StyledSimpleMenu";
 
 const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
     flow,
-    refreshFlows,
     variant = "card",
+    teamId,
 }) => {
     type OpenFlowDialog = "unarchive";
     const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(null);
     const unarchivedSlug = flow.slug.replace("-archive", "");
-    const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug);
+    const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
 
     const toast = useToast();
 
     const handleClose = () => {
         setOpenFlowDialog(null);
-        refreshFlows();
         }; // TODO: this is repetitive, refactor? 
 
     const handleUnarchive = async () => {
         try {
             await unarchiveFlow();
-            refreshFlows();
             toast.success("Unarchived flow");
         } catch (error) {
             toast.error(

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -24,14 +24,14 @@ import {
 interface Props {
   flow: FlowSummary;
   flows: FlowSummary[];
-  refreshFlows: () => void;
   view: FlowView;
 }
 
-const FlowCard: React.FC<Props> = ({ flow, refreshFlows, view }) => {
-  const [canUserEditTeam, teamSlug] = useStore((state) => [
+const FlowCard: React.FC<Props> = ({ flow, view }) => {
+  const [canUserEditTeam, teamSlug, teamId] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
+    state.teamId
   ]);
 
   const {
@@ -121,17 +121,17 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, view }) => {
       {canUserEditTeam(teamSlug) && view === "flows" && (
         <ActiveFlowMenu
           flow={flow}
-          refreshFlows={refreshFlows}
           isAnyTemplate={isAnyTemplate}
           variant="card"
+          teamId={teamId}
         />
       )}
       {canUserEditTeam(teamSlug) && view === "archive" && (
         <ArchivedFlowMenu
           flow={flow}
-          refreshFlows={refreshFlows}
           isAnyTemplate={isAnyTemplate}
           variant="card"
+          teamId={teamId}
         />
       )}
     </Card>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import { FlowView } from "pages/Team";
 import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType } from "ui/editor/FlowTag/types";
@@ -7,7 +8,8 @@ import TruncatedText from "ui/editor/TruncatedText";
 
 import { useStore } from "../../../FlowEditor/lib/store";
 import { FlowSummary } from "../../../FlowEditor/lib/store/editor";
-import FlowMenu from "../FlowMenu";
+import ActiveFlowMenu from "../ActiveFlowMenu";
+import ArchivedFlowMenu from "../ArchivedFlowMenu";
 import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
@@ -23,10 +25,10 @@ interface Props {
   flow: FlowSummary;
   flows: FlowSummary[];
   refreshFlows: () => void;
-  showDetails: boolean;
+  view: FlowView;
 }
 
-const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
+const FlowCard: React.FC<Props> = ({ flow, refreshFlows, view }) => {
   const [canUserEditTeam, teamSlug] = useStore((state) => [
     state.canUserEditTeam,
     state.teamSlug,
@@ -81,7 +83,7 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
             </Typography>
             <LinkSubText>{displayFormatted}</LinkSubText>
           </Box>
-          {showDetails && (
+          {view === "flows" && (
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
               {displayTags
                 .filter((tag) => tag.shouldAddTag)
@@ -106,7 +108,7 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
               {flow.summary}
             </TruncatedText>
           )}
-          {showDetails && (
+          {view === "flows" && (
             <FlowCardLink
               to="/app/$team/$flow"
               params={{ team: teamSlug, flow: flow.slug }}
@@ -116,8 +118,16 @@ const FlowCard: React.FC<Props> = ({ flow, refreshFlows, showDetails }) => {
           )}
         </CardContent>
       </Box>
-      {canUserEditTeam(teamSlug) && showDetails && (
-        <FlowMenu
+      {canUserEditTeam(teamSlug) && view === "flows" && (
+        <ActiveFlowMenu
+          flow={flow}
+          refreshFlows={refreshFlows}
+          isAnyTemplate={isAnyTemplate}
+          variant="card"
+        />
+      )}
+      {canUserEditTeam(teamSlug) && view === "archive" && (
+        <ArchivedFlowMenu
           flow={flow}
           refreshFlows={refreshFlows}
           isAnyTemplate={isAnyTemplate}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -31,14 +31,12 @@ interface FlowTableProps {
   flows: FlowSummary[];
   teamId: number;
   teamSlug: string;
-  refreshFlows: () => void;
   view: FlowView;
 }
 
 export const FlowTable: React.FC<FlowTableProps> = ({
   flows,
   teamSlug,
-  refreshFlows,
   view,
 }) => {
   const { headerText } = useFlowSortDisplay();
@@ -64,7 +62,6 @@ export const FlowTable: React.FC<FlowTableProps> = ({
             key={flow.slug}
             flow={flow}
             teamSlug={teamSlug}
-            refreshFlows={refreshFlows}
             view={view}
           />
         ))}
@@ -76,17 +73,15 @@ export const FlowTable: React.FC<FlowTableProps> = ({
 interface FlowTableRowProps {
   flow: FlowSummary;
   teamSlug: string;
-  refreshFlows: () => void;
   view: FlowView;
 }
 
 const FlowTableRow: React.FC<FlowTableRowProps> = ({
   flow,
   teamSlug,
-  refreshFlows,
   view,
 }) => {
-  const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
+  const [canUserEditTeam, teamId] = useStore((state) => [state.canUserEditTeam, state.teamId]);
 
   const {
     isSubmissionService,
@@ -177,17 +172,17 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
             {view === "flows" && (
               <ActiveFlowMenu
                 flow={flow}
-                refreshFlows={refreshFlows}
                 isAnyTemplate={isAnyTemplate}
                 variant="table"
+                teamId={teamId}
               />
             )}
 
             {view === "archive" && (
               <ArchivedFlowMenu
                 flow={flow}
-                refreshFlows={refreshFlows}
                 variant="table"
+                teamId={teamId}
               />
             )}
           </FlowActionsCell>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -4,13 +4,15 @@ import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import { FlowView } from "pages/Team";
 import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType } from "ui/editor/FlowTag/types";
 import TruncatedText from "ui/editor/TruncatedText";
 
 import { useStore } from "../../../FlowEditor/lib/store";
-import FlowMenu from "../FlowMenu";
+import ActiveFlowMenu from "../ActiveFlowMenu";
+import ArchivedFlowMenu from "../ArchivedFlowMenu";
 import { FlowTemplateIndicator } from "../FlowTemplateIndicator";
 import { useFlowDates } from "../hooks/useFlowDates";
 import { useFlowMetadata } from "../hooks/useFlowMetadata";
@@ -30,14 +32,14 @@ interface FlowTableProps {
   teamId: number;
   teamSlug: string;
   refreshFlows: () => void;
-  showDetails: boolean;
+  view: FlowView;
 }
 
 export const FlowTable: React.FC<FlowTableProps> = ({
   flows,
   teamSlug,
   refreshFlows,
-  showDetails,
+  view,
 }) => {
   const { headerText } = useFlowSortDisplay();
 
@@ -46,14 +48,14 @@ export const FlowTable: React.FC<FlowTableProps> = ({
       <StyledTableHead>
         <TableRow>
           <FlowTitleCell>Flow title</FlowTitleCell>
-          {showDetails && (
+          {view === "flows" && (
             <>
               <FlowStatusCell>Online status</FlowStatusCell>
               <FlowStatusCell>Flow type</FlowStatusCell>
               <TableCell>{headerText}</TableCell>
-              <FlowActionsCell align="center">Actions</FlowActionsCell>
             </>
           )}
+          <FlowActionsCell align="center">Actions</FlowActionsCell>
         </TableRow>
       </StyledTableHead>
       <TableBody>
@@ -63,7 +65,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
             flow={flow}
             teamSlug={teamSlug}
             refreshFlows={refreshFlows}
-            showDetails={showDetails}
+            view={view}
           />
         ))}
       </TableBody>
@@ -75,14 +77,14 @@ interface FlowTableRowProps {
   flow: FlowSummary;
   teamSlug: string;
   refreshFlows: () => void;
-  showDetails: boolean;
+  view: FlowView;
 }
 
 const FlowTableRow: React.FC<FlowTableRowProps> = ({
   flow,
   teamSlug,
   refreshFlows,
-  showDetails,
+  view,
 }) => {
   const [canUserEditTeam] = useStore((state) => [state.canUserEditTeam]);
 
@@ -95,9 +97,10 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   } = useFlowMetadata(flow);
 
   const { displayTimeAgo, displayActor } = useFlowDates(flow);
+  const isRowLinkActive = view === "flows" ? true : false;
 
   return (
-    <StyledTableRow isTemplated={isAnyTemplate} clickable={showDetails}>
+    <StyledTableRow isTemplated={isAnyTemplate} clickable={isRowLinkActive}>
       <FlowTitleCell>
         <Box>
           {isAnyTemplate && (
@@ -112,7 +115,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           <Typography variant="h4" component="span">
             {flow.name}
           </Typography>
-          {showDetails && (
+          {view === "flows" && (
             <FlowRowLink
               to="/app/$team/$flow"
               params={{ team: teamSlug, flow: flow.slug }}
@@ -132,7 +135,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           )}
         </Box>
       </FlowTitleCell>
-      {showDetails && (
+      {view === "flows" && (
         <>
           <FlowStatusCell>
             <Box sx={{ display: "inline-flex" }}>
@@ -162,16 +165,28 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               )}
             </Box>
           </TableCell>
+          </>
+        )}
+        {canUserEditTeam(teamSlug) && (
+          <>
           <FlowActionsCell
             className="actions-cell"
             align="center"
             onClick={(e) => e.stopPropagation()}
           >
-            {canUserEditTeam(teamSlug) && (
-              <FlowMenu
+            {view === "flows" && (
+              <ActiveFlowMenu
                 flow={flow}
                 refreshFlows={refreshFlows}
                 isAnyTemplate={isAnyTemplate}
+                variant="table"
+              />
+            )}
+
+            {view === "archive" && (
+              <ArchivedFlowMenu
+                flow={flow}
+                refreshFlows={refreshFlows}
                 variant="table"
               />
             )}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -14,6 +14,7 @@ export const StyledTable = styled(Table)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   borderBottom: 0,
   borderCollapse: "separate",
+  tableLayout: "fixed",
   [`& .${tableCellClasses.root}`]: {
     padding: theme.spacing(1.5, 2),
     borderBottom: `1px solid ${theme.palette.border.main}`,
@@ -80,7 +81,7 @@ export const FlowRowLink = styled(CustomLink)(() => ({
 })) as typeof CustomLink;
 
 export const FlowTitleCell = styled(TableCell)(() => ({
-  width: "45%",
+  width: "auto",
   minWidth: "240px",
 }));
 
@@ -90,7 +91,7 @@ export const FlowStatusCell = styled(TableCell)(() => ({
 }));
 
 export const FlowActionsCell = styled(TableCell)(({ theme }) => ({
-  width: "5%",
+  width: "100px",
   maxWidth: "100px",
   backgroundColor: theme.palette.background.paper,
   borderLeft: `1px solid ${theme.palette.border.main}`,

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -42,7 +42,6 @@ type Props = {
   sortedFlows: FlowSummary[] | null;
   sortOptions: SortableFields<FlowSummary>[];
   flowCardView: FlowCardView;
-  fetchFlows: () => void;
   teamId: number;
   flows: FlowSummary[] | null;
   handleViewChange: (
@@ -59,7 +58,6 @@ const Flows: React.FC<Props> = ({
   sortedFlows,
   sortOptions,
   flowCardView,
-  fetchFlows,
   teamId,
   handleViewChange,
   slug,
@@ -152,7 +150,6 @@ const Flows: React.FC<Props> = ({
                     flow={flow}
                     flows={sortedFlows}
                     key={flow.slug}
-                    refreshFlows={fetchFlows}
                     view={"flows"}
                   />
                 ))}
@@ -162,7 +159,6 @@ const Flows: React.FC<Props> = ({
                 flows={sortedFlows}
                 teamId={teamId}
                 teamSlug={slug}
-                refreshFlows={fetchFlows}
                 view={"flows"}
               />
             )}

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -153,7 +153,7 @@ const Flows: React.FC<Props> = ({
                     flows={sortedFlows}
                     key={flow.slug}
                     refreshFlows={fetchFlows}
-                    showDetails={true}
+                    view={"flows"}
                   />
                 ))}
               </DashboardList>
@@ -163,7 +163,7 @@ const Flows: React.FC<Props> = ({
                 teamId={teamId}
                 teamSlug={slug}
                 refreshFlows={fetchFlows}
-                showDetails={true}
+                view={"flows"}
               />
             )}
           </>

--- a/apps/editor.planx.uk/src/pages/Team/components/StyledSimpleMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/StyledSimpleMenu.tsx
@@ -4,9 +4,9 @@ import SimpleMenu from "ui/editor/SimpleMenu";
 
 export interface FlowMenuProps {
   flow: FlowSummary;
-  refreshFlows: () => void;
   isAnyTemplate?: boolean;
   variant?: "card" | "table";
+  teamId: number;
 }
 
 export const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/pages/Team/components/StyledSimpleMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/StyledSimpleMenu.tsx
@@ -1,0 +1,28 @@
+import { styled } from "@mui/material/styles";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import SimpleMenu from "ui/editor/SimpleMenu";
+
+export interface FlowMenuProps {
+  flow: FlowSummary;
+  refreshFlows: () => void;
+  isAnyTemplate?: boolean;
+  variant?: "card" | "table";
+}
+
+export const StyledSimpleMenu = styled(SimpleMenu)(({ theme }) => ({
+  display: "flex",
+  marginTop: "auto",
+  borderTop: `1px solid ${theme.palette.border.light}`,
+  backgroundColor: theme.palette.background.paper,
+  overflow: "hidden",
+  borderRadius: "0px 0px 4px 4px",
+  maxHeight: "35px",
+  "& > button": {
+    padding: theme.spacing(0.25, 1),
+    width: "100%",
+    justifyContent: "flex-start",
+    "& > svg": {
+      display: "none",
+    },
+  },
+}));

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
@@ -4,9 +4,15 @@ import {
   ARCHIVE_FLOW,
   ArchiveFlowQuery,
   ArchiveFlowQueryVars,
+  GET_ARCHIVED_FLOWS,
+  GET_FLOWS,
 } from "../../queries";
 
-export const useArchiveFlow = (id: string, slug: string) =>
+export const useArchiveFlow = (id: string, slug: string, teamId: number) =>
   useMutation<ArchiveFlowQuery, ArchiveFlowQueryVars>(ARCHIVE_FLOW, {
     variables: { id, slug: `${slug}-archive` },
+    refetchQueries: [
+      { query: GET_FLOWS, variables: { teamId } },
+      { query: GET_ARCHIVED_FLOWS, variables: { teamId } },
+    ],
   });

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@apollo/client";
+
+import {
+  ARCHIVE_FLOW,
+  ArchiveFlowQuery,
+  ArchiveFlowQueryVars,
+} from "../../queries";
+
+export const useArchiveFlow = (id: string, slug: string) =>
+  useMutation<ArchiveFlowQuery, ArchiveFlowQueryVars>(ARCHIVE_FLOW, {
+    variables: { id, slug: `${slug}-archive` },
+  });

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetArchivedFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetArchivedFlows.ts
@@ -4,7 +4,7 @@ import {
   GET_ARCHIVED_FLOWS,
   GetArchivedFlowsQuery,
   GetArchivedFlowsVars,
-} from "../queries";
+} from "../../queries";
 
 export const useGetArchivedFlows = (teamId: number) =>
   useQuery<GetArchivedFlowsQuery, GetArchivedFlowsVars>(GET_ARCHIVED_FLOWS, {

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
@@ -9,5 +9,5 @@ import {
 export const useGetFlows = (teamId: number) =>
   useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_FLOWS, {
     variables: { teamId },
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: "cache-first",
   });

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
@@ -1,13 +1,13 @@
 import { useQuery } from "@apollo/client";
 
 import {
-  GET_ARCHIVED_FLOWS,
+  GET_FLOWS,
   GetAnyFlowsQuery,
   GetAnyFlowsVars,
 } from "../../queries";
 
-export const useGetArchivedFlows = (teamId: number) =>
-  useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_ARCHIVED_FLOWS, {
+export const useGetFlows = (teamId: number) =>
+  useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_FLOWS, {
     variables: { teamId },
     fetchPolicy: "cache-and-network",
   });

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useUnarchiveFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useUnarchiveFlow.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@apollo/client";
+
+import {
+  UNARCHIVE_FLOW,
+  UnarchiveFlowQuery,
+  UnarchiveFlowQueryVars,
+} from "../../queries";
+
+export const useUnarchiveFlow = (id: string, slug: string) =>
+  useMutation<UnarchiveFlowQuery, UnarchiveFlowQueryVars>(UNARCHIVE_FLOW, {
+    variables: { id, slug },
+  });

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useUnarchiveFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useUnarchiveFlow.ts
@@ -1,12 +1,18 @@
 import { useMutation } from "@apollo/client";
 
 import {
+  GET_ARCHIVED_FLOWS,
+  GET_FLOWS,
   UNARCHIVE_FLOW,
   UnarchiveFlowQuery,
   UnarchiveFlowQueryVars,
 } from "../../queries";
 
-export const useUnarchiveFlow = (id: string, slug: string) =>
+export const useUnarchiveFlow = (id: string, slug: string, teamId: number) =>
   useMutation<UnarchiveFlowQuery, UnarchiveFlowQueryVars>(UNARCHIVE_FLOW, {
     variables: { id, slug },
+    refetchQueries: [
+      { query: GET_FLOWS, variables: { teamId } },
+      { query: GET_ARCHIVED_FLOWS, variables: { teamId } },
+    ],
   });

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography";
 import { useSearch } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { isEmpty, orderBy } from "lodash";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { InfoChip } from "ui/editor/InfoChip";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
@@ -15,6 +15,7 @@ import Archive from "./components/Archive";
 import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
+import { useGetFlows } from "./components/hooks/useGetFlows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
 
@@ -40,20 +41,20 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
   const [
     { id: teamId, slug },
     canUserEditTeam,
-    getFlows,
     isTrial,
     flowCardView,
     setFlowCardView,
   ] = useStore((state) => [
     state.getTeam(),
     state.canUserEditTeam,
-    state.getFlows,
     state.teamSettings?.isTrial,
     state.flowCardView,
     state.setFlowCardView,
   ]);
 
-  const [flows, setFlows] = useState<FlowSummary[] | null>(initialFlows);
+  const { data } = useGetFlows(teamId);
+  const flows = data?.flows ?? null;
+
   const [flowView, setFlowView] = useState<FlowView>("flows");
 
   const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(
@@ -133,13 +134,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
     }
   };
 
-  const fetchFlows = useCallback(() => {
-    getFlows(teamId).then((flows) => {
-      // Copy the array and sort by most recently edited desc using last associated operation.createdAt, not flow.updatedAt
-      setFlows(flows);
-    });
-  }, [teamId, setFlows, getFlows]);
-
   useEffect(() => {
     if (shouldClearSearch) {
       setShouldClearSearch(false);
@@ -200,7 +194,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             sortedFlows={sortedFlows}
             sortOptions={sortOptions}
             flowCardView={flowCardView}
-            fetchFlows={fetchFlows}
             teamId={teamId}
             flows={flows}
             handleViewChange={handleViewChange}
@@ -213,7 +206,6 @@ const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
             handleViewChange={handleViewChange}
             teamId={teamId}
             slug={slug}
-            fetchFlows={fetchFlows}
           />
         )}
 

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -33,11 +33,7 @@ const GetStarted: React.FC = () => (
   </DashboardList>
 );
 
-interface TeamProps {
-  flows: FlowSummary[];
-}
-
-const Team: React.FC<TeamProps> = ({ flows: initialFlows }) => {
+const Team: React.FC = () => {
   const [
     { id: teamId, slug },
     canUserEditTeam,

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -15,7 +15,6 @@ import Archive from "./components/Archive";
 import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
-import { useGetArchivedFlows } from "./components/hooks/useGetArchivedFlows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
 

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -15,6 +15,7 @@ import Archive from "./components/Archive";
 import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
+import { useGetArchivedFlows } from "./components/hooks/useGetArchivedFlows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
 

--- a/apps/editor.planx.uk/src/pages/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/queries.ts
@@ -52,6 +52,27 @@ export type GetArchivedFlowsVars = {
   teamId: number;
 };
 
+export const ARCHIVE_FLOW = gql`
+  mutation ArchiveFlow($id: uuid!, $slug: String!) {
+    flow: update_flows_by_pk(pk_columns: {id: $id}, _set: {archived_at: "now()", status: offline, slug: $slug}) {
+      id
+      name
+    }
+  }
+`
+
+export type ArchiveFlowQuery = {
+  flow: {
+    id: string;
+    name: string; 
+  }
+}
+
+export type ArchiveFlowQueryVars = {
+  id: string; 
+  slug: string;
+}
+
 export const UNARCHIVE_FLOW = gql`
   mutation UnarchiveFlow($id: uuid!, $slug: String!) {
     flow: update_flows_by_pk(pk_columns: {id: $id}, _set: {archived_at: null, slug: $slug}) {
@@ -64,7 +85,7 @@ export const UNARCHIVE_FLOW = gql`
 export type UnarchiveFlowQuery = {
   flow: {
     id: string;
-    name: string; 
+    slug: string; 
   }
 }
 

--- a/apps/editor.planx.uk/src/pages/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/queries.ts
@@ -51,3 +51,24 @@ export type GetArchivedFlowsQuery = {
 export type GetArchivedFlowsVars = {
   teamId: number;
 };
+
+export const UNARCHIVE_FLOW = gql`
+  mutation UnarchiveFlow($id: uuid!, $slug: String!) {
+    flow: update_flows_by_pk(pk_columns: {id: $id}, _set: {archived_at: null, slug: $slug}) {
+      id
+      name
+    }
+  }
+`
+
+export type UnarchiveFlowQuery = {
+  flow: {
+    id: string;
+    name: string; 
+  }
+}
+
+export type UnarchiveFlowQueryVars = {
+  id: string; 
+  slug: string;
+}

--- a/apps/editor.planx.uk/src/pages/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/queries.ts
@@ -1,6 +1,49 @@
 import { gql } from "@apollo/client";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 
+export const GET_FLOWS = gql`
+  query GetFlows($teamId: Int!) {
+    flows(
+      where: {
+        team: { id: { _eq: $teamId } }
+        archived_at: { _is_null: true }
+      }
+    ) {
+      id
+      name
+      slug
+      status
+      summary
+      updatedAt: updated_at
+      isListedOnLPS: is_listed_on_lps
+      operations(limit: 1, order_by: { created_at: desc }) {
+        createdAt: created_at
+        actor {
+          firstName: first_name
+          lastName: last_name
+        }
+      }
+      templatedFrom: templated_from
+      isTemplate: is_template
+      template {
+        team {
+          id
+          name
+        }
+      }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        publishedAt: created_at
+        hasSendComponent: has_send_component
+        hasVisiblePayComponent: has_pay_component
+        hasEnabledServiceCharge: service_charge_enabled
+      }
+    }
+  }
+`
+
 export const GET_ARCHIVED_FLOWS = gql`
   query GetArchivedFlows($teamId: Int!) {
     flows(
@@ -44,11 +87,11 @@ export const GET_ARCHIVED_FLOWS = gql`
   }
 `;
 
-export type GetArchivedFlowsQuery = {
+export type GetAnyFlowsQuery = {
   flows: FlowSummary[];
 };
 
-export type GetArchivedFlowsVars = {
+export type GetAnyFlowsVars = {
   teamId: number;
 };
 
@@ -77,7 +120,7 @@ export const UNARCHIVE_FLOW = gql`
   mutation UnarchiveFlow($id: uuid!, $slug: String!) {
     flow: update_flows_by_pk(pk_columns: {id: $id}, _set: {archived_at: null, slug: $slug}) {
       id
-      name
+      slug
     }
   }
 `

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
@@ -46,7 +46,7 @@ export const Route = createFileRoute("/_authenticated/app/$team/")({
 });
 
 function TeamComponent() {
-  const { flows } = Route.useLoaderData();
+  Route.useLoaderData();
 
-  return <Team flows={flows} />;
+  return <Team />;
 }

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -460,9 +460,7 @@ update_permissions:
         - summary
         - team_id
         - templated_from
-      filter:
-        archived_at:
-          _is_null: true
+      filter: {}
       check:
         _not:
           _and:
@@ -509,8 +507,6 @@ update_permissions:
                       _eq: x-hasura-user-id
                   - role:
                       _eq: teamEditor
-          - archived_at:
-              _is_null: true
           - is_template:
               _eq: false
       check:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
@@ -50,6 +50,7 @@ insert_permissions:
         - email
         - first_name
         - id
+        - is_analyst
         - is_platform_admin
         - is_staging_only
         - last_name

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
@@ -50,7 +50,6 @@ insert_permissions:
         - email
         - first_name
         - id
-        - is_analyst
         - is_platform_admin
         - is_staging_only
         - last_name


### PR DESCRIPTION
Still feature flagged!

In sum, creates unarchive functionality in the `Archive` view:

https://github.com/user-attachments/assets/d8acf83d-1b8c-424d-a546-a8ee2fceac6a

More specifically: 
- Creates an `ARCHIVE_FLOW` mutation and `useArchiveFlow` hook / removing the `archiveFlow` method from the Zustand store
- Creates a `GET_FLOWS` mutation too to run as part of mutation `refetchQueries` (question about this below) 
- Refactors `FlowMenu` into `ActiveFlowMenu` and `ArchivedFlowMenu` (the components have some similarity but enough distinction that I decided to keep them separate instead of having a generic component)
- `ArchivedFlowMenu` has an 'Unarchive' menu item (forthcoming PR to add 'Delete')
- Updates styling for actions column in table view 

