### PR TITLE
feat: Add drawing numbers to `FileUploadAndLabel`, update passport and payloads

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -12,7 +12,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@aws-sdk/s3-request-presigner": "^3.1000.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#77d54fa",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#efbcb9c",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.16",
     "ai": "^6.0.116",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^3.1000.0
         version: 3.1015.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#77d54fa
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#efbcb9c
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.14)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1218,8 +1218,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7}
     version: 1.0.0
 
   '@opentelemetry/api@1.9.0':
@@ -5486,7 +5486,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -17,7 +17,7 @@
     "@mui/x-charts": "^7.29.1",
     "@mui/x-data-grid": "^7.29.12",
     "@opensystemslab/map": "1.0.0-alpha.11",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#77d54fa",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#efbcb9c",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-router-devtools": "^1.163.3",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#77d54fa
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@18.3.28)
+        specifier: github:theopensystemslab/planx-core#efbcb9c
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@18.3.28)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.95.2(react@18.3.1)
@@ -1857,8 +1857,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.11':
     resolution: {integrity: sha512-ETACPCk5Coef1L2kNT3MhIzLxVPDpyopxsTNcgeRyEqL71HBfTklGyC5+t7HgEgxRkX5wlUXqmKPNL9DdpVj8g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -8551,7 +8551,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@18.3.28)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@18.3.28)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
@@ -9149,7 +9149,7 @@ snapshots:
       '@tanstack/router-core': 1.168.3
       '@tanstack/router-utils': 1.161.6
       '@tanstack/virtual-file-routes': 1.161.7
-      prettier: 3.8.1
+      prettier: 3.8.3
       recast: 0.23.11
       source-map: 0.7.6
       tsx: 4.21.0

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -6,7 +6,6 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { EditorProps } from "@planx/components/shared/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import { getIn } from "formik";
-import { hasFeatureFlag } from "lib/featureFlags";
 import { merge } from "lodash";
 import React from "react";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
@@ -110,7 +109,7 @@ function FileUploadAndLabelComponent(props: Props) {
                   !formik.values.showDrawingNumber,
                 )
               }
-              label="Show a drawing number field for each uploaded file"
+              label="Show an optional drawing number input for each uploaded file"
               disabled={props.disabled}
             />
           </InputRow>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -101,23 +101,19 @@ function FileUploadAndLabelComponent(props: Props) {
               disabled={props.disabled}
             />
           </InputRow>
-          {hasFeatureFlag("UPLOAD_LABEL_REBUILD") ? (
-            <InputRow>
-              <Switch
-                checked={formik.values.showDrawingNumber}
-                onChange={() =>
-                  formik.setFieldValue(
-                    "showDrawingNumber",
-                    !formik.values.showDrawingNumber,
-                  )
-                }
-                label="Show a drawing number field for each uploaded file"
-                disabled={props.disabled}
-              />
-            </InputRow>
-          ) : (
-            <></>
-          )}
+          <InputRow>
+            <Switch
+              checked={formik.values.showDrawingNumber}
+              onChange={() =>
+                formik.setFieldValue(
+                  "showDrawingNumber",
+                  !formik.values.showDrawingNumber,
+                )
+              }
+              label="Show a drawing number field for each uploaded file"
+              disabled={props.disabled}
+            />
+          </InputRow>
         </ModalSectionContent>
       </ModalSection>
       <ModalSection>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/FileUploadAndLabel.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/FileUploadAndLabel.stories.tsx
@@ -72,6 +72,64 @@ export const Basic = {
   },
 } satisfies Story;
 
+export const WithDrawingNumbers = {
+  args: {
+    title: "Upload and label",
+    description:
+      "Based on your answers so far, these are the documents and drawings you need to submit.",
+    handleSubmit: () => {},
+    hideDropZone: false,
+    showDrawingNumber: true,
+    fileTypes: [
+      {
+        fn: "always",
+        name: "Site plan",
+        rule: {
+          condition: Condition.AlwaysRequired,
+        },
+      },
+      {
+        fn: "conditional",
+        name: "Roof plan",
+        rule: {
+          condition: Condition.AlwaysRequired,
+        },
+      },
+      {
+        fn: "documents.designAndAccess",
+        name: "Design and Access statement",
+        rule: {
+          condition: Condition.AlwaysRecommended,
+        },
+        moreInformation: {
+          info: "<p>It&apos;s a design and access statement innit.</p>",
+        },
+      },
+      {
+        fn: "proposal.drawing.section",
+        name: "Section drawings",
+        rule: {
+          condition: Condition.AlwaysRecommended,
+        },
+      },
+      {
+        fn: "optional",
+        name: "Heritage statement",
+        rule: {
+          condition: Condition.NotRequired,
+        },
+      },
+      {
+        fn: "optional2",
+        name: "Utility bill",
+        rule: {
+          condition: Condition.NotRequired,
+        },
+      },
+    ],
+  },
+} satisfies Story;
+
 export const OptionalFilesOnly = {
   args: {
     title: "Upload and label",

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -324,7 +324,7 @@ describe("Accordion trigger", () => {
   });
 });
 
-describe("Adding tags and syncing state", () => {
+describe("Adding tags", () => {
   test("Can continue when all required file types are uploaded and tagged", async () => {
     const handleSubmit = vi.fn();
     const { getAllByTestId, getByTestId, getByText, user } = await setup(
@@ -430,6 +430,74 @@ describe("Adding tags and syncing state", () => {
       /Please upload and label all required information/,
     );
     expect(error).toBeVisible();
+  });
+});
+
+describe("Adding drawing numbers", () => {
+  it("allows submission without a drawing number", async () => {
+    const handleSubmit = vi.fn();
+    const { getByTestId, user } = await setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        handleSubmit={handleSubmit}
+        fileTypes={mockFileTypesUniqueKeys}
+        showDrawingNumber={true}
+      />,
+    );
+
+    // Upload file
+    const file = new File(["test"], "test.jpg", { type: "image/jpg" });
+    const input = getByTestId("upload-input");
+    await user.upload(input, file);
+
+    // Tag the file
+    const tagCheckbox = screen.getByLabelText("Roof plan");
+    await user.click(tagCheckbox);
+
+    // Save and continue
+    await user.click(screen.getByRole("button", { name: /Save/ }));
+    await user.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+
+    const submittedData = handleSubmit.mock.calls[0][0];
+    const submittedFile = submittedData.data.roofPlan[0];
+    expect(submittedFile.drawingNumber).toBeUndefined();
+  });
+
+  it("maps the drawing number to the passport payload", async () => {
+    const handleSubmit = vi.fn();
+    const { getByTestId, user } = await setup(
+      <FileUploadAndLabelComponent
+        title="Test title"
+        handleSubmit={handleSubmit}
+        fileTypes={mockFileTypesUniqueKeys}
+        showDrawingNumber={true}
+      />,
+    );
+
+    // Upload file
+    const file = new File(["test"], "test.jpg", { type: "image/jpg" });
+    const input = getByTestId("upload-input");
+    await user.upload(input, file);
+
+    // Tag the file
+    const tagCheckbox = screen.getByLabelText("Roof plan");
+    await user.click(tagCheckbox);
+
+    // Enter drawing number
+    const drawingNumberInput = screen.getByLabelText(/Drawing number/i);
+    await user.type(drawingNumberInput, "ABC-12345");
+
+    // Save and continue
+    await user.click(screen.getByRole("button", { name: /Save/ }));
+    await user.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+
+    const submittedData = handleSubmit.mock.calls[0][0];
+    const submittedFile = submittedData.data.roofPlan[0];
+    expect(submittedFile.drawingNumber).toBe("ABC-12345");
   });
 });
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -179,7 +179,7 @@ export default function Component(props: Props) {
                   createSlot={(baseSlot) => ({
                     ...baseSlot,
                     tags: [],
-                    drawingNumber: "",
+                    drawingNumber: undefined,
                   })}
                 />
               </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -55,7 +55,7 @@ export const newFileType = (): FileType => ({
 
 export interface FileUploadAndLabelSlot extends FileUploadSlot {
   tags: string[];
-  drawingNumber: string;
+  drawingNumber: string | undefined;
 }
 
 export interface FormattedUserFile {
@@ -63,6 +63,7 @@ export interface FormattedUserFile {
   rule: Rule;
   url: string | undefined;
   filename: string | undefined;
+  drawingNumber: string | undefined;
   /**
    * Store the data required for the UI in the breadcrumbs
    * This allows us to restore the UI on refresh / resume / back
@@ -205,6 +206,7 @@ export const generatePayload = (
         rule: definition.rule,
         url: slot.url,
         filename: slot.file.name,
+        drawingNumber: slot.drawingNumber,
         cachedSlot: {
           ...slot,
           file: {

--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,8 +1,5 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = [
-  "UPLOAD_LABEL_REBUILD",
-  "ARCHIVE_VIEW",
-] as const;
+const AVAILABLE_FEATURE_FLAGS = ["ARCHIVE_VIEW"] as const;
 
 type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.30.2",
   "dependencies": {
     "@cucumber/cucumber": "^11.3.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#77d54fa",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#efbcb9c",
     "axios": "^1.15.0",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.3.0
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#77d54fa
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#efbcb9c
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.6)
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2152,7 +2152,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#77d54fa",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#efbcb9c",
     "axios": "^1.15.0",
     "dotenv": "^16.6.1",
     "eslint": "^8.57.1",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#77d54fa
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#efbcb9c
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.6)
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -318,8 +318,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7}
     version: 1.0.0
 
   '@playwright/test@1.58.2':
@@ -1790,7 +1790,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/77d54fa87e74c730ead6c79fd4270699bde5122c(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/efbcb9cb0fdabb46a9ea2833bf2885f5ef263fa7(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)


### PR DESCRIPTION
## What does this PR do?
This PR finialises the work began in https://github.com/theopensystemslab/planx-new/pull/6216 to introduce the `drawingNumbers` property to the file upload and label component.

The UI already exists, behind a feature flag, and this PR introduces the following changes -
 - Drops the feature flag
 - Populates the passport with a `drawingNumber` if provided
 - Basic test coverage for feature
 - Updates `planx-core` ([see change here](https://github.com/theopensystemslab/planx-core/pull/975)) to populate the `file.number` field in the ODP schema
 - Adds Storybook story - https://storybook.6502.planx.pizza/?path=/story/planx-components-fileuploadandlabel--with-drawing-numbers
 
### Testing
  - Upload files on a service, and submit to create a valid payload
  - Check payload - the `numbers` field should be populated as expected
  - Example submission here - TODO

## Next steps...
Add "drawing number" UI and payload creation to single file upload.

Please see https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1776677646846729 (OSL Slack)
