### PR TITLE
chore: devX improvements for e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ The root of the project has several scripts set up to help you manage your docke
 - `pnpm destroy` will remove volumes (i.e. database data) and can be a useful hard reset when necessary.
 - `pnpm sync-data` will sync production records with modified data in your database
 - `pnpm clean-data` will sync production records and reset any modified data
-- `pnpm tests` will recreate your docker containers and include test services
+- `pnpm dev` will tear down any e2e containers and recreate your dev docker containers from scratch, including seeding the database - useful when switching from a test environment
+- `pnpm tests` will tear down any dev containers and recreate your docker containers and include test services - useful when switching from a dev environment
 - `pnpm analytics` will recreate your docker containers and include [Metabase](https://www.metabase.com/)
 - `pnpm logs` will print docker log entries (this can be filtered by appending `-- [service name]`, for example `pnpm logs -- api`)
 

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -157,6 +157,7 @@
   },
   "packageManager": "pnpm@10.30.2",
   "scripts": {
+    "prestart": "../../scripts/check-containers.sh dev",
     "start": "vite --open",
     "build": "tsc && vite build",
     "serve": "vite preview",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "pretest": "../scripts/check-containers.sh e2e",
     "test": "pnpm test:api && pnpm test:ui",
     "test:ui": "cd tests/ui-driven && pnpm test",
     "test:api": "cd tests/api-driven && pnpm test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "up": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.e2e.yml --profile mock-services --project-name planx-e2e down --volumes --remove-orphans; pnpm recreate && pnpm sync-data",
+    "up": "pnpm recreate && pnpm sync-data",
     "down": "pnpm destroy",
     "restart": "pnpm stop && pnpm start",
     "start": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull",
@@ -10,6 +10,7 @@
     "sync-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database",
     "test-sync": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.seed.yml run seed-database reset_flows",
     "clean-data": "docker compose -f ./docker-compose.yml -f ./docker-compose.seed.yml run seed-database reset_all",
+    "dev": "./scripts/start-containers-for-dev.sh",
     "tests": "./scripts/start-containers-for-tests.sh",
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",
     "logs": "docker compose logs --tail 30 -f"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "up": "pnpm recreate && pnpm sync-data",
+    "up": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml -f ./docker-compose.e2e.yml --profile mock-services --project-name planx-e2e down --volumes --remove-orphans; pnpm recreate && pnpm sync-data",
     "down": "pnpm destroy",
     "restart": "pnpm stop && pnpm start",
     "start": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services up -d --quiet-pull",

--- a/scripts/check-containers.sh
+++ b/scripts/check-containers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Usage: check-containers.sh [e2e|dev]
+# Exits with an error if the expected Docker Compose project is not running.
+
+ENV=${1:-dev}
+
+if [ "$ENV" = "e2e" ]; then
+  PROJECT="planx-e2e"
+  FIX_CMD="pnpm tests"
+else
+  PROJECT="planx-new"
+  FIX_CMD="pnpm dev"
+fi
+
+RUNNING=$(docker ps --filter "label=com.docker.compose.project=$PROJECT" --filter "status=running" -q)
+
+if [ -z "$RUNNING" ]; then
+  echo ""
+  echo "Error: $ENV containers are not running (project: $PROJECT)."
+  echo "Run '$FIX_CMD' from the project root first."
+  echo ""
+  exit 1
+fi

--- a/scripts/start-containers-for-dev.sh
+++ b/scripts/start-containers-for-dev.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -o errexit -o errtrace
+
+# run from project root
+cd "$(dirname $0)/.."
+
+# clear DOCKER_DEFAULT_PLATFORM in case it was set in .env for Apple Silicon.
+function dev_compose() {
+  DOCKER_DEFAULT_PLATFORM= docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.local.yml \
+    --profile mock-services \
+    "$@"
+}
+
+trap 'echo "Error detected! Saving logs..."; \
+      dev_compose logs > docker_compose_logs.txt; \
+      echo "Logs saved to docker_compose_logs.txt"; \
+      dev_compose down --remove-orphans' ERR
+
+function setupContainers(){
+  # Bring down e2e containers (including volumes) to avoid conflicts
+  # project-name planx-e2e matches what start-containers-for-tests.sh uses
+  DOCKER_DEFAULT_PLATFORM= docker compose \
+    --project-name planx-e2e \
+    -f docker-compose.yml \
+    -f docker-compose.e2e.yml \
+    --profile mock-services \
+    down --volumes --remove-orphans
+
+  # Destroy any previous dev containers and data
+  dev_compose down --volumes --remove-orphans
+
+  # Remove any dangling images that might cause conflicts
+  echo "Cleaning up dangling images..."
+  docker image prune -f || true
+
+  echo "Starting docker…"
+
+  DOCKER_BUILDKIT=1 dev_compose up -d --quiet-pull --build --renew-anon-volumes --force-recreate
+
+  echo "Seeding database..."
+  DOCKER_DEFAULT_PLATFORM= docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.local.yml \
+    -f docker-compose.seed.yml \
+    run seed-database
+
+  echo "All containers ready."
+}
+
+setupContainers

--- a/scripts/start-containers-for-dev.sh
+++ b/scripts/start-containers-for-dev.sh
@@ -19,7 +19,7 @@ trap 'echo "Error detected! Saving logs..."; \
       dev_compose down --remove-orphans' ERR
 
 function setupContainers(){
-  # Bring down e2e containers (including volumes) to avoid conflicts
+  # Bring down e2e containers and their volumes - we're done with testing
   # project-name planx-e2e matches what start-containers-for-tests.sh uses
   DOCKER_DEFAULT_PLATFORM= docker compose \
     --project-name planx-e2e \
@@ -28,23 +28,15 @@ function setupContainers(){
     --profile mock-services \
     down --volumes --remove-orphans
 
-  # Destroy any previous dev containers and data
-  dev_compose down --volumes --remove-orphans
-
   # Remove any dangling images that might cause conflicts
   echo "Cleaning up dangling images..."
   docker image prune -f || true
 
   echo "Starting docker…"
 
-  DOCKER_BUILDKIT=1 dev_compose up -d --quiet-pull --build --renew-anon-volumes --force-recreate
-
-  echo "Seeding database..."
-  DOCKER_DEFAULT_PLATFORM= docker compose \
-    -f docker-compose.yml \
-    -f docker-compose.local.yml \
-    -f docker-compose.seed.yml \
-    run seed-database
+  # Bring dev containers back up, preserving existing volumes so local data changes are not lost.
+  # For a clean first-time setup, use `pnpm up` instead.
+  DOCKER_BUILDKIT=1 dev_compose up -d --quiet-pull --build --force-recreate
 
   echo "All containers ready."
 }

--- a/scripts/start-containers-for-tests.sh
+++ b/scripts/start-containers-for-tests.sh
@@ -4,14 +4,34 @@ set -o errexit -o errtrace
 # run from project root
 cd "$(dirname $0)/.."
 
+# --project-name planx-e2e isolates e2e volumes from the dev project
+#
+# clear DOCKER_DEFAULT_PLATFORM in case it was set in .env for Apple Silicon.
+function e2e_compose() {
+  DOCKER_DEFAULT_PLATFORM= docker compose \
+    --project-name planx-e2e \
+    -f docker-compose.yml \
+    -f docker-compose.e2e.yml \
+    --profile mock-services \
+    "$@"
+}
+
 trap 'echo "Error detected! Saving logs..."; \
-      docker compose logs > docker_compose_logs.txt; \
+      e2e_compose logs > docker_compose_logs.txt; \
       echo "Logs saved to docker_compose_logs.txt"; \
-      docker compose down --volumes --remove-orphans' ERR
+      e2e_compose down --volumes --remove-orphans' ERR
 
 function setupContainers(){
-  # Destroy all previous containers and data (just in case)
-  docker compose down --volumes --remove-orphans
+  # Bring down the dev environment containers
+  # volumes are kept as they are a different docker project
+  docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.local.yml \
+    --profile mock-services \
+    down --remove-orphans
+
+  # Destroy any previous e2e containers and data
+  e2e_compose down --volumes --remove-orphans
 
   # Remove any dangling images that might cause conflicts
   echo "Cleaning up dangling images..."
@@ -19,20 +39,9 @@ function setupContainers(){
 
   echo "Starting docker…"
 
-  # Build
-  DOCKER_BUILDKIT=1 docker compose \
-    -f docker-compose.yml \
-    -f docker-compose.e2e.yml \
-    --profile mock-services \
-    build
-
-  # Run
-  DOCKER_BUILDKIT=1 docker compose \
-    -f docker-compose.yml \
-    -f docker-compose.e2e.yml \
-    --profile mock-services \
-    up --wait test-ready
-    echo "All containers ready."
-  }
+  DOCKER_BUILDKIT=1 e2e_compose build
+  DOCKER_BUILDKIT=1 e2e_compose up --wait test-ready
+  echo "All containers ready."
+}
 
 setupContainers


### PR DESCRIPTION
### What's in this PR?
Docker volume isolation for regular dev containers vs e2e test containers. This helps reduce friction when switching between dev and test mode. 

#### How does it work?
The idea here is that we still `down` and `up` the containers when moving between local dev and test mode, but its a lot quicker and crucially we keep the volumes separate, using a separate docker project for the test environment. This means that the data we are working with for local dev stays in place. 

#### Extras
- created a new package script 'dev' which calls `./scripts/start-containers-for-dev.sh` which basically has the inverse operations to the `./scripts/start-containers-for-tests.sh` , so the process of switching between the two is a single command in either direction - `pnpm tests` / `pnpm dev`
- Added a `pretest` and `prestart` script that runs `check-containers` before starting the editor/running the e2e tests. If the correct set of containers are not running it exists immediately with a command.
    - Q: should we use this elsewhere as well? 