### PR TITLE
fix(ci): Remove incorrect secrets:inherit in child action

### DIFF
--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -28,8 +28,6 @@ on:
         required: false
         type: string
         default: apps/editor.planx.uk
-    secrets:
-      inherit: true
 
 permissions:
   contents: read


### PR DESCRIPTION
This is throwing an error here, blocking deploys to `main` - https://github.com/theopensystemslab/planx-new/actions/runs/25055359240]

<img width="906" height="240" alt="image" src="https://github.com/user-attachments/assets/56860be4-5497-46c4-bbf9-4ba1de33dcfd" />

The parent caller is already setting `secrets: inherit` at the top level here.
