### PR TITLE
fix: add `flows.deleted_at` to nightly data sync

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -21,7 +21,8 @@ CREATE TEMPORARY TABLE sync_flows (
   can_create_from_copy boolean,
   is_listed_on_lps boolean,
   category text,
-  submission_email_id uuid
+  submission_email_id uuid,
+  deleted_at timestamptz
   );
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
 
@@ -45,7 +46,8 @@ INSERT INTO flows (
   can_create_from_copy,
   is_listed_on_lps,
   category,
-  submission_email_id
+  submission_email_id,
+  deleted_at
 )
 SELECT
   id,
@@ -67,7 +69,8 @@ SELECT
   can_create_from_copy,
   is_listed_on_lps,
   category,
-  submission_email_id
+  submission_email_id,
+  deleted_at
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -88,7 +91,8 @@ SET
   archived_at = EXCLUDED.archived_at,
   can_create_from_copy = EXCLUDED.can_create_from_copy,
   category = EXCLUDED.category,
-  submission_email_id = NULL;
+  submission_email_id = NULL,
+  deleted_at = EXCLUDED.deleted_at;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
Currently throwing `psql:write/flows.sql:26: ERROR:  extra data after last expected colum` otherwise ! 

These are easy to miss! Flows is a table which does a `select * from ...` via `container.sh`, so columns need to be kept manually in sync with Hasura migrations (_but_ only once that migration merges to prod!).