### PR TITLE
test(editor): Fix warnings in MapAndLabel tests

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Public/index.tsx
@@ -18,7 +18,7 @@ import { point } from "@turf/helpers";
 import { Feature } from "geojson";
 import type { GeoJSONChangeEvent } from "lib/gis";
 import { Store, useStore } from "pages/FlowEditor/lib/store";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -228,8 +228,18 @@ export default function Component(props: Props) {
    */
   const clipGeojsonData = (() => {
     if (boundary) return buffer(boundary, bufferInMeters, { units: "meters" });
-    if (addressPoint) return buffer(addressPoint, bufferInMeters, { units: "meters" });
+    if (addressPoint)
+      return buffer(addressPoint, bufferInMeters, { units: "meters" });
   })();
+
+  const mapRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      (
+        node as HTMLElement & { ariaLabelOlFixedOverlay: string }
+      ).ariaLabelOlFixedOverlay =
+        "An interactive map for providing your location plan boundary";
+    }
+  }, []);
 
   function getBody(mapValidationError?: string, fileValidationError?: string) {
     if (page === "draw") {
@@ -272,8 +282,8 @@ export default function Component(props: Props) {
                 )}
                 {/* @ts-ignore */}
                 <my-map
+                  ref={mapRef}
                   id="draw-boundary-map"
-                  ariaLabelOlFixedOverlay="An interactive map for providing your location plan boundary"
                   drawMode
                   drawPointer="crosshair"
                   drawGeojsonData={boundary}

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/Map.tsx
@@ -13,7 +13,7 @@ import {
 } from "@planx/components/shared/Preview/MapContainer";
 import type { GeoJSONChangeEvent } from "lib/gis";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -90,6 +90,15 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
     }
   };
 
+  const mapRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      (
+        node as HTMLElement & { ariaLabelOlFixedOverlay: string }
+      ).ariaLabelOlFixedOverlay =
+        "An interactive map for providing your site location";
+    }
+  }, []);
+
   const mapValidationErrorRef = useRef(props.mapValidationError);
   useEffect(() => {
     mapValidationErrorRef.current = props.mapValidationError;
@@ -140,15 +149,14 @@ export default function PlotNewAddress(props: PlotNewAddressProps): FCReturn {
             </p>
             {/* @ts-ignore */}
             <my-map
+              ref={mapRef}
               id="plot-new-address-map"
-              ariaLabelOlFixedOverlay="An interactive map for providing your site location"
               data-testid="map-web-component"
               zoom={10}
               drawMode
               drawType="Point"
               drawGeojsonData={
-                coordinates &&
-                {
+                coordinates && {
                   type: "Feature",
                   geometry: {
                     type: "Point",

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/CopyFeature.tsx
@@ -31,10 +31,18 @@ export const CopyFeature: React.FC<Props> = ({
 
   const formik = useFormik({
     initialValues: {
-      sourceLabel: sourceFeatures[0]?.properties?.label,
+      sourceLabel: sourceFeatures[0]?.properties?.label ?? "",
     },
     onSubmit: ({ sourceLabel }) => copyFeature(sourceLabel, destinationIndex),
   });
+
+  // Fall back to first available option if formik's value is stale (e.g. that feature was removed)
+  const isFormikValueStillValid = sourceFeatures.some(
+    (f) => f.properties?.label === formik.values.sourceLabel,
+  );
+  const sourceLabel = isFormikValueStillValid
+    ? formik.values.sourceLabel
+    : (sourceFeatures[0]?.properties?.label ?? "");
 
   return (
     <Box
@@ -52,7 +60,7 @@ export const CopyFeature: React.FC<Props> = ({
             bordered
             required
             title={"Copy from"}
-            value={formik.values.sourceLabel}
+            value={sourceLabel}
             onChange={(e) =>
               formik.setFieldValue("sourceLabel", e.target.value)
             }

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Public/index.tsx
@@ -15,7 +15,7 @@ import { GeoJsonObject } from "geojson";
 import { useFormErrorFocus } from "hooks/useFormErrorFocus";
 import sortBy from "lodash/sortBy";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -271,11 +271,26 @@ const Root = () => {
 
   const passport = useStore((state) => state.computePassport().data);
 
+  // Set ariaLabelOlFixedOverlay as a DOM property via ref to avoid React's ARIA attribute validation warning
+  const mapRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (node) {
+        (
+          node as HTMLElement & { ariaLabelOlFixedOverlay: string }
+        ).ariaLabelOlFixedOverlay =
+          `An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`;
+      }
+    },
+    [schemaName],
+  );
+
   // If coming "back" or "changing", load initial features & tabs onto the map
   // Pre-populating form fields within tabs is handled via formik.initialValues in Context.tsx
-  if (previouslySubmittedData?.data?.[fn]?.features?.length > 0) {
-    addInitialFeaturesToMap(previouslySubmittedData?.data?.[fn]?.features);
-  }
+  useEffect(() => {
+    if (previouslySubmittedData?.data?.[fn]?.features?.length > 0) {
+      addInitialFeaturesToMap(previouslySubmittedData?.data?.[fn]?.features);
+    }
+  }, [addInitialFeaturesToMap, previouslySubmittedData, fn]);
 
   const rootError: string =
     (errors.min &&
@@ -298,17 +313,16 @@ const Root = () => {
           <MapContainer environment="standalone">
             {/* @ts-ignore */}
             <my-map
+              ref={mapRef}
               id={MAP_ID}
               data-map-id={MAP_ID}
               data-testid={MAP_ID}
               basemap={basemap}
-              ariaLabelOlFixedOverlay={`An interactive map for plotting and describing individual ${schemaName.toLocaleLowerCase()}`}
               geojsonData={passport && passport["proposal.site"]}
               geojsonBuffer={30}
               drawMode
               drawGeojsonData={
-                features &&
-                {
+                features && {
                   type: "FeatureCollection",
                   features: features,
                 }

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/mockPayload.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/mocks/mockPayload.tsx
@@ -18,7 +18,7 @@ export const mockSingleFeaturePayload: MockPayload = {
             coordinates: [-3.685929607119201, 57.15301433687542],
             type: "Point",
           },
-          properties: { mockTreeData, label: "1" },
+          properties: { ...mockTreeData, label: "1" },
           type: "Feature",
         },
       ],
@@ -36,7 +36,7 @@ export const mockDoubleFeaturePayload: MockPayload = {
             coordinates: [-3.685929607119201, 57.15301433687542],
             type: "Point",
           },
-          properties: { mockTreeData, label: "1" },
+          properties: { ...mockTreeData, label: "1" },
           type: "Feature",
         },
         {

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/test/utils.ts
@@ -18,7 +18,9 @@ export const addFeaturesToMap = async (
       "EPSG:3857": { features },
     },
   });
-  await act(() => map.dispatchEvent(mockEvent));
+  await act(async () => {
+    map.dispatchEvent(mockEvent);
+  });
 };
 
 export const addMultipleFeatures = async (

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -12,7 +12,7 @@ import find from "lodash/find";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { HandleSubmit } from "pages/Preview/Node";
-import React from "react";
+import React, { useCallback } from "react";
 
 import type { SiteAddress } from "../FindProperty/model";
 import { MapContainer } from "../shared/Preview/MapContainer";
@@ -107,6 +107,14 @@ export function Presentational(props: PresentationalProps) {
   } = props;
   const [environment] = useStore((state) => [state.previewEnvironment]);
 
+  const mapRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      (
+        node as HTMLElement & { ariaLabelOlFixedOverlay: string }
+      ).ariaLabelOlFixedOverlay = "A static map of the property address";
+    }
+  }, []);
+
   const propertyDetails: PropertyDetail[] = [
     {
       heading: "Address",
@@ -157,8 +165,8 @@ export function Presentational(props: PresentationalProps) {
         </p>
         {/* @ts-ignore */}
         <my-map
+          ref={mapRef}
           id="property-information-map"
-          ariaLabelOlFixedOverlay="A static map of the property address"
           zoom={19.5}
           latitude={address?.latitude}
           longitude={address?.longitude}


### PR DESCRIPTION
Follow on from https://github.com/theopensystemslab/planx-new/pull/6575

The `MapAndLabel` tests will now run without any warning (minus jsdom ones resolved above).