### PR TITLE
feat: enable flow deletion from archive view

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -20,7 +20,8 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
 }) => {
   type OpenDialog = "archive" | "copy" | "rename" | "move";
   const [openDialog, setOpenDialog] = useState<OpenDialog | null>(null);
-  const [archiveFlow] = useArchiveFlow(flow.id, flow.slug, teamId);
+  const archivedSlug = flow.slug.concat("-archived");
+  const [archiveFlow] = useArchiveFlow(flow.id, archivedSlug, teamId);
 
   const toast = useToast();
 
@@ -28,18 +29,18 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
     setOpenDialog(null);
   };
 
-const handleArchive = async () => {
-  try {
-    await archiveFlow();
-    toast.success("Archived flow");
-  } catch (error) {
-    toast.error(
-      "We are unable to archive this flow, refesh and try again or contact an admin",
-    );
-  } finally {
-    setOpenDialog(null);
-  }
-};
+  const handleArchive = async () => {
+    try {
+      await archiveFlow();
+      toast.success("Archived flow");
+    } catch (error) {
+      toast.error(
+        "We are unable to archive this flow, refesh and try again or contact an admin",
+      );
+    } finally {
+      setOpenDialog(null);
+    }
+  };
 
   const menuItems = [
     {

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -20,11 +20,11 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
   const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(
     null,
   );
-    
-  const unarchivedSlug = flow.slug.replace("-archive", "");
+
+  const unarchivedSlug = flow.slug.replace("-archived", "");
   const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
-    
-  const deletedSlug = flow.slug.replace("-archive", "-deleted");
+
+  const deletedSlug = flow.slug.replace("-archived", "-deleted");
   const [deleteFlow] = useDeleteFlow(flow.id, deletedSlug, teamId);
 
   const toast = useToast();
@@ -45,30 +45,30 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
       setOpenFlowDialog(null);
     }
   };
-    
+
   const handleDelete = async () => {
-  try {
+    try {
       await deleteFlow();
       toast.success("Deleted flow");
-  } catch (error) {
+    } catch (error) {
       toast.error(
-      "We are unable to delete this flow, refesh and try again or contact an admin",
+        "We are unable to delete this flow, refesh and try again or contact an admin",
       );
-  } finally {
+    } finally {
       setOpenFlowDialog(null);
-  }
+    }
   };
 
-    const menuItems = [
-      {
+  const menuItems = [
+    {
       label: "Unarchive",
       onClick: () => setOpenFlowDialog("unarchive"),
-      },
-      {
+    },
+    {
       label: "Delete",
       onClick: () => setOpenFlowDialog("delete"),
-      },
-    ];
+    },
+  ];
 
   return (
     <>

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import SimpleMenu from "ui/editor/SimpleMenu";
 
 import { ArchiveDialog } from "./ArchiveDialog";
+import { useDeleteFlow } from "./hooks/useDeleteFlow";
 import { useUnarchiveFlow } from "./hooks/useUnarchiveFlow";
 import { FlowMenuProps } from "./StyledSimpleMenu";
 import { StyledSimpleMenu } from "./StyledSimpleMenu";
@@ -15,12 +16,16 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
   variant = "card",
   teamId,
 }) => {
-  type OpenFlowDialog = "unarchive";
+  type OpenFlowDialog = "unarchive" | "delete";
   const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(
     null,
   );
+    
   const unarchivedSlug = flow.slug.replace("-archive", "");
   const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
+    
+  const deletedSlug = flow.slug.replace("-archive", "-deleted");
+  const [deleteFlow] = useDeleteFlow(flow.id, deletedSlug, teamId);
 
   const toast = useToast();
 
@@ -40,13 +45,30 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
       setOpenFlowDialog(null);
     }
   };
+    
+  const handleDelete = async () => {
+  try {
+      await deleteFlow();
+      toast.success("Deleted flow");
+  } catch (error) {
+      toast.error(
+      "We are unable to delete this flow, refesh and try again or contact an admin",
+      );
+  } finally {
+      setOpenFlowDialog(null);
+  }
+  };
 
-  const menuItems = [
-    {
+    const menuItems = [
+      {
       label: "Unarchive",
       onClick: () => setOpenFlowDialog("unarchive"),
-    },
-  ];
+      },
+      {
+      label: "Delete",
+      onClick: () => setOpenFlowDialog("delete"),
+      },
+    ];
 
   return (
     <>
@@ -58,6 +80,16 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
           handleClose={handleClose}
           onConfirm={handleUnarchive}
           submitLabel="Unarchive this flow"
+        />
+      )}
+      {openFlowDialog === "delete" && (
+        <ArchiveDialog
+          title={`Delete "${flow.name}"`}
+          open={openFlowDialog === "delete"}
+          content={`Are you sure you want to delete "${flow.name}"? You will no longer be able to restore it from the archive.`}
+          handleClose={handleClose}
+          onConfirm={handleDelete}
+          submitLabel="Delete this flow"
         />
       )}
 

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useArchiveFlow.ts
@@ -10,8 +10,8 @@ import {
 
 export const useArchiveFlow = (id: string, slug: string, teamId: number) =>
   useMutation<FlowStatusMutation, FlowStatusMutationVars>(ARCHIVE_FLOW, {
-    variables: { id, slug: `${slug}-archive` },
-        refetchQueries: [
+    variables: { id, slug },
+    refetchQueries: [
       { query: GET_FLOWS, variables: { teamId } },
       { query: GET_ARCHIVED_FLOWS, variables: { teamId } },
     ],

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useDeleteFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useDeleteFlow.ts
@@ -1,14 +1,14 @@
 import { useMutation } from "@apollo/client";
 
 import {
-  ArchiveFlowQuery,
-  ArchiveFlowQueryVars,
   DELETE_FLOW,
+  FlowStatusMutation,
+  FlowStatusMutationVars,
   GET_ARCHIVED_FLOWS,
 } from "../../queries";
 
 export const useDeleteFlow = (id: string, slug: string, teamId: number) =>
-  useMutation<ArchiveFlowQuery, ArchiveFlowQueryVars>(DELETE_FLOW, {
+  useMutation<FlowStatusMutation, FlowStatusMutationVars>(DELETE_FLOW, {
     variables: { id, slug },
     refetchQueries: [
       { query: GET_ARCHIVED_FLOWS, variables: { teamId } },

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useDeleteFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useDeleteFlow.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@apollo/client";
+
+import {
+  ArchiveFlowQuery,
+  ArchiveFlowQueryVars,
+  DELETE_FLOW,
+  GET_ARCHIVED_FLOWS,
+} from "../../queries";
+
+export const useDeleteFlow = (id: string, slug: string, teamId: number) =>
+  useMutation<ArchiveFlowQuery, ArchiveFlowQueryVars>(DELETE_FLOW, {
+    variables: { id, slug },
+    refetchQueries: [
+      { query: GET_ARCHIVED_FLOWS, variables: { teamId } },
+    ],
+  });
+
+

--- a/apps/editor.planx.uk/src/pages/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Team/queries.ts
@@ -102,3 +102,11 @@ export type FlowStatusMutationVars = {
   id: string;
   slug: string;
 };
+
+export const DELETE_FLOW = gql`
+  mutation DeleteFlow($id: uuid!, $slug: String!) {
+    flow: update_flows_by_pk(pk_columns: {id: $id}, _set: {deleted_at: "now()", slug: $slug}) {
+      id
+    }
+  }
+`;

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -266,20 +266,21 @@ select_permissions:
         - first_online_at
         - production_url
       filter:
-        archived_at:
+        deleted_at:
           _is_null: true
       allow_aggregations: true
     comment: ""
   - role: api
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - copied_from
         - created_at
         - creator_id
         - data
-        - archived_at
+        - deleted_at
         - description
         - id
         - is_listed_on_lps
@@ -300,19 +301,20 @@ select_permissions:
         - first_online_at
         - production_url
       filter:
-        archived_at:
+        deleted_at:
           _is_null: true
       allow_aggregations: true
   - role: platformAdmin
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - copied_from
         - created_at
         - creator_id
         - data
-        - archived_at
+        - deleted_at
         - description
         - id
         - is_listed_on_lps
@@ -332,7 +334,9 @@ select_permissions:
         - data_merged
         - first_online_at
         - production_url
-      filter: {}
+      filter:
+        deleted_at:
+          _is_null: true
       allow_aggregations: true
   - role: public
     permission:
@@ -361,7 +365,7 @@ select_permissions:
         - first_online_at
         - production_url
       filter:
-        archived_at:
+        deleted_at:
           _is_null: true
       allow_aggregations: true
     comment: ""
@@ -394,7 +398,9 @@ select_permissions:
         - data_merged
         - first_online_at
         - production_url
-      filter: {}
+      filter:
+        deleted_at:
+          _is_null: true
       allow_aggregations: true
 update_permissions:
   - role: api
@@ -421,7 +427,7 @@ update_permissions:
         _and:
           - is_template:
               _eq: false
-          - archived_at:
+          - deleted_at:
               _is_null: true
       check:
         _not:
@@ -444,11 +450,12 @@ update_permissions:
   - role: platformAdmin
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - copied_from
         - data
-        - archived_at
+        - deleted_at
         - description
         - is_listed_on_lps
         - is_template
@@ -461,7 +468,9 @@ update_permissions:
         - summary
         - team_id
         - templated_from
-      filter: {}
+      filter:
+        deleted_at:
+          _is_null: true
       check:
         _not:
           _and:
@@ -508,6 +517,8 @@ update_permissions:
                       _eq: x-hasura-user-id
                   - role:
                       _eq: teamEditor
+          - deleted_at:
+              _is_null: true
           - is_template:
               _eq: false
       check:

--- a/apps/hasura.planx.uk/migrations/default/1776180340818_alter_table_public_flows_add_column_deleted_at/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776180340818_alter_table_public_flows_add_column_deleted_at/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" drop column "deleted_at";

--- a/apps/hasura.planx.uk/migrations/default/1776180340818_alter_table_public_flows_add_column_deleted_at/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776180340818_alter_table_public_flows_add_column_deleted_at/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."flows" add column "deleted_at" timestamptz
+ null;


### PR DESCRIPTION
Another version of #6483 after another messy rebase (sorry!)

Feature flag will come off in the next PR as there are still a couple small outstanding chores

This PR:
- Creates a flows.deleted_at column (timestamp, nullable) and updates permissions
- Creates mutation + hook for flow deletion
- ArchivedFlowMenu has a new item for deletion

<img width="300" alt="Screenshot 2026-04-20 133213" src="https://github.com/user-attachments/assets/853519ef-d27e-43af-a51b-3225123d21d3" />
<img width="1352" height="408" alt="Screenshot 2026-04-20 133218" src="https://github.com/user-attachments/assets/2853ea90-6794-44fe-a707-518fb876ee7a" />
