### PR TITLE
feat(editor): Support the `drawingNumber` field for single file uploads

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -101,7 +101,7 @@ function Component(props: Props) {
                   !formik.values.showDrawingNumber,
                 )
               }
-              label="Show a drawing number field for each uploaded file"
+              label="Show an optional drawing number input for each uploaded file"
               disabled={props.disabled}
             />
           </InputRow>

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -92,6 +92,19 @@ function Component(props: Props) {
               disabled={props.disabled}
             />
           </InputRow>
+          <InputRow>
+            <Switch
+              checked={formik.values.showDrawingNumber}
+              onChange={() =>
+                formik.setFieldValue(
+                  "showDrawingNumber",
+                  !formik.values.showDrawingNumber,
+                )
+              }
+              label="Show a drawing number field for each uploaded file"
+              disabled={props.disabled}
+            />
+          </InputRow>
         </ModalSectionContent>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/FileUpload.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/FileUpload.stories.tsx
@@ -25,6 +25,18 @@ export const Basic = {
   },
 } satisfies Story;
 
+export const WithDrawingNumbers = {
+  args: {
+    fn: "roofPlan",
+    title: "Upload roof plan",
+    description:
+      "The plan should show the roof of the building as it looks today.",
+    handleSubmit: () => {},
+    howMeasured: `<p>Your roof plan must:</p><ul><li>be drawn to scale. This is usually 1:100 or 1:50 at A3 or A4 size</li><li>have a scale bar</li><li>have a unique drawing reference number</li></ul>`,
+    showDrawingNumber: true,
+  },
+} satisfies Story;
+
 export const WithEditor = () => {
   return <Wrapper Editor={Editor} Public={Public} />;
 };

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -173,3 +173,103 @@ test("shows singular 'Drop file here' text when maxFiles is 1", async () => {
   expect(screen.getByText(/Drop file here/)).toBeInTheDocument();
   expect(screen.queryByText(/Drop files here/)).not.toBeInTheDocument();
 });
+
+describe("drawing numbers", () => {
+  const dataField = "data-field";
+
+  const previouslySubmittedDataWithFile = (dataField: string) => ({
+    data: {
+      [dataField]: [dummyFile],
+      [PASSPORT_REQUESTED_FILES_KEY]: {
+        required: [dataField],
+        recommended: [],
+        optional: [],
+      },
+    },
+  });
+
+  test("does not show a drawing number field by default", async () => {
+    await setup(
+      <FileUpload
+        title="Please upload your files"
+        fn={dataField}
+        handleSubmit={vi.fn()}
+        previouslySubmittedData={previouslySubmittedDataWithFile(dataField)}
+      />,
+    );
+
+    expect(screen.queryByText(/Drawing number/i)).not.toBeInTheDocument();
+  });
+
+  test("shows a drawing number field for each file when showDrawingNumber is true", async () => {
+    await setup(
+      <FileUpload
+        title="Please upload your files"
+        fn={dataField}
+        handleSubmit={vi.fn()}
+        showDrawingNumber={true}
+        previouslySubmittedData={previouslySubmittedDataWithFile(dataField)}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Drawing number \(optional\)/i),
+    ).toBeInTheDocument();
+  });
+
+  test("allows submission without a drawing number when showDrawingNumber is true", async () => {
+    const handleSubmit = vi.fn();
+
+    const { user } = await setup(
+      <FileUpload
+        title="Please upload your files"
+        fn={dataField}
+        handleSubmit={handleSubmit}
+        showDrawingNumber={true}
+        previouslySubmittedData={previouslySubmittedDataWithFile(dataField)}
+      />,
+    );
+
+    await user.click(screen.getByTestId("continue-button"));
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          [dataField]: expect.arrayContaining([
+            expect.objectContaining({ drawingNumber: undefined }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  test("maps the drawing number to the submitted data", async () => {
+    const handleSubmit = vi.fn();
+
+    const { user } = await setup(
+      <FileUpload
+        title="Please upload your files"
+        fn={dataField}
+        handleSubmit={handleSubmit}
+        showDrawingNumber={true}
+        previouslySubmittedData={previouslySubmittedDataWithFile(dataField)}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /Drawing number/i }),
+      "ABC-12345",
+    );
+    await user.click(screen.getByTestId("continue-button"));
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          [dataField]: expect.arrayContaining([
+            expect.objectContaining({ drawingNumber: "ABC-12345" }),
+          ]),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -73,7 +73,54 @@ test("recovers previously submitted files when clicking the back button", async 
   expect(handleSubmit).toHaveBeenCalledWith(uploadedFile);
 });
 
-test.todo("cannot continue until uploads have finished");
+test("cannot continue until uploads have finished", async () => {
+  const handleSubmit = vi.fn();
+  const componentId = uniqueId();
+  const dataField = "data-field";
+
+  const uploadingFile = {
+    url: undefined,
+    filename: "placeholder.png",
+    cachedSlot: {
+      file: {
+        name: "placeholder.png",
+        path: "./placeholder.png",
+        type: "image/png",
+        size: 6146,
+      },
+      status: "uploading",
+      progress: 0.5,
+      id: "uploading-id",
+      url: undefined,
+      drawingNumber: undefined,
+    },
+  };
+
+  const { user } = await setup(
+    <FileUpload
+      title="Please upload your files"
+      fn={dataField}
+      id={componentId}
+      handleSubmit={handleSubmit}
+      previouslySubmittedData={{
+        data: {
+          [dataField]: [uploadingFile],
+          [PASSPORT_REQUESTED_FILES_KEY]: {
+            required: [dataField],
+            recommended: [],
+            optional: [],
+          },
+        },
+      }}
+    />,
+  );
+
+  await user.click(screen.getByTestId("continue-button"));
+  expect(
+    screen.getByText(/Please wait for upload to complete/),
+  ).toBeInTheDocument();
+  expect(handleSubmit).toHaveBeenCalledTimes(0);
+});
 
 const dummyFile = {
   url: "http://localhost:7002/file/private/y2uubi9x/placeholder.png",

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -25,6 +25,7 @@ const FileUploadComponent: React.FC<Props> = (props) => {
       slots.map((slot) => ({
         url: slot.url,
         filename: slot.file.name,
+        drawingNumber: slot.drawingNumber || undefined,
         cachedSlot: {
           ...slot,
           file: {

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.tsx
@@ -100,6 +100,7 @@ const FileUploadComponent: React.FC<Props> = (props) => {
           slots={slots}
           setSlots={setSlots}
           maxFiles={props.maxFiles}
+          showDrawingNumber={props.showDrawingNumber}
         />
       </ErrorWrapper>
     </Card>

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -20,6 +20,7 @@ export interface FileUploadSlot {
   progress: number;
   id: string;
   url?: string;
+  drawingNumber: string | undefined;
   cachedSlot?: Omit<FileUploadSlot, "cachedSlot">;
 }
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/model.tsx
@@ -5,13 +5,14 @@ import {
 } from "@planx/components/shared";
 import { richText } from "lib/yupExtensions";
 import { FileWithPath } from "react-dropzone";
-import { array, number, object, SchemaOf, string } from "yup";
+import { array, boolean, number, object, SchemaOf, string } from "yup";
 
 export interface FileUpload extends BaseNodeData {
   title: string;
   fn: string;
   description?: string;
   maxFiles?: number;
+  showDrawingNumber?: boolean;
 }
 
 export interface FileUploadSlot {
@@ -36,6 +37,7 @@ export const parseFileUpload = (
   policyRef: data?.policyRef,
   title: data?.title || "",
   maxFiles: data?.maxFiles,
+  showDrawingNumber: data?.showDrawingNumber || false,
   ...parseBaseNodeData(data),
 });
 
@@ -79,6 +81,7 @@ export const validationSchema: SchemaOf<FileUpload> =
       title: string().required(),
       fn: string().nullable().required(),
       maxFiles: number().optional(),
+      showDrawingNumber: boolean().optional(),
     }),
   );
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -179,7 +179,6 @@ export default function Component(props: Props) {
                   createSlot={(baseSlot) => ({
                     ...baseSlot,
                     tags: [],
-                    drawingNumber: undefined,
                   })}
                 />
               </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/model.ts
@@ -55,7 +55,6 @@ export const newFileType = (): FileType => ({
 
 export interface FileUploadAndLabelSlot extends FileUploadSlot {
   tags: string[];
-  drawingNumber: string | undefined;
 }
 
 export interface FormattedUserFile {

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -141,6 +141,7 @@ export function Dropzone<T extends FileUploadSlot>({
           status: "uploading",
           progress: 0,
           id: nanoid(),
+          drawingNumber: undefined,
         };
 
         const slot = createSlot

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/PrivateFileUpload.tsx
@@ -10,17 +10,27 @@ interface PrivateFileUploadProps {
   slots: FileUploadSlot[];
   setSlots: React.Dispatch<React.SetStateAction<FileUploadSlot[]>>;
   maxFiles?: number;
+  showDrawingNumber?: boolean;
 }
 
 export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
   slots,
   setSlots,
   maxFiles,
+  showDrawingNumber = false,
 }) => {
   const [fileUploadStatus, setFileUploadStatus] = useState<string | undefined>(
     undefined,
   );
   const hasEmptySlots = !maxFiles || maxFiles > slots.length;
+
+  const onDrawingNumberChange = (slotId: string, drawingNumber: string) => {
+    setSlots((prevSlots) =>
+      prevSlots.map((slot) =>
+        slot.id === slotId ? { ...slot, drawingNumber } : slot,
+      ),
+    );
+  };
 
   return (
     <>
@@ -36,6 +46,8 @@ export const PrivateFileUpload: React.FC<PrivateFileUploadProps> = ({
         {slots.map((slot) => (
           <UploadedFileCard
             {...slot}
+            showDrawingNumber={showDrawingNumber}
+            onDrawingNumberChange={onDrawingNumberChange}
             key={slot.id}
             removeFile={() => {
               setSlots(

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -9,23 +9,26 @@ import { FileUploadSlot } from "@planx/components/FileUpload/model";
 import ImagePreview from "components/ImagePreview";
 import React from "react";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
+import Input from "ui/shared/Input/Input";
 
 interface Props extends FileUploadSlot {
   removeFile: () => void;
   onChange?: () => void;
-  // New accordion UI props
   changeLabel?: string;
   changeIcon?: React.ReactNode;
   hideChangeButton?: boolean;
-  drawingNumber?: string;
-  // Legacy modal UI props
-  tags?: string[];
+  showDrawingNumber?: boolean;
+  onDrawingNumberChange?: (slotId: string, drawingNumber: string) => void;
   FileCardProps?: BoxProps;
 }
 
-const FileCard = styled(Box)(({ theme }) => ({
+const FileCardRoot = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(1.5),
+}));
+
+const FileCard = styled(Box)(({ theme }) => ({
   position: "relative",
   height: "auto",
   display: "flex",
@@ -36,7 +39,6 @@ const FileCard = styled(Box)(({ theme }) => ({
     flexDirection: "row",
     alignItems: "center",
   },
-  padding: theme.spacing(1.5),
   "& > *": {
     zIndex: 1,
   },
@@ -88,6 +90,7 @@ const ActionButtons = styled(Box)(({ theme }) => ({
 }));
 
 export const UploadedFileCard: React.FC<Props> = ({
+  id,
   file,
   progress,
   url,
@@ -99,6 +102,8 @@ export const UploadedFileCard: React.FC<Props> = ({
   drawingNumber,
   status,
   FileCardProps,
+  showDrawingNumber = false,
+  onDrawingNumberChange,
 }) => (
   <Box>
     <ErrorWrapper
@@ -109,87 +114,109 @@ export const UploadedFileCard: React.FC<Props> = ({
       }
     >
       <>
-        <FileCard {...FileCardProps}>
-          <ProgressBar
-            sx={{ width: `${Math.min(Math.ceil(progress * 100), 100)}%` }}
-            role="progressbar"
-            aria-valuenow={progress * 100 || 0}
-            aria-label={`Upload progress of file ${file.name}`}
-          />
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "flex-start",
-              gap: 1,
-              alignItems: "center",
-              width: "100%",
-            }}
-          >
-            <FilePreview>
-              {file instanceof File && file?.type?.includes("image") ? (
-                <ImagePreview file={file} url={url} />
-              ) : (
-                <FileIcon />
-              )}
-            </FilePreview>
-            <Box sx={{ mr: 2 }}>
-              <Typography
-                variant="body1"
-                sx={{
-                  pb: "0.25em",
-                  overflowWrap: "break-word",
-                  wordBreak: "break-all",
-                }}
-                data-testid={file.name}
-              >
-                {file.name}
-              </Typography>
-              <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
-              {drawingNumber && (
+        <FileCardRoot {...FileCardProps}>
+          <FileCard>
+            <ProgressBar
+              sx={{ width: `${Math.min(Math.ceil(progress * 100), 100)}%` }}
+              role="progressbar"
+              aria-valuenow={progress * 100 || 0}
+              aria-label={`Upload progress of file ${file.name}`}
+            />
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "flex-start",
+                gap: 1,
+                alignItems: "center",
+                width: "100%",
+              }}
+            >
+              <FilePreview>
+                {file instanceof File && file?.type?.includes("image") ? (
+                  <ImagePreview file={file} url={url} />
+                ) : (
+                  <FileIcon />
+                )}
+              </FilePreview>
+              <Box sx={{ mr: 2 }}>
                 <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ pt: "0.25em" }}
+                  variant="body1"
+                  sx={{ overflowWrap: "break-word", wordBreak: "break-all", pb: "0.25em" }}
+                  data-testid={file.name}
                 >
-                  Drawing number: {drawingNumber}
+                  {file.name}
                 </Typography>
-              )}
+                <FileSize variant="body2">{formatBytes(file.size)}</FileSize>
+                {drawingNumber && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ pt: "0.25em" }}
+                  >
+                    Drawing number: {drawingNumber}
+                  </Typography>
+                )}
+              </Box>
             </Box>
-          </Box>
-          <ActionButtons>
-            {!hideChangeButton && onChange && (
+            <ActionButtons>
+              {!hideChangeButton && onChange && (
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  startIcon={changeIcon}
+                  sx={{
+                    minWidth: 120,
+                    backgroundColor: "white",
+                  }}
+                  size="small"
+                  onClick={onChange}
+                  data-testid={`${changeLabel.toLowerCase().replace(/\s/g, "-")}-${file.name}`}
+                >
+                  {changeLabel}
+                  <Box sx={visuallyHidden} component="span">
+                    {` what ${file.name} shows`}
+                  </Box>
+                </Button>
+              )}
               <Button
+                size="small"
+                title={`Delete ${file.name}`}
+                onClick={removeFile}
+                sx={{ gap: 1, backgroundColor: "white" }}
+                data-testid={`delete-${file.name}`}
                 variant="contained"
                 color="secondary"
-                startIcon={changeIcon}
-                sx={{
-                  minWidth: 120,
-                  backgroundColor: "white",
-                }}
-                size="small"
-                onClick={onChange}
-                data-testid={`${changeLabel.toLowerCase().replace(/\s/g, "-")}-${file.name}`}
               >
-                {changeLabel}
-                <Box sx={visuallyHidden} component="span">
-                  {` what ${file.name} shows`}
-                </Box>
+                <DeleteIcon color="warning" fontSize="small" />
+                Remove <span style={visuallyHidden}>{file.name}</span>
               </Button>
-            )}
-            <Button
-              size="small"
-              title={`Delete ${file.name}`}
-              onClick={removeFile}
-              sx={{ gap: 1, backgroundColor: "white" }}
-              data-testid={`delete-${file.name}`}
-              variant="contained"
-              color="secondary"
-            >
-              <DeleteIcon color="warning" fontSize="small" />
-              Remove <span style={visuallyHidden}>{file.name}</span>
-            </Button>
-          </ActionButtons>
-        </FileCard>
+            </ActionButtons>
+          </FileCard>
+          {showDrawingNumber && onDrawingNumberChange && (
+            <Box sx={{ mt: 1 }}>
+              <Typography
+                variant="h3"
+                sx={{ display: "inline-block", pb: 0.5 }}
+                id={`drawing-number-label-${id}`}
+                component="label"
+              >
+                Drawing number (optional)
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Separate multiple drawing numbers in this file with a comma
+              </Typography>
+              <Input
+                id={`drawing-number-${id}`}
+                value={drawingNumber || ""}
+                onChange={(e) => onDrawingNumberChange(id, e.target.value)}
+                fullWidth
+                aria-labelledby={`drawing-number-label-${id}`}
+                bordered
+                sx={{ maxWidth: 400 }}
+              />
+            </Box>
+          )}
+        </FileCardRoot>
       </>
     </ErrorWrapper>
   </Box>


### PR DESCRIPTION
## What does this PR do?
This is the final part (hopefully..!) of the work for https://trello.com/c/KMuYlWbz/3269-allow-users-to-add-a-description-a-number-for-each-drawing-and-document-uploaded

This follows on from...
 - https://github.com/theopensystemslab/planx-new/pull/6416
 - https://github.com/theopensystemslab/planx-new/pull/6436
 - https://github.com/theopensystemslab/planx-new/pull/6442
 - https://github.com/theopensystemslab/planx-new/pull/6501
 - https://github.com/theopensystemslab/planx-new/pull/6502

This PR makes the following changes - 
 - Makes `drawingNumber` a prop on all base `FileUploadSlot`s, not just `FileUploadAndLabel`
 - Allows `drawingNumber` to be controlled on `FileUpload` components

The backend is already covered by https://github.com/theopensystemslab/planx-core/pull/975 - any files with an attached drawing number will be populated via the generated payload.

## Exceptions
The `<PrivateFileUpload/>` component touched here is also used in a few other places which I've not updated.
 
### `DrawBoundary`
I don't think it's currently a requirement. An easy fix-forward if we get feedback on this.

### `Schema` (`List` and `Page` components)
This is a trickier one. The `AmendDocuments` schema already exist which have workarounds in place to handle "drawing numbers" by another means. I'll open a Slack thread to check my assumptions here, but my current approach would be to leave the existing pattern in place and revisit this as an option once we return to generating `List` and `Page` schema in-Editor directly

## Demo
<img width="564" height="717" alt="image" src="https://github.com/user-attachments/assets/1b9c84e5-e44b-47df-aba4-06b1c0a96c8b" />

Storybook - https://storybook.6536.planx.pizza/?path=/story/planx-components-fileupload--with-drawing-numbers
