### PR TITLE
fix: Handle `NavMenuItems` with both a compact and disabled state

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
@@ -211,7 +211,7 @@ describe("flowLayoutRoutes", () => {
     expect(menuItems).toHaveLength(5);
     expect(getByLabelText("Submissions")).toBeInTheDocument();
     expect(getByLabelText("Feedback")).toBeInTheDocument();
-    expect(getByLabelText("Analytics")).toBeInTheDocument();
+    expect(getByLabelText(/Analytics/)).toBeInTheDocument();
   });
 });
 

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
@@ -19,44 +19,21 @@ const NavMenuItem = ({
   compact,
   onClick,
 }: Props) => {
-  if (compact) {
-    return (
-      <Tooltip title={title} placement="right">
-        <Box component="span">
-          <MenuButton
-            title={title}
-            isActive={isActive}
-            disabled={disabled}
-            disableRipple
-            onClick={onClick}
-            sx={{ padding: "8px" }}
-          >
-            <Icon />
-          </MenuButton>
-        </Box>
-      </Tooltip>
-    );
-  }
+  const tooltipTitle = disabled ? `${title} unavailable` : title;
+  const showTooltip = compact || disabled;
 
-  if (disabled) {
-    return (
-      <Tooltip title={`${title} unavailable`} placement="right">
-        <Box component="span">
-          <NavMenuButton
-            title={title}
-            Icon={Icon}
-            isActive={isActive}
-            isExternal={isExternal}
-            disabled={disabled}
-            isNew={isNew}
-            onClick={onClick}
-          />
-        </Box>
-      </Tooltip>
-    );
-  }
-
-  return (
+  const buttonContent = compact ? (
+    <MenuButton
+      title={title}
+      isActive={isActive}
+      disabled={disabled}
+      disableRipple
+      onClick={onClick}
+      sx={{ padding: "8px" }}
+    >
+      <Icon />
+    </MenuButton>
+  ) : (
     <NavMenuButton
       title={title}
       Icon={Icon}
@@ -67,6 +44,16 @@ const NavMenuItem = ({
       onClick={onClick}
     />
   );
+
+  if (showTooltip) {
+    return (
+      <Tooltip title={tooltipTitle} placement="right">
+        <Box component="span">{buttonContent}</Box>
+      </Tooltip>
+    );
+  }
+
+  return buttonContent;
 };
 
 export default NavMenuItem;


### PR DESCRIPTION
Small bug I noticed when working on https://github.com/theopensystemslab/planx-new/pull/6518

Currently, we don't correctly update the tooltip if a menu item is both compact and disabled (e.g. flow analytics link). Compare the two tooltips from staging below - 

| Team page | Flow page |
|--------|--------|
| <img width="358" height="104" alt="image" src="https://github.com/user-attachments/assets/9f9a8c1a-9d76-4eb0-805f-dd7d388552cc" /> | <img width="172" height="102" alt="image" src="https://github.com/user-attachments/assets/d242c37b-4642-4e00-a586-dffc2162a3b2" /> |

This PR updates the logic to split out these two conditions

| Team page | Flow page |
|--------|--------|
| <img width="345" height="76" alt="image" src="https://github.com/user-attachments/assets/9b1c6716-d76f-49a9-822b-9138b561597f" /> | <img width="228" height="92" alt="image" src="https://github.com/user-attachments/assets/316897b8-28d2-42bd-9277-4cf2354838ad" /> | 