### PR TITLE
fix: Tidy up zindex and hover states for flow table

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
@@ -14,6 +14,9 @@ export const Card = styled("li")(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
   boxShadow: "0 2px 6px 1px rgba(0, 0, 0, 0.1)",
+  "&:hover": {
+    backgroundColor: theme.palette.background.paper,
+  },
 }));
 
 export const CardBanner = styled(Box)(({ theme }) => ({
@@ -48,6 +51,9 @@ export const FlowCardLink = styled(CustomLink)(() => ({
   zIndex: 1,
   "&:focus": {
     ...inputFocusStyle,
+  },
+  "&:focus-visible": {
+    backgroundColor: "transparent",
   },
 })) as typeof CustomLink;
 

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -178,7 +178,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           </TableCell>
           {showPinnedColumn && (
             <TableCell>
-              <Box onClick={(e) => e.stopPropagation()}>
+              <Box onClick={(e) => e.stopPropagation()} sx={{ textAlign: "center" }}>
                 {userId && updateFlow && (
                   <FlowPinButton
                     flowId={flow.id}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -27,7 +27,7 @@ export const StyledTableHead = styled(TableHead)(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.border.main}`,
     position: "sticky",
     top: 0,
-    zIndex: 2,
+    zIndex: theme.zIndex.appBar,
     "&:last-of-type": {
       borderLeft: `1px solid ${theme.palette.border.main}`,
     },

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -78,6 +78,9 @@ export const FlowRowLink = styled(CustomLink)(() => ({
   "&:focus": {
     ...inputFocusStyle,
   },
+  "&:focus-visible": {
+    backgroundColor: "transparent",
+  },
 })) as typeof CustomLink;
 
 export const FlowTitleCell = styled(TableCell)(() => ({


### PR DESCRIPTION
## What does this PR do?

- Addresses a number of small style regressions with the flow table

### Hover state obscures table row contents

Current:
<img width="1491" height="561" alt="image" src="https://github.com/user-attachments/assets/2bfa3dad-57a8-40d1-8016-9b361984f87e" />

Fixed:
<img width="1491" height="561" alt="image" src="https://github.com/user-attachments/assets/f73091ef-8a39-4c10-8efa-5ea9028ed60f" />

(same issue applies for cards, also fixed)

### zIndex overlap for table items

Current:
<img width="539" height="161" alt="image" src="https://github.com/user-attachments/assets/10574176-16db-4106-b9c7-09d24c16e72f" />

Fixed:
<img width="539" height="161" alt="image" src="https://github.com/user-attachments/assets/8fe37eaa-5024-4358-a52a-d7bfc4433013" />

(also centre-aligned the pin icon)