### PR TITLE
style: make FlowTable column widths uniform across views

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -158,7 +158,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               </Box>
             )}
           </FlowStatusCell>
-          <TableCell>
+          <FlowStatusCell>
             <Box>
               <Typography variant="body2">{displayTimeAgo}</Typography>
               {displayActor && (
@@ -167,7 +167,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
                 </Typography>
               )}
             </Box>
-          </TableCell>
+          </FlowStatusCell>
           {showDetails && (
             <TableCell>
               <Box onClick={(e) => e.stopPropagation()}>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -36,7 +36,11 @@ export const StyledTableHead = styled(TableHead)(({ theme }) => ({
 
 export const StyledTableRow = styled(TableRow, {
   shouldForwardProp: (prop) => prop !== "isTemplated" && prop !== "clickable",
-})<{ isTemplated?: boolean; clickable?: boolean }>(({ theme, isTemplated, clickable = true }) => {
+})<{ isTemplated?: boolean; clickable?: boolean }>(({
+  theme,
+  isTemplated,
+  clickable = true,
+}) => {
   let hoverBackground: string | undefined;
   if (clickable && isTemplated) {
     hoverBackground = theme.palette.template.main;
@@ -84,7 +88,7 @@ export const FlowRowLink = styled(CustomLink)(() => ({
 })) as typeof CustomLink;
 
 export const FlowTitleCell = styled(TableCell)(() => ({
-  width: "45%",
+  width: "100%",
   minWidth: "240px",
 }));
 


### PR DESCRIPTION
Fixes a little styling issue with the Actions column of FlowTable across flows and archive views.

## Before:
<img width="700" alt="main-default" src="https://github.com/user-attachments/assets/e15fc615-bfb1-4ba5-b4d1-e20b14cb8e0f" />
<img width="700" alt="main-default-archive" src="https://github.com/user-attachments/assets/249a17bb-6f46-4be5-b5ec-f67aa2f1d067" />

## After:
<img width="700" alt="feat-default" src="https://github.com/user-attachments/assets/e00245b7-26da-4f15-92c1-85ffab74aa13" />
<img width="700" alt="feat-default-archive" src="https://github.com/user-attachments/assets/23e95f94-135b-43e6-9e56-e297993f648b" />

My fix (replacing `TableCell` with `FlowStatusCell` and making the title cell width 100%) does affect some of the other widths. eg, see 'Last edited' column. I checked the changes on a couple other screen sizes too and think using `FlowStatusCell` sometimes works better after all, eg on smaller screens:

**Main**
<img width="700" alt="main-1280" src="https://github.com/user-attachments/assets/e4ca48ef-24d6-4f02-aa3e-b42adbc6fd40" />

**Feature branch:**
<img width="700" alt="feat-1280" src="https://github.com/user-attachments/assets/cdeed57a-7491-4b3b-9d45-47321da46e5e" />

Let me know if there's a better solution here! 