### PR TITLE
feat: unpin archived flows

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1776784884510_create_delete_pinned_flows_on_archive_trigger/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776784884510_create_delete_pinned_flows_on_archive_trigger/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS delete_pinned_flows_on_archive();
+DROP TRIGGER IF EXISTS delete_pinned_flows_on_archive_trigger ON flows;

--- a/apps/hasura.planx.uk/migrations/default/1776784884510_create_delete_pinned_flows_on_archive_trigger/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776784884510_create_delete_pinned_flows_on_archive_trigger/up.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION delete_pinned_flows_on_archive()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.archived_at IS NULL AND NEW.archived_at IS NOT NULL THEN
+    DELETE FROM user_pinned_flows
+    WHERE flow_id = NEW.id;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_pinned_flows_on_archive_trigger
+AFTER UPDATE ON flows
+FOR EACH ROW
+EXECUTE FUNCTION delete_pinned_flows_on_archive();


### PR DESCRIPTION
When the `useArchiveFlow` hook runs, ensures that all records for that flow are deleted from the `user_pinned_flows `table. As discussed at S+T, this is the behaviour we would expect when archiving a pinned flow. If an archived flow is unarchived, it is no longer pinned for any users that might have pinned it previously. 

I tested this locally for my own user, as well as for an additional record for the same flow pinned by another user. 

https://github.com/user-attachments/assets/ebb8a4e9-4def-4627-977c-1cc6453df18e
