### PR TITLE
fix(e2e): Setup mock endpoint in smocker for Resend

### DIFF
--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/server-mocks.yaml
@@ -56,3 +56,14 @@
       Content-Type: application/json
     body: >
       { "messsage": "MOCKED RESPONSE" }
+
+# Mock Resend endpoint
+- request:
+    method: POST
+    path: /emails
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+    body: >
+      { "id": "test-email-id" }


### PR DESCRIPTION
## What's the problem?
E2E regression tests are failing - specifically the "send to email" tests.

## What's the cause?
The "snd to email" has been [migrated to send emails using Resend](https://github.com/theopensystemslab/planx-new/pull/6458). The `RESEND_BASE_URL` is pointing at smocker here, configured for the "welcome email" tests.

https://github.com/theopensystemslab/planx-new/blob/61e7c559aaea260dc2ec4f15b4e4cab48e23770b/docker-compose.e2e.yml#L32

The `RESEND_BASE_URL` is pointing to smocker in these tests, but we haven't configured and endpoint to respond. The error logged in the API confirms this - 

```json
{
  "message": "No mock found matching the request",
  "request": {
    "path": "/emails",
    "method": "POST",
    "body": { ... },
    "headers": {
      ...
      "Host": [
        "mock-server:8080"
      ],
      "User-Agent": [
        "resend-node:6.9.4"
      ]
    },
  }
}
```

## What's the solution?
Create smocker endpoint for Resend requests.

✅ E2E tests passing locally
✅  E2E tests passing on CI here - https://github.com/theopensystemslab/planx-new/actions/runs/24746267798