### PR TITLE
feat: PlanX dot branding and favicon

### DIFF
--- a/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
@@ -21,7 +21,7 @@ const BreadcrumbsContainer = styled(Box)(({ theme }) => ({
   left: 0,
   zIndex: theme.zIndex.appBar,
   backgroundColor: `rgba(255, 255, 255, 0.2)`,
-  padding: theme.spacing(1, 1.25, 1, 2),
+  padding: theme.spacing(1.2, 1.25, 1.2, 2),
   borderRadius: "0 50px 50px 0",
   backdropFilter: "blur(20px)",
 }));

--- a/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ const BreadcrumbsContainer = styled(Box)(({ theme }) => ({
   left: MENU_WIDTH_COMPACT,
   zIndex: theme.zIndex.appBar,
   backgroundColor: `rgba(255, 255, 255, 0.2)`,
-  padding: theme.spacing(1, 1.25, 1, 2),
+  padding: theme.spacing(1.2, 1.25, 1.2, 2),
   borderRadius: "0 50px 50px 0",
   backdropFilter: "blur(20px)",
 }));

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -41,8 +41,11 @@ const StyledButtonBase = styled(ButtonBase)(({ theme }) => ({
   height: "auto",
   width: "auto",
   textTransform: "capitalize",
-  color: theme.palette.common.white,
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body4.fontSize,
+  gap: 0,
   "&:hover": {
+    color: theme.palette.text.primary,
     backgroundColor: "transparent",
   },
 }));
@@ -125,10 +128,7 @@ export const EnvironmentSelect: React.FC = () => {
     <Root>
       <StyledButtonBase onClick={handleOpen} selected={false}>
         {displayEnv}
-        <UnfoldMoreIcon
-          fontSize="small"
-          sx={(theme) => ({ color: theme.palette.secondary.dark, ml: 0.25 })}
-        />
+        <UnfoldMoreIcon fontSize="small" />
       </StyledButtonBase>
       <StyledDialog
         open={open}

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuHeader.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuHeader.tsx
@@ -25,18 +25,20 @@ const LogoLink = styled(CustomLink)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  gap: theme.spacing(0.5),
-  padding: theme.spacing(0.5, 0.75),
+  gap: theme.spacing(0.75),
+  padding: theme.spacing(0.5, 0.9),
   lineHeight: 0.5,
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
 }));
 
-const LogoIcon = styled(Box)(({ theme }) => ({
-  width: 16,
-  height: 16,
-  backgroundColor: theme.palette.primary.main,
-  borderRadius: "50%",
-}));
+const LogoIcon = styled(Box)<{ teamcolour?: string }>(
+  ({ theme, teamcolour }) => ({
+    width: 12,
+    height: 12,
+    backgroundColor: teamcolour ?? theme.palette.primary.main,
+    borderRadius: "50%",
+  }),
+);
 
 export interface NavMenuHeaderProps {
   compact?: boolean;
@@ -46,6 +48,7 @@ const NavMenuHeader: React.FC<NavMenuHeaderProps> = ({ compact = false }) => {
   const isStandalone = useStore(
     (state) => state.previewEnvironment === "standalone",
   );
+  const teamColour = useStore((state) => state.teamTheme?.primaryColour);
 
   return (
     <HeaderRoot>
@@ -55,7 +58,7 @@ const NavMenuHeader: React.FC<NavMenuHeaderProps> = ({ compact = false }) => {
         {...(isStandalone && { target: "_blank" })}
         variant="subtitle2"
       >
-        <LogoIcon />
+        <LogoIcon teamcolour={teamColour} />
         {compact ? "" : "Plan✕"}
       </LogoLink>
 

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuHeader.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuHeader.tsx
@@ -3,19 +3,39 @@ import { styled } from "@mui/material/styles";
 import EnvironmentSelect from "components/EditorNavMenu/components/EnvironmentSelect";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 const HeaderRoot = styled(Box)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
-  backgroundColor: theme.palette.background.dark,
-  padding: theme.spacing(1),
+  backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(1, 0.85),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  borderRight: `1px solid ${theme.palette.divider}`,
+  marginTop: theme.spacing(0.25),
+  width: "100%",
+  minHeight: 48,
 }));
 
 const LogoLink = styled(CustomLink)(({ theme }) => ({
-  color: theme.palette.common.white,
+  color: theme.palette.text.primary,
   textDecoration: "none",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: theme.spacing(0.5),
+  padding: theme.spacing(0.5, 0.75),
+  lineHeight: 0.5,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+}));
+
+const LogoIcon = styled(Box)(({ theme }) => ({
+  width: 16,
+  height: 16,
+  backgroundColor: theme.palette.primary.main,
+  borderRadius: "50%",
 }));
 
 export interface NavMenuHeaderProps {
@@ -33,9 +53,10 @@ const NavMenuHeader: React.FC<NavMenuHeaderProps> = ({ compact = false }) => {
         to="/"
         preload={false}
         {...(isStandalone && { target: "_blank" })}
-        variant="subtitle1"
+        variant="subtitle2"
       >
-        {compact ? "P✕" : "Plan✕"}
+        <LogoIcon />
+        {compact ? "" : "Plan✕"}
       </LogoLink>
 
       {!compact && <EnvironmentSelect />}

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
-import React from "react";
 
 import { MenuButton } from "../styles";
 import NavMenuButton, { NavMenuButtonProps } from "./NavMenuButton";
@@ -29,9 +28,8 @@ const NavMenuItem = ({
       disabled={disabled}
       disableRipple
       onClick={onClick}
-      sx={{ padding: "8px" }}
     >
-      <Icon />
+      <Icon sx={{ fontSize: "1.4rem" }} />
     </MenuButton>
   ) : (
     <NavMenuButton

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NavMenuItem.tsx
@@ -42,7 +42,7 @@ const NavMenuItem = ({
           gap: 0.25,
         }}
       >
-        <Icon />
+        <Icon sx={{ fontSize: "1.4rem" }} />
         {badgeCount !== undefined ? (
           <BadgeChip
             label={badgeCount}

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
@@ -6,7 +6,7 @@ import Typography from "@mui/material/Typography";
 import { HEADER_HEIGHT_EDITOR } from "components/Header/Header";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-export const MENU_WIDTH_COMPACT = 51;
+export const MENU_WIDTH_COMPACT = 48;
 export const MENU_WIDTH_FULL = 200;
 
 export const Root = styled(Box, {
@@ -40,7 +40,7 @@ export const MenuWrap = styled("ul")(({ theme }) => ({
 }));
 
 export const MenuItem = styled("li")(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
+  margin: theme.spacing(0.75, 0),
   padding: 0,
 }));
 
@@ -51,41 +51,43 @@ export const MenuTitle = styled(Typography)(({ theme }) => ({
 })) as typeof Typography;
 
 export const MenuButton = styled(IconButton, {
-  shouldForwardProp: (prop) => prop !== "isActive",
-})<{ isActive: boolean }>(({ theme, isActive, disabled }) => ({
-  color: theme.palette.text.primary,
-  width: "100%",
-  justifyContent: "flex-start",
-  gap: theme.spacing(0.65),
-  alignItems: "flex-start",
-  borderRadius: theme.shape.borderRadius,
-  padding: theme.spacing(0.8, 0.5),
-  "&:hover": {
-    background: theme.palette.common.white,
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
-  },
-  ...(isActive && {
-    background: theme.palette.common.white,
+  shouldForwardProp: (prop) => prop !== "isActive" && prop !== "compact",
+})<{ isActive: boolean; compact?: boolean }>(
+  ({ theme, isActive, compact, disabled }) => ({
     color: theme.palette.text.primary,
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
-  }),
-  ...(disabled && {
-    color: theme.palette.text.disabled,
+    width: "100%",
+    justifyContent: "flex-start",
+    gap: theme.spacing(0.75),
+    alignItems: "flex-start",
+    borderRadius: theme.shape.borderRadius,
+    padding: compact ? theme.spacing(0.5, 0.25) : theme.spacing(0.8),
     "&:hover": {
-      background: "none",
+      background: theme.palette.common.white,
+      boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    },
+    ...(isActive && {
+      background: theme.palette.common.white,
+      color: theme.palette.text.primary,
+      boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    }),
+    ...(disabled && {
+      color: theme.palette.text.disabled,
+      "&:hover": {
+        background: "none",
+      },
+    }),
+    "& > svg": {
+      opacity: 0.75,
     },
   }),
-  "& > svg": {
-    opacity: 0.75,
-  },
-}));
+);
 
 export const AccordionContent = styled("ul")(({ theme }) => ({
   listStyle: "none",
-  margin: theme.spacing(0, 0.25, 0, 1.25),
+  margin: theme.spacing(0, 0.25, 0, 1.75),
   padding: 0,
   borderLeft: `2px solid ${theme.palette.border.light}`,
-  paddingLeft: theme.spacing(0.75),
+  paddingLeft: theme.spacing(0.8),
 }));
 
 export const Subtitle = styled(Typography)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
@@ -5,7 +5,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-export const MENU_WIDTH_COMPACT = 51;
+export const MENU_WIDTH_COMPACT = 48;
 export const MENU_WIDTH_FULL = 200;
 
 export const Root = styled(Box, {
@@ -39,7 +39,7 @@ export const MenuWrap = styled("ul")(({ theme }) => ({
 }));
 
 export const MenuItem = styled("li")(({ theme }) => ({
-  margin: theme.spacing(0.5, 0),
+  margin: theme.spacing(0.75, 0),
   padding: 0,
 }));
 
@@ -81,10 +81,10 @@ export const MenuButton = styled(IconButton, {
 
 export const AccordionContent = styled("ul")(({ theme }) => ({
   listStyle: "none",
-  margin: theme.spacing(0, 0.25, 0, 1.25),
+  margin: theme.spacing(0, 0.25, 0, 1.75),
   padding: 0,
   borderLeft: `2px solid ${theme.palette.border.light}`,
-  paddingLeft: theme.spacing(0.75),
+  paddingLeft: theme.spacing(0.8),
 }));
 
 export const Subtitle = styled(Typography)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -28,7 +28,7 @@ export interface TeamStore {
 }
 
 const generateCircleFavicon = (color: string): string => {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="16" fill="${color}"/></svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="${color}"/></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -27,6 +27,11 @@ export interface TeamStore {
   clearTeamStore: () => void;
 }
 
+const generateCircleFavicon = (color: string): string => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="16" fill="${color}"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};
+
 export const teamStore: StateCreator<
   TeamStore & SharedStore,
   [],
@@ -57,6 +62,14 @@ export const teamStore: StateCreator<
       teamTheme: team.theme,
       teamDomain: team.domain,
     });
+
+    const favicon = document.getElementById("favicon") as HTMLLinkElement;
+    if (team.theme?.favicon) {
+      favicon.href = team.theme.favicon;
+    } else {
+      const color = team.theme?.primaryColour ?? DEFAULT_PRIMARY_COLOR;
+      favicon.href = generateCircleFavicon(color);
+    }
   },
 
   getTeam: () => ({

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -27,6 +27,11 @@ export interface TeamStore {
   clearTeamStore: () => void;
 }
 
+const generateCircleFavicon = (color: string): string => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="16" fill="${color}"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};
+
 export const teamStore: StateCreator<
   TeamStore & SharedStore,
   [],
@@ -58,9 +63,12 @@ export const teamStore: StateCreator<
       teamDomain: team.domain,
     });
 
+    const favicon = document.getElementById("favicon") as HTMLLinkElement;
     if (team.theme?.favicon) {
-      const favicon = document.getElementById("favicon") as HTMLLinkElement;
       favicon.href = team.theme.favicon;
+    } else {
+      const color = team.theme?.primaryColour ?? DEFAULT_PRIMARY_COLOR;
+      favicon.href = generateCircleFavicon(color);
     }
   },
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -22,13 +22,13 @@ export interface TeamStore {
   teamTheme: TeamTheme;
   teamDomain: string;
 
-  setTeam: (team: Team) => void;
+  setTeam: (team: Team, options?: { useCustomFavicon?: boolean }) => void;
   getTeam: () => Team;
   clearTeamStore: () => void;
 }
 
 const generateCircleFavicon = (color: string): string => {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="${color}"/></svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="12" fill="${color}"/></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };
 
@@ -52,7 +52,7 @@ export const teamStore: StateCreator<
   },
   teamDomain: "",
 
-  setTeam: (team) => {
+  setTeam: (team, options = { useCustomFavicon: true }) => {
     set({
       teamId: team.id,
       teamIntegrations: team.integrations,
@@ -64,7 +64,7 @@ export const teamStore: StateCreator<
     });
 
     const favicon = document.getElementById("favicon") as HTMLLinkElement;
-    if (team.theme?.favicon) {
+    if (options.useCustomFavicon && team.theme?.favicon) {
       favicon.href = team.theme.favicon;
     } else {
       const color = team.theme?.primaryColour ?? DEFAULT_PRIMARY_COLOR;

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -79,7 +79,7 @@ export const Route = createFileRoute("/_authenticated/app/$team")({
   },
   loader: ({ context, cause }) => {
     if (cause !== "preload") {
-      useStore.getState().setTeam(context.team);
+      useStore.getState().setTeam(context.team, { useCustomFavicon: false });
     }
     return context.team;
   },

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -71,7 +71,7 @@ export const Route = createFileRoute("/_authenticated/app/$team")({
   },
   loader: ({ context, cause }) => {
     if (cause !== "preload") {
-      useStore.getState().setTeam(context.team);
+      useStore.getState().setTeam(context.team, { useCustomFavicon: false });
     }
     return context.team;
   },

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -33,6 +33,13 @@ export const Route = createFileRoute("/_authenticated/app/$team")({
                 }
               }
             }
+            theme {
+              primaryColour: primary_colour
+              actionColour: action_colour
+              linkColour: link_colour
+              logo
+              favicon
+            }
             integrations {
               hasPlanningData: has_planning_data
             }


### PR DESCRIPTION
## What does this PR do?

- Introduces dot branding for PlanX editor, which is carried over to the favicon
  - Editor — PlanX blue when at root, dot inherits council theme background colour for logo and favicon
  - Public — if no custom favicon is in place, council theme background colour is used
  
<img width="736" height="1660" alt="image" src="https://github.com/user-attachments/assets/befe3a7b-bb8f-47a4-8275-20890a64c3b4" />


To do:

- [ ] Cross-browser testing (currently works on Chrome)