### PR TITLE
fix: Editor menu style regressions

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -155,8 +155,7 @@ export const EnvironmentSelect: React.FC = () => {
             <Typography
               variant="subtitle1"
               component="span"
-              sx={{ mr: 1 }}
-              color="white"
+              sx={{ mr: 1, color: (theme) => theme.palette.common.white }}
             >
               Plan✕
             </Typography>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -29,6 +29,7 @@ const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
     boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
     "&:hover": {
       backgroundColor: theme.palette.background.paper,
+      color: "inherit",
     },
   }),
 );


### PR DESCRIPTION
## What does this PR do?

Fixes two React 19 related styling regressions in the editor menu:
- Team select text disappears on hover
- PlanX text fades when environment select is opened

https://github.com/user-attachments/assets/9af5a882-06e4-4cb7-a88d-336740927dfb


**Fixed:**


https://github.com/user-attachments/assets/ad57ebb1-7c29-4a0b-965f-60c22aefbee3


