### PR TITLE
fix: ensure teamId is always populated when writing feedback

### DIFF
--- a/apps/editor.planx.uk/src/lib/feedback.ts
+++ b/apps/editor.planx.uk/src/lib/feedback.ts
@@ -13,8 +13,8 @@ type UserData = {
 };
 
 export type FeedbackMetadata = {
-  teamId?: number;
-  flowId?: string;
+  teamId: number;
+  flowId: string;
   nodeId?: string | null;
   nodeType?: string | null;
   device: Bowser.Parser.ParsedResult;
@@ -48,8 +48,8 @@ export async function getInternalFeedbackMetadata(): Promise<FeedbackMetadata> {
 }
 
 export async function insertFeedbackMutation(data: {
-  teamId?: number;
-  flowId?: string;
+  teamId: number;
+  flowId: string;
   nodeId?: string | null;
   nodeType?: string | null;
   device?: Bowser.Parser.ParsedResult;

--- a/apps/editor.planx.uk/src/utils/routeUtils/publishedQueries.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/publishedQueries.ts
@@ -37,20 +37,15 @@ export const fetchSettingsForPublishedView = async (
 };
 
 const GET_SETTINGS_FOR_PUBLISHED_VIEW = gql`
-  query GetSettingsForPublishedView(
-    $flowSlug: String!
-    $teamSlug: String!
-  ) {
+  query GetSettingsForPublishedView($flowSlug: String!, $teamSlug: String!) {
     flows(
       limit: 1
-      where: {
-        slug: { _eq: $flowSlug }
-        team: { slug: { _eq: $teamSlug } }
-      }
+      where: { slug: { _eq: $flowSlug }, team: { slug: { _eq: $teamSlug } } }
     ) {
       id
       name
       team {
+        id
         theme {
           primaryColour: primary_colour
           actionColour: action_colour


### PR DESCRIPTION
Fixing bug as [identified by Alki](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1777558901763419), regression introduced [here](https://github.com/theopensystemslab/planx-new/pull/6493/changes/BASE..b111e220c586503a961626498c65790ecf8f8fba#diff-fb19f6aafe4f97bc986da8975127fca69628a90a19f8c2de86053a89ca887155L99) (we were relying on fetching `teamId` from the store, but it wasn't being written to the store in the first place)

Next step is to migrate data directly on prod, and then merge a migration to update db constraints (`flow_id` and `team_id` should never be `null` in `feedback` table)

# Testing
- Open published flow, leave feedback, check feedback table to ensure it has correctly been populated