### PR TITLE
fix(editor): Drop `Object.groupBy` in favour of lodash version

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -5,6 +5,7 @@ import FormLabel from "@mui/material/FormLabel";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
+import { groupBy } from "lodash";
 import capitalize from "lodash/capitalize";
 import React, { useMemo } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -89,7 +90,7 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
    * Group options by category for rendering
    */
   const groupedOptions = useMemo(
-    () => Object.groupBy(options, ({ category }) => category),
+    () => groupBy(options, ({ category }) => category),
     [options],
   );
 


### PR DESCRIPTION
## What's the problem?
Despite `Object.groupBy` [being baseline 2024](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy), a user has reported an issue here which did not allow them to proceed past file upload.

[Airbrake confirms](https://planx.airbrake.io/projects/329753/groups/4312684051212375131?filters=%7B%22order%22%3A%22last_notice%22%2C%22resolved%22%3A%22any%22%2C%22search%22%3A%22object.groupby%22%7D&tab=overview) that this was thrown by user running Firefox 115 (from 2023...! 🙃)

This version is still used by ~6% of Firefox users it turns out - https://en.wikipedia.org/wiki/Firefox_version_history

## What's the solution?
Just use lodash as we do elsewhere, and I guess make a note that even with baseline 2024 we'll still hit issues 😕 