### PR TITLE
fix: ITP e2e regression tests

### DIFF
--- a/apps/editor.planx.uk/src/pages/Pay/MakePayment.tsx
+++ b/apps/editor.planx.uk/src/pages/Pay/MakePayment.tsx
@@ -162,7 +162,12 @@ export default function MakePayment({
       </Banner>
     ) : (
       <Container maxWidth="contentWrap">
-        <Typography sx={{ maxWidth: "formWrap", pt: 5 }} gutterBottom>
+        <Typography
+          component="h1"
+          variant="h1"
+          sx={{ maxWidth: "formWrap", pt: 5 }}
+          gutterBottom
+        >
           Pay
         </Typography>
       </Container>


### PR DESCRIPTION
Per this bug thread: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1777384379009619

See continued failure on `main` here: https://github.com/theopensystemslab/planx-new/actions/runs/25066487944/job/73437573480 

:white_check_mark: Regression tests now passing on this branch here: https://github.com/theopensystemslab/planx-new/actions/runs/25087517520