### PR TITLE
fix: Progress bar position on upload

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -26,10 +26,10 @@ const FileCardRoot = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.main}`,
   backgroundColor: theme.palette.background.paper,
   padding: theme.spacing(1.5),
+  position: "relative",
 }));
 
 const FileCard = styled(Box)(({ theme }) => ({
-  position: "relative",
   height: "auto",
   display: "flex",
   flexDirection: "column",
@@ -115,13 +115,13 @@ export const UploadedFileCard: React.FC<Props> = ({
     >
       <>
         <FileCardRoot {...FileCardProps}>
+          <ProgressBar
+            sx={{ width: `${Math.min(Math.ceil(progress * 100), 100)}%` }}
+            role="progressbar"
+            aria-valuenow={progress * 100 || 0}
+            aria-label={`Upload progress of file ${file.name}`}
+          />
           <FileCard>
-            <ProgressBar
-              sx={{ width: `${Math.min(Math.ceil(progress * 100), 100)}%` }}
-              role="progressbar"
-              aria-valuenow={progress * 100 || 0}
-              aria-label={`Upload progress of file ${file.name}`}
-            />
             <Box
               sx={{
                 display: "flex",


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Places progress indicator bar in parent container to fix positioning when uploading files

**Before:**
<img width="736" height="279" alt="image" src="https://github.com/user-attachments/assets/fd03b352-0dc0-4350-a57b-098fa493f559" />


**After:**
<img width="736" height="279" alt="image" src="https://github.com/user-attachments/assets/96aa6d97-ad90-4ae1-ae38-89d97258ade2" />
