### PR TITLE
chore(ci): Split up GHA into reusable composite actions and workflow

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,25 @@
+name: Setup Node and pnpm
+description: Install pnpm, set up Node with pnpm cache, and apply .gitconfig
+
+inputs:
+  pnpm-version:
+    description: pnpm version to install
+    required: true
+  node-version:
+    description: Node.js version to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v5.0.0
+      with:
+        version: ${{ inputs.pnpm-version }}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+        cache-dependency-path: "**/pnpm-lock.yaml"
+    - name: Setup .gitconfig
+      shell: bash
+      run: mv .gitconfig ~/.gitconfig

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -2,12 +2,14 @@ name: Setup Node and pnpm
 description: Install pnpm, set up Node with pnpm cache, and apply .gitconfig
 
 inputs:
-  pnpm-version:
-    description: pnpm version to install
-    required: true
   node-version:
-    description: Node.js version to install
-    required: true
+    description: The Node.js version to use
+    required: false
+    default: 24.14.0
+  pnpm-version:
+    description: The pnpm version to use
+    required: false
+    default: 10.30.2
 
 runs:
   using: composite
@@ -15,11 +17,13 @@ runs:
     - uses: pnpm/action-setup@v5.0.0
       with:
         version: ${{ inputs.pnpm-version }}
+        
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
+        
     - name: Setup .gitconfig
       shell: bash
       run: mv .gitconfig ~/.gitconfig

--- a/.github/actions/setup-pizza-env/action.yml
+++ b/.github/actions/setup-pizza-env/action.yml
@@ -1,0 +1,39 @@
+name: Setup Pizza environment
+description: Configure AWS credentials, pull secrets from S3, and optionally verify .env files exist
+
+inputs:
+  aws-access-key-id:
+    description: AWS access key ID
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key
+    required: true
+  api-directory:
+    description: Path to API directory, used for .env.test existence check
+    required: true
+  hasura-directory:
+    description: Path to Hasura directory, used for .env.test existence check
+    required: true
+  check-env-files:
+    description: Whether to verify .env files exist after pulling from S3
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: eu-west-2
+    - name: Copy .env files from Staging S3
+      shell: bash
+      run: ./scripts/pull-secrets.sh
+    - name: Check if .env files exist
+      if: inputs.check-env-files == 'true'
+      uses: andstor/file-existence-action@v2
+      with:
+        files: ".env, .env.staging, ${{ inputs.api-directory }}/.env.test, ${{ inputs.hasura-directory }}/.env.test"
+        fail: true

--- a/.github/actions/setup-pizza-env/action.yml
+++ b/.github/actions/setup-pizza-env/action.yml
@@ -10,14 +10,12 @@ inputs:
     required: true
   api-directory:
     description: Path to API directory, used for .env.test existence check
-    required: true
+    required: false
+    default: apps/api.planx.uk
   hasura-directory:
     description: Path to Hasura directory, used for .env.test existence check
-    required: true
-  check-env-files:
-    description: Whether to verify .env files exist after pulling from S3
     required: false
-    default: 'true'
+    default: apps/hasura.planx.uk
 
 runs:
   using: composite
@@ -32,7 +30,6 @@ runs:
       shell: bash
       run: ./scripts/pull-secrets.sh
     - name: Check if .env files exist
-      if: inputs.check-env-files == 'true'
       uses: andstor/file-existence-action@v2
       with:
         files: ".env, .env.staging, ${{ inputs.api-directory }}/.env.test, ${{ inputs.hasura-directory }}/.env.test"

--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -1,0 +1,62 @@
+name: Build PlanX Frontend
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Deployment environment name (e.g. staging, production)
+        required: true
+        type: string
+      vite-api-url:
+        description: Value for VITE_APP_API_URL
+        required: true
+        type: string
+      vite-hasura-url:
+        description: Value for VITE_APP_HASURA_URL
+        required: true
+        type: string
+      vite-hasura-websocket:
+        description: Value for VITE_APP_HASURA_WEBSOCKET
+        required: true
+        type: string
+      vite-sharedb-url:
+        description: Value for VITE_APP_SHAREDB_URL
+        required: true
+        type: string
+      editor-directory:
+        description: Path to the editor app directory
+        required: false
+        type: string
+        default: apps/editor.planx.uk
+    secrets:
+      inherit: true
+
+jobs:
+  build_planx_frontend:
+    name: Build PlanX frontend
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
+      - run: pnpm install --frozen-lockfile
+        working-directory: ${{ inputs.editor-directory }}
+      - run: pnpm build
+        working-directory: ${{ inputs.editor-directory }}
+        env:
+          VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
+          VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
+          VITE_APP_API_URL: ${{ inputs.vite-api-url }}
+          VITE_APP_ENV: ${{ inputs.environment }}
+          VITE_APP_HASURA_URL: ${{ inputs.vite-hasura-url }}
+          VITE_APP_HASURA_WEBSOCKET: ${{ inputs.vite-hasura-websocket }}
+          VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          VITE_APP_SHAREDB_URL: ${{ inputs.vite-sharedb-url }}
+      - name: Upload PlanX frontend build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: planx_frontend_build
+          path: ./${{ inputs.editor-directory }}/build
+          if-no-files-found: error

--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -41,9 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ inputs.editor-directory }}
       - run: pnpm build

--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -31,6 +31,9 @@ on:
     secrets:
       inherit: true
 
+permissions:
+  contents: read
+
 jobs:
   build_planx_frontend:
     name: Build PlanX frontend

--- a/.github/workflows/deploy-lps-production.yml
+++ b/.github/workflows/deploy-lps-production.yml
@@ -31,15 +31,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-          cache: pnpm
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-lps-staging.yml
+++ b/.github/workflows/deploy-lps-staging.yml
@@ -29,15 +29,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-          cache: pnpm
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,30 +70,16 @@ jobs:
     if: ${{ needs.changes.outputs.api == 'true' || needs.changes.outputs.e2e == 'true' || needs.changes.outputs.editor == 'true' || needs.changes.outputs.sharedb == 'true' || needs.changes.outputs.hasura == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Start test containers
@@ -113,30 +99,16 @@ jobs:
     if: ${{ needs.changes.outputs.api == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.API_DIRECTORY }}
@@ -151,30 +123,16 @@ jobs:
     if: ${{ needs.changes.outputs.editor == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -292,14 +250,10 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - uses: pnpm/action-setup@v5.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build assets
@@ -530,26 +484,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v5.0.0
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+          check-env-files: 'false'
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: ${{ vars.PNPM_VERSION }}
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,8 +74,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
@@ -100,8 +98,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
@@ -122,8 +118,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
@@ -459,9 +453,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
-          check-env-files: 'false'
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,9 +77,6 @@ jobs:
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Start test containers
@@ -105,10 +102,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.API_DIRECTORY }}
@@ -129,10 +124,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -157,10 +150,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles(format('{0}/pnpm-lock.yaml,{0}/src/**,{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
             ${{ runner.os }}-
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
@@ -183,10 +174,8 @@ jobs:
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}
@@ -234,10 +223,8 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build assets
@@ -475,10 +462,8 @@ jobs:
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
           check-env-files: 'false'
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -157,18 +157,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles(format('{0}/pnpm-lock.yaml,{0}/src/**,{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v5.0.0
-        if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
@@ -191,18 +183,10 @@ jobs:
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
-      - uses: pnpm/action-setup@v5.0.0
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,59 +19,14 @@ env:
 jobs:
   build_planx_frontend:
     name: Build PlanX frontend
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-      # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: NPM cache
-        uses: actions/cache@v5
-        env:
-          cache-name: cache-npm
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: PNPM cache
-        uses: actions/cache@v5
-        env:
-          cache-name: cache-pnpm
-        with:
-          # pnpm cache files are stored in `~/.local/share/pnpm/store` on Linux
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
-      - run: pnpm install --frozen-lockfile
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm build
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-        env:
-          VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          VITE_APP_API_URL: https://api.editor.planx.dev
-          VITE_APP_ENV: staging
-          VITE_APP_HASURA_URL: https://hasura.editor.planx.dev/v1/graphql
-          VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          VITE_APP_HASURA_WEBSOCKET: wss://hasura.editor.planx.dev/v1/graphql
-          VITE_APP_SHAREDB_URL: wss://sharedb.editor.planx.dev
-      - name: Upload PlanX frontend build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: planx_frontend_build
-          path: ./${{ env.EDITOR_DIRECTORY }}/build
-          if-no-files-found: error
+    uses: ./.github/workflows/build-planx-frontend.yml
+    secrets: inherit
+    with:
+      environment: staging
+      vite-api-url: https://api.editor.planx.dev
+      vite-hasura-url: https://hasura.editor.planx.dev/v1/graphql
+      vite-hasura-websocket: wss://hasura.editor.planx.dev/v1/graphql
+      vite-sharedb-url: wss://sharedb.editor.planx.dev
 
   preview:
     name: Pulumi Up
@@ -80,17 +35,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
-        working-directory: infrastructure/application
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build artifact

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -42,9 +42,6 @@ jobs:
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build artifact

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -44,9 +44,6 @@ jobs:
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
       - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build artifact

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -18,60 +18,15 @@ env:
 
 jobs:
   build_planx_frontend:
-    name: Test and Build
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-      # https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: NPM cache
-        uses: actions/cache@v5
-        env:
-          cache-name: cache-npm
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: PNPM cache
-        uses: actions/cache@v5
-        env:
-          cache-name: cache-pnpm
-        with:
-          # pnpm cache files are stored in `~/.local/share/pnpm/store` on Linux
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
-      - run: pnpm install --frozen-lockfile
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-      - run: pnpm build
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-        env:
-          VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          VITE_APP_API_URL: https://api.editor.planx.uk
-          VITE_APP_ENV: production
-          VITE_APP_HASURA_URL: https://hasura.editor.planx.uk/v1/graphql
-          VITE_APP_HASURA_WEBSOCKET: wss://hasura.editor.planx.uk/v1/graphql
-          VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          VITE_APP_SHAREDB_URL: wss://sharedb.editor.planx.uk
-      - name: Upload PlanX frontend build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: planx_frontend_build
-          path: ./${{ env.EDITOR_DIRECTORY }}/build
-          if-no-files-found: error
+    name: Build PlanX frontend
+    uses: ./.github/workflows/build-planx-frontend.yml
+    secrets: inherit
+    with:
+      environment: production
+      vite-api-url: https://api.editor.planx.uk
+      vite-hasura-url: https://hasura.editor.planx.uk/v1/graphql
+      vite-hasura-websocket: wss://hasura.editor.planx.uk/v1/graphql
+      vite-sharedb-url: wss://sharedb.editor.planx.uk
 
   preview:
     name: Pulumi Up
@@ -82,17 +37,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           aws-region: eu-west-2
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      - run: npm install -g pnpm@${{ vars.PNPM_VERSION }}
-        working-directory: infrastructure/application
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: infrastructure/application
       - name: Download PlanX frontend build artifact

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -19,30 +19,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Start test containers
@@ -60,30 +46,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.API_DIRECTORY }}
@@ -96,30 +68,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
-      - uses: pnpm/action-setup@v5.0.0
-        with:
-          version: ${{ vars.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -133,26 +91,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v5.0.0
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
+          check-env-files: 'false'
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: ${{ vars.PNPM_VERSION }}
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
+          pnpm-version: ${{ vars.PNPM_VERSION }}
           node-version: ${{ vars.NODE_VERSION }}
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
-      - name: Setup .gitconfig
-        run: mv .gitconfig ~/.gitconfig
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -26,9 +26,6 @@ jobs:
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Start test containers
@@ -52,10 +49,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.API_DIRECTORY }}
@@ -74,10 +69,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
       - run: pnpm build
@@ -98,10 +91,8 @@ jobs:
           api-directory: ${{ env.API_DIRECTORY }}
           hasura-directory: ${{ env.HASURA_DIRECTORY }}
           check-env-files: 'false'
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          pnpm-version: ${{ vars.PNPM_VERSION }}
-          node-version: ${{ vars.NODE_VERSION }}
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
         working-directory: e2e

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
         working-directory: ${{ env.EDITOR_DIRECTORY }}
@@ -47,8 +45,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
@@ -67,8 +63,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
@@ -88,9 +82,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
-          check-env-files: 'false'
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install

--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -30,8 +30,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          api-directory: ${{ env.API_DIRECTORY }}
-          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Run sync script
         run: |
           {

--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -26,20 +26,12 @@ jobs:
         working-directory: infrastructure/data
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-      - name: Copy .env files from Staging S3 to the current working directory with AWS CLI
-        run: ./scripts/pull-secrets.sh
-      - name: Check if .env files exist
-        id: check_files
-        uses: andstor/file-existence-action@v2
-        with:
-          files: ".env, .env.staging, ${{ env.API_DIRECTORY }}/.env.test, ${{ env.HASURA_DIRECTORY }}/.env.test"
-          fail: true
+          api-directory: ${{ env.API_DIRECTORY }}
+          hasura-directory: ${{ env.HASURA_DIRECTORY }}
       - name: Run sync script
         run: |
           {

--- a/doc/how-to/how-to-upgrade-nodejs.md
+++ b/doc/how-to/how-to-upgrade-nodejs.md
@@ -6,7 +6,7 @@ We should always aim to be on an LTS version (even release numbers). For the ful
 
 ## planx-new
 
-1. Locally install desired Node.js version  
+1. Locally install desired Node.js version
 
 ```shell
 nvm install 24.14.0
@@ -16,8 +16,9 @@ nvm use 24.14.0
 2. Update `.nvmrc` file
 
 3. Update Dockerfiles -
-  - `apps/api.planx.uk/Dockerfile`
-  - `apps/sharedb.planx.uk/Dockerfile`
+
+- `apps/api.planx.uk/Dockerfile`
+- `apps/sharedb.planx.uk/Dockerfile`
 
 4. Update `@types/node` package across all projects ([npm](https://www.npmjs.com/package/@types/node)). Note: Only major.minor version need to match e.g. types version 22.10.7893 would be fine for Node 22.10.x ([docs](https://github.com/definitelytyped/definitelytyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)).
 
@@ -27,9 +28,9 @@ nvm use 24.14.0
 
 7. Update `README.md`
 
-8. Rebuild docker containers, test and run locally 
+8. Rebuild docker containers, test and run locally
 
-9. Upgrade the `NODE_VERSION` on GitHub (Settings > Secrets and variables > Actions > "Variables" tab > Update `NODE_VERSION` variable). This variable is used across our GitHub actions to define which Node version runs our CI services.
+9. Upgrade the Node version used for GitHub Actions by updating our "Setup Node and pnpm" action (/.github/actions/setup-node-pnpm/action.yml). This shared action is used across our GHA jobs to define which Node version runs our CI services.
 
 Please note - this update is immediate and will effect other open PRs. It's advisable to hardcode the desired Node version into the GitHub action files initially to test CI and regression tests, before making this change.
 
@@ -45,13 +46,12 @@ We have an AWS Lambda application (Scanii) which also runs on Node. This applica
 
 The runtime Node version used for Lambda functions is not tied to the Node version used by PlanX, but it's worth upgrading at the same time to keep these in sync.
 
-The following steps need to be taken on both AWS Staging and Production account - 
+The following steps need to be taken on both AWS Staging and Production account -
 
 1. Log in to AWS environment
 2. Navigate to AWS Lambda > Functions
 3. For each function (currently 2) update the runtime
 
-  
 **Steps**
 
 Select function > Runtime settings > Edit > Runtime > Select Node version > Save


### PR DESCRIPTION
## What does this PR do?
Reduces repetition in our GHA workflows by extracting two composite actions and a reusable workflow. This was one of the first issues I hit last time I started on the monorepo work here - https://github.com/theopensystemslab/planx-new/pull/5458

**`.github/actions/setup-node-pnpm`**
Installs pnpm, sets up Node with pnpm cache, and applies `.gitconfig` - currently repeated 11× across workflows.

**`.github/actions/setup-pizza-env`**
Configures AWS credentials, pulls secrets from S3, and verifies `.env` files exist - currently repeated 8×  across workflows.

**`.github/workflows/build-planx-frontend.yml`**
Reusable workflow for building the PlanX Editor. Replaces a near-identical job duplicated across `push-main.yml` and `push-production.yml`.