### PR TITLE
fix(hasura): Allow analyst role to select `flows.archived_at` column

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -241,6 +241,7 @@ select_permissions:
   - role: analyst
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - created_at


### PR DESCRIPTION
## What's the problem?
`analyst` roles cannot select flows as we now have an additional `archived_at` column which we haven't granted permission for.

## What's the solution?
Grant access!