### PR TITLE
fix(iac): Invalidate CloudFront cache after deployments

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -107,6 +107,12 @@ jobs:
           edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Invalidate CloudFront cache
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          DIST_ID=$(pulumi stack output cdnDistributionId --stack staging --cwd infrastructure/application)
+          aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"
 
   notifications:
     name: Notifications

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -110,6 +110,12 @@ jobs:
           edit-pr-comment: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Invalidate CloudFront cache
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          DIST_ID=$(pulumi stack output cdnDistributionId --stack production --cwd infrastructure/application)
+          aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"
 
   notifications:
     name: Notifications

--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -490,6 +490,7 @@ export = async () => {
 
   return {
     customDomains,
+    cdnDistributionId: cdn.id,
     metabaseServiceName: metabaseService.service.name,
     hasuraServiceName: hasuraService.service.name,
     apiServiceName: apiService.service.name,


### PR DESCRIPTION
## What's the problem?
Ticket: https://trello.com/c/2INGMHaM/3519-investigate-blank-screen-when-loading-production-homepage

After a deploy to staging or production, it's possible to see a "white screen of death" - this is happening because CloudFront can serve a stale `index.html` for up to 10 minutes (the current cache TTL). Vite generates random filenames that change every build and a stale `index.html` will point to old files, causing the issue.

## What's the solution?
Invalidate the cache on each deploy. We handle this here for LPS but the step is missing for PlanX.

https://github.com/theopensystemslab/planx-new/blob/main/scripts/deploy-lps.sh#L47-L50

## Next steps...
Let's test this on merge to `main` and `production` - we should see the action running, see an invalidation in the AWS console, and not see the blank white screen on deploys.


