### PR TITLE
fix: correctly validate multiple Pay nodes when only one is ITP on publish

### DIFF
--- a/apps/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
+++ b/apps/api.planx.uk/modules/flows/validate/service/inviteToPay.ts
@@ -64,7 +64,7 @@ const inviteToPayEnabled = (flowGraph: FlowGraph): boolean => {
   );
   return (
     payNodeStatuses.length > 0 &&
-    payNodeStatuses.every((status) => status === true)
+    payNodeStatuses.some((status) => status === true)
   );
 };
 

--- a/apps/api.planx.uk/modules/flows/validate/validate.test.ts
+++ b/apps/api.planx.uk/modules/flows/validate/validate.test.ts
@@ -5,7 +5,10 @@ import { authHeader, getTestJWT } from "../../../tests/mockJWT.js";
 import app from "../../../server.js";
 import { flowWithInviteToPay } from "../../../tests/mocks/inviteToPayData.js";
 import { userContext } from "../../auth/middleware.js";
-import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import {
+  ComponentType,
+  type FlowGraph,
+} from "@opensystemslab/planx-core/types";
 import { mockFlowData } from "../../../tests/mocks/validateAndPublishMocks.js";
 
 beforeAll(() => {
@@ -472,7 +475,14 @@ describe("invite to pay validation on diff", () => {
   it("does not update if invite to pay is enabled, but there is more than one Pay component", async () => {
     const invalidFlow = {
       ...flowWithInviteToPay,
-      PayTwo: { ...flowWithInviteToPay.Pay },
+      PayTwo: {
+        type: ComponentType.Pay,
+        data: {
+          fn: "application.fee.payable",
+          hidePay: true, // "PayTwo" is in info-only mode
+          allowInviteToPay: false,
+        },
+      },
       _root: {
         edges: [...flowWithInviteToPay._root.edges!, "PayTwo"],
       },


### PR DESCRIPTION
Another follow-up on this bug thread! https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1777378853726259?thread_ts=1777306960.440849&cid=C088K9ZL8EA

Scenario: 
- We threw a production error `could not initiate a payment request: found more than one Pay node`
- But was content enabling invite-to-pay with more than one Pay node allowed to be published in the first place? 
  - We need to account for only `some` of Pay nodes having allow to pay toggled on, with others in info-only mode
  
In the future, we want to revisit this more holistically and treat info-only Pay agnostically (should _never_ interfere with ITP or be "counted" as a Pay node really!), but this is pragmatic fix to avoid this content pattern in meantime until we can build full external payment journey.