### PR TITLE
chore(editor): Remove final instances of `CoreDomainClient`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -13,18 +13,6 @@ const { getState, setState } = useStore;
 
 let initialState: FullStore;
 
-vi.mock("@opensystemslab/planx-core", async (importOriginal) => {
-  const actual = await importOriginal<typeof planxCore>();
-  return {
-    ...actual,
-    CoreDomainClient: vi.fn().mockImplementation(() => ({
-      export: {
-        csvData: () => vi.fn(),
-      },
-    })),
-  };
-});
-
 vi.mock("hooks/usePublicRouteContext", () => ({
   usePublicRouteContext: vi.fn(() => "/$flow"),
 }));

--- a/apps/editor.planx.uk/src/lib/feedback.ts
+++ b/apps/editor.planx.uk/src/lib/feedback.ts
@@ -27,10 +27,9 @@ export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
     breadcrumbs,
     currentCard: node,
     computePassport,
-    fetchCurrentTeam,
+    teamId,
     id: flowId,
   } = useStore.getState();
-  const { id: teamId } = await fetchCurrentTeam();
   const userData = {
     breadcrumbs: breadcrumbs,
     passport: computePassport(),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/auth.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/auth.ts
@@ -1,12 +1,9 @@
-import { CoreDomainClient } from "@opensystemslab/planx-core";
 import type { User } from "@opensystemslab/planx-core/types";
 import { getUser, logout } from "lib/api/auth/requests";
 import { clearCookie, setCookie } from "lib/cookie";
 import { client } from "lib/graphql";
 import { disconnectShareDB } from "pages/FlowEditor/lib/sharedb";
 import { type StateCreator } from "zustand";
-
-import type { SharedStore } from "./shared";
 
 export interface AuthStore {
   authStatus: "idle" | "loading" | "authenticated" | "unauthenticated";
@@ -17,12 +14,10 @@ export interface AuthStore {
   logout: () => Promise<void>;
 }
 
-export const authStore: StateCreator<
-  AuthStore & SharedStore,
-  [],
-  [],
-  AuthStore
-> = (set, get) => ({
+export const authStore: StateCreator<AuthStore, [], [], AuthStore> = (
+  set,
+  get,
+) => ({
   authStatus: "idle",
   user: null,
   jwt: null,
@@ -34,7 +29,7 @@ export const authStore: StateCreator<
     set({ authStatus: "loading" });
 
     // On local and Pizza environments, JWT is stored as a URL param due to restrictions on
-    // cross-domain cookies (we auth via planx.dev). On staging and production these cookies 
+    // cross-domain cookies (we auth via planx.dev). On staging and production these cookies
     // are set via response headers from the API.
     const url = new URL(window.location.href);
     const jwtParam = url.searchParams.get("jwt");
@@ -44,7 +39,11 @@ export const authStore: StateCreator<
       setCookie("auth", JSON.stringify({ loggedIn: true }));
 
       url.searchParams.delete("jwt");
-      window.history.replaceState({}, document.title, url.pathname + url.search);
+      window.history.replaceState(
+        {},
+        document.title,
+        url.pathname + url.search,
+      );
     }
 
     try {
@@ -60,10 +59,6 @@ export const authStore: StateCreator<
         authStatus: "authenticated",
         user,
         jwt,
-        $client: new CoreDomainClient({
-          targetURL: import.meta.env.VITE_APP_HASURA_URL!,
-          auth: { jwt },
-        }),
       });
     } catch (err) {
       set({ authStatus: "unauthenticated", user: null, jwt: null });
@@ -71,7 +66,7 @@ export const authStore: StateCreator<
   },
 
   logout: async () => {
-    await logout()
+    await logout();
 
     // Clean up client connections
     disconnectShareDB();
@@ -86,9 +81,6 @@ export const authStore: StateCreator<
       authStatus: "unauthenticated",
       user: null,
       jwt: null,
-      $client: new CoreDomainClient({
-        targetURL: import.meta.env.VITE_APP_HASURA_URL!,
-      }),
     });
   },
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/shared.ts
@@ -1,4 +1,3 @@
-import { CoreDomainClient } from "@opensystemslab/planx-core";
 import { NodeId } from "@opensystemslab/planx-core/types";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import { removeSessionIdSearchParam } from "utils";
@@ -6,10 +5,6 @@ import type { StateCreator } from "zustand";
 
 import type { Store } from ".";
 import { NavigationStore } from "./navigation";
-
-type Auth = NonNullable<
-  ConstructorParameters<typeof CoreDomainClient>[0]
->["auth"];
 
 export type PreviewEnvironment = "editor" | "standalone";
 export interface SharedStore extends Store.Store {
@@ -30,8 +25,6 @@ export interface SharedStore extends Store.Store {
   wasVisited: (id: NodeId) => boolean;
   previewEnvironment: PreviewEnvironment;
   setPreviewEnvironment: (previewEnvironment: PreviewEnvironment) => void;
-  $public: (auth?: Auth) => CoreDomainClient;
-  $client: CoreDomainClient;
 }
 
 export const sharedStore: StateCreator<
@@ -104,18 +97,4 @@ export const sharedStore: StateCreator<
       ]),
     ).has(id);
   },
-
-  $public(auth: Auth | undefined): CoreDomainClient {
-    return new CoreDomainClient({
-      targetURL: import.meta.env.VITE_APP_HASURA_URL!,
-      auth: auth,
-    });
-  },
-
-  /**
-   * Authenticated client is re-instantiated upon user login
-   */
-  $client: new CoreDomainClient({
-    targetURL: import.meta.env.VITE_APP_HASURA_URL!,
-  }),
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -4,7 +4,6 @@ import {
   TeamSettings,
   TeamTheme,
 } from "@opensystemslab/planx-core/types";
-import { CreateTeam } from "pages/Teams/AddTeamButton";
 import { DEFAULT_PRIMARY_COLOR } from "theme";
 import type { StateCreator } from "zustand";
 
@@ -26,8 +25,6 @@ export interface TeamStore {
   setTeam: (team: Team) => void;
   getTeam: () => Team;
   clearTeamStore: () => void;
-  fetchCurrentTeam: () => Promise<Team>;
-  createTeam: (newTeam: CreateTeam) => Promise<number>;
 }
 
 export const teamStore: StateCreator<
@@ -77,11 +74,6 @@ export const teamStore: StateCreator<
     domain: get().teamDomain,
   }),
 
-  createTeam: async (newTeam) => {
-    const { $client } = get();
-    return await $client.team.create(newTeam);
-  },
-
   clearTeamStore: () =>
     set({
       teamId: 0,
@@ -91,13 +83,4 @@ export const teamStore: StateCreator<
       teamSlug: "",
       teamTheme: undefined,
     }),
-
-  /**
-   * Fetch current team
-   * Does not necessarily match team held in store as this is context-based (e.g. we don't use the team theme in the Editor)
-   */
-  fetchCurrentTeam: async () => {
-    const { teamSlug, $client } = get();
-    return await $client.team.getBySlug(teamSlug);
-  },
 });

--- a/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -7,7 +7,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import { Form, Formik, FormikConfig } from "formik";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { AddButton } from "ui/editor/AddButton";
 import Permission from "ui/editor/Permission";
@@ -17,6 +16,8 @@ import Input from "ui/shared/Input/Input";
 import { Switch } from "ui/shared/Switch";
 import { slugify } from "utils";
 import { boolean, object, SchemaOf, string } from "yup";
+
+import { useCreateTeam } from "./hooks/useCreateTeam";
 
 export interface CreateTeam {
   name: string;
@@ -35,8 +36,10 @@ const validationSchema: SchemaOf<CreateTeam> = object({
 });
 
 export const AddTeamButton: React.FC = () => {
-  const [createTeam] = useStore((state) => [state.createTeam]);
   const navigate = useNavigate();
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+  const { createTeam } = useCreateTeam();
 
   const initialValues: CreateTeam = {
     name: "",
@@ -46,12 +49,24 @@ export const AddTeamButton: React.FC = () => {
     },
   };
 
-  const onSubmit: FormikConfig<CreateTeam>["onSubmit"] = async (values) => {
-    await createTeam(values);
-    navigate({ to: `/app/$team`, params: { team: values.slug } });
-  };
+  const onSubmit: FormikConfig<CreateTeam>["onSubmit"] = async (
+    values,
+    { setSubmitting },
+  ) => {
+    try {
+      await createTeam({
+        name: values.name,
+        slug: values.slug,
+        settings: values.settings,
+      });
 
-  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+      navigate({ to: `/app/$team`, params: { team: values.slug } });
+    } catch (error) {
+      console.error("Failed to create team:", error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <Permission.IsPlatformAdmin>

--- a/apps/editor.planx.uk/src/pages/Teams/hooks/useCreateTeam.tsx
+++ b/apps/editor.planx.uk/src/pages/Teams/hooks/useCreateTeam.tsx
@@ -1,0 +1,51 @@
+import { gql, useMutation } from "@apollo/client";
+
+const CREATE_TEAM_MUTATION = gql`
+  mutation CreateTeam(
+    $name: String!
+    $slug: String!
+    $domain: String
+    $settings: team_settings_insert_input!
+    $theme: team_themes_insert_input!
+  ) {
+    insert_teams_one(
+      object: {
+        name: $name
+        slug: $slug
+        # Create empty records for associated tables - these can get populated later
+        team_settings: { data: $settings }
+        theme: { data: $theme }
+        integrations: { data: {} }
+      }
+    ) {
+      id
+    }
+  }
+`;
+
+export interface TeamPayload {
+  name: string;
+  slug: string;
+  settings: {
+    isTrial: boolean;
+  };
+}
+
+export const useCreateTeam = () => {
+  const [mutate, mutationState] = useMutation(CREATE_TEAM_MUTATION);
+
+  const createTeam = async ({ name, slug, settings }: TeamPayload) => {
+    return mutate({
+      variables: {
+        name,
+        slug,
+        settings: {
+          is_trial: settings.isTrial,
+        },
+        theme: {},
+      },
+    });
+  };
+
+  return { createTeam, ...mutationState };
+};


### PR DESCRIPTION
## What does this PR do?
- Removes final references of `CoreDomainClient` from the frontend - now all requests are made via the API or Hasura directly (via Apollo) - not via `planx-core`
- Adds hook for team creation
- Removes deprecated `fetchCurrentTeam()` call

## Motivation
I realised whilst working on https://github.com/theopensystemslab/planx-new/pull/6450 that there were just two references to this left and removing it would be another step along the path towards https://github.com/orgs/theopensystemslab/projects/7