### PR TITLE
fix(editor): Restore toolbar to all `<DataTable/>` instances

### DIFF
--- a/apps/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/PlatformAdminPanel/PlatformAdminPanel.tsx
@@ -1,6 +1,5 @@
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { AdminPanelData, type LiveFlow } from "types";
 import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import Box from "@mui/material/Box";
+import type { GridToolbarProps, ToolbarPropsOverrides } from "@mui/x-data-grid";
 import {
   DataGrid,
   GridColDef,
@@ -25,6 +26,32 @@ import {
   getValueOptions,
 } from "./utils";
 
+declare module "@mui/x-data-grid" {
+  interface ToolbarPropsOverrides {
+    customTools?: React.FC[];
+    csvExportFileName?: string;
+  }
+}
+
+const CustomToolbar = (props: GridToolbarProps & ToolbarPropsOverrides) => {
+  const { customTools, csvExportFileName } = props;
+
+  return (
+    <GridToolbarContainer>
+      {customTools &&
+        customTools.map((CustomTool, index) => <CustomTool key={index} />)}
+      <GridToolbarColumnsButton />
+      <GridToolbarFilterButton />
+      <GridToolbarDensitySelector />
+      <GridToolbarExport
+        csvOptions={{
+          fileName: csvExportFileName,
+        }}
+      />
+    </GridToolbarContainer>
+  );
+};
+
 export const DataTable = <T,>({
   rows,
   columns,
@@ -44,23 +71,6 @@ export const DataTable = <T,>({
     }
     const ComponentRenderer = columnCellComponentRegistry[column.type];
     return ComponentRenderer(params.value, filterValues);
-  };
-
-  const CustomToolbar = () => {
-    return (
-      <GridToolbarContainer>
-        {customTools &&
-          customTools.map((CustomTool, index) => <CustomTool key={index} />)}
-        <GridToolbarColumnsButton />
-        <GridToolbarFilterButton />
-        <GridToolbarDensitySelector />
-        <GridToolbarExport
-          csvOptions={{
-            fileName: csvExportFileName,
-          }}
-        />
-      </GridToolbarContainer>
-    );
   };
 
   const [filterValues, setFilterValues] = useState<string[]>([]);
@@ -129,6 +139,12 @@ export const DataTable = <T,>({
           }
           slots={{
             toolbar: CustomToolbar,
+          }}
+          slotProps={{
+            toolbar: {
+              customTools,
+              csvExportFileName,
+            },
           }}
           showToolbar
           getRowId={(row) => row.id}

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -130,6 +130,7 @@ export const DataTable = <T,>({
           slots={{
             toolbar: CustomToolbar,
           }}
+          showToolbar
           getRowId={(row) => row.id}
           processRowUpdate={onProcessRowUpdate}
           checkboxSelection={checkboxSelection}

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/components/MultipleOptionSelectFilter.tsx
@@ -1,7 +1,7 @@
 import FormControl from "@mui/material/FormControl";
+import { outlinedInputClasses } from "@mui/material/OutlinedInput";
 import TextField from "@mui/material/TextField";
-import { GridFilterFormProps } from "@mui/x-data-grid";
-import React from "react";
+import { GridFilterInputValueProps } from "@mui/x-data-grid";
 import {
   OptionalAutocompleteProps,
   RequiredAutocompleteProps,
@@ -10,21 +10,30 @@ import {
 
 type Props<T> = RequiredAutocompleteProps<T> &
   OptionalAutocompleteProps<T> &
-  GridFilterFormProps & { applyValue: (args: Record<string, any>) => void };
+  GridFilterInputValueProps;
 
 export function MultipleOptionSelectFilter<T>(props: Props<T>) {
-  const { item, applyValue } = props;
+  const { item, applyValue, options, focusElementRef, ...otherProps } = props;
 
-  const [chipData, setChipData] = React.useState(item.value);
+  const currentValue = Array.isArray(item.value) ? item.value : [];
 
   return (
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
       <StyledAutocomplete
+        {...otherProps}
         role="status"
         aria-atomic={true}
         aria-live="polite"
         disableCloseOnSelect
         multiple
+        disableClearable
+        value={currentValue}
+        sx={{
+          backgroundColor: "transparent",
+          [`&. ${outlinedInputClasses.root}`]: {
+            backgroundColor: "transparent",
+          },
+        }}
         renderInput={(params) => (
           <TextField
             {...params}
@@ -32,32 +41,25 @@ export function MultipleOptionSelectFilter<T>(props: Props<T>) {
               ...params.slotProps,
               inputLabel: { ...params.slotProps.inputLabel, shrink: true },
             }}
-            label="Option"
-            variant="standard"
+            label="Value"
+            variant="outlined"
+            inputRef={focusElementRef}
+            size="small"
           />
         )}
         slotProps={{
           chip: {
             variant: "uploadedFileTag",
             size: "small",
-            onDelete: (event) => {
-              const element = event.currentTarget;
-              const chipIndex = Number(
-                element.parentElement.getAttribute("data-tag-index"),
-              );
-              setChipData((prev: string[]) => {
-                prev.splice(chipIndex, 1);
-              });
-              applyValue({ ...item, chipData });
-              setChipData(item.value);
+          },
+          popper: {
+            sx: {
+              width: "max-content !important",
             },
           },
         }}
-        options={props.options}
-        onChange={(_e, value) => {
-          setChipData(value);
-          return applyValue({ ...item, value });
-        }}
+        options={options}
+        onChange={(_e, value) => applyValue({ ...item, value })}
       />
     </FormControl>
   );


### PR DESCRIPTION
## What's the problem?
The toolbar is missing from all `<DataTable/>` instances - feedback, admin panel, submissions.

## What caused this?
When upgrading `@mui/x-data-grid` from v7 to v9 we missed this change from the the migration guide - 

> _The `showToolbar` prop is now required to display the toolbar._

Source: https://mui.com/x/migration/migration-data-grid-v7/#changes-to-the-public-api

## What's the solution?
Add the prop, update and fix style and behavioural issues.

## Also done this PR...
- [x] Run the codemod and all migration guide steps for v8 (this would have auto-fixed this)
- [x] Run the codemod and all migration guide steps for v9
- [x] Update `PlatformAdminPanel` and associated components (see code comments)

This highlights that we really need to be more conscious of test coverage for these Editor facing features - this is a change which has broken several Editor facing features, and remained undetected for a few days. I've started this here - https://github.com/theopensystemslab/planx-new/pull/6626