### PR TITLE
fix: mui props in DowntimeBanner

### DIFF
--- a/apps/editor.planx.uk/src/components/DowntimeBanner/DowntimeBanner.tsx
+++ b/apps/editor.planx.uk/src/components/DowntimeBanner/DowntimeBanner.tsx
@@ -27,14 +27,16 @@ const DowntimeBanner: React.FC = () => (
       }}
     >
       <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="space-between"
         role="alert"
         aria-live="assertive"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
       >
         <BrokenImageIcon />
-        <Typography variant="body2" ml={1}>
+        <Typography variant="body2" sx={{ ml: 1 }}>
           <strong>Partial degradation</strong> of some services and features. We
           are actively working on a fix. Please try again soon.
         </Typography>


### PR DESCRIPTION
I think #6516 maybe merged before #6478 (but maybe after CI passed?) so there were some unhappy MUI props. This should fix frontend build issue here: https://github.com/theopensystemslab/planx-new/actions/runs/25041625966/job/73346059426#step:9:34