### PR TITLE
chore(editor): ESLint rule to catch MUI dot notation syntax

### DIFF
--- a/apps/editor.planx.uk/.eslintrc
+++ b/apps/editor.planx.uk/.eslintrc
@@ -113,6 +113,10 @@
         {
           "selector": "MemberExpression[object.name='process'][property.name='env']",
           "message": "Use import.meta.env instead of process.env in Vite applications"
+        },
+        {
+          "selector": "JSXAttribute[name.name=/^(color|bgcolor|backgroundColor|borderColor|fill|stroke)$/] Literal[value=/\\./]",
+          "message": "Passing dot-notation colour strings (e.g., color={'text.primary'}) directly to props is no longer supported in MUI v9. Please use the sx prop instead: sx={{ color: 'text.primary' }}."
         }
     ]
   },

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -71,7 +71,13 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
       {recommended && <RecommendedTag>Recommended</RecommendedTag>}
       <Radio value={id} onChange={onChange} />
       <Box sx={{ position: "relative" }}>
-        <Typography color="text.primary" variant="body1" sx={{ pt: 0.95 }}>
+        <Typography
+          variant="body1"
+          sx={{
+            color: "text.primary",
+            pt: 0.95,
+          }}
+        >
           {title}
         </Typography>
         {description && (

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -112,7 +112,6 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           This question refers to file: {uploadedFile.file.name}
         </Box>
       </Typography>
-
       {Object.entries(groupedOptions).map(([category, categoryOptions]) => (
         <FormControl
           key={category}
@@ -143,7 +142,6 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           </ChecklistGrid>
         </FormControl>
       ))}
-
       {showDrawingNumber && (
         <Box sx={{ mt: 1 }}>
           <Typography
@@ -154,7 +152,13 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           >
             Drawing number (optional)
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.secondary",
+              mb: 1,
+            }}
+          >
             Separate multiple drawing numbers in this file with a comma
           </Typography>
           <Input
@@ -170,7 +174,6 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           />
         </Box>
       )}
-
       {onSave && (
         <Button
           variant="contained"

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -236,7 +236,13 @@ export default function Confirm(props: Props) {
                 ? "Unknown"
                 : formattedPriceWithCurrencySymbol(props.fee)}
             </Typography>
-            <Typography variant="subtitle1" component="span" color="inherit">
+            <Typography
+              variant="subtitle1"
+              component="span"
+              sx={{
+                color: "inherit",
+              }}
+            >
               <ReactMarkdownOrHtml
                 source={props.description}
                 openLinksOnNewTab

--- a/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -40,7 +40,12 @@ const SectionLengthLabel: React.FC<{ length: SectionLength }> = ({
     >
       {length}
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography
+      variant="body2"
+      sx={{
+        color: "text.secondary",
+      }}
+    >
       {SECTION_LENGTH_DESCRIPTIONS[length]}
     </Typography>
   </Box>

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -202,13 +202,21 @@ export function Dropzone<T extends FileUploadSlot>({
             </>
           )}
         </Typography>
-        <Typography color="text.secondary" variant="body2">
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+          }}
+        >
           pdf, jpg, png
         </Typography>
         <Typography
-          color="text.secondary"
           variant="body2"
-          sx={{ fontSize: 14, pt: 1 }}
+          sx={{
+            color: "text.secondary",
+            fontSize: 14,
+            pt: 1,
+          }}
         >
           Max size per file 30MB
         </Typography>

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -141,7 +141,11 @@ export const UploadedFileCard: React.FC<Props> = ({
               <Box sx={{ mr: 2 }}>
                 <Typography
                   variant="body1"
-                  sx={{ overflowWrap: "break-word", wordBreak: "break-all", pb: "0.25em" }}
+                  sx={{
+                    overflowWrap: "break-word",
+                    wordBreak: "break-all",
+                    pb: "0.25em",
+                  }}
                   data-testid={file.name}
                 >
                   {file.name}
@@ -150,8 +154,10 @@ export const UploadedFileCard: React.FC<Props> = ({
                 {drawingNumber && (
                   <Typography
                     variant="body2"
-                    color="text.secondary"
-                    sx={{ pt: "0.25em" }}
+                    sx={{
+                      color: "text.secondary",
+                      pt: "0.25em",
+                    }}
                   >
                     Drawing number: {drawingNumber}
                   </Typography>
@@ -202,7 +208,13 @@ export const UploadedFileCard: React.FC<Props> = ({
               >
                 Drawing number (optional)
               </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: "text.secondary",
+                  mb: 1,
+                }}
+              >
                 Separate multiple drawing numbers in this file with a comma
               </Typography>
               <Input

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
@@ -25,7 +25,13 @@ const DescriptionRadio: React.FC<Props> = ({
     <StyledFormLabel focused={false}>
       <Radio value={id} onChange={onChange} />
       <Box>
-        <Typography variant="body1" sx={{ pt: 0.95, color: "text.primary" }}>
+        <Typography
+          variant="body1"
+          sx={{
+            color: "text.primary",
+            pt: 0.95,
+          }}
+        >
           {title}
         </Typography>
         <Typography variant="body2" sx={{ pt: 0.5 }}>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -204,7 +204,9 @@ export const EnvironmentSelect: React.FC = () => {
                     <Typography
                       variant="body4"
                       component="p"
-                      color="text.secondary"
+                      sx={{
+                        color: "text.secondary",
+                      }}
                     >
                       {env.description}
                     </Typography>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -146,14 +146,22 @@ export const TeamSelect: React.FC<Props> = ({
             alignItems: "flex-start",
           }}
         >
-          <Typography variant="body3" component="span" color="text.secondary">
+          <Typography
+            variant="body3"
+            component="span"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             Team
           </Typography>
           <Typography
             variant="body3"
             component="span"
-            color="text.primary"
-            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            sx={{
+              color: "text.primary",
+              fontWeight: FONT_WEIGHT_SEMI_BOLD,
+            }}
           >
             {currentTeam?.name || "Current team"}
           </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
@@ -38,7 +38,12 @@ const CategoryLabel: React.FC<(typeof CATEGORIES)[number]> = ({
     <Typography variant="body2" sx={{ fontWeight: "bold" }}>
       {label}
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography
+      variant="body2"
+      sx={{
+        color: "text.secondary",
+      }}
+    >
       {description}
     </Typography>
   </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/Favicon/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/Favicon/index.tsx
@@ -68,9 +68,12 @@ const Favicon: React.FC = () => {
             />
           </InputRowItem>
           <Typography
-            color="text.secondary"
             variant="body2"
-            sx={{ pl: 2, alignSelf: "center" }}
+            sx={{
+              color: "text.secondary",
+              pl: 2,
+              alignSelf: "center",
+            }}
           >
             .ico or .png
           </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
@@ -103,9 +103,12 @@ const ThemeAndLogo: React.FC = () => {
               />
             </InputRowItem>
             <Typography
-              color="text.secondary"
               variant="body2"
-              sx={{ pl: 2, alignSelf: "center" }}
+              sx={{
+                color: "text.secondary",
+                pl: 2,
+                alignSelf: "center",
+              }}
             >
               .png or .svg
             </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/SLPInfo.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/SLPInfo.tsx
@@ -14,7 +14,12 @@ export const SLPInfo: React.FC<{ geojsonData?: GeoJsonObject }> = ({
   <SettingsSection background>
     <InputLegend>Boundary</InputLegend>
     <SettingsDescription>
-      <Typography variant="body2" color="text.secondary">
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
         Tewkesbury, Cheltenham and Gloucestershire share a Strategic and Local
         Plan (SLP). Planning applicantions can span across boundaries of these
         three authorities.

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -157,12 +157,15 @@ export const EditHistoryTimeline = ({
                 </Typography>
                 <Typography
                   variant="body2"
-                  sx={{ fontSize: "small", pt: 0.25, pb: 0.75 }}
-                  color={
-                    inUndoScope(i) && isUndoType(op.type)
-                      ? "GrayText"
-                      : "text.secondary"
-                  }
+                  sx={{
+                    fontSize: "small",
+                    pt: 0.25,
+                    pb: 0.75,
+                    color:
+                      inUndoScope(i) && isUndoType(op.type)
+                        ? "GrayText"
+                        : "text.secondary",
+                  }}
                 >
                   <strong>{`${
                     {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/OpenServiceMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/OpenServiceMenu.tsx
@@ -79,7 +79,12 @@ const MenuItemCard: React.FC<MenuItemCardProps> = ({
           <Typography variant="h6" component="div">
             {title}
           </Typography>
-          <Typography variant="body4" color="text.secondary">
+          <Typography
+            variant="body4"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
             {description}
           </Typography>
           {isOnline !== undefined && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/ValidationChecks.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/ValidationChecks.tsx
@@ -95,11 +95,12 @@ export const ValidationChecks = (props: {
                   primary={
                     <Typography
                       variant="body2"
-                      color={
-                        check.status === "Not applicable"
-                          ? "text.disabled"
-                          : "inherit"
-                      }
+                      sx={{
+                        color:
+                          check.status === "Not applicable"
+                            ? "text.disabled"
+                            : "inherit",
+                      }}
                     >
                       {check.title}
                     </Typography>
@@ -107,12 +108,13 @@ export const ValidationChecks = (props: {
                   secondary={
                     <Typography
                       variant="body2"
-                      sx={{ fontSize: "small" }}
-                      color={
-                        check.status === "Not applicable"
-                          ? "text.disabled"
-                          : "inherit"
-                      }
+                      sx={{
+                        fontSize: "small",
+                        color:
+                          check.status === "Not applicable"
+                            ? "text.disabled"
+                            : "inherit",
+                      }}
                     >
                       {check.message}
                     </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -41,7 +41,13 @@ const Reviews = () => {
           ))}
         </List>
       ) : (
-        <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>
+        <Typography
+          variant="body1"
+          sx={{
+            color: "text.secondary",
+            mt: 2,
+          }}
+        >
           No nodes are currently tagged 'To review'.
         </Typography>
       )}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
@@ -7,7 +7,12 @@ export const Contract = () => (
     <Typography variant="h3" component="h4" gutterBottom>
       Contract
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography
+      variant="body2"
+      sx={{
+        color: "text.secondary",
+      }}
+    >
       Terms and key dates of your software contract. OSL invoices annually for
       the fixed subscription cost of Plan✕.
     </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
@@ -31,7 +31,12 @@ export const Discount = ({ serviceCharges }: SubscriptionProps) => {
       <Typography variant="h3" component="h4" gutterBottom>
         Discount
       </Typography>
-      <Typography variant="body2" color="text.secondary">
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
         Service charges exceeding £10k per fiscal year count as a discount
         towards your next renewal cost of Plan✕. Upon reaching £10k, 50% of the
         excess amount is applied as a discount.

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
@@ -34,7 +34,13 @@ export const ServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
       <Typography variant="h3" component="h4" gutterBottom>
         Service charges
       </Typography>
-      <Typography variant="body2" color="text.secondary" gutterBottom>
+      <Typography
+        variant="body2"
+        gutterBottom
+        sx={{
+          color: "text.secondary",
+        }}
+      >
         Summary of service charges collected by your team on behalf of OSL.
         Service charges are transferred to OSL quarterly.
       </Typography>

--- a/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -112,7 +112,12 @@ const Step = ({ title, description, url }: ListItemProps) => (
       >
         {title}
       </Typography>
-      <Typography variant="body2" color="text.secondary">
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+        }}
+      >
         {description}
       </Typography>
     </Box>

--- a/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -61,18 +61,20 @@ export default function ChecklistItem({
         <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
           <Label
             variant="body1"
-            color="text.primary"
             className="label"
             component={"label"}
             htmlFor={id}
-            sx={{ pb: 0 }}
+            sx={{ pb: 0, color: "text.primary" }}
           >
             {label}
           </Label>
           <Typography
             id={`checkbox-description-${id}`}
             variant="body2"
-            sx={{ px: 1.5, py: 0.5, color: "text.secondary" }}
+            sx={{
+              color: "text.secondary",
+              px: 1.5,
+            }}
           >
             {description}
           </Typography>


### PR DESCRIPTION
To follow on from https://github.com/theopensystemslab/planx-new/pull/6567 - this should fail until all instances of this are resolved.

Fixes implemented by running `npx @mui/codemod@latest v9.0.0/system-props .` in Editor directory, plus sweep up using `pnpm lint:error`

Docs - https://mui.com/material-ui/migration/upgrade-to-v9#system-props