### PR TITLE
fix(editor): Use `on` prefix for custom element events (React 19)

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -16,8 +16,9 @@ import { squareMetresToHectares } from "@planx/components/shared/utils";
 import buffer from "@turf/buffer";
 import { point } from "@turf/helpers";
 import { Feature } from "geojson";
+import type { GeoJSONChangeEvent } from "lib/gis";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -108,28 +109,21 @@ export default function Component(props: Props) {
   useEffect(() => {
     if (isMounted.current) setSlots([]);
     isMounted.current = true;
+  }, [setSlots]);
 
-    const geojsonChangeHandler = ({ detail: geojson }: any) => {
-      if (geojson["EPSG:3857"]?.features) {
-        // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
-        setBoundary(geojson["EPSG:3857"].features[0]);
-        setArea(
-          geojson["EPSG:3857"].features[0]?.properties?.["area.squareMetres"],
-        );
-      } else {
-        // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined & area to 0
-        setBoundary(undefined);
-        setArea(0);
-      }
-    };
-
-    const map: any = document.getElementById("draw-boundary-map");
-    map?.addEventListener("geojsonChange", geojsonChangeHandler);
-
-    return function cleanup() {
-      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
-    };
-  }, [page, setArea, setBoundary, setSlots]);
+  const geojsonChangeHandler = ({ detail: geojson }: GeoJSONChangeEvent) => {
+    if (geojson["EPSG:3857"]?.features) {
+      // only a single polygon can be drawn, so get first feature in geojson "FeatureCollection"
+      setBoundary(geojson["EPSG:3857"].features[0]);
+      setArea(
+        geojson["EPSG:3857"].features[0]?.properties?.["area.squareMetres"],
+      );
+    } else {
+      // if the user clicks 'reset' to erase the drawing, geojson will be empty object, so set boundary to undefined & area to 0
+      setBoundary(undefined);
+      setArea(0);
+    }
+  };
 
   /**
    * Declare refs to hold a mutable copy the up-to-date validation errors
@@ -307,6 +301,7 @@ export default function Component(props: Props) {
                   collapseAttributions={
                     self.innerWidth < 500 ? true : undefined
                   }
+                  ongeojsonChange={geojsonChangeHandler}
                 />
               </MapContainer>
             </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -227,14 +227,8 @@ export default function Component(props: Props) {
    * Clip map extent to buffered boundary, with a fallback to address point if required
    */
   const clipGeojsonData = (() => {
-    if (boundary)
-      return JSON.stringify(
-        buffer(boundary, bufferInMeters, { units: "meters" }),
-      );
-    if (addressPoint)
-      return JSON.stringify(
-        buffer(addressPoint, bufferInMeters, { units: "meters" }),
-      );
+    if (boundary) return buffer(boundary, bufferInMeters, { units: "meters" });
+    if (addressPoint) return buffer(addressPoint, bufferInMeters, { units: "meters" });
   })();
 
   function getBody(mapValidationError?: string, fileValidationError?: string) {
@@ -282,7 +276,7 @@ export default function Component(props: Props) {
                   ariaLabelOlFixedOverlay="An interactive map for providing your location plan boundary"
                   drawMode
                   drawPointer="crosshair"
-                  drawGeojsonData={JSON.stringify(boundary)}
+                  drawGeojsonData={boundary}
                   drawGeojsonDataBuffer={10}
                   clipGeojsonData={clipGeojsonData}
                   zoom={20}

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Autocomplete.tsx
@@ -7,7 +7,7 @@ import {
 import { useBLPUCodes } from "hooks/data/useBLPUCodes";
 import find from "lodash/find";
 import { parse, toNormalised } from "postcode";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import InputLabel from "ui/public/InputLabel";
 import Input from "ui/shared/Input/Input";
 
@@ -59,14 +59,14 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
   const { data } = useBLPUCodes();
 
   const { setAddress } = props;
-  useEffect(() => {
-    if (!data?.blpuCodes) return;
-    // Handles mapping the raw Ordnance Survey record to planx's address model
-    const addressSelectionHandler = ({
+
+  const addressSelectionHandler = ({
       detail,
     }: {
       detail: Record<"address", Record<string, any>>;
     }) => {
+      if (!data?.blpuCodes) return;
+
       const selectedAddress: Record<string, any> | undefined =
         detail?.address?.LPI;
       if (selectedAddress) {
@@ -127,17 +127,6 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
         });
       }
     };
-
-    const autocomplete: any = document.getElementById("address-autocomplete");
-    autocomplete?.addEventListener("addressSelection", addressSelectionHandler);
-
-    return function cleanup() {
-      autocomplete?.removeEventListener(
-        "addressSelection",
-        addressSelectionHandler,
-      );
-    };
-  }, [sanitizedPostcode, selectedOption, data?.blpuCodes, setAddress]);
 
   const handleCheckPostcode = () => {
     if (!sanitizedPostcode) setShowPostcodeError(true);
@@ -211,6 +200,7 @@ export default function PickOSAddress(props: PickOSAddressProps): FCReturn {
           }/proxy/ordnance-survey`}
           arrowStyle="light"
           labelStyle="static"
+          onaddressSelection={addressSelectionHandler}
         />
       )}
     </AutocompleteWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -148,7 +148,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
               drawType="Point"
               drawGeojsonData={
                 coordinates &&
-                JSON.stringify({
+                {
                   type: "Feature",
                   geometry: {
                     type: "Point",
@@ -158,7 +158,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
                     ],
                   },
                   properties: {},
-                })
+                }
               }
               resetControlImage="trash"
               showScale
@@ -166,7 +166,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
               osProxyEndpoint={`${
                 import.meta.env.VITE_APP_API_URL
               }/proxy/ordnance-survey`}
-              clipGeojsonData={JSON.stringify(boundaryBBox)}
+              clipGeojsonData={boundaryBBox}
               osCopyright={`© Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160`}
               collapseAttributions={window.innerWidth < 500 ? true : undefined}
               ongeojsonChange={geojsonChangeHandler}

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -11,6 +11,7 @@ import {
   MapContainer,
   MapFooter,
 } from "@planx/components/shared/Preview/MapContainer";
+import type { GeoJSONChangeEvent } from "lib/gis";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useRef, useState } from "react";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
@@ -48,6 +49,8 @@ export const DescriptionInput = styled(Box)(({ theme }) => ({
 }));
 
 export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
+  const { setAddress, setMapValidationError } = props;
+
   const [coordinates, setCoordinates] = useState<Coordinates | undefined>(
     props.initialProposedAddress
       ? {
@@ -67,27 +70,25 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
     state.teamSettings.boundaryBBox,
   ]);
 
-  useEffect(() => {
-    const geojsonChangeHandler = ({ detail: geojson }: any) => {
-      if (geojson["EPSG:3857"]?.features && geojson["EPSG:27700"]?.features) {
-        // only a single point can be plotted, so get first feature in geojson "FeatureCollection" per projection
-        const [longitude, latitude] =
-          geojson["EPSG:3857"].features[0]?.geometry?.coordinates;
-        const [x, y] = geojson["EPSG:27700"].features[0]?.geometry?.coordinates;
-        setCoordinates({ longitude, latitude, x, y });
-      } else {
-        // triggered if a user "clears" their point on the map
-        setCoordinates(undefined);
-      }
-    };
+  const geojsonChangeHandler = ({ detail: geojson }: GeoJSONChangeEvent) => {
+    if (geojson["EPSG:3857"]?.features && geojson["EPSG:27700"]?.features) {
+      // Only a single point can be plotted, so get first feature in geojson "FeatureCollection" per projection
+      const geomWebMercator = geojson["EPSG:3857"].features[0]?.geometry;
+      const geomBNG = geojson["EPSG:27700"].features[0]?.geometry;
 
-    const map: any = document.getElementById("plot-new-address-map");
-    map?.addEventListener("geojsonChange", geojsonChangeHandler);
+      // Type-narrowing to exclude GeometryCollection
+      const coordsWebMercator =
+        geomWebMercator?.type === "Point" ? geomWebMercator.coordinates : [];
+      const coordsBNG = geomBNG?.type === "Point" ? geomBNG.coordinates : [];
 
-    return function cleanup() {
-      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
-    };
-  }, [setCoordinates]);
+      const [longitude, latitude] = coordsWebMercator;
+      const [x, y] = coordsBNG;
+      setCoordinates({ longitude, latitude, x, y });
+    } else {
+      // triggered if a user "clears" their point on the map
+      setCoordinates(undefined);
+    }
+  };
 
   const mapValidationErrorRef = useRef(props.mapValidationError);
   useEffect(() => {
@@ -96,22 +97,22 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
 
   useEffect(() => {
     if (mapValidationErrorRef.current) {
-      props.setMapValidationError(undefined);
+      setMapValidationError(undefined);
     }
-  }, [coordinates]);
+  }, [coordinates, setMapValidationError]);
 
   useEffect(() => {
     // when we have all required address parts, call setAddress to enable the "Continue" button
     if (siteDescription && coordinates) {
-      props.setAddress({
+      setAddress({
         ...coordinates,
         title: siteDescription,
         source: "proposed",
       });
     } else {
-      props.setAddress(undefined);
+      setAddress(undefined);
     }
-  }, [coordinates, siteDescription]);
+  }, [coordinates, siteDescription, setAddress]);
 
   const handleSiteDescriptionCheck = () => {
     if (!siteDescription) props.setShowSiteDescriptionError(true);
@@ -168,6 +169,7 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
               clipGeojsonData={JSON.stringify(boundaryBBox)}
               osCopyright={`© Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160`}
               collapseAttributions={window.innerWidth < 500 ? true : undefined}
+              ongeojsonChange={geojsonChangeHandler}
             />
           </MapContainer>
         </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/List/utils.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/utils.tsx
@@ -78,10 +78,10 @@ export const formatSchemaDisplayValue = <T extends Field>(
           <my-map
             id="inactive-list-map"
             basemap={field.data.mapOptions?.basemap}
-            geojsonData={JSON.stringify({
+            geojsonData={{
               type: "FeatureCollection",
               features: value,
-            })}
+            }}
             geojsonColor={field.data.mapOptions?.drawColor}
             geojsonFill
             geojsonBuffer={20}

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/Context.tsx
@@ -10,7 +10,7 @@ import {
 } from "@planx/components/shared/utils";
 import { FormikProps, useFormik } from "formik";
 import { Feature, FeatureCollection } from "geojson";
-import { GeoJSONChange, GeoJSONChangeEvent, useGeoJSONChange } from "lib/gis";
+import type { GeoJSONChange, GeoJSONChangeEvent } from "lib/gis";
 import { get, omit } from "lodash";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React, {
@@ -41,6 +41,7 @@ interface MapAndLabelContextValue {
     min: boolean;
     max: boolean;
   };
+  handleGeoJSONChange: (event: GeoJSONChangeEvent) => void,
 }
 
 type MapAndLabelProviderProps = PropsWithChildren<PresentationalProps>;
@@ -162,7 +163,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
     }
   };
 
-  const [features, setFeatures] = useGeoJSONChange(MAP_ID, handleGeoJSONChange);
+  const [features, setFeatures] = useState<Feature[] | undefined>(undefined)
 
   const [updateMapKey, setUpdateMapKey] = useState<number>(0);
 
@@ -290,6 +291,7 @@ export const MapAndLabelProvider: React.FC<MapAndLabelProviderProps> = (
           min: minError,
           max: maxError,
         },
+        handleGeoJSONChange,
       }}
     >
       {children}

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -303,17 +303,15 @@ const Root = () => {
               data-testid={MAP_ID}
               basemap={basemap}
               ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
-              geojsonData={
-                passport && JSON.stringify(passport["proposal.site"])
-              }
+              geojsonData={passport && passport["proposal.site"]}
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={
                 features &&
-                JSON.stringify({
+                {
                   type: "FeatureCollection",
                   features: features,
-                })
+                }
               }
               drawGeojsonDataBuffer={25}
               drawMany
@@ -332,7 +330,7 @@ const Root = () => {
                   ? `© Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160`
                   : ``
               }
-              clipGeojsonData={boundaryBBox && JSON.stringify(boundaryBBox)}
+              clipGeojsonData={boundaryBBox && boundaryBBox}
               mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
               collapseAttributions
               ongeojsonChange={handleGeoJSONChange}

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -250,6 +250,7 @@ const Root = () => {
     updateMapKey,
     validateAndSubmitForm,
     addInitialFeaturesToMap,
+    handleGeoJSONChange,
   } = useMapAndLabelContext();
   const {
     title,
@@ -334,6 +335,7 @@ const Root = () => {
               clipGeojsonData={boundaryBBox && JSON.stringify(boundaryBBox)}
               mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
               collapseAttributions
+              ongeojsonChange={handleGeoJSONChange}
             />
           </MapContainer>
         </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/geojson.ts
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/geojson.ts
@@ -33,4 +33,11 @@ export const point3: Feature<Point, { label: string }> = {
   },
 };
 
-export const mockFeaturePointObj = `{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"label":"1"},"geometry":{"type":"Point","coordinates":[-3.685929607119201,57.15301433687542]}}]}`;
+export const mockFeaturePointObj = { 
+  "type": "FeatureCollection", 
+  "features": [{ 
+    "type": "Feature", 
+    "properties": { "label": "1" }, 
+    "geometry": { "type": "Point", "coordinates": [-3.685929607119201, 57.15301433687542] } 
+  }]
+};

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
@@ -1,7 +1,6 @@
 import { MyMap } from "@opensystemslab/map";
 import { Presentational as MapAndLabel } from "@planx/components/MapAndLabel/Public";
 import { waitFor, within } from "@testing-library/react";
-import React from "react";
 import { setup } from "testUtils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
@@ -208,8 +207,7 @@ describe("basic interactions - happy path", () => {
     expect(firstTabPanel).toBeVisible();
 
     map = getByTestId("map-and-label-map");
-    // React 19 sets known web component properties directly (not as HTML attributes)
-    expect((map as any).drawGeojsonData).toBe(mockFeaturePointObj);
+    expect((map as any).drawGeojsonData).toStrictEqual(mockFeaturePointObj);
   });
 
   it("a user can input details on a single feature and submit", async () => {
@@ -476,10 +474,7 @@ describe("remove feature button", () => {
 
     map = getByTestId("map-and-label-map");
 
-    // React 19 sets known web component properties directly (not as HTML attributes)
-    expect((map as any).drawGeojsonData).toBe(
-      `{"type":"FeatureCollection","features":[]}`,
-    );
+    expect((map as any).drawGeojsonData).toStrictEqual({"type":"FeatureCollection","features":[]});
   });
 });
 
@@ -611,10 +606,7 @@ describe("back navigation", () => {
     );
 
     const map = getByTestId("map-and-label-map");
-    // React 19 sets known web component properties directly (not as HTML attributes)
-    expect((map as any).drawGeojsonData).toBe(
-      JSON.stringify(breadcrumb["data"]["trees"]),
-    );
+    expect((map as any).drawGeojsonData).toStrictEqual(breadcrumb["data"]["trees"]);
 
     const secondTabPanel = getByTestId("vertical-tabpanel-1");
     expect(secondTabPanel).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -171,7 +171,7 @@ export function Presentational(props: PresentationalProps) {
           markerLatitude={address?.latitude}
           markerLongitude={address?.longitude}
           // markerColor={team?.settings?.design?.color} // defaults to black
-          geojsonData={JSON.stringify(titleBoundary)}
+          geojsonData={titleBoundary}
           geojsonColor="#0010A4"
           geojsonBuffer={30}
           osCopyright={`Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160`}

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -602,7 +602,7 @@ function DrawBoundary(props: ComponentProps) {
             <my-map
               id="review-boundary-map"
               ariaLabelOlFixedOverlay="A static map of your location plan"
-              geojsonData={JSON.stringify(geodata)}
+              geojsonData={geodata}
               geojsonColor="#ff0000"
               geojsonFill
               geojsonBuffer={20}

--- a/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -4,8 +4,9 @@ import { MapContainer } from "@planx/components/shared/Preview/MapContainer";
 import type { MapField } from "@planx/components/shared/Schema/model";
 import { GraphError } from "components/Error/GraphError";
 import { Feature } from "geojson";
+import type { GeoJSONChangeEvent } from "lib/gis";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
@@ -37,26 +38,16 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
     editableFeatures?.length > 0 ? editableFeatures : undefined,
   );
 
-  useEffect(() => {
-    const geojsonChangeHandler = async ({ detail: geojson }: any) => {
-      if (geojson["EPSG:3857"]?.features) {
-        setFeatures(geojson["EPSG:3857"].features);
-        formik.setFieldValue(name, geojson["EPSG:3857"].features);
-      } else {
-        // if the user clicks 'reset' on the map, geojson will be empty object, so set features to undefined
-        setFeatures(undefined);
-        formik.setFieldValue(name, undefined);
-      }
-    };
-
-    const map: HTMLElement | null = document.getElementById(id);
-
-    map?.addEventListener("geojsonChange", geojsonChangeHandler);
-
-    return function cleanup() {
-      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
-    };
-  }, [setFeatures]);
+  const geojsonChangeHandler = async ({ detail: geojson }: GeoJSONChangeEvent) => {
+    if (geojson["EPSG:3857"]?.features) {
+      setFeatures(geojson["EPSG:3857"].features);
+      formik.setFieldValue(name, geojson["EPSG:3857"].features);
+    } else {
+      // if the user clicks 'reset' on the map, geojson will be empty object, so set features to undefined
+      setFeatures(undefined);
+      formik.setFieldValue(name, undefined);
+    }
+  };
 
   return (
     <Box sx={{ "& > label": { maxWidth: "100% !important" } }}>
@@ -105,6 +96,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               }
               mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
               collapseAttributions
+              ongeojsonChange={geojsonChangeHandler}
             />
           </MapContainer>
         </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Schema/InputFields/MapFieldInput.tsx
@@ -62,15 +62,15 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               // ariaLabelOlFixedOverlay={`An interactive map for plotting and describing ${schema.type.toLocaleLowerCase()}`}
               height={400}
               basemap={mapOptions?.basemap}
-              geojsonData={JSON.stringify(passport.data?.["proposal.site"])}
+              geojsonData={passport.data?.["proposal.site"]}
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={
                 features &&
-                JSON.stringify({
+                {
                   type: "FeatureCollection",
                   features: features,
-                })
+                }
               }
               drawMany={mapOptions?.drawMany}
               hideDrawLabels={mapOptions?.drawMany}
@@ -92,7 +92,7 @@ export const MapFieldInput: React.FC<Props<MapField>> = (props) => {
               }
               clipGeojsonData={
                 teamSettings?.boundaryBBox &&
-                JSON.stringify(teamSettings?.boundaryBBox)
+                teamSettings?.boundaryBBox
               }
               mapboxAccessToken={import.meta.env.VITE_APP_MAPBOX_ACCESS_TOKEN}
               collapseAttributions

--- a/apps/editor.planx.uk/src/lib/gis.ts
+++ b/apps/editor.planx.uk/src/lib/gis.ts
@@ -1,7 +1,6 @@
 import bbox from "@turf/bbox";
 import bboxPolygon from "@turf/bbox-polygon";
 import { Feature, type Polygon } from "geojson";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
 
 import type { Entity } from "./planningData/types";
 
@@ -9,47 +8,6 @@ type Projection = "EPSG:3857" | "EPSG:27700";
 
 export type GeoJSONChange = Record<Projection, { features: Feature[] }>;
 export type GeoJSONChangeEvent = CustomEvent<GeoJSONChange>;
-
-const isGeoJSONChangeEvent = (event: Event): event is GeoJSONChangeEvent => {
-  return event instanceof CustomEvent;
-};
-
-type UseGeoJSONChange = (
-  mapId: string,
-  callback: (event: GeoJSONChangeEvent) => void,
-) => [Feature[] | undefined, Dispatch<SetStateAction<Feature[] | undefined>>];
-
-/**
- * Hook for interacting with @opensystemslab/map
- * Assign a callback function to be triggered on the "geojsonChange" event
- */
-export const useGeoJSONChange: UseGeoJSONChange = (mapId, callback) => {
-  const [features, setFeatures] = useState<Feature[] | undefined>(undefined);
-
-  useEffect(() => {
-    const geojsonChangeHandler: EventListener = (event) => {
-      if (!isGeoJSONChangeEvent(event)) return;
-
-      callback(event);
-    };
-
-    // React 19 sets `id` as a DOM property (not HTML attribute) on custom elements
-    // in some environments (e.g. jsdom), causing getElementById to return null.
-    // Fall back to querying by data-map-id attribute which is always set as an attribute.
-    const map: HTMLElement | null =
-      document.getElementById(mapId) ??
-      (document.querySelector(
-        `[data-map-id="${mapId}"]`,
-      ) as HTMLElement | null);
-    map?.addEventListener("geojsonChange", geojsonChangeHandler);
-
-    return function cleanup() {
-      map?.removeEventListener("geojsonChange", geojsonChangeHandler);
-    };
-  }, [callback, mapId]);
-
-  return [features, setFeatures];
-};
 
 /**
  * Convert a complex local authority boundary to a simplified bounding box

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/PreviewMap.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/PreviewMap.tsx
@@ -16,7 +16,7 @@ export const PreviewMap: React.FC<{ geojsonData?: GeoJsonObject }> = ({
       <my-map
         id="team-boundary-map"
         ariaLabelOlFixedOverlay="A static map displaying your team's boundary"
-        geojsonData={JSON.stringify(geojsonData)}
+        geojsonData={geojsonData}
         geojsonColor="#ff0000"
         geojsonFill
         geojsonBuffer={1_000}


### PR DESCRIPTION
## What's the problem?
The address autocomplete component is not working as expected - nothing happens on address selection, meaning the user cannot proceed.

## What's the cause?
In [React 19](https://github.com/theopensystemslab/planx-new/pull/6478) architectural changes the component body executes strictly before the DOM is updated or painted. As a result, when the component renders, the `<address-autocomplete>` element doesn't exist in the DOM yet, `getElementById()` returns `null`, and the event listener silently fails to attach.

## What's the solution?
Leverage the native custom element support in React 19, but attaching a listener directly via the `on` prefix.

Docs - https://react.dev/reference/react-dom/components#custom-element-events

## Next steps...
Regression tests running here - https://github.com/theopensystemslab/planx-new/actions/runs/25060274739 ✅ 
 - One ITP test is failing - this is related to a separate issue, which we're also looking into.

The `useGeoJSONChange()` hook had already accounted for this React 19 change, but most `<my-map/>` elements do not implement this.

https://github.com/theopensystemslab/planx-new/blob/38e8e722ed084012c74c0bd9720768d49985d975/apps/editor.planx.uk/src/lib/gis.ts#L36-L48

## Testing
The following components have been touched via this change / React 19 bump - 
 - `FindProperty`
 - `DrawBoundary`
 - `List` (with `MapFields`)
 - `Page` (with `MapFields`)
 - `MapAndLabel`