### PR TITLE
chore: Bump planx-core

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -12,7 +12,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@aws-sdk/s3-request-presigner": "^3.1000.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#b71d470",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#025b73e",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.16",
     "ai": "^6.0.116",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^3.1000.0
         version: 3.1015.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#b71d470
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#025b73e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.14)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1218,8 +1218,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14}
     version: 1.0.0
 
   '@opentelemetry/api@1.9.0':
@@ -5486,7 +5486,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@18.3.1))(@types/react@19.2.14)(react@18.3.1)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -17,7 +17,7 @@
     "@mui/x-charts": "^7.29.1",
     "@mui/x-data-grid": "^7.29.12",
     "@opensystemslab/map": "1.0.0-alpha.11",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#b71d470",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#025b73e",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-router-devtools": "^1.163.3",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#b71d470
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@18.3.28)
+        specifier: github:theopensystemslab/planx-core#025b73e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@18.3.28)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.95.2(react@18.3.1)
@@ -1857,8 +1857,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.11':
     resolution: {integrity: sha512-ETACPCk5Coef1L2kNT3MhIzLxVPDpyopxsTNcgeRyEqL71HBfTklGyC5+t7HgEgxRkX5wlUXqmKPNL9DdpVj8g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -8551,7 +8551,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@18.3.28)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@18.3.28)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.30.2",
   "dependencies": {
     "@cucumber/cucumber": "^11.3.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#b71d470",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#025b73e",
     "axios": "^1.15.0",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.3.0
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#b71d470
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#025b73e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.6)
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2152,7 +2152,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#b71d470",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#025b73e",
     "axios": "^1.15.0",
     "dotenv": "^16.6.1",
     "eslint": "^8.57.1",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#b71d470
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#025b73e
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.6)
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -318,8 +318,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14}
     version: 1.0.0
 
   '@playwright/test@1.58.2':
@@ -1790,7 +1790,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/b71d47048eebbe79928ac0505f157ecb9dab5e7e(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/025b73e964eda4f7498248ac6c0703933df42c14(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@18.3.1))(@types/react@19.2.6)(react@18.3.1)


### PR DESCRIPTION
Bumps `planx-core` to the latest commit on `main` which includes the following changes - 
 - https://github.com/theopensystemslab/planx-core/commit/025b73e964eda4f7498248ac6c0703933df42c14
 - https://github.com/theopensystemslab/planx-core/commit/b71d47048eebbe79928ac0505f157ecb9dab5e7e
 
 The latest commit on `planx-new` `main` does not contain https://github.com/theopensystemslab/planx-core/pull/975 due to a sequencing error on my part sorry..!
