### PR TITLE
chore(ci): Configure linting for GitHub actions and workflows

### DIFF
--- a/.github/workflows/lint-gha.yml
+++ b/.github/workflows/lint-gha.yml
@@ -1,0 +1,19 @@
+name: Lint GHA workflows and actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.12
+        with:
+          args: >-
+            .github/workflows/*.yml
+            .github/actions/*/action.yml

--- a/.github/workflows/lint-gha.yml
+++ b/.github/workflows/lint-gha.yml
@@ -6,6 +6,9 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-gha.yml
+++ b/.github/workflows/lint-gha.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
-      - '.github/actions/**'
 
 permissions:
   contents: read
@@ -16,7 +15,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run actionlint
         uses: rhysd/actionlint@v1.7.12
-        with:
-          args: >-
-            .github/workflows/*.yml
-            .github/actions/*/action.yml


### PR DESCRIPTION
We've had a few issues in the past where a broken GHA has lead to downstream issues.

This PR sets up a new GHA which will run a linting process when a PR is opened on any changed files using https://github.com/rhysd/actionlint 

This does not currently support actions, just workflows - https://github.com/rhysd/actionlint/issues/46

We could also set up something like this to run on a pre-commit hook - I'll revisit this once we resolve the current Husky / monorepo setup (soon! 🤞)