### PR TITLE
fix: Update text color properties

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -71,7 +71,7 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
       {recommended && <RecommendedTag>Recommended</RecommendedTag>}
       <Radio value={id} onChange={onChange} />
       <Box sx={{ position: "relative" }}>
-        <Typography color="text.primary" variant="body1" sx={{ pt: 0.95 }}>
+        <Typography color="textPrimary" variant="body1" sx={{ pt: 0.95 }}>
           {title}
         </Typography>
         {description && (

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -154,7 +154,7 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           >
             Drawing number (optional)
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
             Separate multiple drawing numbers in this file with a comma
           </Typography>
           <Input

--- a/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -40,7 +40,7 @@ const SectionLengthLabel: React.FC<{ length: SectionLength }> = ({
     >
       {length}
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography variant="body2" color="textSecondary">
       {SECTION_LENGTH_DESCRIPTIONS[length]}
     </Typography>
   </Box>

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -202,11 +202,11 @@ export function Dropzone<T extends FileUploadSlot>({
             </>
           )}
         </Typography>
-        <Typography color="text.secondary" variant="body2">
+        <Typography color="textSecondary" variant="body2">
           pdf, jpg, png
         </Typography>
         <Typography
-          color="text.secondary"
+          color="textSecondary"
           variant="body2"
           sx={{ fontSize: 14, pt: 1 }}
         >

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -141,7 +141,11 @@ export const UploadedFileCard: React.FC<Props> = ({
               <Box sx={{ mr: 2 }}>
                 <Typography
                   variant="body1"
-                  sx={{ overflowWrap: "break-word", wordBreak: "break-all", pb: "0.25em" }}
+                  sx={{
+                    overflowWrap: "break-word",
+                    wordBreak: "break-all",
+                    pb: "0.25em",
+                  }}
                   data-testid={file.name}
                 >
                   {file.name}
@@ -150,7 +154,7 @@ export const UploadedFileCard: React.FC<Props> = ({
                 {drawingNumber && (
                   <Typography
                     variant="body2"
-                    color="text.secondary"
+                    color="textSecondary"
                     sx={{ pt: "0.25em" }}
                   >
                     Drawing number: {drawingNumber}
@@ -202,7 +206,7 @@ export const UploadedFileCard: React.FC<Props> = ({
               >
                 Drawing number (optional)
               </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
                 Separate multiple drawing numbers in this file with a comma
               </Typography>
               <Input

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio.tsx
@@ -25,7 +25,7 @@ const DescriptionRadio: React.FC<Props> = ({
     <StyledFormLabel focused={false}>
       <Radio value={id} onChange={onChange} />
       <Box>
-        <Typography variant="body1" sx={{ pt: 0.95, color: "text.primary" }}>
+        <Typography color="textPrimary" variant="body1" sx={{ pt: 0.95 }}>
           {title}
         </Typography>
         <Typography variant="body2" sx={{ pt: 0.5 }}>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -204,7 +204,7 @@ export const EnvironmentSelect: React.FC = () => {
                     <Typography
                       variant="body4"
                       component="p"
-                      color="text.secondary"
+                      color="textSecondary"
                     >
                       {env.description}
                     </Typography>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -146,13 +146,13 @@ export const TeamSelect: React.FC<Props> = ({
             alignItems: "flex-start",
           }}
         >
-          <Typography variant="body3" component="span" color="text.secondary">
+          <Typography variant="body3" component="span" color="textSecondary">
             Team
           </Typography>
           <Typography
             variant="body3"
             component="span"
-            color="text.primary"
+            color="textPrimary"
             sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
           >
             {currentTeam?.name || "Current team"}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/LPS/components/CategorySelection.tsx
@@ -38,7 +38,7 @@ const CategoryLabel: React.FC<(typeof CATEGORIES)[number]> = ({
     <Typography variant="body2" sx={{ fontWeight: "bold" }}>
       {label}
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography variant="body2" color="textSecondary">
       {description}
     </Typography>
   </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/Favicon/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/Favicon/index.tsx
@@ -68,7 +68,7 @@ const Favicon: React.FC = () => {
             />
           </InputRowItem>
           <Typography
-            color="text.secondary"
+            color="textSecondary"
             variant="body2"
             sx={{ pl: 2, alignSelf: "center" }}
           >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
@@ -103,7 +103,7 @@ const ThemeAndLogo: React.FC = () => {
               />
             </InputRowItem>
             <Typography
-              color="text.secondary"
+              color="textSecondary"
               variant="body2"
               sx={{ pl: 2, alignSelf: "center" }}
             >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/SLPInfo.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/Boundary/components/SLPInfo.tsx
@@ -14,7 +14,7 @@ export const SLPInfo: React.FC<{ geojsonData?: GeoJsonObject }> = ({
   <SettingsSection background>
     <InputLegend>Boundary</InputLegend>
     <SettingsDescription>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" color="textSecondary">
         Tewkesbury, Cheltenham and Gloucestershire share a Strategic and Local
         Plan (SLP). Planning applicantions can span across boundaries of these
         three authorities.

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/OpenServiceMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/OpenServiceMenu.tsx
@@ -79,7 +79,7 @@ const MenuItemCard: React.FC<MenuItemCardProps> = ({
           <Typography variant="h6" component="div">
             {title}
           </Typography>
-          <Typography variant="body4" color="text.secondary">
+          <Typography variant="body4" color="textSecondary">
             {description}
           </Typography>
           {isOnline !== undefined && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Review/index.tsx
@@ -41,7 +41,7 @@ const Reviews = () => {
           ))}
         </List>
       ) : (
-        <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>
+        <Typography variant="body1" color="textSecondary" sx={{ mt: 2 }}>
           No nodes are currently tagged 'To review'.
         </Typography>
       )}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
@@ -7,7 +7,7 @@ export const Contract = () => (
     <Typography variant="h3" component="h4" gutterBottom>
       Contract
     </Typography>
-    <Typography variant="body2" color="text.secondary">
+    <Typography variant="body2" color="textSecondary">
       Terms and key dates of your software contract. OSL invoices annually for
       the fixed subscription cost of Plan✕.
     </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
@@ -31,7 +31,7 @@ export const Discount = ({ serviceCharges }: SubscriptionProps) => {
       <Typography variant="h3" component="h4" gutterBottom>
         Discount
       </Typography>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" color="textSecondary">
         Service charges exceeding £10k per fiscal year count as a discount
         towards your next renewal cost of Plan✕. Upon reaching £10k, 50% of the
         excess amount is applied as a discount.

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
@@ -34,7 +34,7 @@ export const ServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
       <Typography variant="h3" component="h4" gutterBottom>
         Service charges
       </Typography>
-      <Typography variant="body2" color="text.secondary" gutterBottom>
+      <Typography variant="body2" color="textSecondary" gutterBottom>
         Summary of service charges collected by your team on behalf of OSL.
         Service charges are transferred to OSL quarterly.
       </Typography>

--- a/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -112,7 +112,7 @@ const Step = ({ title, description, url }: ListItemProps) => (
       >
         {title}
       </Typography>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" color="textSecondary">
         {description}
       </Typography>
     </Box>

--- a/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ChecklistItem/ChecklistItem.tsx
@@ -61,7 +61,7 @@ export default function ChecklistItem({
         <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
           <Label
             variant="body1"
-            color="text.primary"
+            color="textPrimary"
             className="label"
             component={"label"}
             htmlFor={id}
@@ -72,7 +72,8 @@ export default function ChecklistItem({
           <Typography
             id={`checkbox-description-${id}`}
             variant="body2"
-            sx={{ px: 1.5, py: 0.5, color: "text.secondary" }}
+            sx={{ px: 1.5, py: 0.5 }}
+            color="textSecondary"
           >
             {description}
           </Typography>


### PR DESCRIPTION
## Issue

- MUI 9 syntax no longer supports color properties applied to components using theme tokens (for example) `text.primary`

## Solution

- Use semantic color properties, i.e. `textPrimary`
