### PR TITLE
test(editor): Optimise RTL setup for React 19

### DIFF
--- a/apps/editor.planx.uk/.eslintrc
+++ b/apps/editor.planx.uk/.eslintrc
@@ -46,14 +46,14 @@
           },
           {
             "name": "@testing-library/user-event",
-            "message": "Please import setup() from testUtils to get test user"
+            "message": "Please import setup() from test/utils to get test user"
           },
           {
             "name": "@testing-library/react",
             "importNames": [
               "render"
             ],
-            "message": "Please import setup() from testUtils to render test component"
+            "message": "Please import setup() from test/utils to render test component"
           },
           {
             "name": "@mui/styles",

--- a/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, within } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import AddressInputComponent from "./Editor";
 

--- a/apps/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/AddressInput/Public.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Calculate/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Calculate/Public.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import Calculate from "./Public";

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -8,7 +8,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import { ChecklistEditor } from "./Editor";

--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -3,7 +3,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { act, screen, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, within } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import ContactInputComponent from "./Editor";
 

--- a/apps/editor.planx.uk/src/@planx/components/ContactInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ContactInput/Public.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Content/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Content/Public.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, screen } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import DateInputComponent from "./Editor";

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Public.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/Public.test.tsx
@@ -4,7 +4,7 @@ import { act, screen, waitFor } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import React from "react";
 import server from "test/mockServer";
 import { setup } from "test/utils";
 import { axe } from "vitest-axe";
@@ -50,7 +49,9 @@ describe("Passport generation", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
+
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -104,7 +105,8 @@ describe("Passport generation", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -158,7 +160,8 @@ describe("Passport generation", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -215,7 +218,8 @@ describe("Passport generation", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -358,11 +362,10 @@ describe("navigating back to the EnhancedTextInput component", () => {
     );
 
     // User navigate back and then enters a new description
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL, {
-      initialSelectionStart: 0,
-      initialSelectionEnd:
-        previouslySubmittedData.data["proposal.description"].length,
-    });
+    const textBox = screen.getByRole("textbox", { name: /test/i });
+    await user.clear(textBox);
+    await user.paste(ORIGINAL);
+
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -446,10 +449,9 @@ describe("basic layout and behaviour", () => {
 
     expect(screen.getByText("You have 250 characters remaining")).toBeVisible();
 
-    await user.type(
-      screen.getByRole("textbox", { name: /test/i }),
-      ORIGINAL + ORIGINAL,
-    );
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL + ORIGINAL);
+
     expect(screen.getByText("You have 182 characters too many")).toBeVisible();
 
     await user.click(screen.getByTestId("continue-button"));
@@ -470,7 +472,9 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
+
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -502,7 +506,9 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
+
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -524,7 +530,8 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -574,7 +581,8 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -631,7 +639,9 @@ describe("basic layout and behaviour", () => {
     // Exit sidebar
     await user.keyboard("{Esc}");
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
+
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for next screen
@@ -671,7 +681,8 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
 
     // Wait for API response before interacting with selection step
@@ -717,7 +728,8 @@ describe("basic layout and behaviour", () => {
     ).not.toBeInTheDocument();
 
     // Proceed to "task" step
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
     expect(
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
@@ -743,7 +755,8 @@ describe("basic layout and behaviour", () => {
     );
 
     // Proceed to "task" step
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
     expect(
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
@@ -756,10 +769,13 @@ describe("basic layout and behaviour", () => {
     const NEW_INPUT = "A new description because I've changed my mind";
 
     // Enter new description, triggering a new API request
-    await user.type(screen.getByRole("textbox", { name: /test/i }), NEW_INPUT, {
-      initialSelectionStart: 0,
-      initialSelectionEnd: ENHANCED.length,
+    const textBox: HTMLInputElement = screen.getByRole("textbox", {
+      name: /test/i,
     });
+    await user.click(textBox);
+    textBox.setSelectionRange(0, ENHANCED.length);
+    await user.paste(NEW_INPUT);
+
     await user.click(screen.getByTestId("continue-button"));
 
     expect(requestSpy).toHaveBeenCalledTimes(2);
@@ -782,7 +798,8 @@ describe("basic layout and behaviour", () => {
     );
 
     // Proceed to "task" step
-    await user.type(screen.getByRole("textbox", { name: /test/i }), ORIGINAL);
+    await user.click(screen.getByRole("textbox", { name: /test/i }));
+    await user.paste(ORIGINAL);
     await user.click(screen.getByTestId("continue-button"));
     expect(
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { axe } from "vitest-axe";
 
 import { taskDefaults } from "../model";

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import server from "test/mockServer";
 import { setup } from "test/utils";
@@ -430,8 +430,10 @@ describe("basic layout and behaviour", () => {
       />,
     );
 
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await act(async () => {
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 
   it("enforces a character limit", async () => {
@@ -516,8 +518,10 @@ describe("basic layout and behaviour", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await act(async () => {
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
   });
 
   it("allows the user to select between the enhanced and original description", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { http, type HttpHandler, HttpResponse } from "msw";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import { taskDefaults } from "../model";
 import EnhancedTextInputComponent from ".";

--- a/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.test.tsx
@@ -1,7 +1,7 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import ExternalPortalForm from "./Editor";

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import { FeedbackEditor } from "./Editor";
 

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
@@ -4,7 +4,7 @@ import {
   insertFeedbackMutation,
 } from "lib/feedback";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.submit.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.submit.test.tsx
@@ -4,7 +4,7 @@ import {
   insertFeedbackMutation,
 } from "lib/feedback";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import FeedbackComponent from "../Public";

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Public.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.test.tsx
@@ -3,7 +3,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import FileUploadAndLabelComponent from "./Editor";
 

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -4,7 +4,7 @@ import type { UserEvent } from "@testing-library/user-event";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { Breadcrumbs } from "types";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Filter/Editor.test.tsx
@@ -5,7 +5,7 @@ import {
 } from "@opensystemslab/planx-core/types";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import Filter from "./Editor";

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Public.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "msw";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/InternalPortal/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/InternalPortal/Editor.test.tsx
@@ -1,7 +1,7 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
@@ -337,7 +337,8 @@ describe("Building a list", () => {
       await user.click(secondEditButton);
 
       const emailInput = getByLabelText(/email/);
-      await user.type(emailInput, "my.new.email@test.com");
+      await user.click(emailInput);
+      await user.paste("my.new.email@test.com");
 
       const secondCancelButton = getAllByText(/Cancel/, {
         selector: "button",

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
@@ -2,7 +2,7 @@ import { within } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { cloneDeep, merge } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, test, vi } from "vitest";
 
 import { mockMaxOneProps } from "../../schemas/mocks/MaxOne";

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.payloadGeneration.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.payloadGeneration.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, vi } from "vitest";
 
 import {

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, test, vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { cloneDeep, merge } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { test, vi } from "vitest";
 
 import { mockZooProps } from "../../schemas/mocks/Zoo/props";

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
@@ -83,8 +83,8 @@ describe("Form validation and error handling", () => {
       );
 
       const nameInput = screen.getByLabelText(/What's their name/);
-      await user.type(
-        nameInput,
+      await user.click(nameInput);
+      await user.paste(
         "This is a long string of text over one hundred and twenty characters, which should trigger the 'short' text validation warning",
       );
       await user.click(getByRole("button", { name: /Save/ }));
@@ -281,10 +281,12 @@ describe("Form validation and error handling", () => {
       );
       // Start filling out item
       const nameInput = getByLabelText(/What's their name/);
-      await user.type(nameInput, "Richard Parker");
+      await user.click(nameInput);
+      await user.paste("Richard Parker");
 
       const emailInput = getByLabelText(/email/);
-      await user.type(emailInput, "richard.parker@pi.com");
+      await user.click(emailInput);
+      await user.paste("richard.parker@pi.com");
 
       // Try to add a new item
       await user.click(getByTestId(/list-add-button/));
@@ -305,10 +307,12 @@ describe("Form validation and error handling", () => {
       );
       // Start filling out item
       const nameInput = getByLabelText(/What's their name/);
-      await user.type(nameInput, "Richard Parker");
+      await user.click(nameInput);
+      await user.paste("Richard Parker");
 
       const emailInput = getByLabelText(/email/);
-      await user.type(emailInput, "richard.parker@pi.com");
+      await user.click(emailInput);
+      await user.paste("richard.parker@pi.com");
 
       // Try to continue
       await user.click(getByTestId(/continue-button/));

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/testUtils.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/testUtils.tsx
@@ -10,16 +10,21 @@ const mockedUploadPrivateFile = vi.mocked(uploadPrivateFile);
 
 /**
  * Helper function to fill out a list item form
+ * XXX: user.paste() is significantly more preformant that user.type()
+ * This is a worthwile optimisation as this helper is called many times
  */
 export const fillInResponse = async (user: UserEvent) => {
   const nameInput = screen.getByLabelText(/What's their name/);
-  await user.type(nameInput, "Richard Parker");
+  await user.click(nameInput);
+  await user.paste("Richard Parker");
 
   const emailInput = screen.getByLabelText(/email/);
-  await user.type(emailInput, "richard.parker@pi.com");
+  await user.click(emailInput);
+  await user.paste("richard.parker@pi.com");
 
   const ageInput = screen.getByLabelText(/old/);
-  await user.type(ageInput, "10");
+  await user.click(ageInput);
+  await user.paste("10");
 
   const sizeSelect = screen.getByRole("combobox");
   await user.click(sizeSelect);
@@ -36,9 +41,12 @@ export const fillInResponse = async (user: UserEvent) => {
   const dayInput = screen.getByLabelText("Day");
   const monthInput = screen.getByLabelText("Month");
   const yearInput = screen.getByLabelText("Year");
-  await user.type(dayInput, "14");
-  await user.type(monthInput, "7");
-  await user.type(yearInput, "1988");
+  await user.click(dayInput);
+  await user.paste("14");
+  await user.click(monthInput);
+  await user.paste("7");
+  await user.click(yearInput);
+  await user.paste("1988");
 
   const line1Input = screen.getByLabelText("Address line 1");
   const line2Input = screen.getByLabelText("Address line 2 (optional)");
@@ -46,12 +54,18 @@ export const fillInResponse = async (user: UserEvent) => {
   const countyInput = screen.getByLabelText("County (optional)");
   const postcodeInput = screen.getByLabelText("Postcode");
   const countryInput = screen.getByLabelText("Country (optional)");
-  await user.type(line1Input, "134 Corstorphine Rd");
-  await user.type(line2Input, "Corstorphine");
-  await user.type(townInput, "Edinburgh");
-  await user.type(countyInput, "Midlothian");
-  await user.type(postcodeInput, "EH12 6TS");
-  await user.type(countryInput, "Scotland");
+  await user.click(line1Input);
+  await user.paste("134 Corstorphine Rd");
+  await user.click(line2Input);
+  await user.paste("Corstorphine");
+  await user.click(townInput);
+  await user.paste("Edinburgh");
+  await user.click(countyInput);
+  await user.paste("Midlothian");
+  await user.click(postcodeInput);
+  await user.paste("EH12 6TS");
+  await user.click(countryInput);
+  await user.paste("Scotland");
 
   const file1 = new File(["test1"], "test1.png", { type: "image/png" });
   const file2 = new File(["test2"], "test2.png", { type: "image/png" });

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.backNavigation.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.backNavigation.test.tsx
@@ -1,6 +1,6 @@
 import { MyMap } from "@opensystemslab/map";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, vi } from "vitest";
 
 import { Presentational as MapAndLabel } from "../Public";

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/public.test.tsx
@@ -1,7 +1,7 @@
 import { MyMap } from "@opensystemslab/map";
 import { Presentational as MapAndLabel } from "@planx/components/MapAndLabel/Public";
 import { waitFor, within } from "@testing-library/react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
@@ -474,7 +474,10 @@ describe("remove feature button", () => {
 
     map = getByTestId("map-and-label-map");
 
-    expect((map as any).drawGeojsonData).toStrictEqual({"type":"FeatureCollection","features":[]});
+    expect((map as any).drawGeojsonData).toStrictEqual({
+      type: "FeatureCollection",
+      features: [],
+    });
   });
 });
 
@@ -606,7 +609,9 @@ describe("back navigation", () => {
     );
 
     const map = getByTestId("map-and-label-map");
-    expect((map as any).drawGeojsonData).toStrictEqual(breadcrumb["data"]["trees"]);
+    expect((map as any).drawGeojsonData).toStrictEqual(
+      breadcrumb["data"]["trees"],
+    );
 
     const secondTabPanel = getByTestId("vertical-tabpanel-1");
     expect(secondTabPanel).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/NextSteps/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NextSteps/Public.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { axe } from "vitest-axe";
 
 import NextStepsComponent from "./Public";

--- a/apps/editor.planx.uk/src/@planx/components/Notice/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Notice/Public.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NumberInput/Public.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Page/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Page/Public.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -4,7 +4,7 @@ import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { axe } from "vitest-axe";
 
 import { FeeBreakdown } from "./FeeBreakdown";

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -6,7 +6,7 @@ import ErrorFallback from "components/Error/ErrorFallback";
 import { FullStore, Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { ApplicationPath, Breadcrumbs } from "types";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
@@ -5,7 +5,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import ErrorFallback from "components/Error/ErrorFallback";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import { presentationalPropsMock } from "./mocks/propsMock";

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import Question from "./Editor";
 

--- a/apps/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Public.test.tsx
@@ -2,7 +2,7 @@ import { QuestionLayout } from "@planx/components/shared/BaseQuestion/model";
 import { act, waitFor } from "@testing-library/react";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -8,7 +8,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import { Condition } from "../shared/RuleBuilder/types";

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import { Condition, Operator } from "../shared/RuleBuilder/types";
 import ResponsiveQuestion from "./Editor";

--- a/apps/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Result/Public.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Review/Public/Public.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/Section/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Public/index.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { SectionNode, SectionStatus } from "types";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
@@ -5,7 +5,7 @@ import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { act } from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it, vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/Public.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -229,12 +229,10 @@ test("character limit counter shows error state when over limit", async () => {
   const { user } = await setup(
     <TextInput title="hello" type={TextInputType.Long} />,
   );
-  const textArea = screen.getByRole("textbox", {
-    name: /hello/i,
-  });
+  const textArea = screen.getByRole("textbox", { name: /hello/i });
 
-  await user.type(textArea, `${twentyFiveCharacterTest.repeat(10)}`);
-  await user.type(textArea, `extra`);
+  await user.click(textArea);
+  await user.paste(`${twentyFiveCharacterTest.repeat(10)}extra`);
 
   const errorCharacterCounter = await screen.findByText(
     "You have 5 characters too many",
@@ -247,19 +245,18 @@ test("character limit counter should meet accessibility requirements", async () 
   const { user, container } = await setup(
     <TextInput title="hello" type={TextInputType.Long} />,
   );
-  const textArea = screen.getByRole("textbox", {
-    name: /hello/i,
-  });
+  const textArea = screen.getByRole("textbox", { name: /hello/i });
 
   const results = await axe(container);
   expect(results).toHaveNoViolations();
 
-  await user.type(textArea, `${twentyFiveCharacterTest.repeat(10)}`);
+  await user.click(textArea);
+  await user.paste(`${twentyFiveCharacterTest.repeat(10)}`);
 
   const resultsAfterTyping = await axe(container);
   expect(resultsAfterTyping).toHaveNoViolations();
 
-  await user.type(textArea, `extra`);
+  await user.paste(`extra`);
   const resultsWithError = await axe(container);
   expect(resultsWithError).toHaveNoViolations();
 });

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Public.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { uniqueId } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.exclusiveOr.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.exclusiveOr.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import Checklist from "../../../../Checklist/Public";

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.grouped.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.grouped.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { cloneDeep } from "lodash";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/tests/Public.test.tsx
@@ -1,7 +1,7 @@
 import { ChecklistLayout } from "@planx/components/shared/BaseChecklist/model";
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/Card.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/Card.test.tsx
@@ -3,7 +3,7 @@ import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { act, screen, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { ApplicationPath } from "types";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";

--- a/apps/editor.planx.uk/src/components/Breadcrumbs.test.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.test.tsx
@@ -1,7 +1,7 @@
 import * as TanStackRouter from "@tanstack/react-router";
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import Breadcrumbs from "./Breadcrumbs";

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
@@ -1,7 +1,7 @@
 import * as TanStackRouter from "@tanstack/react-router";
 import { within } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import EditorNavMenu from "./EditorNavMenu";

--- a/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
+++ b/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
@@ -2,7 +2,7 @@ import { logger } from "airbrake";
 import ErrorFallback from "components/Error/ErrorFallback";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/Feedback/FeedbackForm/FeedbackForm.test.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/FeedbackForm/FeedbackForm.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/FeedbackPhaseBanner.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/Feedback/MoreInfoFeedback/MoreInfoFeedback.test.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/MoreInfoFeedback/MoreInfoFeedback.test.tsx
@@ -4,7 +4,7 @@ import {
   insertFeedbackMutation,
 } from "lib/feedback";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/Feedback/index.test.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/index.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "lib/feedback";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/Footer/Footer.test.tsx
+++ b/apps/editor.planx.uk/src/components/Footer/Footer.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 
 import Footer from "./Footer";

--- a/apps/editor.planx.uk/src/components/Header/Header.test.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.test.tsx
@@ -3,7 +3,7 @@ import * as TanStackRouter from "@tanstack/react-router";
 import { act, screen } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/components/ImagePreview.tsx
+++ b/apps/editor.planx.uk/src/components/ImagePreview.tsx
@@ -4,5 +4,7 @@ import React from "react";
 export default function ImagePreview(props: UseFileUrlProps) {
   const { fileUrl } = useFileUrl(props);
 
+  if (!fileUrl) return null;
+
   return <img src={fileUrl} alt={`Preview of uploaded file: ${fileUrl}`} />;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/tests/FeedbackLog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/tests/FeedbackLog.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 
 import { FeedbackLog } from "../FeedbackLog";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlowLink.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlowLink.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RecentFlowLink } from "./RecentFlowLink";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RecentFlows from "./RecentFlows";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/About/index.test.tsx
@@ -4,7 +4,7 @@ import { graphql, HttpResponse } from "msw";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/components/test/utils.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/FlowStatus/components/test/utils.tsx
@@ -2,7 +2,7 @@ import { screen, waitForElementToBeRemoved } from "@testing-library/react";
 import { delay, graphql, HttpResponse } from "msw";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import FlowStatus from "../..";
 import type { GetFlowStatus } from "../../types";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortalList.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/ExternalPortalList/ExternalPortalList.test.tsx
@@ -1,7 +1,7 @@
 import { act, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/Headline.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/Headline.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { FONT_WEIGHT_BOLD } from "theme";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchHeader.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import Search from ".";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
@@ -2,7 +2,7 @@ import * as planxCore from "@opensystemslab/planx-core";
 import { waitFor, within } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsLog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsLog.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 
 import EventsLog from "./components/EventsLog";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 
 import { TeamMembers } from "../TeamMembers";
 import { getUsersWithNoTeamEditorHandler } from "./mocks/handlers";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
@@ -6,7 +6,7 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 import server from "test/mockServer";
 import { axe } from "vitest-axe";
 
-import { setup } from "../../../../../testUtils";
+import { setup } from "../../../../../test/utils";
 import { AddUserModal } from "../components/AddUserModal";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
 import { userTriesToAddNewMember } from "./helpers/userTriesToAddNewMember";
@@ -77,7 +77,7 @@ describe("when the addNewMember modal is rendered", () => {
   it("should not have any accessibility issues", async () => {
     const { container } = await setup(
       <DndProvider backend={HTML5Backend}>
-        <AddUserModal onClose={vi.fn()}/>
+        <AddUserModal onClose={vi.fn()} />
       </DndProvider>,
     );
     await screen.findByTestId("modal-create-user");
@@ -86,7 +86,6 @@ describe("when the addNewMember modal is rendered", () => {
     expect(results).toHaveNoViolations();
   });
 });
-
 
 describe("when a user is not a platform admin", () => {
   beforeEach(async () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
@@ -4,7 +4,7 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import server from "test/mockServer";
 
-import { setup } from "../../../../../../testUtils";
+import { setup } from "../../../../../../test/utils";
 import { TeamMembers } from "../../TeamMembers";
 import { getNoExistingUserHandler, getUsersHandler } from "../mocks/handlers";
 

--- a/apps/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.test.tsx
+++ b/apps/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.test.tsx
@@ -2,7 +2,7 @@ import { screen, within } from "@testing-library/react";
 import { graphql, HttpResponse } from "msw";
 import React from "react";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { mockTeams } from "ui/shared/DataTable/mockTeams";
 import { it } from "vitest";
 

--- a/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/SaveAndReturn.test.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button";
 import { act, screen, waitFor } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/test/jsdom.ts
+++ b/apps/editor.planx.uk/src/test/jsdom.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+
+// jsdom does not implement window.scrollTo
+Object.defineProperty(window, "scrollTo", { value: vi.fn(), writable: true });
+
+// jsdom requires the optional `canvas` package for HTMLCanvasElement.getContext.
+// Mock it globally so tests that render canvas-containing components don't warn.
+Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+  value: vi.fn(),
+  writable: true,
+});
+
+window.alert = vi.fn();
+
+// Minimal indexedDB stub — enough to silence the error, tests don't actually use IDB
+global.indexedDB = { open: vi.fn() } as any;

--- a/apps/editor.planx.uk/src/test/mui.tsx
+++ b/apps/editor.planx.uk/src/test/mui.tsx
@@ -15,16 +15,29 @@ import { vi } from "vitest";
  */
 const mockFade = vi.fn(({ children }: FadeProps) => <div>{children}</div>);
 
-const mockCollapse = vi.fn(
-  ({
-    children,
-    in: inProp,
-    id,
-    "data-testid": dataTestId,
-  }: CollapseProps & { "data-testid"?: string }) => (
+// Separate named component so we can use hooks (vi.fn wrappers can't use hooks directly)
+function MockCollapseImpl({
+  children,
+  in: inProp,
+  onExited,
+  id,
+  "data-testid": dataTestId,
+}: CollapseProps & { "data-testid"?: string }) {
+  // Fire onExited immediately when closing to simulate animation completion
+  React.useEffect(() => {
+    if (!inProp) onExited?.(null!);
+  }, [inProp, onExited]);
+
+  return (
     <div hidden={!inProp} id={id} data-testid={dataTestId}>
       {children}
     </div>
+  );
+}
+
+const mockCollapse = vi.fn(
+  (props: CollapseProps & { "data-testid"?: string }) => (
+    <MockCollapseImpl {...props} />
   ),
 );
 

--- a/apps/editor.planx.uk/src/test/mui.tsx
+++ b/apps/editor.planx.uk/src/test/mui.tsx
@@ -2,22 +2,36 @@ import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/vitest";
 import "vitest-axe/extend-expect";
 
+import { CollapseProps } from "@mui/material/Collapse";
 import { FadeProps } from "@mui/material/Fade";
 import React from "react";
 import { vi } from "vitest";
 
 /**
- * Mock the MUI Fade component used in @planx/components/shared/Preview/Card.tsx
- * Required as this frequently updates following the final "expect()" call of a test,
- * leading to multiple "an update was not wrapped in act(...)" warnings
+ * Mock MUI animation components to prevent "an update was not wrapped in act()"
+ * warnings. These components schedule internal state updates (measuring animated
+ * element dimensions, managing ripple effects) that fire after the act() boundary.
  * Docs: https://testing-library.com/docs/example-react-transition-group/
  */
 const mockFade = vi.fn(({ children }: FadeProps) => <div>{children}</div>);
 
-vi.doMock("@mui/material/Fade", () => ({
-  default: mockFade,
-}));
+const mockCollapse = vi.fn(
+  ({
+    children,
+    in: inProp,
+    id,
+    "data-testid": dataTestId,
+  }: CollapseProps & { "data-testid"?: string }) => (
+    <div hidden={!inProp} id={id} data-testid={dataTestId}>
+      {children}
+    </div>
+  ),
+);
+
+vi.mock("@mui/material/Fade", () => ({ default: mockFade }));
+vi.mock("@mui/material/Collapse", () => ({ default: mockCollapse }));
 
 beforeEach(() => {
   mockFade.mockClear();
+  mockCollapse.mockClear();
 });

--- a/apps/editor.planx.uk/src/test/utils.tsx
+++ b/apps/editor.planx.uk/src/test/utils.tsx
@@ -66,6 +66,7 @@ export const setup = async (
   jsx: React.JSX.Element,
 ): Promise<Record<"user", UserEvent> & RenderResult> => {
   testQueryClient.clear();
+  const user = userEvent.setup();
 
   const rootRoute = createRootRoute({
     component: () => (
@@ -113,8 +114,5 @@ export const setup = async (
     { timeout: 1000 },
   );
 
-  return {
-    user: userEvent.setup(),
-    ...renderResult,
-  };
+  return { user, ...renderResult };
 };

--- a/apps/editor.planx.uk/src/test/utils.tsx
+++ b/apps/editor.planx.uk/src/test/utils.tsx
@@ -22,7 +22,7 @@ import { ToastContextProvider } from "contexts/ToastContext";
 import React from "react";
 import { CatchAllComponent } from "routes/$";
 
-import { defaultTheme } from "./theme";
+import { defaultTheme } from "../theme";
 
 const testQueryClient = new QueryClient({
   defaultOptions: {

--- a/apps/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ComponentTagSelect.test.tsx
@@ -6,7 +6,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 
 const { setState } = useStore;

--- a/apps/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/Filter/tests/Filter.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { describe, vi } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/src/ui/shared/SearchBox/tests/SearchBox.test.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SearchBox/tests/SearchBox.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { it } from "vitest";
 import { axe } from "vitest-axe";
 

--- a/apps/editor.planx.uk/vitest.config.ts
+++ b/apps/editor.planx.uk/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: [
+      "./src/test/jsdom.ts",
       "./src/test/mockServer.ts",
       "./src/test/mui.tsx",
     ],

--- a/doc/guides/data-fetching-and-state-management.md
+++ b/doc/guides/data-fetching-and-state-management.md
@@ -9,29 +9,29 @@ Our architecture is built using a hybrid, "best-tool-for-the-job" approach. We s
 When implementing a new feature, use this decision tree to choose your tools:
 
 1.  **Are you fetching/mutating data from our GraphQL API (Hasura)?**
-      * ➡️ **Use Apollo Client** via `useQuery()` and `useMutation()`
-      * 🔮 In future, via auto-generated hooks and types
+    - ➡️ **Use Apollo Client** via `useQuery()` and `useMutation()`
+    - 🔮 In future, via auto-generated hooks and types
 2.  **Are you fetching/mutating data from a REST API (internal or external)?**
-      * ➡️ **Use TanStack Query** consuming our typed API layer
+    - ➡️ **Use TanStack Query** consuming our typed API layer
 3.  **Are you managing UI state (modals, clipboard, layout preferences)?**
-      * ➡️ **Use Zustand**
+    - ➡️ **Use Zustand**
 4.  **Are you managing flow state (breadcrumbs, passport, etc)?**
-      * ➡️ **Use Zustand**
+    - ➡️ **Use Zustand**
 5.  **Are you testing a component that fetches data?**
-      * ➡️ **Use MSW (Mock Service Worker)** to mock the network requests, not the implementation.
-
+    - ➡️ **Use MSW (Mock Service Worker)** to mock the network requests, not the implementation.
 
 ## 1. GraphQL Data (Apollo Client)
-   
+
 We use Apollo Client for interacting with our Hasura middleware. It provides a normalized cache that keeps our UI consistent without manual state management.
 
->[!NOTE] Future architecture: codegen 
+> [!NOTE] Future architecture: codegen
 > We are in the process of migrating to GraphQL Code Generator. Once fully set up, we will define queries in `.graphql` files and import auto-generated, fully-typed hooks.
 
-For now, please follow the manual pattern below - 
+For now, please follow the manual pattern below -
 
-###  Workflow
-**1. Define query** 
+### Workflow
+
+**1. Define query**
 Write your GraphQL query using the `gql` tag within a custom hook file. The Hasura GraphiQL playground is very helpful for defining these.
 
 **2. Type query**
@@ -43,73 +43,72 @@ Export a custom hook that wraps Apollo's `useQuery()` or `useMutation()`.
 **4. Consume hook**
 Use the hook within our React components. Apollo manages loading and error states, as well as caching, and refetching.
 
-
 ### Example
-```ts 
+
+```ts
 import { gql, useQuery } from "@apollo/client";
 
 // 1. Define the query
 const GET_FLOW =  gql`
-  GetFlow($flowId: uuid!) { 
-    flow: flows_by_pk(id: $flowId) { 
-      id 
-      name 
-      slug 
+  GetFlow($flowId: uuid!) {
+    flow: flows_by_pk(id: $flowId) {
+      id
+      name
+      slug
       team {
         # Apollo uses the id field to manage the cache
         # Queries and mutations should always include this field
         id
         name
         slug
-      } 
+      }
     }
   };
 `
 
-// 2. Define the types (Codegen will do this for us in the future) 
-interface GetFlow { 
-  id: string; 
+// 2. Define the types (Codegen will do this for us in the future)
+interface GetFlow {
+  id: string;
   name: string;
   slug: string
   team: {
     id: number
     name: string
     slug: string
-  } 
+  }
 } | null;
 
-interface GetFlowVars { 
+interface GetFlowVars {
   flowId: string;
 }
 
 // 3. Write a hook
-export const useFlow = (flowId: string) => 
-  useQuery<GetFlow, GetFlowVars>(GET_FLOW, { 
+export const useFlow = (flowId: string) =>
+  useQuery<GetFlow, GetFlowVars>(GET_FLOW, {
     variables: { flowId }
   });
 ```
 
-```tsx 
+```tsx
 // 4. Consume the hook
 import { useFlow } from "../hooks/useFlow";
 
-export const FlowDetails: React.FC<{ flowId: string}> = ({ flowId }) => { 
+export const FlowDetails: React.FC<{ flowId: string}> = ({ flowId }) => {
 
 const { data, loading, error } = useFlow(flowId);
 
-if (loading) return <DelayedLoadingIndicator />; 
+if (loading) return <DelayedLoadingIndicator />;
 if (error) return <ErrorSummary error={error} />;
 
 const flow = data?.flow;
 
-return ( 
+return (
   <Box>
     <Typography component="h1">{flow.name}</Typography>
     <Typography component="h2">{flow.team.name}</Typography>
   </Box>
 )
 ```
-
 
 ## 2. REST API Data (TanStack Query + API Layer)
 
@@ -127,8 +126,8 @@ For REST endpoints, we use **TanStack Query** for state management and caching. 
 
 Filepath: `src/lib/api/flow/requests.ts`
 
->[!NOTE]
-We use a centralised `apiClient` that automatically handles auth headers and error handling
+> [!NOTE]
+> We use a centralised `apiClient` that automatically handles auth headers and error handling
 
 ```ts
 import { FlowGraph } from "@opensystemslab/planx-core/types";
@@ -174,21 +173,18 @@ Filepath: Feature based
 
 ```tsx
 export const CreateFlowButton = () => {
- const { mutate: createFlow, isPending } = useCreateFlow()
+  const { mutate: createFlow, isPending } = useCreateFlow();
 
-return (
-  <Button
-    onClick={createFlow}
-    disabled={isPending}
-  >
-    {isPending ? "Creating..." : "Create"}
-  </Button>
-)};
+  return (
+    <Button onClick={createFlow} disabled={isPending}>
+      {isPending ? "Creating..." : "Create"}
+    </Button>
+  );
+};
 ```
 
->[!NOTE]
-It's not always necessary to use a custom hook if an API call is simple (no side effects, no custom logic), and only used in one location. However, it is a simple abstraction to make and usually worth doing.
-
+> [!NOTE]
+> It's not always necessary to use a custom hook if an API call is simple (no side effects, no custom logic), and only used in one location. However, it is a simple abstraction to make and usually worth doing.
 
 ## 3. Client state (Zustand)
 
@@ -198,18 +194,18 @@ We use **Zustand** stores for global client-side state.
 
 **Do not store server data in Zustand**
 
-  * ❌ **Bad:** Storing `teamSettings`, `teamMembers`, or `planningConstraints` in a global store. (Use Apollo/TanStack Query caches for this).
-  * ✅ **Good:** Storing `isSidebarOpen`, `breadcrumbs`, or `sectionNodes` (simple UI data, client side data, or complex derived flow data)
+- ❌ **Bad:** Storing `teamSettings`, `teamMembers`, or `planningConstraints` in a global store. (Use Apollo/TanStack Query caches for this).
+- ✅ **Good:** Storing `isSidebarOpen`, `breadcrumbs`, or `sectionNodes` (simple UI data, client side data, or complex derived flow data)
 
->[!NOTE]
->Currently, this rule is very much not adhered to in our codebase! Going forward we're working to improve and simplify this by taking server state out of the stores and relying on Apollo and Tanstack caches.
+> [!NOTE]
+> Currently, this rule is very much not adhered to in our codebase! Going forward we're working to improve and simplify this by taking server state out of the stores and relying on Apollo and Tanstack caches.
 >
->Whilst working on this migration, we should not add *additional* server state to the stores
+> Whilst working on this migration, we should not add _additional_ server state to the stores
 >
->Please see [ADR#11](https://github.com/theopensystemslab/planx-new/blob/90297a934dbd39f9b5659873d64cd538f778d0c6/doc/architecture/decisions/0011-standardised-data-fetching-and-state-management.md) for further information here.
-
+> Please see [ADR#11](https://github.com/theopensystemslab/planx-new/blob/90297a934dbd39f9b5659873d64cd538f778d0c6/doc/architecture/decisions/0011-standardised-data-fetching-and-state-management.md) for further information here.
 
 ### Example
+
 Filepath: `apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts`
 
 ```ts
@@ -225,23 +221,23 @@ export const editorUIStore: StateCreator<
   EditorUIStore
 > = (set, get) => ({
   showSidebar: true,
-  
+
   toggleSidebar: () => {
     set({ showSidebar: !get().showSidebar });
   },
 });
 ```
 
-
 ## 4. Testing strategy
 
 Where possible, we try to prioritise integration tests over implementation details - we want to test that our components work from a user's perspective.
 
-  * **Do not mock the hook** (for example, don't mock `createFlow()`)
-  * **Do not mock the Zustand store state** (unless strictly required, e.g. complex graph logic)
-  * **Mock the network** using [MSW (Mock Service Worker)](https://mswjs.io/)
+- **Do not mock the hook** (for example, don't mock `createFlow()`)
+- **Do not mock the Zustand store state** (unless strictly required, e.g. complex graph logic)
+- **Mock the network** using [MSW (Mock Service Worker)](https://mswjs.io/)
 
 ### Example: REST API calls
+
 ```tsx
 const handlers: HttpHandler[] = [
   // GIS requests
@@ -260,9 +256,7 @@ beforeEach(() => {
 
 // Tests can now make network requests, and receive mocks back
 it("renders correctly", async () => {
-  setup(
-    <PlanningConstraints title="Planning constraints" />
-  );
+  setup(<PlanningConstraints title="Planning constraints" />);
 
   expect(
     getByRole("heading", { name: "Planning constraints" }),
@@ -276,10 +270,11 @@ it("renders correctly", async () => {
 ```
 
 ### Example: GraphQL API calls
+
 ```tsx
 import { graphql, HttpResponse } from "msw";
 import server from "test/mockServer";
-import { setup } from "testUtils";
+import { setup } from "test/utils";
 import { mockTeams } from "ui/shared/DataTable/mockTeams";
 
 import { PlatformAdminPanel } from "./PlatformAdminPanel";
@@ -304,41 +299,40 @@ it("renders the admin panel", async () => {
 });
 ```
 
-
 ## Legacy patterns to avoid
 
 As we migrate our codebase, you will still see older patterns. **Please do not replicate these in new code, and follow the guidelines laid out here.**
 
-1.  **"The God Store"** 
+1.  **"The God Store"**
 
-      Large Zustand stores that fetch data, hold it in state, and manage UI logic (e.g., `teamStore.ts`).
+    Large Zustand stores that fetch data, hold it in state, and manage UI logic (e.g., `teamStore.ts`).
 
-2.  **Manually managing loading or error state via React state** 
-      ```ts
-      const [isLoading, setIsLoading] = useState(false)
-      ```
+2.  **Manually managing loading or error state via React state**
 
-      We should use derived state from our queries and mutations - 
+    ```ts
+    const [isLoading, setIsLoading] = useState(false);
+    ```
 
-      ```ts
-      const { isPending, isError } = useQuery({...})
-      ```
+    We should use derived state from our queries and mutations -
 
-3.  **Calling Axios directly from components** 
-      ```ts
-      useEffect(() => { axios.get(...) }, [])
-      ```
+    ```ts
+    const { isPending, isError } = useQuery({...})
+    ```
 
-      This can cause loading waterfalls, and managing async calls within `useEffect()`s can get complex. This method does not have any caching we can rely on. 
-      
-      Instead we should use our API layer for making requests, via TanStack query.
+3.  **Calling Axios directly from components**
 
-      External APIs, such as PlanningData, should still be wrapped in a query.
+    ```ts
+    useEffect(() => { axios.get(...) }, [])
+    ```
 
-4.  **Mocking implementations within tests** 
-      
-      ```ts
-      vi.mock("axios", () => {...})
-      ```
-      
-      Instead, we should mock network requests via `msw`.
+    This can cause loading waterfalls, and managing async calls within `useEffect()`s can get complex. This method does not have any caching we can rely on.
+
+    Instead we should use our API layer for making requests, via TanStack query.
+
+    External APIs, such as PlanningData, should still be wrapped in a query.
+
+4.  **Mocking implementations within tests**
+    ```ts
+    vi.mock("axios", () => {...})
+    ```
+    Instead, we should mock network requests via `msw`.


### PR DESCRIPTION
## What does this PR do?
After bumping to React 19 / MUI 9, React tests are timing out more frequently in CI. They usually pass on a re-run, and pass locally also. Stats show that these are now running at ~11m, up from ~8m30s historically - https://github.com/theopensystemslab/planx-new/actions/metrics/performance?dateRangeType=DATE_RANGE_TYPE_CUSTOM&tab=jobs&range=1777507200000-1777507200000

This PR attempts to improve to the performance of these tests by identifying issues (mainly turning off the `--silent` flag, as well as identifying where the timeouts are happening). Multiple re-runs on this PR have the React tests running in ~8m30m.

I think the underlying change here is concurrent rendering and stricter batching behaviour in React 19.

Most the changes should be grouped in commits, but here's the broad strokes - 

 - Move `/testUtils.ts` to be colcated with other test setup files in `/test/utils.ts` - noisy change sorry..!
 - Setup the `user` prior to render in our test setup util
 - Setup jsdom mocks to suppress warnings (makes it easier to spot actual issues)
 - Replace `user.type()` for long strings / frequently called helpers with `user.paste()` - one event rather than one per-key stroke.

## Next steps...
There's plenty more room for improvement here, but hopefully this gets us over the initial timeouts. I think from here we can work through tests in batches trying to resolve warnings, and focus on methods for improving long-running ones. I'll aim to pick up one suite a day...! 🛠️ 