### PR TITLE
fix: Preserve router state in navigation calls within FormModal

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -150,6 +150,7 @@ const TextInputToggle: React.FC<{
         ...prev,
         type: SLUGS[destinationType] as NodeSearchParams["type"],
       }),
+      state: (prev) => prev,
     });
   };
 
@@ -333,6 +334,7 @@ const FormModal: React.FC<FormModalProps> = ({
         ...prev,
         type: SLUGS[type] as NodeSearchParams["type"],
       }),
+      state: (prev) => prev,
     });
   };
 


### PR DESCRIPTION
## What's the problem?
Navigation is breaking once the form modal is open - Editors aren't able to change node type once a recent flows entry exists.

## What's the cause?
As we're not preserving state on these navigation events (e.g. changing component type), we end up with a race condition and React overwriting router history - resulting in a no-op navigation event (nothing happens).

## What's the solution?
Manually pass state along - please see https://github.com/theopensystemslab/planx-new/pull/6339#discussion_r2960935192 for more context.

## Next steps...
I'm not _that_ happy with this as a solution - I think we're going to keep hitting this class of bug if we don't find an alternate approach. We've already seen this once here - https://github.com/theopensystemslab/planx-new/pull/6345

I'll take another look on the approach from https://github.com/theopensystemslab/planx-new/pull/6339 and add test coverage here as well. 

For now I'm going to merge this forwards as a hotfix, and follow up with a fuller solution.