### PR TITLE
fix(editor): Force full re-render of `TeamComponent` on navigation

### DIFF
--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
@@ -53,6 +53,6 @@ export const Route = createFileRoute("/_authenticated/app/$team/")({
 });
 
 function TeamComponent() {
-  const { flows } = Route.useLoaderData();
-  return <Team flows={flows} />;
+  const { flows, team } = Route.useLoaderData();
+  return <Team key={team.id} flows={flows} />;
 }


### PR DESCRIPTION
## What's the problem?
When switching teams via the team switcher (remaining within the `/app/$team` route), the list of flows does not correctly update.

Reported here - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1776676527468709 (OSL Slack)

## What's the cause?
When switching teams, Apollo is fetching the new data as expected - we can see this via network logs (returning `[]` for an empty team). However, because we are mirroring props in state, the `<SearchBox />` component's local state (`searchedFlows`) is holding onto the previous team's populated array.

The line const `sourceFlows = searchedFlows || flows;` then evaluates to `true` for the old, stale, date - meaning the UI does not re-render.

## What's the solution?
This is a pragmatic / nuclear solution to get this fix across to production asap - we just unmount the `TeamComponent` and remount when `team.id` updates. This will reset all state and solves the issue.

## Next steps...
The underlying issue here is that we have many sources of truth - we're mirroring the fetched data in local state. We've found ourselves in this position as the component has gone through a few iterations without a step-back to look at the wider picture. We've introduced the following updates one at a time, adding complexity along the way - 
 - search
 - filtering
 - Tanstack Router update (data fetching paradigm)
 - pinned flows
 - archived flows
 
 I think the right solution here is to just rely on the list of flows from Apollo, and derive state from this.
 
 I'll see if I can find time this week to take a look at this.