### PR TITLE
fix: skip `govUkPayment` initialisation when Pay is in "info-only" mode

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -245,8 +245,8 @@ function Component(props: Props) {
   const startNewPayment = async () => {
     dispatch(Action.StartNewPayment);
 
-    // Skip the redirect process if viewing this within the Editor
-    if (environment !== "standalone") {
+    // Skip the redirect process if viewing this within the Editor or using Pay in info-only mode
+    if (environment !== "standalone" || props.hidePay) {
       handleSuccess();
       return;
     }


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1777306960440849

To test :
- On staging, create a basic submission flow with a Pay component in "info-only" mode. When you "continue" through it, check your `lowcal_session.data` for a "govUkPayment" key with status "created"
- On this pizza, for the same flow, confirm your `lowcal_session.data` does _not_ have a `govUkPayment` property at all after "Continue"

(Adding an e2e api-driven test would also be good follow-up here!)