### PR TITLE
chore: stub out migrations for `flows.email_template` selection

### DIFF
--- a/apps/api.planx.uk/lib/notify/index.test.ts
+++ b/apps/api.planx.uk/lib/notify/index.test.ts
@@ -1,4 +1,4 @@
-import { sendEmail } from "./index.js";
+import { resolveNotifyTemplate, sendEmail } from "./index.js";
 import { NotifyClient } from "notifications-node-client";
 import type { TemplateRegistry } from "./templates/index.js";
 import { NOTIFY_TEST_EMAIL } from "./utils.js";
@@ -19,6 +19,34 @@ const mockConfig: TemplateRegistry["save"]["config"] = {
     helpPhone: "test",
   },
 };
+
+describe("resolveNotifyTemplate", () => {
+  it("returns the base template for 'application'", () => {
+    expect(resolveNotifyTemplate("save", "application")).toBe("save");
+    expect(resolveNotifyTemplate("resume", "application")).toBe("resume");
+  });
+
+  it("returns the general template for 'general'", () => {
+    expect(resolveNotifyTemplate("save", "general")).toBe("general-save");
+    expect(resolveNotifyTemplate("resume", "general")).toBe("general-resume");
+    expect(resolveNotifyTemplate("reminder", "general")).toBe("general-reminder");
+    expect(resolveNotifyTemplate("expiry", "general")).toBe("general-expiry");
+    expect(resolveNotifyTemplate("confirmation", "general")).toBe("general-confirmation");
+    expect(resolveNotifyTemplate("invite-to-pay", "general")).toBe("general-invite-to-pay");
+    expect(resolveNotifyTemplate("invite-to-pay-agent", "general")).toBe("general-invite-to-pay-agent");
+    expect(resolveNotifyTemplate("payment-reminder", "general")).toBe("general-payment-reminder");
+    expect(resolveNotifyTemplate("payment-reminder-agent", "general")).toBe("general-payment-reminder-agent");
+    expect(resolveNotifyTemplate("payment-expiry", "general")).toBe("general-payment-expiry");
+    expect(resolveNotifyTemplate("payment-expiry-agent", "general")).toBe("general-payment-expiry-agent");
+    expect(resolveNotifyTemplate("confirmation-agent", "general")).toBe("general-confirmation-agent");
+    expect(resolveNotifyTemplate("confirmation-payee", "general")).toBe("general-confirmation-payee");
+    expect(resolveNotifyTemplate("new-download-link", "general")).toBe("general-new-download-link");
+  });
+
+  it("falls back to the base template for unmapped templates", () => {
+    expect(resolveNotifyTemplate("lps-login", "general")).toBe("lps-login");
+  });
+});
 
 describe("sendEmail", () => {
   it("throws an error if an invalid template is used", async () => {

--- a/apps/api.planx.uk/lib/notify/index.ts
+++ b/apps/api.planx.uk/lib/notify/index.ts
@@ -6,6 +6,31 @@ import {
   type TemplateRegistry,
 } from "./templates/index.js";
 
+export type GovNotifyEmailTemplate = "application" | "general";
+
+const GENERAL_TEMPLATE_MAP: Partial<Record<Template, Template>> = {
+  save: "general-save",
+  reminder: "general-reminder",
+  expiry: "general-expiry",
+  confirmation: "general-confirmation",
+  resume: "general-resume",
+  "invite-to-pay": "general-invite-to-pay",
+  "invite-to-pay-agent": "general-invite-to-pay-agent",
+  "payment-reminder": "general-payment-reminder",
+  "payment-reminder-agent": "general-payment-reminder-agent",
+  "payment-expiry": "general-payment-expiry",
+  "payment-expiry-agent": "general-payment-expiry-agent",
+  "confirmation-agent": "general-confirmation-agent",
+  "confirmation-payee": "general-confirmation-payee",
+  "new-download-link": "general-new-download-link",
+};
+
+export const resolveNotifyTemplate = (
+  base: Template,
+  emailTemplate: GovNotifyEmailTemplate,
+): Template =>
+  emailTemplate === "general" ? (GENERAL_TEMPLATE_MAP[base] ?? base) : base;
+
 const notifyClient = new NotifyClient(process.env.GOVUK_NOTIFY_API_KEY);
 
 export type SendEmail = <T extends Template>(
@@ -28,7 +53,7 @@ const sendEmail: SendEmail = async (template, emailAddress, config) => {
       expiryDate?: string;
     } = { message: "Success" };
 
-    if (template === "save") {
+    if (template === "save" || template === "general-save") {
       const saveConfig = config as TemplateRegistry["save"]["config"];
       returnValue.expiryDate = saveConfig.personalisation.expiryDate;
     }

--- a/apps/api.planx.uk/lib/notify/templates/index.ts
+++ b/apps/api.planx.uk/lib/notify/templates/index.ts
@@ -1,19 +1,19 @@
 import type { UUID } from "crypto";
-import { confirmationAgentTemplate } from "./inviteToPay/confirmation-agent.js";
-import { confirmationPayeeTemplate } from "./inviteToPay/confirmation-payee.js";
-import { invitationToPayTemplate } from "./inviteToPay/invitation-to-pay.js";
-import { invitationToPayAgentTemplate } from "./inviteToPay/invitation-to-pay-agent.js";
-import { paymentExpiryTemplate } from "./inviteToPay/payment-expiry.js";
-import { paymentExpiryAgentTemplate } from "./inviteToPay/payment-expiry-agent.js";
-import { paymentReminderTemplate } from "./inviteToPay/payment-reminder.js";
-import { paymentReminderAgentTemplate } from "./inviteToPay/payment-reminder-agent.js";
-import { expiryTemplate } from "./saveAndReturn/expiry.js";
-import { reminderTemplate } from "./saveAndReturn/reminder.js";
-import { saveTemplate } from "./saveAndReturn/save-application.js";
-import { userConfirmationTemplate } from "./saveAndReturn/user-confirmation.js";
-import { resumeTemplate } from "./saveAndReturn/resume-application.js";
+import { confirmationAgentTemplate, generalConfirmationAgentTemplate } from "./inviteToPay/confirmation-agent.js";
+import { confirmationPayeeTemplate, generalConfirmationPayeeTemplate } from "./inviteToPay/confirmation-payee.js";
+import { invitationToPayTemplate, generalInvitationToPayTemplate } from "./inviteToPay/invitation-to-pay.js";
+import { invitationToPayAgentTemplate, generalInvitationToPayAgentTemplate } from "./inviteToPay/invitation-to-pay-agent.js";
+import { paymentExpiryTemplate, generalPaymentExpiryTemplate } from "./inviteToPay/payment-expiry.js";
+import { paymentExpiryAgentTemplate, generalPaymentExpiryAgentTemplate } from "./inviteToPay/payment-expiry-agent.js";
+import { paymentReminderTemplate, generalPaymentReminderTemplate } from "./inviteToPay/payment-reminder.js";
+import { paymentReminderAgentTemplate, generalPaymentReminderAgentTemplate } from "./inviteToPay/payment-reminder-agent.js";
+import { expiryTemplate, generalExpiryTemplate } from "./saveAndReturn/expiry.js";
+import { reminderTemplate, generalReminderTemplate } from "./saveAndReturn/reminder.js";
+import { saveTemplate, generalSaveTemplate } from "./saveAndReturn/save-application.js";
+import { userConfirmationTemplate, generalUserConfirmationTemplate } from "./saveAndReturn/user-confirmation.js";
+import { resumeTemplate, generalResumeTemplate } from "./saveAndReturn/resume-application.js";
 import { lpsLoginTemplate } from "./lps/lpsLoginTemplate.js";
-import { newDownloadLinkTemplate } from "./sendToEmail/new-download-link.js";
+import { newDownloadLinkTemplate, generalNewDownloadLinkTemplate } from "./sendToEmail/new-download-link.js";
 
 export type NotifyConfig<T> = { personalisation: T; emailReplyToId: string };
 
@@ -44,7 +44,7 @@ export interface NotifyTemplate<T> {
 }
 
 export const templateRegistry = {
-  // Invite to pay
+  // Invite to pay — application
   "confirmation-agent": confirmationAgentTemplate,
   "confirmation-payee": confirmationPayeeTemplate,
   "invite-to-pay": invitationToPayTemplate,
@@ -53,14 +53,31 @@ export const templateRegistry = {
   "payment-expiry-agent": paymentExpiryAgentTemplate,
   "payment-reminder": paymentReminderTemplate,
   "payment-reminder-agent": paymentReminderAgentTemplate,
-  // Save & Return
+  // Invite to pay — general
+  "general-confirmation-agent": generalConfirmationAgentTemplate,
+  "general-confirmation-payee": generalConfirmationPayeeTemplate,
+  "general-invite-to-pay": generalInvitationToPayTemplate,
+  "general-invite-to-pay-agent": generalInvitationToPayAgentTemplate,
+  "general-payment-expiry": generalPaymentExpiryTemplate,
+  "general-payment-expiry-agent": generalPaymentExpiryAgentTemplate,
+  "general-payment-reminder": generalPaymentReminderTemplate,
+  "general-payment-reminder-agent": generalPaymentReminderAgentTemplate,
+  // Save & Return — application
   expiry: expiryTemplate,
   reminder: reminderTemplate,
   resume: resumeTemplate,
   save: saveTemplate,
   confirmation: userConfirmationTemplate,
-  // Send to email
+  // Save & Return — general
+  "general-expiry": generalExpiryTemplate,
+  "general-reminder": generalReminderTemplate,
+  "general-resume": generalResumeTemplate,
+  "general-save": generalSaveTemplate,
+  "general-confirmation": generalUserConfirmationTemplate,
+  // Send to email — application
   "new-download-link": newDownloadLinkTemplate,
+  // Send to email — general
+  "general-new-download-link": generalNewDownloadLinkTemplate,
   // localplanning.services
   "lps-login": lpsLoginTemplate,
 } as const;

--- a/apps/api.planx.uk/modules/auth/middleware.ts
+++ b/apps/api.planx.uk/modules/auth/middleware.ts
@@ -69,16 +69,30 @@ export const useSendEmailAuth: RequestHandler = (req, res, next): void => {
     case "payment-expiry-agent":
     case "confirmation-agent":
     case "confirmation-payee":
+    case "general-reminder":
+    case "general-expiry":
+    case "general-confirmation":
+    case "general-invite-to-pay":
+    case "general-invite-to-pay-agent":
+    case "general-payment-reminder":
+    case "general-payment-reminder-agent":
+    case "general-payment-expiry":
+    case "general-payment-expiry-agent":
+    case "general-confirmation-agent":
+    case "general-confirmation-payee":
     case "welcome":
       return useHasuraAuth(req, res, next);
     // Public access
     case "save":
+    case "general-save":
       return next();
     // Handled by other routes
     case "submit":
     case "resume":
+    case "general-resume":
     case "lps-login":
     case "new-download-link":
+    case "general-new-download-link":
       return next();
     default: {
       return handleInvalidTemplate(template);

--- a/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -1,7 +1,7 @@
 import { formatRawProjectTypes } from "@opensystemslab/planx-core";
 import { gql } from "graphql-request";
 import { $api } from "../../../../client/index.js";
-import { sendEmail } from "../../../../lib/notify/index.js";
+import { resolveNotifyTemplate, sendEmail } from "../../../../lib/notify/index.js";
 import type { TemplateRegistry } from "../../../../lib/notify/templates/index.js";
 
 export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
@@ -11,6 +11,7 @@ export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
     payeeEmail,
     projectTypes,
     emailReplyToId,
+    emailTemplate,
   } = await getDataForPayeeAndAgentEmails(sessionId);
   const projectType = projectTypes.length
     ? formatRawProjectTypes(projectTypes)
@@ -22,8 +23,16 @@ export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
     },
     emailReplyToId,
   };
-  await sendEmail("confirmation-agent", applicantEmail, config);
-  await sendEmail("confirmation-payee", payeeEmail, config);
+  await sendEmail(
+    resolveNotifyTemplate("confirmation-agent", emailTemplate),
+    applicantEmail,
+    config,
+  );
+  await sendEmail(
+    resolveNotifyTemplate("confirmation-payee", emailTemplate),
+    payeeEmail,
+    config,
+  );
 
   return { message: "Success" };
 }
@@ -40,6 +49,7 @@ type PayeeAndAgentEmailData = {
   payeeEmail: string;
   projectTypes: string[];
   emailReplyToId: string;
+  emailTemplate: "application" | "general";
 };
 
 async function getDataForPayeeAndAgentEmails(
@@ -52,6 +62,7 @@ async function getDataForPayeeAndAgentEmails(
         flow {
           name
           slug
+          email_template
           team {
             notifyPersonalisation: team_settings {
               helpEmail: help_email
@@ -80,6 +91,7 @@ async function getDataForPayeeAndAgentEmails(
       flow: {
         slug: string;
         name: string;
+        email_template: "application" | "general";
         team: {
           notifyPersonalisation: {
             emailReplyToId: string;
@@ -120,5 +132,6 @@ async function getDataForPayeeAndAgentEmails(
     applicantEmail,
     payeeEmail,
     projectTypes,
+    emailTemplate: data.flow.email_template,
   };
 }

--- a/apps/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/apps/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -4,6 +4,7 @@ import { gql } from "graphql-request";
 import type { Template } from "../../../../lib/notify/templates/index.js";
 import {
   getClientForTemplate,
+  resolveNotifyTemplate,
   sendEmail,
 } from "../../../../lib/notify/index.js";
 import {
@@ -16,6 +17,7 @@ interface SessionDetails {
   flow: {
     slug: string;
     name: string;
+    email_template: "application" | "general";
     team: Team;
   };
 }
@@ -40,7 +42,11 @@ const sendSinglePaymentEmail = async ({
     const recipient = template.includes("-agent")
       ? session.email
       : paymentRequest.payeeEmail;
-    return await sendEmail(template, recipient, config);
+    const resolvedTemplate = resolveNotifyTemplate(
+      template,
+      session.flow.email_template,
+    );
+    return await sendEmail(resolvedTemplate, recipient, config);
   } catch (error) {
     throw Error((error as Error).message);
   }
@@ -68,6 +74,7 @@ const validatePaymentRequest = async (
             flow {
               slug
               name
+              email_template
               team {
                 id
                 name

--- a/apps/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -4,7 +4,7 @@ import { differenceInDays } from "date-fns";
 import { gql } from "graphql-request";
 
 import { $api } from "../../../client/index.js";
-import { sendEmail } from "../../../lib/notify/index.js";
+import { resolveNotifyTemplate, sendEmail } from "../../../lib/notify/index.js";
 import type { LowCalSession } from "../../../types.js";
 import {
   DAYS_UNTIL_EXPIRY,
@@ -25,7 +25,14 @@ const resumeApplication = async (teamSlug: string, email: string) => {
     reference: null,
     emailReplyToId: team.settings.emailReplyToId,
   };
-  const response = await sendEmail("resume", email, config);
+  const hasGeneralSession = sessions.some(
+    (s) => s.flow.email_template === "general",
+  );
+  const template = resolveNotifyTemplate(
+    "resume",
+    hasGeneralSession ? "general" : "application",
+  );
+  const response = await sendEmail(template, email, config);
   return response;
 };
 
@@ -62,6 +69,7 @@ const validateRequest = async (
           data
           flow {
             slug
+            email_template
           }
         }
         teams(where: { slug: { _eq: $teamSlug } }) {

--- a/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -5,7 +5,7 @@ import { gql } from "graphql-request";
 
 import { $api } from "../../../client/index.js";
 import type { Template } from "../../../lib/notify/templates/index.js";
-import { getClientForTemplate, sendEmail } from "../../../lib/notify/index.js";
+import { getClientForTemplate, resolveNotifyTemplate, sendEmail } from "../../../lib/notify/index.js";
 import type { LowCalSession } from "../../../types.js";
 
 const DAYS_UNTIL_EXPIRY = 28;
@@ -57,7 +57,7 @@ const sendSingleApplicationEmail = async ({
   sessionId: string;
 }) => {
   try {
-    const { flowSlug, flowName, team, session } =
+    const { flowSlug, flowName, team, session, resolvedTemplate } =
       await validateSingleSessionRequest(email, sessionId, template);
     const config = {
       personalisation: getPersonalisation(session, flowSlug, flowName, team),
@@ -67,7 +67,7 @@ const sendSingleApplicationEmail = async ({
     const firstSave = !session.hasUserSaved;
     if (firstSave && !session.submittedAt)
       await setupEmailEventTriggers(sessionId);
-    return await sendEmail(template, email, config);
+    return await sendEmail(resolvedTemplate, email, config);
   } catch (error) {
     throw Error((error as Error).message);
   }
@@ -97,6 +97,7 @@ const validateSingleSessionRequest = async (
           flow {
             slug
             name
+            email_template
             team {
               name
               slug
@@ -128,11 +129,15 @@ const validateSingleSessionRequest = async (
 
     if (!session) throw Error(`Unable to find session: ${sessionId}`);
 
+    const emailTemplate = session.flow.email_template;
+    const resolvedTemplate = resolveNotifyTemplate(template, emailTemplate);
+
     return {
       flowSlug: session.flow.slug,
       flowName: session.flow.name,
       team: session.flow.team,
       session: getSessionDetails(session),
+      resolvedTemplate,
     };
   } catch (error) {
     throw Error(`Unable to validate request. ${(error as Error).message}`);

--- a/apps/api.planx.uk/modules/send/email/newLink/controller.ts
+++ b/apps/api.planx.uk/modules/send/email/newLink/controller.ts
@@ -29,6 +29,7 @@ export const sendNewDownloadLink: Controller = async (req, res, next) => {
       sessionId,
       token,
       serviceName: session.flow.name,
+      emailTemplate: session.flow.email_template,
     });
 
     return res.status(200).json({ message: "An email sent to your inbox" });

--- a/apps/api.planx.uk/modules/send/email/newLink/service.ts
+++ b/apps/api.planx.uk/modules/send/email/newLink/service.ts
@@ -5,7 +5,7 @@ import {
   DEVOPS_EMAIL_REPLY_TO_ID,
   type TemplateRegistry,
 } from "../../../../lib/notify/templates/index.js";
-import { sendEmail } from "../../../../lib/notify/index.js";
+import { resolveNotifyTemplate, sendEmail } from "../../../../lib/notify/index.js";
 
 export const createAccessToken = async (
   sessionId: string,
@@ -25,7 +25,12 @@ export const getSession = async (sessionId: string) => {
   const { session } = await $api.client.request<{
     session: {
       submittedAt: string;
-      flow: { id: string; name: string; team: { id: number } };
+      flow: {
+        id: string;
+        name: string;
+        email_template: "application" | "general";
+        team: { id: number };
+      };
     } | null;
   }>(
     gql`
@@ -36,6 +41,7 @@ export const getSession = async (sessionId: string) => {
           flow {
             id
             name
+            email_template
             team {
               id
             }
@@ -54,11 +60,13 @@ export const emailNewDownloadLink = async ({
   submissionEmailAddress,
   token,
   serviceName,
+  emailTemplate,
 }: {
   sessionId: string;
   submissionEmailAddress: string;
   token: string;
   serviceName: string;
+  emailTemplate: "application" | "general";
 }) => {
   const config: TemplateRegistry["new-download-link"]["config"] = {
     personalisation: {
@@ -69,5 +77,6 @@ export const emailNewDownloadLink = async ({
     emailReplyToId: DEVOPS_EMAIL_REPLY_TO_ID,
   };
 
-  await sendEmail("new-download-link", submissionEmailAddress, config);
+  const template = resolveNotifyTemplate("new-download-link", emailTemplate);
+  await sendEmail(template, submissionEmailAddress, config);
 };

--- a/apps/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
+++ b/apps/api.planx.uk/tests/mocks/saveAndReturnMocks.ts
@@ -66,6 +66,7 @@ export const mockLowcalSession: LowCalSession = {
   flow: {
     slug: "apply-for-a-lawful-development-certificate",
     name: "Apply for a Lawful Development Certificate",
+    email_template: "application" as const,
     team: mockTeam,
   },
   flow_id: mockFlow.id,

--- a/apps/api.planx.uk/types.ts
+++ b/apps/api.planx.uk/types.ts
@@ -76,6 +76,7 @@ export interface LowCalSession {
   flow: {
     slug: string;
     name: string;
+    email_template: "application" | "general";
     team: Team;
   };
   lockedAt?: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@apollo/client";
+import EmailIcon from "@mui/icons-material/Email";
 import GavelIcon from "@mui/icons-material/Gavel";
 import HelpIcon from "@mui/icons-material/Help";
 import InfoIcon from "@mui/icons-material/Info";
@@ -40,6 +41,7 @@ const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
       icon: StarIcon,
       condition: Boolean(data?.flow.templatedFrom),
     },
+    { label: "Notifications", path: "/notifications", icon: EmailIcon },
   ];
 
   return (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/components/EmailTemplateForm.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/components/EmailTemplateForm.tsx
@@ -1,0 +1,82 @@
+import RadioGroup from "@mui/material/RadioGroup";
+import DescriptionRadio from "@planx/components/shared/Radio/DescriptionRadio/DescriptionRadio";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+import SettingsFormContainer from "../../../shared/SettingsForm";
+import {
+  GET_FLOW_EMAIL_TEMPLATE,
+  UPDATE_FLOW_EMAIL_TEMPLATE,
+} from "../queries";
+import type {
+  FormValues,
+  GetFlowEmailTemplate,
+  UpdateFlowEmailTemplate,
+} from "../types";
+import { defaultValues, validationSchema } from "../validationSchema";
+
+const EmailTemplateForm: React.FC = () => {
+  const [flowId] = useStore((state) => [state.id]);
+
+  return (
+    <SettingsFormContainer<
+      GetFlowEmailTemplate,
+      UpdateFlowEmailTemplate,
+      FormValues
+    >
+      query={GET_FLOW_EMAIL_TEMPLATE}
+      mutation={UPDATE_FLOW_EMAIL_TEMPLATE}
+      validationSchema={validationSchema}
+      legend="Email template"
+      description="Choose the email template category for notifications sent to users of this service. Use 'Application' for statutory planning services and 'General' for discretionary services."
+      defaultValues={defaultValues}
+      getInitialValues={({ flow }) => ({
+        emailTemplate: flow.email_template,
+      })}
+      queryVariables={{ flowId }}
+      getMutationVariables={({ emailTemplate }) => ({
+        flowId,
+        emailTemplate,
+      })}
+    >
+      {({ formik }) => (
+        <RadioGroup
+          aria-label="Email template category"
+          value={formik.values.emailTemplate}
+          onChange={(e) =>
+            formik.setFieldValue("emailTemplate", e.target.value)
+          }
+          sx={{
+            display: "flex",
+            gap: 2,
+          }}
+        >
+          <DescriptionRadio
+            data={{
+              text: "Application",
+              description:
+                "Uses 'application' language, suitable for statutory planning services",
+            }}
+            onChange={(e) =>
+              formik.setFieldValue("emailTemplate", e.target.value)
+            }
+            id="application"
+          />
+          <DescriptionRadio
+            data={{
+              text: "General",
+              description:
+                "Uses 'submission' language, suitable for discretionary services",
+            }}
+            onChange={(e) =>
+              formik.setFieldValue("emailTemplate", e.target.value)
+            }
+            id="general"
+          />
+        </RadioGroup>
+      )}
+    </SettingsFormContainer>
+  );
+};
+
+export default EmailTemplateForm;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import EmailTemplateForm from "./components/EmailTemplateForm";
+
+const Notifications: React.FC = () => (
+  <>
+    <EmailTemplateForm />
+  </>
+);
+
+export default Notifications;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/queries.ts
@@ -1,0 +1,25 @@
+import gql from "graphql-tag";
+
+export const GET_FLOW_EMAIL_TEMPLATE = gql`
+  query GetFlowEmailTemplate($flowId: uuid!) {
+    flow: flows_by_pk(id: $flowId) {
+      id
+      email_template
+    }
+  }
+`;
+
+export const UPDATE_FLOW_EMAIL_TEMPLATE = gql`
+  mutation UpdateFlowEmailTemplate(
+    $flowId: uuid!
+    $emailTemplate: gov_notify_email_template_enum_enum!
+  ) {
+    flow: update_flows_by_pk(
+      pk_columns: { id: $flowId }
+      _set: { email_template: $emailTemplate }
+    ) {
+      id
+      email_template
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/types.ts
@@ -1,0 +1,17 @@
+export type EmailTemplate = "application" | "general";
+
+export interface GetFlowEmailTemplate {
+  flow: {
+    id: string;
+    email_template: EmailTemplate;
+  };
+}
+
+export interface UpdateFlowEmailTemplate {
+  flowId: string;
+  emailTemplate: EmailTemplate;
+}
+
+export interface FormValues {
+  emailTemplate: EmailTemplate;
+}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/validationSchema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Notifications/validationSchema.ts
@@ -1,0 +1,13 @@
+import { object, type SchemaOf, string } from "yup";
+
+import type { FormValues } from "./types";
+
+export const validationSchema: SchemaOf<FormValues> = object({
+  emailTemplate: string()
+    .oneOf(["application", "general"] as const)
+    .required() as SchemaOf<FormValues["emailTemplate"]>,
+});
+
+export const defaultValues: FormValues = {
+  emailTemplate: "application",
+};

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes
 import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
 import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
 import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
+import { Route as AuthenticatedAppTeamFlowSettingsNotificationsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/notifications'
 import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
 import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
@@ -502,6 +503,12 @@ const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
     path: '/templates',
     getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
   } as any)
+const AuthenticatedAppTeamFlowSettingsNotificationsRoute =
+  AuthenticatedAppTeamFlowSettingsNotificationsRouteImport.update({
+    id: '/notifications',
+    path: '/notifications',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
 const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
   AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
     id: '/legal-disclaimer',
@@ -687,6 +694,7 @@ export interface FileRoutesByFullPath {
   '/app/$team/$flow/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
   '/app/$team/$flow/settings/about': typeof AuthenticatedAppTeamFlowSettingsAboutRoute
   '/app/$team/$flow/settings/legal-disclaimer': typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute
+  '/app/$team/$flow/settings/notifications': typeof AuthenticatedAppTeamFlowSettingsNotificationsRoute
   '/app/$team/$flow/settings/templates': typeof AuthenticatedAppTeamFlowSettingsTemplatesRoute
   '/app/$team/$flow/settings/visibility': typeof AuthenticatedAppTeamFlowSettingsVisibilityRoute
   '/$flow/pay/invite/failed': typeof PublicCustomDomainFlowPayInviteFailedRoute
@@ -764,6 +772,7 @@ export interface FileRoutesByTo {
   '/app/$team/$flow/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
   '/app/$team/$flow/settings/about': typeof AuthenticatedAppTeamFlowSettingsAboutRoute
   '/app/$team/$flow/settings/legal-disclaimer': typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute
+  '/app/$team/$flow/settings/notifications': typeof AuthenticatedAppTeamFlowSettingsNotificationsRoute
   '/app/$team/$flow/settings/templates': typeof AuthenticatedAppTeamFlowSettingsTemplatesRoute
   '/app/$team/$flow/settings/visibility': typeof AuthenticatedAppTeamFlowSettingsVisibilityRoute
   '/$flow/pay/invite/failed': typeof PublicCustomDomainFlowPayInviteFailedRoute
@@ -856,6 +865,7 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/$flow/_flowEditor/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
   '/_authenticated/app/$team/$flow/settings/about': typeof AuthenticatedAppTeamFlowSettingsAboutRoute
   '/_authenticated/app/$team/$flow/settings/legal-disclaimer': typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute
+  '/_authenticated/app/$team/$flow/settings/notifications': typeof AuthenticatedAppTeamFlowSettingsNotificationsRoute
   '/_authenticated/app/$team/$flow/settings/templates': typeof AuthenticatedAppTeamFlowSettingsTemplatesRoute
   '/_authenticated/app/$team/$flow/settings/visibility': typeof AuthenticatedAppTeamFlowSettingsVisibilityRoute
   '/_public/_customDomain/$flow/pay/invite/failed': typeof PublicCustomDomainFlowPayInviteFailedRoute
@@ -947,6 +957,7 @@ export interface FileRouteTypes {
     | '/app/$team/$flow/nodes'
     | '/app/$team/$flow/settings/about'
     | '/app/$team/$flow/settings/legal-disclaimer'
+    | '/app/$team/$flow/settings/notifications'
     | '/app/$team/$flow/settings/templates'
     | '/app/$team/$flow/settings/visibility'
     | '/$flow/pay/invite/failed'
@@ -1024,6 +1035,7 @@ export interface FileRouteTypes {
     | '/app/$team/$flow/nodes'
     | '/app/$team/$flow/settings/about'
     | '/app/$team/$flow/settings/legal-disclaimer'
+    | '/app/$team/$flow/settings/notifications'
     | '/app/$team/$flow/settings/templates'
     | '/app/$team/$flow/settings/visibility'
     | '/$flow/pay/invite/failed'
@@ -1115,6 +1127,7 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/$flow/_flowEditor/nodes'
     | '/_authenticated/app/$team/$flow/settings/about'
     | '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+    | '/_authenticated/app/$team/$flow/settings/notifications'
     | '/_authenticated/app/$team/$flow/settings/templates'
     | '/_authenticated/app/$team/$flow/settings/visibility'
     | '/_public/_customDomain/$flow/pay/invite/failed'
@@ -1648,6 +1661,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
     }
+    '/_authenticated/app/$team/$flow/settings/notifications': {
+      id: '/_authenticated/app/$team/$flow/settings/notifications'
+      path: '/notifications'
+      fullPath: '/app/$team/$flow/settings/notifications'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsNotificationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
     '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
       id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
       path: '/legal-disclaimer'
@@ -1879,6 +1899,7 @@ const AuthenticatedAppTeamFlowFlowEditorRouteRouteWithChildren =
 interface AuthenticatedAppTeamFlowSettingsRouteRouteChildren {
   AuthenticatedAppTeamFlowSettingsAboutRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRoute
   AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute
+  AuthenticatedAppTeamFlowSettingsNotificationsRoute: typeof AuthenticatedAppTeamFlowSettingsNotificationsRoute
   AuthenticatedAppTeamFlowSettingsTemplatesRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRoute
   AuthenticatedAppTeamFlowSettingsVisibilityRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRoute
   AuthenticatedAppTeamFlowSettingsIndexRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRoute
@@ -1892,6 +1913,8 @@ const AuthenticatedAppTeamFlowSettingsRouteRouteChildren: AuthenticatedAppTeamFl
       AuthenticatedAppTeamFlowSettingsAboutRoute,
     AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute:
       AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute,
+    AuthenticatedAppTeamFlowSettingsNotificationsRoute:
+      AuthenticatedAppTeamFlowSettingsNotificationsRoute,
     AuthenticatedAppTeamFlowSettingsTemplatesRoute:
       AuthenticatedAppTeamFlowSettingsTemplatesRoute,
     AuthenticatedAppTeamFlowSettingsVisibilityRoute:

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/settings/notifications.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/settings/notifications.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import EmailTemplateSettings from "pages/FlowEditor/components/Settings/Flow/Notifications";
+
+export const Route = createFileRoute(
+  "/_authenticated/app/$team/$flow/settings/notifications",
+)({
+  component: EmailTemplateSettings,
+});

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -248,6 +248,7 @@ select_permissions:
         - creator_id
         - data
         - description
+        - email_template
         - id
         - is_listed_on_lps
         - is_template
@@ -282,6 +283,7 @@ select_permissions:
         - data
         - deleted_at
         - description
+        - email_template
         - id
         - is_listed_on_lps
         - is_template
@@ -316,6 +318,7 @@ select_permissions:
         - data
         - deleted_at
         - description
+        - email_template
         - id
         - is_listed_on_lps
         - is_template
@@ -347,6 +350,7 @@ select_permissions:
         - creator_id
         - data
         - description
+        - email_template
         - id
         - is_listed_on_lps
         - is_template
@@ -380,6 +384,7 @@ select_permissions:
         - data
         - archived_at
         - description
+        - email_template
         - id
         - is_listed_on_lps
         - is_template
@@ -457,6 +462,7 @@ update_permissions:
         - data
         - deleted_at
         - description
+        - email_template
         - is_listed_on_lps
         - is_template
         - limitations
@@ -498,6 +504,7 @@ update_permissions:
         - data
         - archived_at
         - description
+        - email_template
         - is_listed_on_lps
         - limitations
         - name

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
@@ -1,3 +1,22 @@
 table:
   name: gov_notify_email_template_enum
   schema: public
+select_permissions:
+  - role: api
+    permission:
+      columns:
+        - column
+        - value
+      filter: {}
+  - role: platformAdmin
+    permission:
+      columns:
+        - column
+        - value
+      filter: {}
+  - role: teamEditor
+    permission:
+      columns:
+        - column
+        - value
+      filter: {}

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
@@ -1,0 +1,3 @@
+table:
+  name: gov_notify_email_template_enum
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_gov_notify_email_template_enum.yaml
@@ -1,6 +1,7 @@
 table:
   name: gov_notify_email_template_enum
   schema: public
+is_enum: true
 select_permissions:
   - role: api
     permission:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -31,6 +31,7 @@
 - "!include public_flow_status_history.yaml"
 - "!include public_flows.yaml"
 - "!include public_global_settings.yaml"
+- "!include public_gov_notify_email_template_enum.yaml"
 - "!include public_lowcal_sessions.yaml"
 - "!include public_lps_magic_links.yaml"
 - "!include public_notification_type_enum.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1777856096943_setup_gov_notify_email_template_enums/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1777856096943_setup_gov_notify_email_template_enums/down.sql
@@ -1,0 +1,4 @@
+alter table "public"."flows" drop constraint "flows_email_template_fkey";
+alter table "public"."flows" drop column "email_template";
+
+DROP TABLE "public"."gov_notify_email_template_enum" CASCADE;

--- a/apps/hasura.planx.uk/migrations/default/1777856096943_setup_gov_notify_email_template_enums/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1777856096943_setup_gov_notify_email_template_enums/up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "public"."gov_notify_email_template_enum" (
+  "value" text NOT NULL, 
+  "column" text NOT NULL, 
+  PRIMARY KEY ("value") , 
+  UNIQUE ("value"));
+COMMENT ON TABLE "public"."gov_notify_email_template_enum" IS E'Enum of available GOV.UK Notify save-and-return email template groups';
+
+INSERT INTO "public"."gov_notify_email_template_enum"("value", "column") VALUES (E'general', E'Email templates which use general "submission" language, most suitable for discretionary services');
+
+INSERT INTO "public"."gov_notify_email_template_enum"("value", "column") VALUES (E'application', E'Email templates which use "application" language, most suitable for apply-for or statutory services');
+
+alter table "public"."flows" add column "email_template" text
+ not null default 'application';
+
+alter table "public"."flows"
+  add constraint "flows_email_template_fkey"
+  foreign key ("email_template")
+  references "public"."gov_notify_email_template_enum"
+  ("value") on update no action on delete no action;


### PR DESCRIPTION
Another quick one in ahead of handing off this Trello ticket: https://trello.com/c/IOY0ZHEC/3121-add-a-second-govnotify-template-to-make-language-for-discretionary-services-less-application-planning-focused

**Changes:**
- Introduces an enum table `gov_notify_email_template_enum` with acceptable values "application" or "general"
- Adds column `flows.email_template` and sets all flows to "application" by default

**What this does _not_ do yet:**
- Does not add any role-based access permissions yet!
- Does not cross-check/adjust any planx-core `flow` types or data sync scripts yet
- Does not add any frontend UI to select email template in flow settings
- Does not add frontend queries or mutations to update `flows.email_template` yet
- ~Does not stub out migration for "application" versus "general" help email/help phone/help opening hours/email reply-to variables (find existing "application" defaults in `team_settings`)~ (No longer applicable per dev call)