### PR TITLE
chore: revert minimumReleaseAgeExclude packages

### DIFF
--- a/apps/api.planx.uk/pnpm-workspace.yaml
+++ b/apps/api.planx.uk/pnpm-workspace.yaml
@@ -2,8 +2,3 @@ allowBuilds:
   "@opensystemslab/planx-core": true
 
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - prettier
-  - "@formatjs/intl-listformat"
-  - "@formatjs/intl-localematcher"
-  - "@formatjs/fast-memoize"

--- a/apps/editor.planx.uk/pnpm-workspace.yaml
+++ b/apps/editor.planx.uk/pnpm-workspace.yaml
@@ -1,9 +1,1 @@
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - prettier
-  - fast-xml-parser
-  - "@formatjs/intl-listformat"
-  - "@formatjs/intl-localematcher"
-  - "@formatjs/fast-memoize"
-  - "@nodable/entities"
-  - path-expression-matcher

--- a/e2e/tests/api-driven/pnpm-workspace.yaml
+++ b/e2e/tests/api-driven/pnpm-workspace.yaml
@@ -1,9 +1,1 @@
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - prettier
-  - fast-xml-parser
-  - "@formatjs/intl-listformat"
-  - "@formatjs/intl-localematcher"
-  - "@formatjs/fast-memoize"
-  - "@nodable/entities"
-  - path-expression-matcher

--- a/e2e/tests/ui-driven/pnpm-workspace.yaml
+++ b/e2e/tests/ui-driven/pnpm-workspace.yaml
@@ -1,9 +1,1 @@
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - prettier
-  - fast-xml-parser
-  - "@formatjs/intl-listformat"
-  - "@formatjs/intl-localematcher"
-  - "@formatjs/fast-memoize"
-  - "@nodable/entities"
-  - "path-expression-matcher"


### PR DESCRIPTION
These rules were added so we could update the repo to use the latest planx-core version, which contained some newer packages that violated the rule.

planx-core has since been updated to enforce the same constraint, so these rules can be removed in ~7 days. 