### PR TITLE
test(editor): Don't create router per-test if not needed

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.test.tsx
@@ -12,6 +12,7 @@ describe("AddressInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <AddressInputComponent id="test" />
       </DndProvider>,
+      { withRouter: true },
     );
     expect(screen.getByText("Address input")).toBeInTheDocument();
   });
@@ -22,6 +23,7 @@ describe("AddressInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <AddressInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     fireEvent.submit(screen.getByRole("form"));
@@ -37,6 +39,7 @@ describe("AddressInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <AddressInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const title = screen.getByPlaceholderText("Title");
@@ -58,6 +61,7 @@ describe("AddressInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <AddressInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const title = screen.getByPlaceholderText("Title");

--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.test.tsx
@@ -30,6 +30,7 @@ it("should not have any accessibility violations", async () => {
       moreInfo="more info"
       contactInfo="contact info"
     />,
+    { withRouter: true },
   );
   const results = await axe(container);
   expect(results).toHaveNoViolations();
@@ -70,6 +71,7 @@ describe("Confirmation component", () => {
         contactInfo="contact info"
         handleSubmit={handleSubmit}
       />,
+      { withRouter: true },
     );
 
     expect(screen.queryByText("Continue")).not.toBeInTheDocument();
@@ -109,6 +111,7 @@ describe("Confirmation component", () => {
         contactInfo="contact info"
         handleSubmit={handleSubmit}
       />,
+      { withRouter: true },
     );
 
     expect(screen.queryByText("Continue")).toBeInTheDocument();

--- a/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.test.tsx
@@ -12,6 +12,7 @@ describe("ContactInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <ContactInputComponent id="test" />
       </DndProvider>,
+      { withRouter: true },
     );
     expect(screen.getByText("Contact input")).toBeInTheDocument();
   });
@@ -22,6 +23,7 @@ describe("ContactInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <ContactInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     fireEvent.submit(screen.getByRole("form"));
@@ -37,6 +39,7 @@ describe("ContactInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <ContactInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const title = screen.getByPlaceholderText("Title");
@@ -58,6 +61,7 @@ describe("ContactInputComponent - Editor Modal", () => {
       <DndProvider backend={HTML5Backend}>
         <ContactInputComponent id="test" handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const title = screen.getByPlaceholderText("Title");

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.accessibility.test.tsx
@@ -23,6 +23,7 @@ describe("when the Feedback component is rendered", async () => {
   it("should not have any accessibility violations", async () => {
     const { container } = await setup(
       <FeedbackComponent feedbackRequired={false} />,
+      { withRouter: true },
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -30,6 +31,7 @@ describe("when the Feedback component is rendered", async () => {
   it("should be navigable by keyboard", async () => {
     const { user } = await setup(
       <FeedbackComponent feedbackRequired={false} />,
+      { withRouter: true },
     );
 
     const ratingButtons = screen.getAllByRole("button");

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.submit.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/tests/Public.submit.test.tsx
@@ -53,6 +53,7 @@ describe.each([
           handleSubmit={handleSubmit}
           feedbackRequired={false}
         />,
+        { withRouter: true },
       );
 
       switch (dataType) {
@@ -85,6 +86,7 @@ describe("when feedback is required but the user does not submit any data", asyn
   beforeEach(async () => {
     const { user } = await setup(
       <FeedbackComponent handleSubmit={handleSubmit} feedbackRequired={true} />,
+      { withRouter: true },
     );
     await user.click(screen.getByTestId("continue-button"));
   });
@@ -117,6 +119,7 @@ describe("When the user presses to go back to the feedback component", () => {
           },
         }}
       />,
+      { withRouter: true },
     );
 
     expect(screen.getByText("I wrote this previously")).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
@@ -52,6 +52,7 @@ describe("error state", () => {
           dataValues={["test1", "test2", "test3"]}
         />
       </ErrorBoundary>,
+      { withRouter: true },
     );
 
     expect(getByTestId("error-summary-invalid-graph")).toBeInTheDocument();
@@ -69,6 +70,7 @@ describe("error state", () => {
           dataValues={["test1", "test2", "test3"]}
         />
       </ErrorBoundary>,
+      { withRouter: true },
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -100,6 +102,7 @@ describe("following a FindProperty component", () => {
         handleSubmit={handleSubmit}
         dataValues={["test1", "test2", "test3"]}
       />,
+      { withRouter: true },
     );
 
     expect(
@@ -135,6 +138,7 @@ describe("following a FindProperty component", () => {
         disclaimer="This page does not include information about historic planning conditions that may apply to this property."
         dataValues={["test1", "test2", "test3"]}
       />,
+      { withRouter: true },
     );
 
     expect(
@@ -155,6 +159,7 @@ describe("following a FindProperty component", () => {
         handleSubmit={vi.fn()}
         dataValues={["test1", "test2", "test3"]}
       />,
+      { withRouter: true },
     );
 
     expect(
@@ -172,6 +177,7 @@ describe("following a FindProperty component", () => {
         handleSubmit={vi.fn()}
         dataValues={["test1", "test2", "test3", "road.classified"]}
       />,
+      { withRouter: true },
     );
 
     expect(
@@ -203,6 +209,7 @@ describe("following a FindProperty component", () => {
         handleSubmit={vi.fn()}
         dataValues={["test1", "test2", "test3", "road.classified"]}
       />,
+      { withRouter: true },
     );
 
     // GIS data present
@@ -227,6 +234,7 @@ describe("following a FindProperty component", () => {
           handleSubmit={vi.fn()}
           dataValues={["test1", "test2", "test3"]}
         />,
+        { withRouter: true },
       );
 
     expect(
@@ -267,6 +275,7 @@ describe("following a FindProperty component", () => {
         fn="property.constraints.planning"
         handleSubmit={vi.fn()}
       />,
+      { withRouter: true },
     );
 
     expect(
@@ -306,6 +315,7 @@ describe("selectable datasets in editor", () => {
           .filter((d) => d.val !== "road.classified")
           .map((d) => d.val)}
       />,
+      { withRouter: true },
     );
 
     // GIS data present
@@ -329,6 +339,7 @@ describe("selectable datasets in editor", () => {
         handleSubmit={vi.fn()}
         dataValues={["road.classified"]}
       />,
+      { withRouter: true },
     );
 
     await act(async () => {

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -11,6 +11,7 @@ it("renders without error", async () => {
     <DndProvider backend={HTML5Backend}>
       <Question node={{}} options={[]} />
     </DndProvider>,
+    { withRouter: true },
   );
   expect(screen.getByText("Question")).toBeInTheDocument();
   expect(screen.getByText("Add option")).toBeInTheDocument();
@@ -21,6 +22,7 @@ it("displays the options editor when the 'Add option' button is clicked", async 
     <DndProvider backend={HTML5Backend}>
       <Question node={{}} options={[]} />
     </DndProvider>,
+    { withRouter: true },
   );
   await user.click(screen.getByRole("button", { name: /Add option/i }));
 
@@ -34,6 +36,7 @@ describe("validation", () => {
       <DndProvider backend={HTML5Backend}>
         <Question node={{}} options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
     await user.click(screen.getByRole("button", { name: /Add option/i }));
     await user.type(

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -39,6 +39,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
     expect(screen.getByText("Responsive checklist")).toBeInTheDocument();
     expect(screen.getByText("Add option")).toBeInTheDocument();
@@ -49,6 +50,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     await user.click(screen.getByLabelText("Expandable"));
@@ -63,6 +65,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     await user.click(screen.getByRole("button", { name: /Add option/i }));
@@ -76,6 +79,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     await user.click(screen.getByLabelText("Expandable"));
@@ -94,6 +98,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     expect(
@@ -112,6 +117,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
@@ -144,6 +150,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} handleSubmit={handleSubmit} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
@@ -183,6 +190,7 @@ describe("Responsive Checklist editor component", async () => {
       <DndProvider backend={HTML5Backend}>
         <ResponsiveChecklistEditor options={[]} />
       </DndProvider>,
+      { withRouter: true },
     );
 
     await user.click(screen.getByRole("button", { name: /Add option/i }));
@@ -256,6 +264,7 @@ describe("Responsive Checklist editor component", async () => {
           {...props}
         />
       </DndProvider>,
+      { withRouter: true },
     );
 
     fireEvent.submit(screen.getByTestId("checklistEditorForm"));
@@ -325,6 +334,7 @@ describe("Responsive Checklist editor component", async () => {
           {...props}
         />
       </DndProvider>,
+      { withRouter: true },
     );
 
     expect(screen.getByDisplayValue("Apple")).toBeVisible();
@@ -397,6 +407,7 @@ describe("Responsive Checklist editor component", async () => {
           {...props}
         />
       </DndProvider>,
+      { withRouter: true },
     );
 
     expect(screen.getByDisplayValue("First group")).toBeVisible();
@@ -417,6 +428,7 @@ describe("Responsive Checklist editor component", async () => {
           handleSubmit={handleSubmit}
         />
       </DndProvider>,
+      { withRouter: true },
     );
 
     // Set title

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveQuestion/Editor.test.tsx
@@ -13,6 +13,7 @@ it("renders without error", async () => {
     <DndProvider backend={HTML5Backend}>
       <ResponsiveQuestion node={{}} options={[]} />
     </DndProvider>,
+    { withRouter: true },
   );
   expect(screen.getByText("Responsive question")).toBeInTheDocument();
   expect(screen.getByText("Add option")).toBeInTheDocument();
@@ -23,6 +24,7 @@ it("displays the options editor when the 'Add option' button is clicked", async 
     <DndProvider backend={HTML5Backend}>
       <ResponsiveQuestion node={{}} options={[]} />
     </DndProvider>,
+    { withRouter: true },
   );
   await user.click(screen.getByRole("button", { name: /Add option/i }));
 
@@ -61,6 +63,7 @@ it("populates the modal with existing data", async () => {
         ]}
       />
     </DndProvider>,
+    { withRouter: true },
   );
 
   expect(screen.getByDisplayValue("My title")).toBeVisible();
@@ -75,6 +78,7 @@ it("can construct a valid payload", async () => {
     <DndProvider backend={HTML5Backend}>
       <ResponsiveQuestion node={{}} options={[]} handleSubmit={handleSubmit} />
     </DndProvider>,
+    { withRouter: true },
   );
 
   // Set title

--- a/apps/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Public.test.tsx
@@ -53,6 +53,7 @@ it("displays a warning at /draft URLs", async () => {
   window.history.pushState({}, "", "/draft");
   const { getByText } = await setup(
     <SendComponent title="Send" destinations={["bops", "uniform"]} />,
+    { withRouter: true },
   );
 
   expect(getByText(/You can only test submissions on/)).toBeVisible();
@@ -62,6 +63,7 @@ it("displays a warning at /preview URLs", async () => {
   window.history.pushState({}, "", "/preview");
   const { getByText } = await setup(
     <SendComponent title="Send" destinations={["bops", "uniform"]} />,
+    { withRouter: true },
   );
 
   expect(getByText(/You can only test submissions on/)).toBeVisible();
@@ -85,6 +87,7 @@ it("displays loading messages to the user", async () => {
       destinations={["bops", "uniform"]}
       handleSubmit={handleSubmit}
     />,
+    { withRouter: true },
   );
 
   // Initial loading state
@@ -117,6 +120,7 @@ it("generates a valid payload for the API", async () => {
       destinations={destinations}
       handleSubmit={handleSubmit}
     />,
+    { withRouter: true },
   );
 
   await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
@@ -139,6 +143,7 @@ it("generates a valid breadcrumb", { retry: 1 }, async () => {
       destinations={["bops", "uniform"]}
       handleSubmit={handleSubmit}
     />,
+    { withRouter: true },
   );
 
   await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
@@ -161,6 +166,7 @@ it("should not have any accessibility violations", async () => {
       destinations={["bops", "uniform"]}
       handleSubmit={handleSubmit}
     />,
+    { withRouter: true },
   );
   const results = await axe(container);
   expect(results).toHaveNoViolations();

--- a/apps/editor.planx.uk/src/test/utils.tsx
+++ b/apps/editor.planx.uk/src/test/utils.tsx
@@ -55,30 +55,44 @@ const testApolloClient = new ApolloClient({
   },
 });
 
+interface SetupOptions {
+  withRouter?: boolean;
+}
+
+const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ToastContextProvider>
+    <ApolloProvider client={testApolloClient}>
+      <QueryClientProvider client={testQueryClient}>
+        <ThemeProvider theme={defaultTheme}>{children}</ThemeProvider>
+      </QueryClientProvider>
+    </ApolloProvider>
+  </ToastContextProvider>
+);
+
 /**
- * Setup @testing-library/react environment with userEvent and TanStack Router
+ * Setup @testing-library/react environment with userEvent and (optionally) TanStack Router
  * https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent
  *
  * Note: This function is async to allow the router to finish rendering.
- * Tests must await the setup() call.
  */
 export const setup = async (
   jsx: React.JSX.Element,
+  { withRouter = false }: SetupOptions = {},
 ): Promise<Record<"user", UserEvent> & RenderResult> => {
   testQueryClient.clear();
   const user = userEvent.setup();
 
+  // Lightweight setup - no router
+  if (!withRouter) {
+    const renderResult = render(<Providers>{jsx}</Providers>);
+    return { user, ...renderResult };
+  }
+
   const rootRoute = createRootRoute({
     component: () => (
-      <ToastContextProvider>
-        <ApolloProvider client={testApolloClient}>
-          <QueryClientProvider client={testQueryClient}>
-            <ThemeProvider theme={defaultTheme}>
-              <Outlet />
-            </ThemeProvider>
-          </QueryClientProvider>
-        </ApolloProvider>
-      </ToastContextProvider>
+      <Providers>
+        <Outlet />
+      </Providers>
     ),
     notFoundComponent: CatchAllComponent,
   });


### PR DESCRIPTION
Another follow up to https://github.com/theopensystemslab/planx-new/pull/6575

This PR conditionally runs through router generation - this is not needed for most tests, but is an overhead every single time.