### PR TITLE
fix: Question with image layout

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/ChecklistItems.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/ChecklistItems.tsx
@@ -40,11 +40,7 @@ export const ChecklistItems = ({
           </Grid>
         </FormWrapper>
       ) : (
-        <Grid
-          size={{ xs: 12, sm: 6 }}
-          sx={{ contentWrap: 4 }}
-          key={option.data.text}
-        >
+        <Grid size={{ xs: 12, sm: 6, contentWrap: 4 }} key={option.data.text}>
           <ImageButton
             title={option.data.text}
             id={option.id}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Public/index.tsx
@@ -77,6 +77,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
               aria-labelledby={`radio-buttons-group-label-${props.id}`}
               name={`radio-buttons-group-${props.id}`}
               value={formik.values.selected.id}
+              sx={{ display: "block" }}
             >
               <Grid
                 container
@@ -125,8 +126,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
                     case QuestionLayout.Images:
                       return (
                         <Grid
-                          size={{ xs: 12, sm: 6 }}
-                          sx={{ contentWrap: 4 }}
+                          size={{ xs: 12, sm: 6, contentWrap: 4 }}
                           key={response.id}
                         >
                           <ImageRadio {...buttonProps} {...response} />

--- a/apps/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Buttons/ImageButton.tsx
@@ -18,7 +18,6 @@ export interface Props extends ButtonBaseProps {
 const TextLabelRoot = styled(Box)(({ theme }) => ({
   width: "100%",
   pointerEvents: "none",
-  borderTop: "none",
   display: "flex",
   flexGrow: 1,
   alignItems: "flex-start",
@@ -47,7 +46,7 @@ const TextLabel = (props: Props): FCReturn => {
     <TextLabelRoot
       {...({ ref: textContentEl } as any)}
       alignItems={multiline ? "flex-start" : "center"}
-      sx={{ border: borderStyle(theme, selected) }}
+      sx={{ border: borderStyle(theme, selected), borderTop: "none" }}
     >
       <Checkbox id={id} checked={selected} onChange={onClick} />
       <Typography variant="body1" sx={{ ml: 1.5, mt: 0.9 }}>
@@ -85,7 +84,6 @@ const ImageLabelRoot = styled(Box)(({ theme }) => ({
   height: 0,
   overflow: "hidden",
   zIndex: 2,
-  borderBottom: "none",
   backgroundColor: theme.palette.background.default,
 }));
 
@@ -112,7 +110,9 @@ const ImageLabel = (props: ImageLabelProps): FCReturn => {
   };
 
   return (
-    <ImageLabelRoot sx={{ border: borderStyle(theme, selected) }}>
+    <ImageLabelRoot
+      sx={{ border: borderStyle(theme, selected), borderBottom: "none" }}
+    >
       {imgError ? (
         <ImageError>
           <ImageIcon />

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
@@ -25,7 +25,7 @@ const DescriptionRadio: React.FC<Props> = ({
     <StyledFormLabel focused={false}>
       <Radio value={id} onChange={onChange} />
       <Box>
-        <Typography color="text.primary" variant="body1" sx={{ pt: 0.95 }}>
+        <Typography variant="body1" sx={{ pt: 0.95, color: "text.primary" }}>
           {title}
         </Typography>
         <Typography variant="body2" sx={{ pt: 0.5 }}>

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/ImageRadio/ImageRadio.tsx
@@ -59,9 +59,6 @@ const TextLabelContainer = styled(Box)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   color: theme.palette.text.primary,
-  "& > p": {
-    color: theme.palette.text.secondary,
-  },
   "& + p:not(:empty)": {
     paddingTop: theme.spacing(1),
   },
@@ -113,7 +110,7 @@ const TextLabel = (props: Props): FCReturn => {
     >
       <TextLabelContainer>
         <Radio value={id} onChange={onChange} />
-        <Typography>{title}</Typography>
+        <Typography sx={{ color: "text.primary" }}>{title}</Typography>
       </TextLabelContainer>
       <Typography variant="body2">{description}</Typography>
     </TextLabelRoot>

--- a/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -72,8 +72,7 @@ export default function ChecklistItem({
           <Typography
             id={`checkbox-description-${id}`}
             variant="body2"
-            color="text.secondary"
-            sx={{ px: 1.5 }}
+            sx={{ px: 1.5, py: 0.5, color: "text.secondary" }}
           >
             {description}
           </Typography>


### PR DESCRIPTION
## Issue

- Change in specificity and use of props has caused an overflow issue with radio buttons with images

## Solution

- Ensure all props are properly applied, override container with `display: block`
- Also addressed a number of small styling issues caused by depreciation of use of `colour="theme.xxx"` directly when using a component (follow on PR to move all instances to `sx`

**Testing:**
https://storybook.6567.planx.pizza/?path=/story/planx-components-question--with-images