### PR TITLE
feat: set up teamAdmin inherited from teamEditor role

### DIFF
--- a/apps/hasura.planx.uk/metadata/inherited_roles.yaml
+++ b/apps/hasura.planx.uk/metadata/inherited_roles.yaml
@@ -1,1 +1,3 @@
-[]
+- role_name: teamAdmin
+  role_set:
+    - teamEditor

--- a/apps/hasura.planx.uk/tests/analytics.test.js
+++ b/apps/hasura.planx.uk/tests/analytics.test.js
@@ -76,6 +76,21 @@ describe("analytics and analytics_logs", () => {
     });
   });
 
+    describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query analytics_logs", () => {
+      expect(i.queries).not.toContain("analytics_logs");
+    });
+
+    test("cannot create, update, or delete analytics_logs", () => {
+      expect(i).toHaveNoMutationsFor("analytics_logs");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/application_download_tokens.test.js
+++ b/apps/hasura.planx.uk/tests/application_download_tokens.test.js
@@ -59,6 +59,21 @@ describe("application_access_tokens", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query application_access_tokens", () => {
+      expect(i.queries).not.toContain("application_access_tokens");
+    });
+
+    test("cannot create, update, or delete application_access_tokens", () => {
+      expect(i).toHaveNoMutationsFor("application_access_tokens");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/blpu_codes.test.js
+++ b/apps/hasura.planx.uk/tests/blpu_codes.test.js
@@ -59,6 +59,21 @@ describe("blpu_codes", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query blpu_codes", () => {
+      expect(i.queries).not.toContain("blpu_codes");
+    });
+
+    test("cannot create, update, or delete blpu_codes", () => {
+      expect(i).toHaveNoMutationsFor("blpu_codes");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/bops_applications.test.js
+++ b/apps/hasura.planx.uk/tests/bops_applications.test.js
@@ -60,6 +60,21 @@ describe("bops_applications", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query bops_applications", () => {
+      expect(i.queries).not.toContain("bops_applications");
+    });
+
+    test("cannot create, update, or delete bops_applications", () => {
+      expect(i).toHaveNoMutationsFor("bops_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/email_applications.test.js
+++ b/apps/hasura.planx.uk/tests/email_applications.test.js
@@ -61,6 +61,21 @@ describe("email_applications", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query email_applications", () => {
+      expect(i.queries).not.toContain("email_applications");
+    });
+
+    test("cannot create, update, or delete email_applications", () => {
+      expect(i).toHaveNoMutationsFor("email_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/feedback.test.js
+++ b/apps/hasura.planx.uk/tests/feedback.test.js
@@ -96,6 +96,33 @@ describe("feedback", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query feedback", () => {
+      expect(i.queries).toContain("feedback");
+    });
+
+    test("cannot insert feedback", async () => {
+      expect(i.mutations).not.toContain("insert_feedback");
+      expect(i.mutations).not.toContain("insert_feedback_one");
+    });
+
+    test("cannot delete feedback", async () => {
+      expect(i.mutations).not.toContain("delete_feedback");
+      expect(i.mutations).not.toContain("delete_feedback_by_pk");
+    });
+
+    test("can update feedback", async () => {
+      expect(i.mutations).toContain("update_feedback");
+      expect(i.mutations).toContain("update_feedback_by_pk");
+      expect(i.mutations).toContain("update_feedback_many");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/feedback_status.test.js
+++ b/apps/hasura.planx.uk/tests/feedback_status.test.js
@@ -67,6 +67,21 @@ describe("feedback_status_enum", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query feedback_status_enum", () => {
+      expect(i.queries).not.toContain("feedback_status_enum");
+    });
+
+    test("cannot create, update, or delete feedback_status_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_status_enum");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/feedback_type_enum.test.js
+++ b/apps/hasura.planx.uk/tests/feedback_type_enum.test.js
@@ -67,6 +67,21 @@ describe("feedback_type_enum", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query feedback_type_enum", () => {
+      expect(i.queries).not.toContain("feedback_type_enum");
+    });
+
+    test("cannot create, update, or delete feedback_type_enum", () => {
+      expect(i).toHaveNoMutationsFor("feedback_type_enum");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/flow_comments.test.js
+++ b/apps/hasura.planx.uk/tests/flow_comments.test.js
@@ -91,6 +91,31 @@ describe("flow comments", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query flow_comments", () => {
+      expect(i.queries).toContain("flow_comments");
+    });
+
+    test("can create flow_comments", () => {
+      expect(i.mutations).toContain("insert_flow_comments");
+    });
+
+    test("cannot update flow_comments", () => {
+      expect(i.mutations).not.toContain("update_flow_comments");
+      expect(i.mutations).not.toContain("update_flow_comments_by_pk");
+    });
+
+    test("can delete flow_comments", () => {
+      expect(i.mutations).toContain("delete_flow_comments");
+      expect(i.mutations).toContain("delete_flow_comments_by_pk");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/flow_status_history.test.js
+++ b/apps/hasura.planx.uk/tests/flow_status_history.test.js
@@ -61,6 +61,21 @@ describe("flows status history", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query flow_status_history", () => {
+      expect(i.queries).toContain("flow_status_history");
+    });
+
+    test("cannot create, update, or delete flows or their associated operations", () => {
+      expect(i).toHaveNoMutationsFor("flow_status_history");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/flows.test.js
+++ b/apps/hasura.planx.uk/tests/flows.test.js
@@ -142,6 +142,58 @@ describe("flows and operations", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query flows and their associated operations", () => {
+      expect(i.queries).toContain("flows");
+      expect(i.queries).toContain("operations");
+    });
+
+    test("can update flows and their associated operations", () => {
+      expect(i.mutations).toContain("update_flows_by_pk");
+      expect(i.mutations).toContain("update_flows");
+      expect(i.mutations).toContain("update_operations_by_pk");
+      expect(i.mutations).toContain("update_operations");
+    });
+
+    test("can create flows and their associated operations", () => {
+      expect(i.mutations).toContain("insert_flows_one");
+      expect(i.mutations).toContain("insert_flows");
+      expect(i.mutations).toContain("insert_operations_one");
+      expect(i.mutations).toContain("insert_operations");
+    });
+
+    test("cannot delete flows", () => {
+      expect(i.mutations).not.toContain("delete_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_flows");
+    });
+
+    test("cannot delete operations", () => {
+      expect(i.mutations).not.toContain("delete_operations_by_pk");
+      expect(i.mutations).not.toContain("delete_operations");
+    });
+
+    test("can query published flows", () => {
+      expect(i.queries).toContain("published_flows");
+    });
+
+    test("can create published_flows", () => {
+      expect(i.mutations).toContain("insert_published_flows_one");
+      expect(i.mutations).toContain("insert_published_flows");
+    });
+
+    test("cannot update or delete published_flows", () => {
+      expect(i.mutations).not.toContain("delete_published_flows_by_pk");
+      expect(i.mutations).not.toContain("delete_published_flows");
+      expect(i.mutations).not.toContain("update_published_flows_by_pk");
+      expect(i.mutations).not.toContain("update_published_flows");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/global_settings.test.js
+++ b/apps/hasura.planx.uk/tests/global_settings.test.js
@@ -64,6 +64,21 @@ describe("global_settings", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query global_settings view", () => {
+      expect(i.queries).toContain("global_settings");
+    });
+
+    test("cannot create, update, or delete global_settings", () => {
+      expect(i).toHaveNoMutationsFor("global_settings");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/lowcal_sessions.test.js
+++ b/apps/hasura.planx.uk/tests/lowcal_sessions.test.js
@@ -562,6 +562,21 @@ describe("lowcal_sessions", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query lowcal_sessions", () => {
+      expect(i.queries).toContain("lowcal_sessions");
+    });
+
+    test("cannot create, update, or delete lowcal_sessions", () => {
+      expect(i).toHaveNoMutationsFor("lowcal_sessions");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/magic_links.test.js
+++ b/apps/hasura.planx.uk/tests/magic_links.test.js
@@ -62,6 +62,21 @@ describe("lps_magic_links", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query lps_magic_links", () => {
+      expect(i.queries).not.toContain("lps_magic_links");
+    });
+
+    test("cannot create, update, or delete lps_magic_links", () => {
+      expect(i).toHaveNoMutationsFor("lps_magic_links");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/notifications.test.js
+++ b/apps/hasura.planx.uk/tests/notifications.test.js
@@ -47,10 +47,10 @@ describe("notifications", () => {
     });
   });
 
-  describe("teamEditor", () => {
+  describe("teamAdmin", () => {
     let i;
     beforeAll(async () => {
-      i = await introspectAs("teamEditor");
+      i = await introspectAs("teamAdmin");
     });
 
     test("cannot query notifications", () => {

--- a/apps/hasura.planx.uk/tests/payment_requests.test.js
+++ b/apps/hasura.planx.uk/tests/payment_requests.test.js
@@ -130,6 +130,21 @@ describe("payment_requests", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query payment_requests", () => {
+      expect(i.queries).not.toContain("payment_requests");
+    });
+
+    test("cannot create, update, or delete payment_requests", () => {
+      expect(i).toHaveNoMutationsFor("payment_requests");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/payment_status.test.js
+++ b/apps/hasura.planx.uk/tests/payment_status.test.js
@@ -67,6 +67,21 @@ describe("payment_status", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query payment_status", () => {
+      expect(i.queries).not.toContain("payment_status");
+    });
+
+    test("cannot create, update, or delete payment_status", () => {
+      expect(i).toHaveNoMutationsFor("payment_status");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/planning_constraints_requests.test.js
+++ b/apps/hasura.planx.uk/tests/planning_constraints_requests.test.js
@@ -62,6 +62,21 @@ describe("planning_constraints_requests", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query planning_constraints_requests", () => {
+      expect(i.queries).not.toContain("planning_constraints_requests");
+    });
+
+    test("cannot create, update, or delete planning_constraints_requests", () => {
+      expect(i).toHaveNoMutationsFor("planning_constraints_requests");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/reconciliation_requests.test.js
+++ b/apps/hasura.planx.uk/tests/reconciliation_requests.test.js
@@ -64,6 +64,21 @@ describe("reconciliation_requests", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query reconciliation_requests", () => {
+      expect(i.queries).not.toContain("reconciliation_requests");
+    });
+
+    test("cannot create, update, or delete reconciliation_requests", () => {
+      expect(i).toHaveNoMutationsFor("reconciliation_requests");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/revoked_tokens.test.js
+++ b/apps/hasura.planx.uk/tests/revoked_tokens.test.js
@@ -64,6 +64,21 @@ describe("revoked_tokens", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query revoked_tokens", () => {
+      expect(i.queries).not.toContain("revoked_tokens");
+    });
+
+    test("cannot create, update, or delete revoked_tokens", () => {
+      expect(i).toHaveNoMutationsFor("revoked_tokens");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/s3_applications.test.js
+++ b/apps/hasura.planx.uk/tests/s3_applications.test.js
@@ -60,6 +60,21 @@ describe("s3_applications", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query s3_applications", () => {
+      expect(i.queries).not.toContain("s3_applications");
+    });
+
+    test("cannot create, update, or delete s3_applications", () => {
+      expect(i).toHaveNoMutationsFor("s3_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/sessions.test.js
+++ b/apps/hasura.planx.uk/tests/sessions.test.js
@@ -629,6 +629,21 @@ describe("sessions", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query sessions", () => {
+      expect(i.queries).not.toContain("sessions");
+    });
+
+    test("cannot create, update, or delete sessions", () => {
+      expect(i).toHaveNoMutationsFor("sessions");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/submission_emails.test.js
+++ b/apps/hasura.planx.uk/tests/submission_emails.test.js
@@ -80,6 +80,30 @@ describe("submission_emails", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query flow integrations", () => {
+      expect(i.queries).toContain("submission_emails");
+    });
+
+    test("can update flow integrations", () => {
+      expect(i.mutations).toContain("update_submission_emails");
+      expect(i.mutations).toContain("update_submission_emails_by_pk");
+    });
+
+    test("can delete flow integrations", async () => {
+      expect(i.mutations).toContain("delete_submission_emails");
+    });
+
+    test("can add flow integrations", async () => {
+      expect(i.mutations).toContain("insert_submission_emails");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/team_integrations.test.js
+++ b/apps/hasura.planx.uk/tests/team_integrations.test.js
@@ -62,6 +62,22 @@ describe("team_integrations", () => {
     });
   });
 
+  
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query team_integrations", () => {
+      expect(i.queries).toContain("team_integrations");
+    });
+
+    test("cannot create, update, or delete team_integrations", () => {
+      expect(i).toHaveNoMutationsFor("team_integrations");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/team_members.test.js
+++ b/apps/hasura.planx.uk/tests/team_members.test.js
@@ -68,6 +68,26 @@ describe("team_members", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query teams", () => {
+      expect(i.queries).toContain("team_members");
+    });
+
+    test("cannot update team_members", () => {
+      expect(i).not.toContain("update_team_members_by_pk");
+    });
+
+    test("can add and remove team_members", () => {
+      expect(i.mutations).toContain("insert_team_members");
+      expect(i.mutations).toContain("delete_team_members");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/team_settings.test.js
+++ b/apps/hasura.planx.uk/tests/team_settings.test.js
@@ -83,6 +83,30 @@ describe("team_settings", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query team_settings", () => {
+      expect(i.queries).toContain("team_settings");
+    });
+
+    test("can update team_settings", () => {
+      expect(i.mutations).toContain("update_team_settings");
+      expect(i.mutations).toContain("update_team_settings_by_pk");
+    });
+
+    test("cannot delete team_settings", async () => {
+      expect(i.mutations).not.toContain("delete_team_settings");
+    });
+
+    test("cannot insert team_settings", async () => {
+      expect(i.mutations).not.toContain("insert_team_settings");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/team_themes.test.js
+++ b/apps/hasura.planx.uk/tests/team_themes.test.js
@@ -83,6 +83,30 @@ describe("team_themes", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query team_themes", () => {
+      expect(i.queries).toContain("team_themes");
+    });
+
+    test("can update team_themes", () => {
+      expect(i.mutations).toContain("update_team_themes");
+      expect(i.mutations).toContain("update_team_themes_by_pk");
+    });
+
+    test("cannot delete team_themes", async () => {
+      expect(i.mutations).not.toContain("delete_team_themes");
+    });
+
+    test("cannot insert team_themes", async () => {
+      expect(i.mutations).not.toContain("insert_team_themes");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/teams.test.js
+++ b/apps/hasura.planx.uk/tests/teams.test.js
@@ -73,6 +73,30 @@ describe("teams", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query teams", () => {
+      expect(i.queries).toContain("teams");
+    });
+
+    test("cannot update teams", () => {
+      expect(i.mutations).not.toContain("update_teams");
+      expect(i.mutations).not.toContain("update_teams_by_pk");
+    });
+
+    test("cannot delete teams", async () => {
+      expect(i.mutations).not.toContain("delete_teams");
+    });
+
+    test("cannot insert teams", async () => {
+      expect(i.mutations).not.toContain("insert_teams");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/teams_summary.test.js
+++ b/apps/hasura.planx.uk/tests/teams_summary.test.js
@@ -57,6 +57,22 @@ describe("teams_summary", () => {
     });
   });
 
+  
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query teams_summary", () => {
+      expect(i.queries).not.toContain("teams_summary");
+    });
+
+    test("cannot create, update, or delete teams_summary", () => {
+      expect(i).toHaveNoMutationsFor("teams_summary");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/templated_flow_edits.test.js
+++ b/apps/hasura.planx.uk/tests/templated_flow_edits.test.js
@@ -91,6 +91,31 @@ describe("flow template edits", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query templated_flow_edits", () => {
+      expect(i.queries).toContain("templated_flow_edits");
+    });
+
+    test("can create templated_flow_edits", () => {
+      expect(i.mutations).toContain("insert_templated_flow_edits");
+    });
+
+    test("can update templated_flow_edits", () => {
+      expect(i.mutations).toContain("update_templated_flow_edits");
+      expect(i.mutations).toContain("update_templated_flow_edits_by_pk");
+    });
+
+    test("cannot delete templated_flow_edits", () => {
+      expect(i.mutations).not.toContain("delete_templated_flow_edits");
+      expect(i.mutations).not.toContain("delete_templated_flow_edits_by_pk");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/uniform_applications.test.js
+++ b/apps/hasura.planx.uk/tests/uniform_applications.test.js
@@ -60,6 +60,21 @@ describe("uniform_applications", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("cannot query uniform_applications", () => {
+      expect(i.queries).not.toContain("uniform_applications");
+    });
+
+    test("cannot create, update, or delete uniform_applications", () => {
+      expect(i).toHaveNoMutationsFor("uniform_applications");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/user_pinned_flows.test.js
+++ b/apps/hasura.planx.uk/tests/user_pinned_flows.test.js
@@ -84,6 +84,30 @@ describe("user_pinned_flows", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    test("can query user_pinned_flows", () => {
+      expect(i.queries).toContain("user_pinned_flows");
+    });
+
+    test("can create user_pinned_flows", () => {
+      expect(i.mutations).toContain("insert_user_pinned_flows");
+    });
+
+    test("cannot update user_pinned_flows", () => {
+      expect(i.mutations).not.toContain("update_user_pinned_flows");
+      expect(i.mutations).not.toContain("update_user_pinned_flows_by_pk");
+    });
+
+    test("can delete user_pinned_flows", () => {
+      expect(i.mutations).toContain("delete_user_pinned_flows");
+    });
+  });
+
   describe("analyst", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/users.test.js
+++ b/apps/hasura.planx.uk/tests/users.test.js
@@ -70,6 +70,26 @@ describe("users", () => {
     });
   });
 
+  describe("teamAdmin", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamAdmin");
+    });
+
+    // Row-level permissions tested in e2e/tests/api-driven
+    // teamAdmin can only query their own record
+    test("can query users", async () => {
+      expect(i.queries).toContain("users");
+    });
+
+    // Row-level permissions in place
+    // teamAdmin can only mutate other users from their team
+    test("has full access to create and update users", async () => {
+      expect(i.mutations).toContain("insert_users");
+      expect(i.mutations).toContain("update_users_by_pk");
+    });
+  });
+
   describe("api", () => {
     let i;
     beforeAll(async () => {

--- a/apps/hasura.planx.uk/tests/utils.js
+++ b/apps/hasura.planx.uk/tests/utils.js
@@ -92,6 +92,7 @@ const introspectAs = async (role, userId = undefined) => {
     public: gqlPublic,
     platformAdmin: gqlWithRole("platformAdmin", userId),
     teamEditor: gqlWithRole("teamEditor", userId),
+    teamAdmin: gqlWithRole("teamAdmin", userId),
     api: gqlWithRole("api"),
     analyst: gqlWithRole("analyst", userId),
   }[role];


### PR DESCRIPTION
Sets up a teamAdmin role that inherits from teamEditor. 

This is the Hasura step in the ["Create teamAdmin" role ticket](https://trello.com/c/j63eNFql). It specifies that this should configure basic row-level access, but leave specific user management permissions on another ticket, so this is very bare bones.

When we want to override / give teamAdmin more permissions, we can do this:
>...by creating a separate specific permission. After creation, it will override the inherited permission, if any.

(see [Hasura docs for more info](https://hasura.io/docs/2.0/auth/authorization/inherited-roles/))

Ended up reading about this last Friday so went ahead and did this first step, just a heads up to @joecarver !