### PR TITLE
feat: store `cachedBreadcrumbs` on session data when applicable

### DIFF
--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -53,6 +53,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     previousCard,
     record,
     breadcrumbs,
+    cachedBreadcrumbs,
     passport,
     sessionId,
     id,
@@ -68,6 +69,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     state.previousCard,
     state.record,
     state.breadcrumbs,
+    state.cachedBreadcrumbs,
     state.computePassport(),
     state.sessionId,
     state.id,
@@ -138,6 +140,7 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
     const session: Session = {
       breadcrumbs,
+      cachedBreadcrumbs,
       id,
       passport,
       sessionId,

--- a/apps/editor.planx.uk/src/types.ts
+++ b/apps/editor.planx.uk/src/types.ts
@@ -60,6 +60,8 @@ export enum ApplicationPath {
 export type Session = {
   passport: Store.Passport;
   breadcrumbs: Store.Breadcrumbs;
+  /** Only present on journeys where the user has navigated "back" */
+  cachedBreadcrumbs?: Store.CachedBreadcrumbs;
   sessionId: string;
   // TODO: replace `id` with `flow: { id, published_flow_id }`
   id: SharedStore["id"];


### PR DESCRIPTION
Follow up task to this bug thread ! It'll be easier to audit future sessions if we have record of `cachedBreadcrumbs` https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1777306960440849

**To test:** 
- Go to published, online guidance service. Navigate through a few questions, go "back". Check your local IndexDB to confirm you can see `cachedBreadcrumbs`
<img width="1852" height="1112" alt="Screenshot from 2026-04-27 16-22-09" src="https://github.com/user-attachments/assets/8331f6d1-2e58-49db-b8fa-c7d79ca3aea3" />

- Go to published, online submission service. Navigate through a few questions, go "back". Check `lowcal_sessions.data` for `cachedBreadcrumbs`
<img width="1852" height="1112" alt="Screenshot from 2026-04-27 16-24-02" src="https://github.com/user-attachments/assets/ef99e9ec-e723-48fa-99f1-dafa1dcbd48a" />