### PR TITLE
chore(editor): Improve test performance for `List` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.listBuilding.test.tsx
@@ -1,14 +1,14 @@
 import { within } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { cloneDeep, merge } from "lodash";
-import React from "react";
 import { setup } from "test/utils";
 import { it, test, vi } from "vitest";
 
 import { mockMaxOneProps } from "../../schemas/mocks/MaxOne";
+import { mockSimpleProps } from "../../schemas/mocks/Simple";
 import { mockZooProps } from "../../schemas/mocks/Zoo/props";
 import ListComponent from "..";
-import { fillInResponse } from "./testUtils";
+import { fillInSimpleResponse } from "./testUtils";
 
 Element.prototype.scrollIntoView = vi.fn();
 
@@ -72,15 +72,15 @@ describe("Building a list", () => {
     expect(addItemButton).not.toBeInTheDocument();
   });
 
-  test("Adding an item", { timeout: 35_000 }, async () => {
+  test("Adding an item", async () => {
     const { getAllByTestId, getByTestId, user } = await setup(
-      <ListComponent {...mockZooProps} />,
+      <ListComponent {...mockSimpleProps} />,
     );
 
     let cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(1);
 
-    await fillInResponse(user);
+    await fillInSimpleResponse(user);
 
     const addItemButton = getByTestId("list-add-button");
     await user.click(addItemButton);
@@ -103,21 +103,21 @@ describe("Building a list", () => {
     ).toBeInTheDocument();
   });
 
-  test("Editing an item", { timeout: 45_000 }, async () => {
+  test("Editing an item", async () => {
     // Setup three cards
     const { getAllByTestId, getByTestId, user } = await setup(
-      <ListComponent {...mockZooProps} />,
+      <ListComponent {...mockSimpleProps} />,
     );
 
-    await fillInResponse(user);
+    await fillInSimpleResponse(user);
 
     const addItemButton = getByTestId("list-add-button");
 
     await user.click(addItemButton);
-    await fillInResponse(user);
+    await fillInSimpleResponse(user);
 
     await user.click(addItemButton);
-    await fillInResponse(user);
+    await fillInSimpleResponse(user);
 
     const cards = getAllByTestId(/list-card/);
     expect(cards).toHaveLength(3);
@@ -156,7 +156,6 @@ describe("Building a list", () => {
 
   test(
     "Removing an item when all cards are inactive",
-    { timeout: 35_000 },
     async () => {
       // Setup three cards
       const {
@@ -165,17 +164,17 @@ describe("Building a list", () => {
         user,
         getByLabelText,
         queryAllByTestId,
-      } = await setup(<ListComponent {...mockZooProps} />);
+      } = await setup(<ListComponent {...mockSimpleProps} />);
 
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const addItemButton = getByTestId("list-add-button");
 
       await user.click(addItemButton);
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       await user.click(addItemButton);
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       let cards = getAllByTestId(/list-card/);
       expect(cards).toHaveLength(3);
@@ -235,14 +234,13 @@ describe("Building a list", () => {
 
   test(
     "Removing an item when another card is active",
-    { timeout: 35_000 },
     async () => {
       // Setup two cards
       const { getAllByTestId, getByTestId, user } = await setup(
-        <ListComponent {...mockZooProps} />,
+        <ListComponent {...mockSimpleProps} />,
       );
 
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const addItemButton = getByTestId("list-add-button");
 
@@ -272,16 +270,15 @@ describe("Building a list", () => {
 
   test(
     "Cancelling an invalid (new) item removes it",
-    { timeout: 35_000 },
     async () => {
       const { getAllByTestId, getByText, user, queryAllByTestId, getByTestId } =
-        await setup(<ListComponent {...mockZooProps} />);
+        await setup(<ListComponent {...mockSimpleProps} />);
 
       let cards = getAllByTestId(/list-card/);
       expect(cards).toHaveLength(1);
 
       // "Cancel" is hidden from initial item, so fill out an item first
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const addItemButton = getByTestId("list-add-button");
       await user.click(addItemButton);
@@ -303,7 +300,6 @@ describe("Building a list", () => {
 
   test(
     "Cancelling a valid (existing) item resets previous state",
-    { timeout: 35_000 },
     async () => {
       const {
         getByLabelText,
@@ -313,9 +309,9 @@ describe("Building a list", () => {
         getByTestId,
         getAllByTestId,
         getAllByText,
-      } = await setup(<ListComponent {...mockZooProps} />);
+      } = await setup(<ListComponent {...mockSimpleProps} />);
 
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const addItemButton = getByTestId("list-add-button");
       await user.click(addItemButton);
@@ -328,7 +324,7 @@ describe("Building a list", () => {
       ).toBeInTheDocument();
 
       // "Cancel" button was hidden on first item, so fill in second item
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const secondEmail = getAllByText("richard.parker@pi.com")[1];
       expect(secondEmail).toBeInTheDocument();

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
@@ -4,7 +4,7 @@ import { setup } from "test/utils";
 import { it, test, vi } from "vitest";
 import { axe } from "vitest-axe";
 
-import { mockZooPayload } from "../../schemas/mocks/Zoo/payload";
+import { mockZooPreviouslySubmittedData } from "../../schemas/mocks/Zoo/payload";
 import { mockZooProps } from "../../schemas/mocks/Zoo/props";
 import ListComponent from "..";
 import { fillInResponse } from "./testUtils";
@@ -174,7 +174,7 @@ describe("Navigating back", () => {
     const { getAllByText, queryByLabelText, getAllByTestId } = await setup(
       <ListComponent
         {...mockZooProps}
-        previouslySubmittedData={mockZooPayload}
+        previouslySubmittedData={mockZooPreviouslySubmittedData}
       />,
     );
 

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.validation.test.tsx
@@ -1,13 +1,13 @@
 import { screen, waitFor } from "@testing-library/react";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { cloneDeep, merge } from "lodash";
-import React from "react";
 import { setup } from "test/utils";
 import { test, vi } from "vitest";
 
+import { mockSimpleProps } from "../../schemas/mocks/Simple";
 import { mockZooProps } from "../../schemas/mocks/Zoo/props";
 import ListComponent from "..";
-import { fillInResponse } from "./testUtils";
+import { fillInSimpleResponse } from "./testUtils";
 
 Element.prototype.scrollIntoView = vi.fn();
 
@@ -215,9 +215,8 @@ describe("Form validation and error handling", () => {
 
   test(
     "an error displays if the minimum number of items is not met",
-    { timeout: 20_000 },
     async () => {
-      const mockWithMinTwo = merge(cloneDeep(mockZooProps), {
+      const mockWithMinTwo = merge(cloneDeep(mockSimpleProps), {
         schema: { min: 2 },
       });
       const { user, getByTestId, getByText } = await setup(
@@ -228,7 +227,7 @@ describe("Form validation and error handling", () => {
       expect(minNumberOfItems).toEqual(2);
 
       // Fill in one response only
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       await user.click(getByTestId("continue-button"));
 
@@ -241,22 +240,21 @@ describe("Form validation and error handling", () => {
 
   test(
     "an error displays if the maximum number of items is exceeded",
-    { timeout: 40_000 },
     async () => {
       const { user, getAllByTestId, getByTestId, getByText } = await setup(
-        <ListComponent {...mockZooProps} />,
+        <ListComponent {...mockSimpleProps} />,
       );
       const addItemButton = getByTestId(/list-add-button/);
 
-      const maxNumberOfItems = mockZooProps.schema.max;
+      const maxNumberOfItems = mockSimpleProps.schema.max;
       expect(maxNumberOfItems).toEqual(3);
 
       // Complete three items
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
       await user.click(addItemButton);
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
       await user.click(addItemButton);
-      await fillInResponse(user);
+      await fillInSimpleResponse(user);
 
       const cards = getAllByTestId(/list-card/);
       waitFor(() => expect(cards).toHaveLength(3));

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/testUtils.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/testUtils.tsx
@@ -91,3 +91,22 @@ export const fillInResponse = async (user: UserEvent) => {
   });
   await user.click(saveButton);
 };
+
+/**
+ * Helper for tests that only care about list structure
+ * (add / remove / edit / cancel) rather than specific field types
+ *
+ * Use with mockSimpleProps (name and email fields, no file upload)
+ */
+export const fillInSimpleResponse = async (user: UserEvent) => {
+  const nameInput = screen.getByLabelText(/What's their name/);
+  await user.click(nameInput);
+  await user.paste("Richard Parker");
+
+  const emailInput = screen.getByLabelText(/email/);
+  await user.click(emailInput);
+  await user.paste("richard.parker@pi.com");
+
+  const saveButton = screen.getByRole("button", { name: /Save/ });
+  await user.click(saveButton);
+};

--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/mocks/Simple.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/mocks/Simple.ts
@@ -1,0 +1,43 @@
+import { Schema } from "@planx/components/shared/Schema/model";
+import { TextInputType } from "@planx/components/TextInput/model";
+
+import { Props } from "../../Public";
+
+/**
+ * Lightweight 2-field schema for testing structural list behaviour
+ * (adding, removing, editing, cancelling items).
+ *
+ * Field labels deliberately match the Zoo schema's name/email fields so
+ * that assertions like getByLabelText(/What's their name?/) still work.
+ */
+export const Simple: Schema = {
+  type: "Animal",
+  fields: [
+    {
+      type: "text",
+      data: {
+        title: "What's their name?",
+        fn: "name",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
+      data: {
+        title: "What's their email address?",
+        fn: "email.address",
+        type: TextInputType.Email,
+      },
+    },
+  ],
+  min: 1,
+  max: 3,
+} as const;
+
+export const mockSimpleProps: Props = {
+  fn: "mockFn",
+  schema: Simple,
+  schemaName: "Animal",
+  title: "Mock Title",
+  description: "Mock description",
+};

--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/mocks/Zoo/payload.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/mocks/Zoo/payload.ts
@@ -1,5 +1,139 @@
 import { expect } from "vitest";
 
+export const mockZooPreviouslySubmittedData = {
+  data: {
+    mockFn: [
+      {
+        age: 10,
+        "cuteness.amount": "Very",
+        "email.address": "richard.parker@pi.com",
+        name: "Richard Parker",
+        size: "Medium",
+        food: ["meat", "leaves", "bamboo"],
+        birthday: "1988-07-14",
+        address: {
+          line1: "134 Corstorphine Rd",
+          line2: "Corstorphine",
+          town: "Edinburgh",
+          county: "Midlothian",
+          postcode: "EH12 6TS",
+          country: "Scotland",
+        },
+        "photographs.existing": [
+          {
+            file: { path: "./test1.png", relativePath: "./test1.png" },
+            id: "mock-id-animal1-file1",
+            progress: 1,
+            status: "success",
+            url: "https://api.editor.planx.dev/file/private/mock-nanoid/test1.png",
+          },
+          {
+            file: { path: "./test2.png", relativePath: "./test2.png" },
+            id: "mock-id-animal1-file2",
+            progress: 1,
+            status: "success",
+            url: "https://api.editor.planx.dev/file/private/mock-nanoid/test2.png",
+          },
+        ],
+      },
+      {
+        age: 10,
+        "cuteness.amount": "Very",
+        "email.address": "richard.parker@pi.com",
+        name: "Richard Parker",
+        size: "Medium",
+        food: ["meat", "leaves", "bamboo"],
+        birthday: "1988-07-14",
+        address: {
+          line1: "134 Corstorphine Rd",
+          line2: "Corstorphine",
+          town: "Edinburgh",
+          county: "Midlothian",
+          postcode: "EH12 6TS",
+          country: "Scotland",
+        },
+        "photographs.existing": [
+          {
+            file: { path: "./test1.png", relativePath: "./test1.png" },
+            id: "mock-id-animal2-file1",
+            progress: 1,
+            status: "success",
+            url: "https://api.editor.planx.dev/file/private/mock-nanoid/test1.png",
+          },
+          {
+            file: { path: "./test2.png", relativePath: "./test2.png" },
+            id: "mock-id-animal2-file2",
+            progress: 1,
+            status: "success",
+            url: "https://api.editor.planx.dev/file/private/mock-nanoid/test2.png",
+          },
+        ],
+      },
+    ],
+    "mockFn.one.age": 10,
+    "mockFn.one.cuteness.amount": "Very",
+    "mockFn.one.email.address": "richard.parker@pi.com",
+    "mockFn.one.name": "Richard Parker",
+    "mockFn.one.size": "Medium",
+    "mockFn.one.food": ["meat", "leaves", "bamboo"],
+    "mockFn.one.birthday": "1988-07-14",
+    "mockFn.one.address": {
+      line1: "134 Corstorphine Rd",
+      line2: "Corstorphine",
+      town: "Edinburgh",
+      county: "Midlothian",
+      postcode: "EH12 6TS",
+      country: "Scotland",
+    },
+    "mockFn.two.age": 10,
+    "mockFn.two.cuteness.amount": "Very",
+    "mockFn.two.email.address": "richard.parker@pi.com",
+    "mockFn.two.name": "Richard Parker",
+    "mockFn.two.size": "Medium",
+    "mockFn.two.food": ["meat", "leaves", "bamboo"],
+    "mockFn.two.birthday": "1988-07-14",
+    "mockFn.two.address": {
+      line1: "134 Corstorphine Rd",
+      line2: "Corstorphine",
+      town: "Edinburgh",
+      county: "Midlothian",
+      postcode: "EH12 6TS",
+      country: "Scotland",
+    },
+    "mockFn.total.listItems": 2,
+    "photographs.existing": [
+      {
+        file: { path: "./test1.png", relativePath: "./test1.png" },
+        id: "mock-id-animal1-file1",
+        progress: 1,
+        status: "success",
+        url: "https://api.editor.planx.dev/file/private/mock-nanoid/test1.png",
+      },
+      {
+        file: { path: "./test2.png", relativePath: "./test2.png" },
+        id: "mock-id-animal1-file2",
+        progress: 1,
+        status: "success",
+        url: "https://api.editor.planx.dev/file/private/mock-nanoid/test2.png",
+      },
+      {
+        file: { path: "./test1.png", relativePath: "./test1.png" },
+        id: "mock-id-animal2-file1",
+        progress: 1,
+        status: "success",
+        url: "https://api.editor.planx.dev/file/private/mock-nanoid/test1.png",
+      },
+      {
+        file: { path: "./test2.png", relativePath: "./test2.png" },
+        id: "mock-id-animal2-file2",
+        progress: 1,
+        status: "success",
+        url: "https://api.editor.planx.dev/file/private/mock-nanoid/test2.png",
+      },
+    ],
+  },
+};
+
 export const mockZooPayload = {
   data: {
     mockFn: [


### PR DESCRIPTION
Follows on from https://github.com/theopensystemslab/planx-new/pull/6575.

Comparing [a recent PR](https://github.com/theopensystemslab/planx-new/actions/runs/25384836754/job/74442969359) with this one we get the following benchmarks. Locally the results are better than this by about 1.5x


Test suite | Before | After
-- | -- | --
`listBuilding` (9 tests) | 35s | 4s
`validation` (13 tests) | 17s | 6s
`payloadGeneration` (2 tests) | 9s | 9s
`index` (5 tests) | 5s | 5s
**Total** | **66s** | **24s**

This is achieved through simplifying the `Schema` used for testing, so that fewer fields are rendered and interacted with for test that do not require this.

