### PR TITLE
fix(iac): Use single `ResponseHeadersPolicy` instead of one per-CDN

### DIFF
--- a/infrastructure/application/utils/createCDN.ts
+++ b/infrastructure/application/utils/createCDN.ts
@@ -27,6 +27,46 @@ const staticErrorResponses: aws.cloudfront.DistributionArgs["customErrorResponse
   },
 ];
 
+const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
+  "shared-cdn-headers-policy",
+  {
+    corsConfig: {
+      // XXX: might need to turn this back on because the editor side uses cookies
+      //      but when this is true, AllowHeaders can't be `*` so will need to dive deeper
+      accessControlAllowCredentials: false,
+      accessControlAllowHeaders: {
+        items: ["*"],
+      },
+      accessControlAllowMethods: {
+        items: ["GET", "HEAD", "OPTIONS"],
+      },
+      // TODO: Narrow this down to the list of domain names we're actually using
+      accessControlAllowOrigins: {
+        items: ["*"],
+      },
+      originOverride: true,
+    },
+    securityHeadersConfig: {
+      // Prevent iFrames
+      frameOptions: {
+        frameOption: "DENY",
+        override: true,
+      },
+      // Implements HTTP Strict Transport Security
+      strictTransportSecurity: {
+        accessControlMaxAgeSec: 63072000, // maximum (2 years)
+        override: true,
+        includeSubdomains: true,
+        preload: true,
+      },
+      // Set X-Content-Type-Options = "nosniff"
+      contentTypeOptions: {
+        override: true,
+      },
+    },
+  }
+);
+
 export const createCdn = ({
   domain,
   acmCertificateArn,
@@ -86,45 +126,7 @@ export const createCdn = ({
       lambdaFunctionAssociations: lambdaFunctionAssociation
         ? [lambdaFunctionAssociation]
         : [],
-      responseHeadersPolicyId: new aws.cloudfront.ResponseHeadersPolicy(
-        `${domain.replace(/[^a-z0-9_-]/g, "_")}-policy`,
-        {
-          corsConfig: {
-            // XXX: might need to turn this back on because the editor side uses cookies
-            //      but when this is true, AllowHeaders can't be `*` so will need to dive deeper
-            accessControlAllowCredentials: false,
-            accessControlAllowHeaders: {
-              items: ["*"],
-            },
-            accessControlAllowMethods: {
-              items: ["GET", "HEAD", "OPTIONS"],
-            },
-            // TODO: Narrow this down to the list of domain names we're actually using
-            accessControlAllowOrigins: {
-              items: ["*"],
-            },
-            originOverride: true,
-          },
-          securityHeadersConfig: {
-            // Prevent iFrames
-            frameOptions: {
-              frameOption: "DENY",
-              override: true,
-            },
-            // Implements HTTP Strict Transport Security
-            strictTransportSecurity: {
-              accessControlMaxAgeSec: 63072000, // maximum (2 years)
-              override: true,
-              includeSubdomains: true,
-              preload: true,
-            },
-            // Set X-Content-Type-Options = "nosniff"
-            contentTypeOptions: {
-              override: true,
-            },
-          },
-        }
-      ).id,
+      responseHeadersPolicyId: responseHeadersPolicy.id
     },
 
     // "All" is the most broad distribution, and also the most expensive.


### PR DESCRIPTION
## What's the problem?
The latest production deploy has failed with the following error -

```
creating CloudFront Response Headers Policy (planningservices_canterbury_gov_uk-policy-b39f243): operation error CloudFront: CreateResponseHeadersPolicy, https response error StatusCode: 400, RequestID: 98be4a7a-d465-4029-884e-b8e320750eb8, TooManyResponseHeadersPolicies: Account's Response Headers Policies limit reached.
```

Our [AWS console shows we've reached the limit of 20 policies](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=eu-west-2#/policies/responseHeaders) here.

## What's the solution?
Rather than instantiate one policy per-CDN, we can just create a single shared policy.

## Questions / next steps...
Should we just be using a pre-baked AWS policy to simplify this? The `Managed-CORS-with-preflight-and-SecurityHeadersPolicy` policy is very similar, but a little less strict ([docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-cors-preflight-security)) (cc @freemvmt )