### PR TITLE
feat: limit team sizes to 20 members

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MaximumUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MaximumUserModal.tsx
@@ -1,9 +1,7 @@
 import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Typography from "@mui/material/Typography";
-import { Form, Formik } from "formik";
 import React from "react";
 
 import { AddUserModalProps } from "../types";
@@ -12,7 +10,7 @@ export const MaximumUserModal: React.FC<AddUserModalProps> = ({ onClose }) => {
   return (
     <Dialog
       aria-labelledby="dialog-heading"
-      data-testid="dialog-add-user"
+      data-testid="dialog-maximum-users"
       open
       onClose={onClose}
     >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MaximumUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MaximumUserModal.tsx
@@ -1,0 +1,30 @@
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Typography from "@mui/material/Typography";
+import { Form, Formik } from "formik";
+import React from "react";
+
+import { AddUserModalProps } from "../types";
+
+export const MaximumUserModal: React.FC<AddUserModalProps> = ({ onClose }) => {
+  return (
+    <Dialog
+      aria-labelledby="dialog-heading"
+      data-testid="dialog-add-user"
+      open
+      onClose={onClose}
+    >
+      <DialogTitle variant="h3" component="h1" id="dialog-heading">
+        Maximum users reached
+      </DialogTitle>
+      <DialogContent>
+        <Typography>
+          The maximum number of users already exists for this team. To add
+          another member, please remove an existing one or contact an admin.
+        </Typography>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -64,7 +64,7 @@ export const MembersTable = ({
   const removeUser = (member: TeamMember) =>
     setModal({ action: "remove", member });
   const maxUsers = () => setModal({ action: "attemptedAdd" });
-  console.log({ members });
+
   if (members.length === 0) {
     return (
       <>
@@ -166,6 +166,7 @@ export const MembersTable = ({
             {showAddMemberButton && (
               <TableRow>
                 <TableCell colSpan={5}>
+                  {/* the hard-coded team member limit value should be kept in sync with the hasura trigger (see enforce_team_member_limit) */}
                   <AddButton onClick={members.length < 20 ? addUser : maxUsers}>
                     Add a new member
                   </AddButton>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -56,6 +56,8 @@ export const MembersTable = ({
   showEditMemberButton,
   showRemoveMemberButton,
 }: MembersTableProps) => {
+  /** The hard-coded team member limit value should be kept in sync with the hasura trigger (see enforce_team_member_limit **/
+  const MAX_USER_COUNT = 20;
   const [modal, setModal] = useState<ModalState>({ action: "closed" });
 
   const closeModal = () => setModal({ action: "closed" });
@@ -167,7 +169,11 @@ export const MembersTable = ({
               <TableRow>
                 <TableCell colSpan={5}>
                   {/* the hard-coded team member limit value should be kept in sync with the hasura trigger (see enforce_team_member_limit) */}
-                  <AddButton onClick={members.length < 20 ? addUser : maxUsers}>
+                  <AddButton
+                    onClick={
+                      members.length < MAX_USER_COUNT ? addUser : maxUsers
+                    }
+                  >
                     Add a new member
                   </AddButton>
                 </TableCell>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "../types";
 import { AddUserModal } from "./AddUserModal";
 import { EditUserModal } from "./EditUserModal";
+import { MaximumUserModal } from "./MaximumUserModal";
 import { RemoveUserModal } from "./RemoveUserModal";
 
 const TableRowButton = styled(Button)(({ theme }) => ({
@@ -62,7 +63,8 @@ export const MembersTable = ({
   const editUser = (member: TeamMember) => setModal({ action: "edit", member });
   const removeUser = (member: TeamMember) =>
     setModal({ action: "remove", member });
-
+  const maxUsers = () => setModal({ action: "attemptedAdd" });
+  console.log({ members });
   if (members.length === 0) {
     return (
       <>
@@ -84,9 +86,7 @@ export const MembersTable = ({
             </TableBody>
           )}
         </Table>
-        {modal.action !== "closed" && (
-          <AddUserModal onClose={closeModal} />
-        )}
+        {modal.action !== "closed" && <AddUserModal onClose={closeModal} />}
       </>
     );
   }
@@ -166,7 +166,9 @@ export const MembersTable = ({
             {showAddMemberButton && (
               <TableRow>
                 <TableCell colSpan={5}>
-                  <AddButton onClick={addUser}>Add a new member</AddButton>
+                  <AddButton onClick={members.length < 20 ? addUser : maxUsers}>
+                    Add a new member
+                  </AddButton>
                 </TableCell>
               </TableRow>
             )}
@@ -175,21 +177,17 @@ export const MembersTable = ({
       </TableContainer>
 
       {modal.action === "remove" && (
-        <RemoveUserModal
-          onClose={closeModal}
-          member={modal.member}
-        />
+        <RemoveUserModal onClose={closeModal} member={modal.member} />
       )}
 
-      {modal.action === "add" && (
-        <AddUserModal onClose={closeModal}/>
-      )}
+      {modal.action === "add" && <AddUserModal onClose={closeModal} />}
 
       {modal.action === "edit" && (
-        <EditUserModal
-          onClose={closeModal}
-          member={modal.member}
-        />
+        <EditUserModal onClose={closeModal} member={modal.member} />
+      )}
+
+      {modal.action === "attemptedAdd" && (
+        <MaximumUserModal onClose={closeModal} />
       )}
     </>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
@@ -41,7 +41,8 @@ export type ModalState =
   | { action: "closed" }
   | { action: "add" }
   | { action: "edit"; member: TeamMember }
-  | { action: "remove"; member: TeamMember };
+  | { action: "remove"; member: TeamMember }
+  | { action: "attemptedAdd" };
 
 type SharedModalProps = {
   onClose: () => void;

--- a/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER enforce_team_member_limit;
+
+DROP FUNCTION check_team_member_limit();

--- a/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/up.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE FUNCTION check_team_member_limit()
+RETURNS trigger AS $$
+DECLARE
+  member_count INTEGER;
+BEGIN
+  SELECT COUNT(user_id)
+    INTO member_count
+    FROM team_members
+   WHERE team_id = NEW.team_id;
+
+  IF member_count >= 20 THEN
+    RAISE EXCEPTION
+      USING ERRCODE = '22000',
+            MESSAGE = 'Team cannot have more than 20 members';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER enforce_team_member_limit
+BEFORE INSERT OR UPDATE OF team_id ON team_members
+FOR EACH ROW
+EXECUTE PROCEDURE check_team_member_limit();

--- a/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1777376005470_create_limit_team_members_trigger/up.sql
@@ -3,10 +3,12 @@ RETURNS trigger AS $$
 DECLARE
   member_count INTEGER;
 BEGIN
-  SELECT COUNT(user_id)
+  SELECT COUNT(tm.user_id)
     INTO member_count
-    FROM team_members
-   WHERE team_id = NEW.team_id;
+    FROM team_members tm
+    JOIN users u ON u.id = tm.user_id
+   WHERE tm.team_id = NEW.team_id
+     AND u.email IS NOT NULL;
 
   IF member_count >= 20 THEN
     RAISE EXCEPTION


### PR DESCRIPTION
Row-level post-update checks can't seem to run any aggregate functionality, so I can't count the number of rows in `team_members` with a specific `team_id` (correct me if I'm wrong but that's what it looks like [here](https://hasura.io/docs/2.0/auth/authorization/permissions/permissions-operators/)!). So that's why I've gone with an event trigger here. 

In the UI, we also have a new 'Maximum users reached' modal that blocks adding (seemed neater than allowing the interaction only to show an error afterwards).
<img width="700" alt="image" src="https://github.com/user-attachments/assets/bbf8625c-9369-45cb-ac2e-16bd6988f253" />
