### PR TITLE
fix: search into nested flows

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -53,14 +53,15 @@ const ListItemComponent = React.forwardRef<HTMLLIElement>((props, ref) => (
  */
 const Search: React.FC = () => {
   // Get ordered flow of indexed nodes from store
-  const [orderedFlow, setOrderedFlow] = useStore((state) => [
+  const [orderedFlow, setOrderedFlow, flowId] = useStore((state) => [
     state.orderedFlow,
     state.setOrderedFlow,
+    state.id,
   ]);
 
   useEffect(() => {
-    if (!orderedFlow) setOrderedFlow();
-  }, [orderedFlow, setOrderedFlow]);
+    setOrderedFlow();
+  }, [flowId, setOrderedFlow]);
 
   // Set up search input form
   const formik = useFormik<SearchNodes>({

--- a/apps/editor.planx.uk/src/ui/editor/NodeCard/getDisplayDetailsForNodeCard.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/NodeCard/getDisplayDetailsForNodeCard.tsx
@@ -19,14 +19,17 @@ const componentFormatters: ComponentMap = {
   [ComponentType.Answer]: {
     getIconKey: ({ parentId }) => {
       const parentNode = useStore.getState().flow[parentId];
+      if (!parentNode) return ComponentType.Answer;
       return parentNode.type!;
     },
     getTitle: ({ parentId }) => {
       const parentNode = useStore.getState().flow[parentId];
+      if (!parentNode) return "";
       return parentNode.data?.text;
     },
     getComponentType: ({ parentId }) => {
       const parentNode = useStore.getState().flow[parentId];
+      if (!parentNode) return "Answer";
       const parentType = parentNode.type!;
       const formatted = capitalize(SLUGS[parentType].replaceAll("-", " "));
 

--- a/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
@@ -41,7 +41,8 @@ const HeaderRoot = styled(Box)(({ theme }) => ({
 }));
 
 const InternalPortalHeader: React.FC<{ portalId: string }> = ({ portalId }) => {
-  const portalName = useStore((state) => state.flow)[portalId].data?.text;
+  const portalNode = useStore((state) => state.flow)[portalId];
+  const portalName = portalNode?.data?.text || "Nested Flow";
 
   return (
     <HeaderRoot className="node-card portal internal-portal">

--- a/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/NodeCard/index.tsx
@@ -42,7 +42,7 @@ const HeaderRoot = styled(Box)(({ theme }) => ({
 
 const InternalPortalHeader: React.FC<{ portalId: string }> = ({ portalId }) => {
   const portalNode = useStore((state) => state.flow)[portalId];
-  const portalName = portalNode?.data?.text || "Nested Flow";
+  const portalName = portalNode?.data?.text || "Folder";
 
   return (
     <HeaderRoot className="node-card portal internal-portal">


### PR DESCRIPTION
# What does this PR do?
- Adds `flowId` to the useEffect dependency list in the Search component, so that search updates when we navigate to a nested flow
- Creates defensive checks where we were erroring and hitting `undefined`

# Why?
Before, navigating to a nested flow with an open search would [error](https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1777389958624279). The defensive checks alone would preserve the stale search in the Search panel. I think there is a timing thing that prevents the `flowId` dependency update from being sufficient.

# Testing
1. Navigate to `/app/opensystemslab/pd-restructure`
2. Enter a search term in the search panel
3. Click on the nested flow to the left of the flow structure to `/app/opensystemslab/permitteddevelopment-rear-and-side-extensions`
4. Nested flow should load without error & search should refresh (searching within the nested flow now) 