### PR TITLE
fix(editor): Add loading state for offline/online chip

### DIFF
--- a/apps/editor.planx.uk/src/ui/editor/FlowTag/FlowTag.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/FlowTag/FlowTag.tsx
@@ -1,3 +1,4 @@
+import Skeleton from "@mui/material/Skeleton";
 import React from "react";
 
 import { Root } from "./styles";
@@ -7,10 +8,15 @@ const FlowTag: React.FC<FlowTagProps> = ({
   tagType,
   statusVariant,
   children,
-}) => (
-  <Root tagType={tagType} statusVariant={statusVariant}>
-    {children}
-  </Root>
-);
+}) => {
+  if (!statusVariant)
+    return <Skeleton variant="rounded" width={65} height={24} />;
+
+  return (
+    <Root tagType={tagType} statusVariant={statusVariant}>
+      {children}
+    </Root>
+  );
+};
 
 export default FlowTag;


### PR DESCRIPTION
## What does this PR do?
Small UI fix for something which has bugged me for a while...! This chip flashes in incompletely currently before the status is fetched. Video below (scrubbing forwards and backwards over the loading) to demonstrate this - 

https://github.com/user-attachments/assets/43c9e958-1e46-4f65-a32b-9e0682325927

This PR just ensures the chip only renders when we have all the required data.

_TODO: add video when pizza is up_

