### PR TITLE
fix(ci): Invalidate CloudFront cache after each deploy

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -107,6 +107,12 @@ jobs:
           edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Invalidate CloudFront cache
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          DIST_ID=$(pulumi stack output cdnDistributionId --stack staging --cwd infrastructure/application)
+          aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"
 
   notifications:
     name: Notifications

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -110,6 +110,12 @@ jobs:
           edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Invalidate CloudFront cache
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          DIST_ID=$(pulumi stack output cdnDistributionId --stack production --cwd infrastructure/application)
+          aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"
 
   notifications:
     name: Notifications

--- a/apps/api.planx.uk/README.md
+++ b/apps/api.planx.uk/README.md
@@ -1,17 +1,25 @@
 # api.planx.uk
 
-API is a Node/Express server and REST endpoints. We're in the process of migrating this directory to Typescript.
+Node/Express REST API server, written in TypeScript.
 
-Our API handles functionality like:
+The API handles business logic that can't or shouldn't live in the frontend. This falls into two broad categories:
 
-- Logging into the editor via Google
-- Publishing service content
-- Uploading files to S3
-- Saving and resuming an application
-- Querying geospatial data via [Digital Land](https://www.planning.data.gov.uk/)
-- Sending emails via [GOV.UK Notify](https://www.notifications.service.gov.uk/)
-- Paying via [GOV.UK Pay](https://www.payments.service.gov.uk/)
-- Submitting applications to back-office case-management systems
+**Proxying third-party services**
+
+- Payments via [GOV.UK Pay](https://www.payments.service.gov.uk/)
+- Emails via [GOV.UK Notify](https://www.notifications.service.gov.uk/)
+- Address/map data via [Ordnance Survey](https://developer.ordnancesurvey.co.uk/)
+- Geospatial planning data via [Digital Land](https://www.planning.data.gov.uk/)
+
+**Core PlanX business logic**
+
+- Auth (Google/Microsoft OAuth, JWT, roles)
+- File uploads to S3
+- Publishing and managing flows
+- Save & return for applications
+- Submitting applications to back-office systems (BOPS, Idox, Uniform, etc.)
+- Local planning services (LPS)
+- Webhooks, analytics, notifications
 
 ## Running locally
 
@@ -28,6 +36,73 @@ Development notes:
 - if you need to test or pull new changes from @opensystemslab/planx-document-templates or @opensystemslab/planx-core, make sure to update the commit hash in package.json first
 - you can also use `pnpm link {{local relative path to @opensystemslab/planx-document-templates or @opensystemslab/planx-core}}` to manage local development changes these packages without having to reinstall. If you do this, remember to also run `pnpm unlink` to unlink the local directory and then also update the commit hash to point to the most recent version of the package.
 - If you want to test particular files directly, do something like `pnpm vitest server.test.js`.
+
+## Module structure
+
+Modules live under `modules/` and follow the pattern established in [ADR 0007](https://github.com/theopensystemslab/planx-new/blob/main/doc/architecture/decisions/0007-modularise-express-application.md):
+
+```
+api.planx.uk/
+|-- modules/
+|   |-- auth/
+|   |   |-- routes.ts
+|   |   |-- middleware.ts
+|   |   |-- controller.ts
+|   |   |-- service.ts
+|   |-- ...
+|-- app.js
+|-- server.js
+|-- ...
+```
+
+**routes.ts**
+
+- Nice and simple - no business logic, just route definition and documention
+
+**middleware.ts**
+
+- Preprocess incoming requests before reaching route handlers
+
+**controller.ts**
+
+- Orchestrates data processing and interactions with external sources
+- Handles request/response logic (res, req, next), validation, error handling
+
+**service.ts**
+
+- Contains the core business logic and operations
+- Responsible for communicating with database via GraphQL client
+- More easily testable outside the context of the request / response cycle
+- Our planx-core library can also be considered, and used as, the service layer
+
+## Docs
+
+API docs are written as `docs.yaml` files per module and served via Swagger UI at `/docs`.
+
+Inline JSDoc `@swagger` annotations are a legacy pattern — do not add new ones, and migrate them to `docs.yaml` if you come across them.
+
+## Hasura clients
+
+When querying Hasura, use the right client for the context. All clients are exported from `client/index.ts`:
+
+| Client        | Role                | When to use                                               |
+| ------------- | ------------------- | --------------------------------------------------------- |
+| `$api`        | API role (elevated) | Service-to-service requests; side effects like audit logs |
+| `$public`     | Public (no auth)    | Unauthenticated requests                                  |
+| `$admin`      | Admin secret        | Token verification only                                   |
+| `getClient()` | Current user's JWT  | Any operation scoped to the logged-in user's permissions  |
+
+`getClient()` reads the current user's JWT from an [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) context set up by the auth middleware. It will throw a 500 if called outside of an authenticated request context.
+
+## Request validation
+
+Use the `validate()` middleware (from `shared/middleware/validate.ts`) on any route that takes input. It takes a Zod schema, validates the full request (headers, params, body, query), and stores the typed result in `res.locals.parsedReq`. Use the `ValidatedRequestHandler` type in your controller for typed access.
+
+## Testing
+
+- Unit tests on service-layer logic
+- Integration tests using [Supertest](https://github.com/ladjs/supertest) and `graphql-query-mock`
+- Aim for 100% coverage on new modules (`pnpm test --coverage`)
 
 ## Prior art
 

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -486,6 +486,7 @@ export = async () => {
 
   return {
     customDomains,
+    cdnDistributionId: cdn.id,
     metabaseServiceName: metabaseService.service.name,
     hasuraServiceName: hasuraService.service.name,
     apiServiceName: apiService.service.name,


### PR DESCRIPTION
## Problem

After a new Vite build is deployed to S3, CloudFront can serve a stale `index.html` for up to 10 minutes (the current `defaultTtl`/`maxTtl`). Because Vite generates **content-hashed chunk filenames** that change every build, a user who receives the stale `index.html` will request chunk filenames that no longer exist in S3 — resulting in a `vite:preloadError` and a white screen of death.

The existing `vite:preloadError` handler in `index.tsx` is a reactive band-aid; it doesn't prevent the stale state from occurring.

## Solution

Add a `aws cloudfront create-invalidation --paths "/*"` step to the `preview` job in both staging and production deploy workflows, immediately after `pulumi up` completes. This mirrors the pattern already used in `scripts/deploy-lps.sh`.

The distribution ID is read dynamically from a new `cdnDistributionId` Pulumi stack output, keeping it in sync with the IaC state rather than hardcoding it.

## Changes

- `infrastructure/application/index.ts` — export `cdnDistributionId: cdn.id` as a Pulumi stack output
- `.github/workflows/push-main.yml` — add invalidation step (staging)
- `.github/workflows/push-production.yml` — add invalidation step (production)

## Deploy flow after this change

```
pulumi up (uploads new assets to S3)
  → Invalidate CloudFront cache
    → Notifications (Slack / Airbrake)
```

The `vite:preloadError` handler can stay as a safety net for users who have a tab open mid-deploy, but it should rarely trigger.

## Test plan

- [ ] Merge to `main` and confirm the "Invalidate CloudFront cache" step passes in the staging workflow
- [ ] Confirm the invalidation appears in AWS Console → CloudFront → Distributions → Invalidations
- [ ] Verify no white screen errors in Airbrake following the next staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)