### PR TITLE
feat: combine pinned flows and unpinned into same list

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', '!{0}/build/**', env.EDITOR_DIRECTORY)) }}
+          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: Download LPS build assets
         id: cache-localplanning-build-assets
         uses: actions/cache@v5
@@ -373,7 +373,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', '!{0}/build/**', env.EDITOR_DIRECTORY)) }}
+          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: upload built editor
         uses: appleboy/scp-action@master
         with:

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -80,9 +80,11 @@ export const FlowTable: React.FC<FlowTableProps> = ({
                 showDetails={showDetails}
               />
             ))}
-            <SpacerTableRow>
-              <TableCell colSpan={99} />
-            </SpacerTableRow>
+            {pinnedFlows.length > 0 && (
+              <SpacerTableRow>
+                <TableCell colSpan={99} />
+              </SpacerTableRow>
+            )}
             {unpinnedFlows.map((flow) => (
               <FlowTableRow
                 key={flow.slug}

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -24,13 +24,16 @@ import {
   FlowDateCell,
   FlowStatusCell,
   FlowTitleCell,
+  SpacerTableRow,
   StyledTable,
   StyledTableHead,
   StyledTableRow,
 } from "./styles";
 
 interface FlowTableProps {
-  flows: FlowSummary[];
+  flows?: FlowSummary[];
+  pinnedFlows?: FlowSummary[];
+  unpinnedFlows?: FlowSummary[];
   teamId: number;
   teamSlug: string;
   updateFlow?: (flow: FlowSummary) => void;
@@ -39,11 +42,15 @@ interface FlowTableProps {
 
 export const FlowTable: React.FC<FlowTableProps> = ({
   flows,
+  pinnedFlows,
+  unpinnedFlows,
   teamSlug,
   view,
 }) => {
   const { headerText } = useFlowSortDisplay();
   const showDetails = view === "flows";
+  const useSplitLayout =
+    pinnedFlows !== undefined && unpinnedFlows !== undefined;
 
   return (
     <StyledTable>
@@ -62,15 +69,41 @@ export const FlowTable: React.FC<FlowTableProps> = ({
         </TableRow>
       </StyledTableHead>
       <TableBody>
-        {flows.map((flow) => (
-          <FlowTableRow
-            key={flow.slug}
-            flow={flow}
-            teamSlug={teamSlug}
-            view={view}
-            showDetails={showDetails}
-          />
-        ))}
+        {useSplitLayout ? (
+          <>
+            {pinnedFlows.map((flow) => (
+              <FlowTableRow
+                key={flow.slug}
+                flow={flow}
+                teamSlug={teamSlug}
+                view={view}
+                showDetails={showDetails}
+              />
+            ))}
+            <SpacerTableRow>
+              <TableCell colSpan={99} />
+            </SpacerTableRow>
+            {unpinnedFlows.map((flow) => (
+              <FlowTableRow
+                key={flow.slug}
+                flow={flow}
+                teamSlug={teamSlug}
+                view={view}
+                showDetails={showDetails}
+              />
+            ))}
+          </>
+        ) : (
+          flows?.map((flow) => (
+            <FlowTableRow
+              key={flow.slug}
+              flow={flow}
+              teamSlug={teamSlug}
+              view={view}
+              showDetails={showDetails}
+            />
+          ))
+        )}
       </TableBody>
     </StyledTable>
   );

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -5,6 +5,16 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { inputFocusStyle } from "theme";
 
+export const SpacerTableRow = styled(TableRow)(({ theme }) => ({
+  height: theme.spacing(3),
+  backgroundColor: `${theme.palette.background.paper} !important`,
+  pointerEvents: "none",
+  [`& .${tableCellClasses.root}`]: {
+    padding: "0 !important",
+    borderBottom: `1px solid ${theme.palette.border.main} !important`,
+  },
+}));
+
 import { CustomLink } from "../../../../ui/shared/CustomLink/CustomLink";
 
 export const StyledTable = styled(Table)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -22,9 +22,8 @@ export const StyledTable = styled(Table)(({ theme }) => ({
   marginBottom: theme.spacing(2),
   zIndex: 1,
   position: "relative",
-  border: `1px solid ${theme.palette.border.main}`,
-  borderBottom: 0,
   borderCollapse: "separate",
+  borderSpacing: 0,
   [`& .${tableCellClasses.root}`]: {
     padding: theme.spacing(1.5, 2),
     borderBottom: `1px solid ${theme.palette.border.main}`,
@@ -34,12 +33,17 @@ export const StyledTable = styled(Table)(({ theme }) => ({
 export const StyledTableHead = styled(TableHead)(({ theme }) => ({
   [`& .${tableCellClasses.root}`]: {
     backgroundColor: theme.palette.background.default,
+    borderTop: `1px solid ${theme.palette.border.main}`,
     borderBottom: `1px solid ${theme.palette.border.main}`,
     position: "sticky",
     top: 0,
     zIndex: theme.zIndex.appBar,
+    "&:first-of-type": {
+      borderLeft: `1px solid ${theme.palette.border.main}`,
+    },
     "&:last-of-type": {
       borderLeft: `1px solid ${theme.palette.border.main}`,
+      borderRight: `1px solid ${theme.palette.border.main}`,
     },
   },
 }));
@@ -65,6 +69,12 @@ export const StyledTableRow = styled(TableRow, {
       : theme.palette.background.default,
     "&:hover": {
       backgroundColor: hoverBackground,
+    },
+    "& > td:first-of-type": {
+      borderLeft: `1px solid ${theme.palette.border.main}`,
+    },
+    "& > td:last-of-type": {
+      borderRight: `1px solid ${theme.palette.border.main}`,
     },
     "& .actions-cell": {
       cursor: "default",

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -146,41 +146,33 @@ const Flows: React.FC<Props> = ({
             )}
           </Box>
         </Box>
-        {sortedPinnedFlows.length > 0 && (
+        {flowCardView === "grid" ? (
           <>
-            {flowCardView === "grid" ? (
+            {sortedPinnedFlows.length > 0 && (
               <DashboardList>
                 {sortedPinnedFlows.map((flow) => (
                   <FlowCard flow={flow} key={flow.slug} view={"flows"} />
                 ))}
               </DashboardList>
-            ) : (
-              <FlowTable
-                flows={sortedPinnedFlows}
-                teamId={teamId}
-                teamSlug={slug}
-                view={"flows"}
-              />
+            )}
+            {sortedUnpinnedFlows && sortedUnpinnedFlows.length > 0 && (
+              <Box>
+                <DashboardList>
+                  {sortedUnpinnedFlows.map((flow) => (
+                    <FlowCard flow={flow} key={flow.slug} view={"flows"} />
+                  ))}
+                </DashboardList>
+              </Box>
             )}
           </>
-        )}
-        {sortedUnpinnedFlows && sortedUnpinnedFlows.length > 0 && (
-          <Box>
-            {flowCardView === "grid" ? (
-              <DashboardList>
-                {sortedUnpinnedFlows.map((flow) => (
-                  <FlowCard flow={flow} key={flow.slug} view={"flows"} />
-                ))}
-              </DashboardList>
-            ) : (
-              <FlowTable
-                flows={sortedUnpinnedFlows}
-                teamId={teamId}
-                teamSlug={slug}
-                view={"flows"}
-              />
-            )}
-          </Box>
+        ) : (
+          <FlowTable
+            pinnedFlows={sortedPinnedFlows}
+            unpinnedFlows={sortedUnpinnedFlows ?? []}
+            teamId={teamId}
+            teamSlug={slug}
+            view={"flows"}
+          />
         )}
       </>
     )

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -43,8 +43,6 @@ type Props = {
   flowCardView: FlowCardView;
   teamId: number;
   flows: FlowSummary[] | null;
-  pinnedFlows: FlowSummary[];
-  unpinnedFlows: FlowSummary[];
   handleViewChange: (
     _event: React.MouseEvent<HTMLElement>,
     newView: FlowCardView | null,
@@ -60,20 +58,16 @@ const Flows: React.FC<Props> = ({
   sortOptions,
   flowCardView,
   teamId,
-  pinnedFlows,
   handleViewChange,
   slug,
 }) => {
   const teamHasFlows = sortedFlows ? true : false;
   const navigate = useNavigate();
 
-  const showPinnedFlows = pinnedFlows.length > 0 && !flowsHaveBeenFiltered;
-  const sortedPinnedFlows = showPinnedFlows
-    ? (sortedFlows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [])
-    : [];
-  const remainingFlows = showPinnedFlows
-    ? (sortedFlows?.filter((flow) => flow.pinnedFlows.length === 0) ?? null)
-    : sortedFlows;
+  const sortedPinnedFlows =
+    sortedFlows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [];
+  const sortedUnpinnedFlows =
+    sortedFlows?.filter((flow) => flow.pinnedFlows.length === 0) ?? null;
 
   return (
     teamHasFlows && (
@@ -106,32 +100,6 @@ const Flows: React.FC<Props> = ({
             </Tooltip>
           </ToggleButtonGroup>
         </FiltersContainer>
-        {sortedPinnedFlows.length > 0 && (
-          <Box>
-            <Box
-              sx={{ minHeight: "50px", display: "flex", alignItems: "center" }}
-            >
-              <ShowingServicesHeader
-                matchedFlowsCount={sortedPinnedFlows.length}
-                isPinnedFlows={true}
-              />
-            </Box>
-            {flowCardView === "grid" ? (
-              <DashboardList>
-                {sortedPinnedFlows.map((flow) => (
-                  <FlowCard flow={flow} key={flow.slug} view={"flows"} />
-                ))}
-              </DashboardList>
-            ) : (
-              <FlowTable
-                flows={sortedPinnedFlows}
-                teamId={teamId}
-                teamSlug={slug}
-                view={"flows"}
-              />
-            )}
-          </Box>
-        )}
         <Box
           sx={{
             display: "flex",
@@ -178,23 +146,41 @@ const Flows: React.FC<Props> = ({
             )}
           </Box>
         </Box>
-        {remainingFlows && (
+        {sortedPinnedFlows.length > 0 && (
           <>
             {flowCardView === "grid" ? (
               <DashboardList>
-                {remainingFlows.map((flow) => (
+                {sortedPinnedFlows.map((flow) => (
                   <FlowCard flow={flow} key={flow.slug} view={"flows"} />
                 ))}
               </DashboardList>
             ) : (
               <FlowTable
-                flows={remainingFlows}
+                flows={sortedPinnedFlows}
                 teamId={teamId}
                 teamSlug={slug}
                 view={"flows"}
               />
             )}
           </>
+        )}
+        {sortedUnpinnedFlows && sortedUnpinnedFlows.length > 0 && (
+          <Box>
+            {flowCardView === "grid" ? (
+              <DashboardList>
+                {sortedUnpinnedFlows.map((flow) => (
+                  <FlowCard flow={flow} key={flow.slug} view={"flows"} />
+                ))}
+              </DashboardList>
+            ) : (
+              <FlowTable
+                flows={sortedUnpinnedFlows}
+                teamId={teamId}
+                teamSlug={slug}
+                view={"flows"}
+              />
+            )}
+          </Box>
         )}
       </>
     )

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -61,14 +61,6 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
   const [shouldClearSearch, setShouldClearSearch] = useState<boolean>(false);
   const searchParams = useSearch({ from: "/_authenticated/app/$team/" });
 
-  const pinnedFlows = useMemo(() => {
-    return flows?.filter((flow) => flow.pinnedFlows.length > 0) ?? [];
-  }, [flows]);
-
-  const unpinnedFlows = useMemo(() => {
-    return flows?.filter((flow) => flow.pinnedFlows.length === 0) ?? [];
-  }, [flows]);
-
   const sortedFlows = useMemo(() => {
     // Use searchedFlows if available (from SearchBox), otherwise use all flows
     const sourceFlows = searchedFlows || flows;
@@ -200,8 +192,6 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
             flowCardView={flowCardView}
             teamId={teamId}
             flows={flows}
-            pinnedFlows={pinnedFlows}
-            unpinnedFlows={unpinnedFlows}
             handleViewChange={handleViewChange}
             slug={slug}
           />


### PR DESCRIPTION
### What's in this PR?
- addressing this UI suggestion by Silvia & Ian https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1777541377498229
- combines pinned and unpinned flows into the same list so that filters have the same effect on both sets, making it easier to manage pinned flows when using a filtered view