### PR TITLE
fix(editor): Update flow modals to correctly handle non-unique flow names

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useCreateFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useCreateFlow.ts
@@ -1,15 +1,21 @@
 import { useMutation } from "@tanstack/react-query";
+import type { APIError } from "lib/api/client";
 import {
   createFlow,
   createFlowFromCopy,
   createFlowFromTemplate,
 } from "lib/api/flow/requests";
+import type { NewFlow } from "lib/api/flow/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 
 import { CreateFlow } from "../types";
 
 export const useCreateFlow = () => {
-  return useMutation({
+  return useMutation<
+    { mode: CreateFlow["mode"]; flow: NewFlow },
+    APIError<{ error?: string }>,
+    CreateFlow
+  >({
     mutationFn: async ({ mode, flow }: CreateFlow) => {
       const mutation = {
         new: createFlow,

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -6,7 +6,6 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import { useNavigate } from "@tanstack/react-router";
 import { logger } from "airbrake";
-import { isAxiosError } from "axios";
 import { Form, Formik, FormikConfig } from "formik";
 import { useToast } from "hooks/useToast";
 import React, { useState } from "react";
@@ -40,7 +39,7 @@ export const AddFlow: React.FC = () => {
     },
   };
 
-  const { mutateAsync: createFlow } = useCreateFlow();
+  const { mutate: createFlow } = useCreateFlow();
 
   const handleSubmit: FormikConfig<CreateFlow>["onSubmit"] = async (
     values,
@@ -52,18 +51,18 @@ export const AddFlow: React.FC = () => {
     });
 
     showLoading("Creating flow...");
-    try {
-      const result = await createFlow(values);
-      await navigate({
-        to: "/app/$team/$flow",
-        params: { team: teamSlug, flow: result.flow.slug },
-      });
-      hideLoading();
-    } catch (error) {
-      setLoadingCompleteCallback(undefined);
 
-      if (isAxiosError(error)) {
-        const message = error?.response?.data?.error;
+    createFlow(values, {
+      onSuccess: async ({ flow }) => {
+        await navigate({
+          to: "/app/$team/$flow",
+          params: { team: teamSlug, flow: flow.slug },
+        });
+        hideLoading();
+      },
+      onError: (error) => {
+        setLoadingCompleteCallback(undefined);
+        const message = error.data?.error;
         if (message?.includes("Uniqueness violation")) {
           setFieldError("flow.name", "Flow name must be unique");
           hideLoading();
@@ -80,10 +79,10 @@ export const AddFlow: React.FC = () => {
           hideLoading();
           return;
         }
-      }
-      setStatus({ error: "Failed to create flow, please try again." });
-      hideLoading();
-    }
+        setStatus({ error: "Failed to create flow, please try again." });
+        hideLoading();
+      },
+    });
   };
 
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);

--- a/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
@@ -4,7 +4,6 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import { isAxiosError } from "axios";
 import { Form, Formik, FormikConfig } from "formik";
 import { useToast } from "hooks/useToast";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -57,14 +56,12 @@ export const CopyDialog: React.FC<Props> = ({
         toast.success(`Created new flow "${values.flow.name}"`);
       },
       onError: (error) => {
-        if (isAxiosError(error)) {
-          const message = error?.response?.data?.error;
-          if (message?.includes("Uniqueness violation")) {
-            setFieldError("flow.name", "Flow name must be unique");
-          }
+        const message = error.data?.error;
+        if (message?.includes("Uniqueness violation")) {
+          setFieldError("flow.name", "Flow name must be unique");
+          return;
         }
-
-        throw error;
+        toast.error("Failed to copy flow, please try again.");
       },
     });
   };

--- a/apps/editor.planx.uk/src/pages/Team/components/MoveDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/MoveDialog.tsx
@@ -9,9 +9,9 @@ import MenuItem from "@mui/material/MenuItem";
 import Skeleton from "@mui/material/Skeleton";
 import { Team } from "@opensystemslab/planx-core/types";
 import { useMutation } from "@tanstack/react-query";
-import { isAxiosError } from "axios";
 import { Form, Formik, FormikConfig } from "formik";
 import { useToast } from "hooks/useToast";
+import type { APIError } from "lib/api/client";
 import { moveFlow } from "lib/api/flow/requests";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -46,24 +46,26 @@ export const MoveDialog: React.FC<Props> = ({
     state.canUserEditTeam,
   ]);
   const toast = useToast();
-  const moveFlowMutation = useMutation({
+  const moveFlowMutation = useMutation<
+    { message: string },
+    APIError<{ error?: string }>,
+    { flowId: string; teamSlug: string }
+  >({
     mutationFn: moveFlow,
     onSuccess: (data) => {
       toast.success(data.message || "Flow moved successfully");
       handleClose();
     },
     onError: (error) => {
-      if (isAxiosError(error) && error.response) {
-        const apiError = error.response.data?.error;
-        if (apiError?.toLowerCase().includes("uniqueness violation")) {
-          toast.error(
-            `Failed to move. A flow with name '${sourceFlow.name}' already exists in that team. Rename the flow and try again.`,
-          );
-        } else {
-          toast.error(
-            "Failed to move. Make sure you're entering a valid team name and try again.",
-          );
-        }
+      const apiError = error.data?.error;
+      if (apiError?.toLowerCase().includes("uniqueness violation")) {
+        toast.error(
+          `Failed to move. A flow with name '${sourceFlow.name}' already exists in that team. Rename the flow and try again.`,
+        );
+      } else {
+        toast.error(
+          "Failed to move. Make sure you're entering a valid team name...",
+        );
       }
     },
   });


### PR DESCRIPTION
## What's the problem?
Reported here - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1776866810893219 (OSL Slack)

Uniqueness violations on flow create / move / copy are not being handled correctly - there's either an unhandled error (modal closes, no indication of error) or a generic toast which does not raise a field level error.

## What's the cause?
We're incorrectly checking for the `isAxiosError()` condition. As our `APIClient` (axios wrapper) throws a custom `APIError<T>`, this condition is never met.

## What's the solution?
 - Add better type definitions to `useCreateFlow()` so that the types are inferred correctly when called
 - Remove the `isAxiosError()` check
 
 ## To test...
 Try to copy a flow on staging, retaining the original name (remove ` (copy)` suffix). Nothing happens, no user feedback, just a network and console error.
  
On Pizza, this will show a field level error - 
  
<img width="730" height="500" alt="image" src="https://github.com/user-attachments/assets/bfecdbed-6c38-43e0-bf1f-9bc90781165a" />
