### PR TITLE
feat: show active sessions in warning message when turning service offline

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
@@ -2,6 +2,7 @@ import PendingActionsIcon from "@mui/icons-material/PendingActions";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
@@ -18,7 +19,11 @@ import { useSlackMessage } from "../../../hooks/useSlackMessage";
 import SettingsFormContainer from "../../../shared/SettingsForm";
 import { Description } from "./components/Description";
 import { PublicLink } from "./components/PublicLink";
-import { GET_FLOW_STATUS, UPDATE_FLOW_STATUS } from "./queries";
+import {
+  GET_FLOW_STATUS,
+  UPDATE_FLOW_STATUS,
+  useGetActiveSessions,
+} from "./queries";
 import { validationSchema } from "./schema";
 import type {
   FlowStatusFormValues,
@@ -42,6 +47,9 @@ const FlowStatus: React.FC = () => {
   const { mutate: sendSlackMessage } = useSlackMessage();
 
   const { origin } = useLocation();
+
+  const activeSessionsCount =
+    useGetActiveSessions(flowId)?.data?.lowcalSessions?.length || 0;
 
   const publishedLink = `${origin}/${teamSlug}/${flowSlug}/published`;
 
@@ -212,19 +220,35 @@ const FlowStatus: React.FC = () => {
                   <ErrorWrapper
                     error={confirmationError ? `Confirm before continuing` : ``}
                   >
-                    <Grid container component="fieldset" sx={{ margin: 0 }}>
-                      <Typography gutterBottom>
+                    <Stack component="fieldset" sx={{ margin: 0 }}>
+                      <Typography sx={{ mb: 2 }}>
                         {formik.values.status === "online"
-                          ? "Services that are set offline are no longer publicly discoverable and cannot accept responses from users."
+                          ? `Services that are set offline are not publicly discoverable and cannot accept new responses.
+                          ${activeSessionsCount > 0 ? "Ongoing submissions will not be blocked." : ""}`
                           : "Only services that are ready to be publicly discoverable and accept responses from users should be set online."}
                       </Typography>
+
+                      {activeSessionsCount > 0 && (
+                        <>
+                          <Typography sx={{ mb: 2 }}>
+                            This service currently has{" "}
+                            <strong>{activeSessionsCount}</strong> active
+                            session{activeSessionsCount > 1 ? "s" : ""} that can
+                            still be completed.
+                          </Typography>
+                          <Typography sx={{ mb: 2 }}>
+                            Are you sure you want to turn this service offline?
+                          </Typography>
+                        </>
+                      )}
+
                       <Grid size={12} sx={{ pointerEvents: "auto" }}>
                         <ChecklistItem
                           id="status-confirmation-checkbox"
                           data-testid="status-confirmation-checkbox"
                           label={
                             formik.values.status === "online"
-                              ? "This service will no longer be able to receive public responses"
+                              ? "This service will no longer be able to receive new public responses"
                               : "This service is ready to accept public responses"
                           }
                           checked={completed}
@@ -234,7 +258,7 @@ const FlowStatus: React.FC = () => {
                           }}
                         />
                       </Grid>
-                    </Grid>
+                    </Stack>
                   </ErrorWrapper>
                 </Box>
               </ConfirmationDialog>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/index.tsx
@@ -224,7 +224,7 @@ const FlowStatus: React.FC = () => {
                       <Typography sx={{ mb: 2 }}>
                         {formik.values.status === "online"
                           ? `Services that are set offline are not publicly discoverable and cannot accept new responses.
-                          ${activeSessionsCount > 0 ? "Ongoing submissions will not be blocked." : ""}`
+                          ${activeSessionsCount > 0 ? "Sessions which have been saved within the last 28 days or those that are awaiting payment will still be able to resume." : ""}`
                           : "Only services that are ready to be publicly discoverable and accept responses from users should be set online."}
                       </Typography>
 
@@ -234,7 +234,7 @@ const FlowStatus: React.FC = () => {
                             This service currently has{" "}
                             <strong>{activeSessionsCount}</strong> active
                             session{activeSessionsCount > 1 ? "s" : ""} that can
-                            still be completed.
+                            still be resumed.
                           </Typography>
                           <Typography sx={{ mb: 2 }}>
                             Are you sure you want to turn this service offline?

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/queries.ts
@@ -1,3 +1,4 @@
+import { useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 
 export const GET_FLOW_STATUS = gql`
@@ -31,3 +32,35 @@ export const UPDATE_FLOW_STATUS = gql`
     }
   }
 `;
+
+export const GET_ACTIVE_SESSIONS = gql`
+  query GetActiveSessions($flowId: uuid!) {
+    lowcalSessions: lowcal_sessions(
+      where: {
+        flow_id: { _eq: $flowId }
+        deleted_at: { _is_null: true }
+        submitted_at: { _is_null: true }
+        sanitised_at: { _is_null: true }
+      }
+    ) {
+      id
+    }
+  }
+`;
+
+type GetActiveSessionsQuery = {
+  lowcalSessions: {
+    id: string;
+  }[];
+};
+
+type GetActiveSessionsVars = { flowId: string };
+
+export const useGetActiveSessions = (flowId: string) => {
+  return useQuery<GetActiveSessionsQuery, GetActiveSessionsVars>(
+    GET_ACTIVE_SESSIONS,
+    {
+      variables: { flowId },
+    },
+  );
+};


### PR DESCRIPTION
Uses a new query / hook to get the number of active sessions for the service from `lowcal_sessions` and conditionally renders an extra message in the warning dialog:
<img width="700" alt="Screenshot 2026-04-29 103725" src="https://github.com/user-attachments/assets/c3a90d5b-7a9a-43ad-a53f-c33db38a6daf" />

# Testing
This won't work on a Pizza (since the environment specifies "Production", so to test:
1. check out this branch locally
2. replace "production" with "development" in `/FlowStatus/index.tsx` line 58
3. try turning a submission flow offline (both with and without active sessions, created via viewing the published flow)
