### PR TITLE
test: e2e tests for templates

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTemplateIndicator.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTemplateIndicator.tsx
@@ -22,7 +22,10 @@ export const FlowTemplateIndicator: React.FC<Props> = ({
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
       {isTemplatedFlow && (
-        <StarIcon sx={{ color: "#380F77", fontSize: "1rem" }} />
+        <StarIcon
+          data-testid="templated-flow-star"
+          sx={{ color: "#380F77", fontSize: "1rem" }}
+        />
       )}
       <Typography variant="body3" sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
         {text}

--- a/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -124,7 +124,7 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
           </Typography>
           {isComplete && (
             <CheckCircleIcon
-              id="customisation-complete"
+              data-testid="customisation-complete"
               fontSize="small"
               sx={(theme) => ({ color: theme.palette.success.main })}
             />

--- a/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -124,6 +124,7 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
           </Typography>
           {isComplete && (
             <CheckCircleIcon
+              id="customisation-complete"
               fontSize="small"
               sx={(theme) => ({ color: theme.palette.success.main })}
             />

--- a/e2e/tests/ui-driven/.eslintrc
+++ b/e2e/tests/ui-driven/.eslintrc
@@ -4,7 +4,7 @@
     "playwright/expect-expect": [
       "error",
       {
-        "additionalAssertFunctionNames": ["expectSections"]
+        "additionalAssertFunctionNames": ["expectSections", "publishService", "turnServiceOnline"]
       }
     ],
     "playwright/no-networkidle": "warn"

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -3,12 +3,18 @@ import { expect, Locator, Page } from "@playwright/test";
 import { OptionWithDataValues } from "./types.js";
 import { selectedFlag } from "./globalHelpers.js";
 
+export type TemplateNodeConfig = {
+  instructions: string;
+  required: boolean;
+};
+
 const createBaseComponent = async (
   page: Page,
   locatingNode: Locator,
   type: ComponentType,
   title?: string,
   options?: string[],
+  templateConfig?: TemplateNodeConfig,
 ) => {
   await locatingNode.click();
   await page.getByRole("dialog").waitFor();
@@ -176,8 +182,27 @@ const createBaseComponent = async (
       throw new Error(`Unsupported type: ${type}`);
   }
 
+  if (templateConfig) {
+    await page.getByLabel("Allow edits").click({ force: true });
+    await page.locator("#templatedNodeInstructions").fill(templateConfig.instructions);
+    if (templateConfig.required) {
+      await page.getByLabel("Require edits").click({ force: true });
+    }
+  }
+
   await page.locator('button[form="modal"][type="submit"]').click();
   await page.getByRole("dialog").waitFor({ state: "detached" });
+};
+
+export const createTemplatedComponent = async (
+  page: Page,
+  locatingNode: Locator,
+  type: ComponentType,
+  title: string,
+  templateConfig: TemplateNodeConfig,
+  options?: string[],
+) => {
+  await createBaseComponent(page, locatingNode, type, title, options, templateConfig);
 };
 
 export const createQuestionWithOptions = async (

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -164,7 +164,7 @@ const createBaseComponent = async (
     case ComponentType.Feedback:
       break;
     case ComponentType.InternalPortal:
-      await page.getByPlaceholder("Portal name").fill(title || "");
+      await page.getByPlaceholder("Enter a folder name").fill(title || "");
       break;
     case ComponentType.ExternalPortal:
       page.getByTestId("flowId").click();
@@ -184,7 +184,9 @@ const createBaseComponent = async (
 
   if (templateConfig) {
     await page.getByLabel("Allow edits").click({ force: true });
-    await page.locator("#templatedNodeInstructions").fill(templateConfig.instructions);
+    await page
+      .locator("#templatedNodeInstructions")
+      .fill(templateConfig.instructions);
     if (templateConfig.required) {
       await page.getByLabel("Require edits").click({ force: true });
     }
@@ -202,7 +204,14 @@ export const createTemplatedComponent = async (
   templateConfig: TemplateNodeConfig,
   options?: string[],
 ) => {
-  await createBaseComponent(page, locatingNode, type, title, options, templateConfig);
+  await createBaseComponent(
+    page,
+    locatingNode,
+    type,
+    title,
+    options,
+    templateConfig,
+  );
 };
 
 export const createQuestionWithOptions = async (

--- a/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
+++ b/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
@@ -7,6 +7,13 @@ export const navigateToService = async (page: Page, slug: string) => {
   await expect(page.getByRole("link", { name: slug })).toBeVisible();
 };
 
+export const navigateToTeamPage = async (page: Page) => {
+  await page.goto(`/app/${contextDefaults.team.slug}`);
+
+  await expect(page.getByText(contextDefaults.team.name).first()).toBeVisible();
+  await expect(page.locator("h1", { hasText: "Flows" })).toBeVisible();
+};
+
 export const publishService = async (page: Page) => {
   // Open modal
   await page.getByTestId("check-for-changes-to-publish-button").click();
@@ -26,7 +33,9 @@ export const publishService = async (page: Page) => {
   await page.getByTestId("publish-button").click();
 
   // Wait for confirmation of success
-  await expect(page.getByText("Successfully published changes")).toBeVisible();
+  await expect(
+    page.getByText("Successfully published changes").first(),
+  ).toBeVisible();
 };
 
 export const turnServiceOnline = async (page: Page) => {

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -117,29 +117,6 @@ export class PlaywrightEditor {
     ).toBeVisible();
   }
 
-  // Create a new node in a templated flow
-  async createNodeWithTemplateConfig(
-    title: string,
-    instructions: string,
-    required: boolean,
-    locator?: Locator,
-  ): Promise<void> {
-    await (locator ?? this.firstNode).click();
-    await this.page.getByRole("dialog").waitFor();
-
-    await this.page.getByPlaceholder("Text").fill(title);
-
-    // force: true is necessary for MuiSwitch inputs
-    await this.page.getByLabel("Allow edits").click({ force: true });
-    await this.page.locator("#templatedNodeInstructions").fill(instructions);
-    if (required) {
-      await this.page.getByLabel("Require edits").click({ force: true });
-    }
-
-    await this.page.locator('button[form="modal"][type="submit"]').click();
-    await this.page.getByRole("dialog").waitFor({ state: "detached" });
-  }
-
   async createQuestion() {
     await createQuestionWithOptions(
       this.page,

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -78,6 +78,68 @@ export class PlaywrightEditor {
     this.page.getByRole("button", { name: "Add flow " }).click();
   }
 
+  async addNewSourceTemplate(name: string): Promise<void> {
+    const openModalButton = this.page.locator("button", {
+      hasText: "Add a new flow",
+    });
+    await openModalButton.click();
+
+    await this.page.getByLabel("Flow name").fill(name);
+
+    await this.page.getByLabel("Source template").click();
+
+    await this.page.getByRole("button", { name: "Add flow" }).click();
+
+    await expect(this.firstNode).toBeVisible();
+  }
+
+  // Creates a templated flow from a named source template.
+  async addNewFlowFromTemplate(sourceTemplateName: string): Promise<void> {
+    const openModalButton = this.page.locator("button", {
+      hasText: "Add a new flow",
+    });
+    await openModalButton.click();
+
+    // Switch mode to "From a template..."
+    await this.page.locator('[aria-labelledby~="create-flow-mode"]').click();
+    await this.page.getByRole("option", { name: "From a template..." }).click();
+
+    // Select the source template
+    await this.page
+      .locator('[aria-labelledby~="available-templates-select"]')
+      .click();
+    await this.page.getByRole("option", { name: sourceTemplateName }).click();
+
+    // Save flow and redirect
+    await this.page.getByRole("button", { name: "Add flow " }).click();
+    await expect(
+      this.page.getByRole("tab", { name: "Customise" }),
+    ).toBeVisible();
+  }
+
+  // Create a new node in a templated flow
+  async createNodeWithTemplateConfig(
+    title: string,
+    instructions: string,
+    required: boolean,
+    locator?: Locator,
+  ): Promise<void> {
+    await (locator ?? this.firstNode).click();
+    await this.page.getByRole("dialog").waitFor();
+
+    await this.page.getByPlaceholder("Text").fill(title);
+
+    // force: true is necessary for MuiSwitch inputs
+    await this.page.getByLabel("Allow edits").click({ force: true });
+    await this.page.locator("#templatedNodeInstructions").fill(instructions);
+    if (required) {
+      await this.page.getByLabel("Require edits").click({ force: true });
+    }
+
+    await this.page.locator('button[form="modal"][type="submit"]').click();
+    await this.page.getByRole("dialog").waitFor({ state: "detached" });
+  }
+
   async createQuestion() {
     await createQuestionWithOptions(
       this.page,
@@ -305,5 +367,11 @@ export class PlaywrightEditor {
 
   async createFeedback() {
     await createFeedback(this.page, this.getNextNode());
+  }
+
+  async checkNodeExists(nodeName: string): Promise<Locator> {
+    const node = this.nodeList.filter({ hasText: nodeName }).first();
+    await expect(node).toBeVisible();
+    return node;
   }
 }

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -1,0 +1,279 @@
+import { expect, test } from "@playwright/test";
+import {
+  contextDefaults,
+  setUpTestContext,
+  tearDownTestContext,
+} from "./helpers/context.js";
+import { getTeamPage } from "./helpers/getPage.js";
+import {
+  navigateToService,
+  navigateToTeamPage,
+  publishService,
+  turnServiceOnline,
+} from "./helpers/navigateAndPublish.js";
+import { TestContext } from "./helpers/types.js";
+import { PlaywrightEditor } from "./pages/Editor.js";
+
+const SOURCE_TEMPLATE_NAME = "E2E Source Template";
+const SOURCE_TEMPLATE_SLUG = "e2e-source-template";
+
+const REQUIRED_NODE_TITLE = "Required node";
+const REQUIRED_NODE_INSTRUCTIONS =
+  "You have to customise this node before publishing";
+
+const OPTIONAL_NODE_TITLE = "Optional node";
+const OPTIONAL_NODE_INSTRUCTIONS =
+  "You can customise this node if you feel like it";
+
+const TEMPLATED_FLOW_NAME = `${SOURCE_TEMPLATE_NAME} (templated)`;
+const TEMPLATED_FLOW_SLUG = `${SOURCE_TEMPLATE_SLUG}-templated`;
+
+test.describe("Templates", () => {
+  let context: TestContext = { ...contextDefaults };
+
+  test.beforeAll(async () => {
+    try {
+      context = await setUpTestContext(context);
+    } catch (error) {
+      await tearDownTestContext();
+      throw error;
+    }
+  });
+
+  test.afterAll(async () => {
+    await tearDownTestContext();
+  });
+
+  test.describe("As a platform admin", () => {
+    test("can create a source template flow", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      const editor = new PlaywrightEditor(page);
+
+      await editor.addNewSourceTemplate(SOURCE_TEMPLATE_NAME);
+
+      // After creation the editor redirects us into the source template flow
+      await expect(
+        page.getByRole("link", { name: SOURCE_TEMPLATE_SLUG }),
+      ).toBeVisible();
+    });
+
+    test("component modals show a Templates section not present in regular flows", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+      const editor = new PlaywrightEditor(page);
+      await editor.firstNode.click();
+      await page.getByRole("dialog").waitFor();
+
+      // check section is present
+      await expect(
+        page.getByText("This node is in a source template"),
+      ).toBeVisible();
+
+      // check "require edits" control and instructions are not initially visible
+      await expect(page.getByLabel("Require edits")).not.toBeVisible();
+      await expect(page.getByText("Instructions")).not.toBeVisible();
+
+      // check "allow edits" control is visible then click it
+      const allowEditsControl = page.getByLabel("Allow edits");
+      await expect(allowEditsControl).toBeVisible();
+      await allowEditsControl.click({ force: true });
+
+      // check "require edits" control and instructions fields are now visible after clicking "allow edits"
+      await expect(page.getByLabel("Require edits")).toBeVisible();
+      await expect(page.getByText("Instructions")).toBeVisible();
+      await page.getByLabel("Require edits").click({ force: true });
+
+      // Close modal without saving
+      await page.locator('button[aria-label="close"]').click();
+      await page.getByRole("button", { name: "Discard changes" }).click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+
+      // check node is not visible
+      await expect(editor.nodeList).not.toContainText([REQUIRED_NODE_TITLE]);
+    });
+
+    test("can add required and optional nodes to a source template flow", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+      const editor = new PlaywrightEditor(page);
+
+      await editor.createNodeWithTemplateConfig(
+        REQUIRED_NODE_TITLE,
+        REQUIRED_NODE_INSTRUCTIONS,
+        true,
+      );
+
+      await editor.createNodeWithTemplateConfig(
+        OPTIONAL_NODE_TITLE,
+        OPTIONAL_NODE_INSTRUCTIONS,
+        false,
+        editor.getNextNode(),
+      );
+
+      // Check that the required node is visible and has the "Required" label
+      const requiredNode = await editor.checkNodeExists(REQUIRED_NODE_TITLE);
+      await expect(
+        requiredNode.getByText("Required", { exact: true }),
+      ).toBeVisible();
+
+      // Check that the optional node is visible and has the "Optional" label
+      const optionalNode = await editor.checkNodeExists(OPTIONAL_NODE_TITLE);
+      await expect(
+        optionalNode.getByText("Optional", { exact: true }),
+      ).toBeVisible();
+    });
+
+    test("can publish the source template and make it available for use", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+      await publishService(page);
+
+      await turnServiceOnline(page);
+
+      await navigateToTeamPage(page);
+      await expect(page.getByText(SOURCE_TEMPLATE_NAME)).toBeVisible();
+    });
+  });
+
+  // team editor creating a flow from source template, customising it and publishing it
+  // relies on the source template being online and published from the first block
+  test.describe("As a team editor", () => {
+    test("can create a templated flow from an available source template", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      const editor = new PlaywrightEditor(page);
+
+      await editor.addNewFlowFromTemplate(SOURCE_TEMPLATE_NAME);
+
+      await expect(
+        page.getByRole("link", { name: TEMPLATED_FLOW_SLUG }),
+      ).toBeVisible();
+    });
+
+    test("sees the Customise tab open by default with required tasks listed", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // The "Customise" tab is the default active tab for templated flows
+      const customiseTab = page.getByRole("tab", { name: "Customise" });
+      await expect(customiseTab).toBeVisible();
+      await expect(customiseTab).toHaveAttribute("aria-selected", "true");
+
+      const editor = new PlaywrightEditor(page);
+      await editor.checkNodeExists(REQUIRED_NODE_TITLE);
+      await editor.checkNodeExists(OPTIONAL_NODE_TITLE);
+    });
+
+    // TODO - test("Cannot add new nodes in a templated flow");
+
+    test("cannot proceed past the Review step when required customisations are incomplete", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // Make a change to the flow by editing the optional template node.
+      // this is required to get past the 'has any changes' step on publish
+      await page.getByRole("link", { name: OPTIONAL_NODE_TITLE }).click();
+      await page.getByRole("dialog").waitFor();
+      await page
+        .getByPlaceholder("Text")
+        .fill(`${OPTIONAL_NODE_TITLE} (updated)`);
+      await page.locator('button[form="modal"][type="submit"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+
+      // Open the publish dialog
+      await page.getByTestId("check-for-changes-to-publish-button").click();
+      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
+
+      // Validation should report a failure for the uncustomised required node
+      await expect(page.getByText("Fail")).toBeVisible();
+
+      // Clicking "Next" should be blocked and show an error
+      await page.getByTestId("next-step-test-button").click();
+      await expect(
+        page.getByText("Fix errors before continuing"),
+      ).toBeVisible();
+
+      // Close dialog and return to editor
+      await page.getByRole("button", { name: "Keep editing" }).click();
+    });
+
+    test("can complete a required customisation task and then publish successfully", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // Edit the required templated node to satisfy the customisation requirement.
+      await page.getByRole("link", { name: REQUIRED_NODE_TITLE }).click();
+      await page.getByRole("dialog").waitFor();
+      await page
+        .getByPlaceholder("Text")
+        .fill("Updated proposal description for this team");
+      await page.locator('button[form="modal"][type="submit"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+
+      // Check that our required node is complete in the customisation task list
+      const requiredCustomisationTask = page
+        .locator("li")
+        .filter({
+          has: page.getByRole("button", { name: REQUIRED_NODE_TITLE }),
+        })
+        .first();
+
+      await expect(
+        requiredCustomisationTask.locator("#customisation-complete"),
+      ).toBeVisible();
+
+      await publishService(page);
+
+      await navigateToTeamPage(page);
+      await expect(page.getByText(TEMPLATED_FLOW_NAME)).toBeVisible();
+    });
+  });
+});

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -28,6 +28,8 @@ const OPTIONAL_NODE_INSTRUCTIONS =
 const TEMPLATED_FLOW_NAME = `${SOURCE_TEMPLATE_NAME} (templated)`;
 const TEMPLATED_FLOW_SLUG = `${SOURCE_TEMPLATE_SLUG}-templated`;
 
+const REGULAR_FLOW_NAME = "E2E Regular Flow";
+
 test.describe("Templates", () => {
   let context: TestContext = { ...contextDefaults };
 
@@ -157,6 +159,29 @@ test.describe("Templates", () => {
 
       await navigateToTeamPage(page);
       await expect(page.getByText(SOURCE_TEMPLATE_NAME)).toBeVisible();
+    });
+
+    test("can filter flows for source templates only", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+
+      // Create a regular flow so we can assert it is excluded by the filter
+      await page.locator("button", { hasText: "Add a new flow" }).click();
+      await page.getByLabel("Flow name").fill(REGULAR_FLOW_NAME);
+      await page.getByRole("button", { name: "Add flow" }).click();
+      await page.locator("li.hanger > a").first().waitFor();
+
+      await navigateToTeamPage(page);
+
+      // Apply the "source template" filter from the Templates filter control
+      await page.locator('[aria-labelledby~="Templates-label"]').click();
+      await page.getByRole("option", { name: "Source template" }).click();
+
+      await expect(page.getByText(SOURCE_TEMPLATE_NAME)).toBeVisible();
+      await expect(page.getByText(REGULAR_FLOW_NAME)).not.toBeVisible();
     });
   });
 

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -18,10 +18,12 @@ const SOURCE_TEMPLATE_NAME = "E2E Source Template";
 const SOURCE_TEMPLATE_SLUG = "e2e-source-template";
 
 const REQUIRED_NODE_TITLE = "Required node";
+const UPDATED_REQUIRED_NODE_TITLE = `${REQUIRED_NODE_TITLE} (updated)`;
 const REQUIRED_NODE_INSTRUCTIONS =
   "You have to customise this node before publishing";
 
 const OPTIONAL_NODE_TITLE = "Optional node";
+const UPDATED_OPTIONAL_NODE_TITLE = `${OPTIONAL_NODE_TITLE} (updated)`;
 const OPTIONAL_NODE_INSTRUCTIONS =
   "You can customise this node if you feel like it";
 
@@ -29,6 +31,8 @@ const TEMPLATED_FLOW_NAME = `${SOURCE_TEMPLATE_NAME} (templated)`;
 const TEMPLATED_FLOW_SLUG = `${SOURCE_TEMPLATE_SLUG}-templated`;
 
 const REGULAR_FLOW_NAME = "E2E Regular Flow";
+
+const REPUBLISH_MESSAGE = "lorem ipsum";
 
 test.describe("Templates", () => {
   let context: TestContext = { ...contextDefaults };
@@ -271,9 +275,7 @@ test.describe("Templates", () => {
       // this is required to get past the 'has any changes' step on publish
       await page.getByRole("link", { name: OPTIONAL_NODE_TITLE }).click();
       await page.getByRole("dialog").waitFor();
-      await page
-        .getByPlaceholder("Text")
-        .fill(`${OPTIONAL_NODE_TITLE} (updated)`);
+      await page.getByPlaceholder("Text").fill(UPDATED_OPTIONAL_NODE_TITLE);
       await page.locator('button[form="modal"][type="submit"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 
@@ -307,9 +309,7 @@ test.describe("Templates", () => {
       // Edit the required templated node to satisfy the customisation requirement.
       await page.getByRole("link", { name: REQUIRED_NODE_TITLE }).click();
       await page.getByRole("dialog").waitFor();
-      await page
-        .getByPlaceholder("Text")
-        .fill("Updated proposal description for this team");
+      await page.getByPlaceholder("Text").fill(UPDATED_REQUIRED_NODE_TITLE);
       await page.locator('button[form="modal"][type="submit"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 
@@ -372,10 +372,47 @@ test.describe("Templates", () => {
       ).toBeVisible();
 
       // Complete the publish
-      await page.getByTestId("publish-summary-input").fill("lorem ipsum");
+      await page.getByTestId("publish-summary-input").fill(REPUBLISH_MESSAGE);
       await page.getByTestId("publish-button").click();
       await expect(
         page.getByText("Successfully published changes").first(),
+      ).toBeVisible();
+    });
+  });
+
+  // relies on the source template being republished in the "As a platform admin" block above
+  test.describe("As a team editor", () => {
+    test("sees a History entry describing the source template update and still has Customise tasks to complete", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // The History tab should contain an auto-generated entry for the source template update
+      await page.getByRole("tab", { name: "History" }).click();
+      await expect(
+        page.getByText(`Source template published: "${REPUBLISH_MESSAGE}"`),
+      ).toBeVisible();
+
+      // The Customise tab should still list the required and optional tasks
+      await page.getByRole("tab", { name: "Customise" }).click();
+      await expect(page.getByText(REQUIRED_NODE_INSTRUCTIONS)).toBeVisible();
+      await expect(page.getByText(OPTIONAL_NODE_INSTRUCTIONS)).toBeVisible();
+
+      // Check that our required node is complete in the customisation task list
+      const requiredCustomisationTask = page
+        .locator("li")
+        .filter({
+          has: page.getByRole("button", { name: UPDATED_REQUIRED_NODE_TITLE }),
+        })
+        .first();
+
+      await expect(
+        requiredCustomisationTask.getByTestId("customisation-complete"),
       ).toBeVisible();
     });
   });

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -225,6 +225,34 @@ test.describe("Templates", () => {
       await editor.checkNodeExists(OPTIONAL_NODE_TITLE);
     });
 
+    test("can filter flows for templated flows only", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+
+      // Apply the "templated" filter from the Templates filter control
+      await page.locator('[aria-labelledby~="Templates-label"]').click();
+      await page.getByRole("option", { name: "Templated" }).click();
+
+      // The templated flow card should be visible in the filtered results
+      const templatedCard = page
+        .locator("li")
+        .filter({ hasText: TEMPLATED_FLOW_NAME })
+        .first();
+      await expect(templatedCard).toBeVisible();
+
+      // The card should show a purple banner with the team name and a star icon
+      await expect(templatedCard.getByText(context.team.name)).toBeVisible();
+      await expect(
+        templatedCard.locator('[data-testid="templated-flow-star"]'),
+      ).toBeVisible();
+
+      // The source template should not appear in the filtered results
+      await expect(page.getByText(SOURCE_TEMPLATE_NAME)).not.toBeVisible();
+    });
+
     // TODO - test("Cannot add new nodes in a templated flow");
 
     test("cannot proceed past the Review step when required customisations are incomplete", async ({
@@ -336,9 +364,7 @@ test.describe("Templates", () => {
       await expect(
         page.getByRole("heading", { name: "Publish" }),
       ).toBeVisible();
-      await expect(
-        page.getByText("This flow is a template"),
-      ).toBeVisible();
+      await expect(page.getByText("This flow is a template")).toBeVisible();
       await expect(
         page.getByText(new RegExp(TEMPLATED_FLOW_SLUG)),
       ).toBeVisible();

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -1,3 +1,4 @@
+import { ComponentType } from "@opensystemslab/planx-core/types";
 import { expect, test } from "@playwright/test";
 import {
   contextDefaults,
@@ -11,6 +12,7 @@ import {
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
+import { createTemplatedComponent } from "./helpers/addComponent.js";
 import { TestContext } from "./helpers/types.js";
 import { PlaywrightEditor } from "./pages/Editor.js";
 
@@ -121,17 +123,20 @@ test.describe("Templates", () => {
 
       const editor = new PlaywrightEditor(page);
 
-      await editor.createNodeWithTemplateConfig(
+      await createTemplatedComponent(
+        page,
+        editor.firstNode,
+        ComponentType.Question,
         REQUIRED_NODE_TITLE,
-        REQUIRED_NODE_INSTRUCTIONS,
-        true,
+        { instructions: REQUIRED_NODE_INSTRUCTIONS, required: true },
       );
 
-      await editor.createNodeWithTemplateConfig(
-        OPTIONAL_NODE_TITLE,
-        OPTIONAL_NODE_INSTRUCTIONS,
-        false,
+      await createTemplatedComponent(
+        page,
         editor.getNextNode(),
+        ComponentType.Question,
+        OPTIONAL_NODE_TITLE,
+        { instructions: OPTIONAL_NODE_INSTRUCTIONS, required: false },
       );
 
       // Check that the required node is visible and has the "Required" label

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -246,11 +246,13 @@ test.describe("Templates", () => {
       // The card should show a purple banner with the team name and a star icon
       await expect(templatedCard.getByText(context.team.name)).toBeVisible();
       await expect(
-        templatedCard.locator('[data-testid="templated-flow-star"]'),
+        templatedCard.getByTestId("templated-flow-star"),
       ).toBeVisible();
 
       // The source template should not appear in the filtered results
-      await expect(page.getByText(SOURCE_TEMPLATE_NAME)).not.toBeVisible();
+      await expect(
+        page.getByText(SOURCE_TEMPLATE_NAME, { exact: true }),
+      ).not.toBeVisible();
     });
 
     // TODO - test("Cannot add new nodes in a templated flow");
@@ -320,7 +322,7 @@ test.describe("Templates", () => {
         .first();
 
       await expect(
-        requiredCustomisationTask.locator("#customisation-complete"),
+        requiredCustomisationTask.getByTestId("customisation-complete"),
       ).toBeVisible();
 
       await publishService(page);

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -366,7 +366,9 @@ test.describe("Templates", () => {
       await page.getByRole("link", { name: REQUIRED_NODE_TITLE }).click();
       await page.getByRole("dialog").waitFor();
       await expect(page.getByText("Customise (required)")).toBeVisible();
-      await expect(page.getByText(REQUIRED_NODE_INSTRUCTIONS)).toBeVisible();
+      await expect(
+        page.getByText(REQUIRED_NODE_INSTRUCTIONS).first(),
+      ).toBeVisible();
       await page.locator('button[aria-label="close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
     });
@@ -434,11 +436,10 @@ test.describe("Templates", () => {
       });
       await navigateToService(page, TEMPLATED_FLOW_SLUG);
 
-      // Navigate into the templated folder
       await page.getByRole("link", { name: TEMPLATED_FOLDER_NAME }).click();
       await page.locator("li.hanger > a").first().waitFor();
 
-      // Hangers inside a templated folder are visible (not hidden), enabling DnD
+      // Hangers inside a templated folder are visible (not hidden)
       await expect(page.locator("li.hanger").first()).not.toHaveClass(/hidden/);
 
       // Nodes inside the folder are fully editable (submit button enabled)
@@ -466,7 +467,38 @@ test.describe("Templates", () => {
       );
     });
 
-    // TODO - test("Cannot add new nodes in a templated flow");
+    test("cannot add new nodes or restructure a templated flow", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      await page
+        .getByRole("link", { name: NON_TEMPLATED_NODE_TITLE })
+        .waitFor();
+
+      // hidden hanger means no new nodes can be added
+      await expect(page.locator("li.hanger").first()).toHaveClass(/hidden/);
+
+      // Right-clicking a node shows Copy/Clone/Cut as disabled
+      await page
+        .getByRole("link", { name: NON_TEMPLATED_NODE_TITLE })
+        .click({ button: "right" });
+      await expect(
+        page.getByRole("menuitem", { name: "Copy" }),
+      ).toHaveAttribute("aria-disabled", "true");
+      await expect(
+        page.getByRole("menuitem", { name: "Clone" }),
+      ).toHaveAttribute("aria-disabled", "true");
+      await expect(page.getByRole("menuitem", { name: "Cut" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
 
     test("cannot proceed past the Review step when required customisations are incomplete", async ({
       browser,

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -12,7 +12,10 @@ import {
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
-import { createTemplatedComponent } from "./helpers/addComponent.js";
+import {
+  createNotice,
+  createTemplatedComponent,
+} from "./helpers/addComponent.js";
 import { TestContext } from "./helpers/types.js";
 import { PlaywrightEditor } from "./pages/Editor.js";
 
@@ -33,6 +36,13 @@ const TEMPLATED_FLOW_NAME = `${SOURCE_TEMPLATE_NAME} (templated)`;
 const TEMPLATED_FLOW_SLUG = `${SOURCE_TEMPLATE_SLUG}-templated`;
 
 const REGULAR_FLOW_NAME = "E2E Regular Flow";
+
+const NON_TEMPLATED_NODE_TITLE = "Non-templated node";
+
+const TEMPLATED_FOLDER_NAME = "Templated folder";
+const FOLDER_INSTRUCTIONS = "You can edit this folder";
+const FIRST_NODE_IN_FOLDER = "First node in folder";
+const SECOND_NODE_IN_FOLDER = "Second node in folder";
 
 const REPUBLISH_MESSAGE = "lorem ipsum";
 
@@ -152,7 +162,7 @@ test.describe("Templates", () => {
       ).toBeVisible();
     });
 
-    test("can publish the source template and make it available for use", async ({
+    test("can add a non-templated node to the source template", async ({
       browser,
     }) => {
       const page = await getTeamPage({
@@ -162,12 +172,123 @@ test.describe("Templates", () => {
       });
       await navigateToService(page, SOURCE_TEMPLATE_SLUG);
 
+      const editor = new PlaywrightEditor(page);
+
+      await createNotice(page, editor.getNextNode(), NON_TEMPLATED_NODE_TITLE);
+
+      // Non-templated nodes have no template-card wrapper
+      const nonTemplatedNode = await editor.checkNodeExists(
+        NON_TEMPLATED_NODE_TITLE,
+      );
+      await expect(nonTemplatedNode.locator(".template-card")).not.toBeAttached();
+    });
+
+    test("can add a templated folder to the source template", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+      const editor = new PlaywrightEditor(page);
+
+      await createTemplatedComponent(
+        page,
+        editor.getNextNode(),
+        ComponentType.InternalPortal,
+        TEMPLATED_FOLDER_NAME,
+        { instructions: FOLDER_INSTRUCTIONS, required: false },
+      );
+
+      const templatedFolder = await editor.checkNodeExists(TEMPLATED_FOLDER_NAME);
+      await expect(
+        templatedFolder.getByText("Optional", { exact: true }),
+      ).toBeVisible();
+
+      // Navigate into the folder and add two nodes for later drag-and-drop testing
+      await page.getByRole("link", { name: TEMPLATED_FOLDER_NAME }).click();
+      await page.locator("li.hanger > a").first().waitFor();
+
+      await createNotice(
+        page,
+        page.locator("li.hanger > a").first(),
+        FIRST_NODE_IN_FOLDER,
+      );
+      await createNotice(
+        page,
+        page.locator(".hanger > a").last(),
+        SECOND_NODE_IN_FOLDER,
+      );
+
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+      await expect(page.getByText(TEMPLATED_FOLDER_NAME)).toBeVisible();
+    });
+
+    test("can publish the source template", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
       await publishService(page);
+    });
+
+    test("source template is not yet selectable in 'New flow' modal before going online", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+
+      await page.locator("button", { hasText: "Add a new flow" }).click();
+      await page.locator('[aria-labelledby~="create-flow-mode"]').click();
+      await page.getByRole("option", { name: "From a template..." }).click();
+
+      await page.locator('[aria-labelledby~="available-templates-select"]').click();
+      await expect(
+        page.getByRole("option", { name: SOURCE_TEMPLATE_NAME }),
+      ).not.toBeVisible();
+
+      await page.keyboard.press("Escape");
+    });
+
+    test("can set the source template online", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
 
       await turnServiceOnline(page);
+    });
 
-      await navigateToTeamPage(page);
-      await expect(page.getByText(SOURCE_TEMPLATE_NAME)).toBeVisible();
+    test("source template is selectable in 'New flow' modal after going online", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+
+      await page.locator("button", { hasText: "Add a new flow" }).click();
+      await page.locator('[aria-labelledby~="create-flow-mode"]').click();
+      await page.getByRole("option", { name: "From a template..." }).click();
+
+      await page.locator('[aria-labelledby~="available-templates-select"]').click();
+      await expect(
+        page.getByRole("option", { name: SOURCE_TEMPLATE_NAME }),
+      ).toBeVisible();
+
+      await page.keyboard.press("Escape");
     });
 
     test("can filter flows for source templates only", async ({ browser }) => {
@@ -262,6 +383,71 @@ test.describe("Templates", () => {
       await expect(
         page.getByText(SOURCE_TEMPLATE_NAME, { exact: true }),
       ).not.toBeVisible();
+    });
+
+    test("non-templated node is read-only in the templated flow", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // Click the non-templated node to open its edit modal
+      await page.getByRole("link", { name: NON_TEMPLATED_NODE_TITLE }).click();
+      await page.getByRole("dialog").waitFor();
+
+      // Submit button is disabled for non-templated nodes in a templated flow
+      await expect(
+        page.locator('button[form="modal"][type="submit"]'),
+      ).toBeDisabled();
+
+      await page.locator('button[aria-label="close"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+    });
+
+    test("templated folder is fully editable in the templated flow, including drag and drop", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+      // Navigate into the templated folder
+      await page.getByRole("link", { name: TEMPLATED_FOLDER_NAME }).click();
+      await page.locator("li.hanger > a").first().waitFor();
+
+      // Hangers inside a templated folder are visible (not hidden), enabling DnD
+      await expect(page.locator("li.hanger").first()).not.toHaveClass(/hidden/);
+
+      // Nodes inside the folder are fully editable (submit button enabled)
+      await page.getByRole("link", { name: FIRST_NODE_IN_FOLDER }).click();
+      await page.getByRole("dialog").waitFor();
+      await expect(
+        page.locator('button[form="modal"][type="submit"]'),
+      ).not.toBeDisabled();
+      await page.locator('button[aria-label="close"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+
+      // Drag SECOND_NODE_IN_FOLDER to before FIRST_NODE_IN_FOLDER
+      const sourceNode = page
+        .locator(".card.decision")
+        .filter({ hasText: SECOND_NODE_IN_FOLDER });
+      const targetHanger = page.locator("li.hanger").first();
+      await sourceNode.dragTo(targetHanger);
+
+      // Assert SECOND now appears before FIRST in the folder
+      await expect(page.locator(".card.decision").first()).toContainText(
+        SECOND_NODE_IN_FOLDER,
+      );
+      await expect(page.locator(".card.decision").nth(1)).toContainText(
+        FIRST_NODE_IN_FOLDER,
+      );
     });
 
     // TODO - test("Cannot add new nodes in a templated flow");

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -180,7 +180,9 @@ test.describe("Templates", () => {
       const nonTemplatedNode = await editor.checkNodeExists(
         NON_TEMPLATED_NODE_TITLE,
       );
-      await expect(nonTemplatedNode.locator(".template-card")).not.toBeAttached();
+      await expect(
+        nonTemplatedNode.locator(".template-card"),
+      ).not.toBeAttached();
     });
 
     test("can add a templated folder to the source template", async ({
@@ -203,7 +205,9 @@ test.describe("Templates", () => {
         { instructions: FOLDER_INSTRUCTIONS, required: false },
       );
 
-      const templatedFolder = await editor.checkNodeExists(TEMPLATED_FOLDER_NAME);
+      const templatedFolder = await editor.checkNodeExists(
+        TEMPLATED_FOLDER_NAME,
+      );
       await expect(
         templatedFolder.getByText("Optional", { exact: true }),
       ).toBeVisible();
@@ -251,7 +255,9 @@ test.describe("Templates", () => {
       await page.locator('[aria-labelledby~="create-flow-mode"]').click();
       await page.getByRole("option", { name: "From a template..." }).click();
 
-      await page.locator('[aria-labelledby~="available-templates-select"]').click();
+      await page
+        .locator('[aria-labelledby~="available-templates-select"]')
+        .click();
       await expect(
         page.getByRole("option", { name: SOURCE_TEMPLATE_NAME }),
       ).not.toBeVisible();
@@ -283,7 +289,9 @@ test.describe("Templates", () => {
       await page.locator('[aria-labelledby~="create-flow-mode"]').click();
       await page.getByRole("option", { name: "From a template..." }).click();
 
-      await page.locator('[aria-labelledby~="available-templates-select"]').click();
+      await page
+        .locator('[aria-labelledby~="available-templates-select"]')
+        .click();
       await expect(
         page.getByRole("option", { name: SOURCE_TEMPLATE_NAME }),
       ).toBeVisible();
@@ -353,6 +361,14 @@ test.describe("Templates", () => {
       const editor = new PlaywrightEditor(page);
       await editor.checkNodeExists(REQUIRED_NODE_TITLE);
       await editor.checkNodeExists(OPTIONAL_NODE_TITLE);
+
+      // Clicking a customise card opens its modal with instructions visible
+      await page.getByRole("link", { name: REQUIRED_NODE_TITLE }).click();
+      await page.getByRole("dialog").waitFor();
+      await expect(page.getByText("Customise (required)")).toBeVisible();
+      await expect(page.getByText(REQUIRED_NODE_INSTRUCTIONS)).toBeVisible();
+      await page.locator('button[aria-label="close"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
     });
 
     test("can filter flows for templated flows only", async ({ browser }) => {

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -301,4 +301,54 @@ test.describe("Templates", () => {
       await expect(page.getByText(TEMPLATED_FLOW_NAME)).toBeVisible();
     });
   });
+
+  // relies on the templated flow being created in the "As a team editor" block
+  test.describe("As a platform admin", () => {
+    test("can publish changes to the source template and sees affected templated flows listed", async ({
+      browser,
+    }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+      // Make a change to the source template by editing the optional node
+      await page.getByRole("link", { name: OPTIONAL_NODE_TITLE }).click();
+      await page.getByRole("dialog").waitFor();
+      await page
+        .getByPlaceholder("Text")
+        .fill(`${OPTIONAL_NODE_TITLE} (source updated)`);
+      await page.locator('button[form="modal"][type="submit"]').click();
+      await page.getByRole("dialog").waitFor({ state: "detached" });
+
+      // Open the publish dialog and advance to the Publish step
+      await page.getByTestId("check-for-changes-to-publish-button").click();
+      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
+      await page.getByTestId("next-step-test-button").click();
+
+      await expect(page.getByRole("heading", { name: "Test" })).toBeVisible();
+      await page.getByTestId("test-confirmation-checkbox").click();
+      await page.getByTestId("next-step-publish-button").click();
+
+      // The Publish step should show template-specific messaging and list affected flows
+      await expect(
+        page.getByRole("heading", { name: "Publish" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("This flow is a template"),
+      ).toBeVisible();
+      await expect(
+        page.getByText(new RegExp(TEMPLATED_FLOW_SLUG)),
+      ).toBeVisible();
+
+      // Complete the publish
+      await page.getByTestId("publish-summary-input").fill("lorem ipsum");
+      await page.getByTestId("publish-button").click();
+      await expect(
+        page.getByText("Successfully published changes").first(),
+      ).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
### What's in this PR?
Set of e2e tests for template creation, updates, and creating flows from templates.

### Notes
- Separate test blocks for admin actions and editor actions
- Tests are very much still interdependent - the entire file must be run as most tests depend on an action carried out by a previous test
- Added a few new helpers for navigation and creating flows
