### PR TITLE
chore: create analytics_first_used view

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_first_used.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_first_used.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_first_used
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -4,6 +4,7 @@
 - "!include public_analytics.yaml"
 - "!include public_analytics_action_nodes.yaml"
 - "!include public_analytics_exits.yaml"
+- "!include public_analytics_first_used.yaml"
 - "!include public_analytics_journeys_aggregated.yaml"
 - "!include public_analytics_logs.yaml"
 - "!include public_analytics_planning_data_teams.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1776944606549_create_analytics_first_used_view/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776944606549_create_analytics_first_used_view/down.sql
@@ -1,0 +1,1 @@
+DROP REPLACE VIEW "public"."analytics_first_used";

--- a/apps/hasura.planx.uk/migrations/default/1776944606549_create_analytics_first_used_view/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1776944606549_create_analytics_first_used_view/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW "public"."analytics_first_used" AS 
+SELECT
+  a.flow_id AS flow_id,
+  MIN(a.created_at)::date AS first_used_at
+FROM
+  analytics a
+GROUP BY
+  a.flow_id;
+
+GRANT SELECT ON "public"."analytics_first_used" TO metabase_read_only;


### PR DESCRIPTION
Creates a new view just for `flow_id` and `first_used_at` date. It was slow / expensive to run this as part of an existing view, hence the new table. This can be used to automate Metabot alerts so we can keep on top of new services coming online.

Decision explained in more depth [here](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1776947637441539?thread_ts=1776354127.151379&cid=C01E3AC0C03).