### PR TITLE
fix: Flow table - flow type and styling fixes

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/utils.ts
@@ -38,9 +38,10 @@ export const formatLastEditMessage = (
   date: string,
   actor?: { firstName: string; lastName: string },
 ): DateMessage => {
-  const timeAgo = `Last edited ${formatLastEditDate(date)}`;
+  const timeAgo = formatLastEditDate(date);
   const actorName = actor ? `${actor.firstName} ${actor.lastName}` : undefined;
-  const formatted = actorName ? `${timeAgo} by ${actorName}` : timeAgo;
+  const withLabel = `Last edited ${timeAgo}`;
+  const formatted = actorName ? `${withLabel} by ${actorName}` : withLabel;
   return {
     timeAgo,
     actor: actorName,
@@ -59,8 +60,9 @@ export const formatLastPublishMessage = (
       formatted: "Not yet published",
     };
   }
-  const timeAgo = `Last published ${formatLastEditDate(date)}`;
-  const formatted = user ? `${timeAgo} by ${user}` : timeAgo;
+  const timeAgo = formatLastEditDate(date);
+  const withLabel = `Last published ${timeAgo}`;
+  const formatted = user ? `${withLabel} by ${user}` : withLabel;
   return {
     timeAgo,
     actor: user,

--- a/apps/editor.planx.uk/src/pages/Team/TeamLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/TeamLayout.tsx
@@ -31,7 +31,14 @@ const TeamLayout: React.FC<Props> = ({ flowView, setFlowView }) => {
   };
 
   return (
-    <Box sx={{ width: "100%", bgcolor: "background.paper" }}>
+    <Box
+      sx={{
+        width: "100%",
+        bgcolor: "background.paper",
+        borderBottom: 1,
+        borderColor: "border.main",
+      }}
+    >
       <TabList>
         <Tabs onChange={handleChange} value={flowView} aria-label={"Flows"}>
           {tabs.map(({ label, path }) => (

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -70,20 +70,20 @@ const Archive: React.FC<Props> = ({
           justifyContent: "space-between",
           alignItems: "center",
           gap: 2,
+          pt: 1,
         }}
       >
         <Box
           sx={{
-            pt: 2,
             display: "flex",
             justifyContent: "flex-start",
             alignItems: "center",
-            gap: 2,
             minHeight: "50px",
           }}
         >
           <ShowingServicesHeader
             matchedFlowsCount={archivedFlows?.length || 0}
+            isArchived
           />
         </Box>
         <ToggleButtonGroup

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -21,6 +21,7 @@ import { useFlowSortDisplay } from "../hooks/useFlowSortDisplay";
 import { FlowRowLink } from "./styles";
 import {
   FlowActionsCell,
+  FlowDateCell,
   FlowStatusCell,
   FlowTitleCell,
   StyledTable,
@@ -53,7 +54,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
             <>
               <FlowStatusCell>Online status</FlowStatusCell>
               <FlowStatusCell>Flow type</FlowStatusCell>
-              <TableCell>{headerText}</TableCell>
+              <FlowDateCell>{headerText}</FlowDateCell>
               {showDetails && <TableCell>Pinned</TableCell>}
             </>
           )}
@@ -158,7 +159,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
               </Box>
             )}
           </FlowStatusCell>
-          <FlowStatusCell>
+          <FlowDateCell>
             <Box>
               <Typography variant="body2">{displayTimeAgo}</Typography>
               {displayActor && (
@@ -167,9 +168,9 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
                 </Typography>
               )}
             </Box>
-          </FlowStatusCell>
+          </FlowDateCell>
           {showDetails && (
-            <TableCell>
+            <TableCell align="center">
               <Box onClick={(e) => e.stopPropagation()}>
                 <FlowPinButton
                   flowId={flow.id}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -97,6 +97,11 @@ export const FlowStatusCell = styled(TableCell)(() => ({
   minWidth: "150px",
 }));
 
+export const FlowDateCell = styled(TableCell)(() => ({
+  width: "20%",
+  minWidth: "240px",
+}));
+
 export const FlowActionsCell = styled(TableCell)(({ theme }) => ({
   width: "5%",
   maxWidth: "100px",

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -23,7 +23,7 @@ import { StyledToggleButton } from "./StyledToggleButton";
 
 const FiltersContainer = styled(Box)(({ theme }) => ({
   width: "100%",
-  margin: theme.spacing(1, 0, 2),
+  margin: theme.spacing(0, 0, 2),
   padding: theme.spacing(1.5, 0),
   display: "flex",
   flexDirection: "row",
@@ -31,7 +31,6 @@ const FiltersContainer = styled(Box)(({ theme }) => ({
   alignItems: "center",
   justifyContent: "space-between",
   gap: theme.spacing(1),
-  borderTop: `1px solid ${theme.palette.border.light}`,
   borderBottom: `1px solid ${theme.palette.border.light}`,
 }));
 

--- a/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -5,10 +5,12 @@ export const ShowingServicesHeader = ({
   matchedFlowsCount,
   isFiltered = false,
   isPinnedFlows = false,
+  isArchived = false,
 }: {
   matchedFlowsCount: number;
   isFiltered?: boolean;
   isPinnedFlows?: boolean;
+  isArchived?: boolean;
 }) => {
   let message =
     matchedFlowsCount !== 1
@@ -27,6 +29,13 @@ export const ShowingServicesHeader = ({
       matchedFlowsCount !== 1
         ? `Showing ${matchedFlowsCount} pinned flows`
         : `Showing ${matchedFlowsCount} pinned flow`;
+  }
+
+  if (isArchived) {
+    message =
+      matchedFlowsCount !== 1
+        ? `Showing ${matchedFlowsCount} archived flows`
+        : `Showing ${matchedFlowsCount} archived flow`;
   }
 
   return (

--- a/apps/editor.planx.uk/src/ui/editor/FlowTag/FlowTag.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/FlowTag/FlowTag.tsx
@@ -2,14 +2,14 @@ import Skeleton from "@mui/material/Skeleton";
 import React from "react";
 
 import { Root } from "./styles";
-import { FlowTagProps } from "./types";
+import { FlowTagProps, FlowTagType } from "./types";
 
 const FlowTag: React.FC<FlowTagProps> = ({
   tagType,
   statusVariant,
   children,
 }) => {
-  if (!statusVariant)
+  if (tagType === FlowTagType.Status && !statusVariant)
     return <Skeleton variant="rounded" width={65} height={24} />;
 
   return (


### PR DESCRIPTION
## What does this PR do?

Fixes and tidies up a number of issues with the flow table
- Flow type chip now loading correctly
- Column widths optimised for dates (current setup causes word-wrapping / cell bloat)
- Removed replicated "Last edited" and "Last published" text from table view
- Border-bottom added to `Flows` / `Archive` tabs
- Archive view now reads `Showing x archived flows` (consistent with language around `pinned` and `filtered`)

**Testing:**
https://6563.planx.pizza/app/barnet
(switch to table view)
