### PR TITLE
fix: drop `demoUser` option from `user_roles` enum

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1778202123936_delete_demo_user_role/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778202123936_delete_demo_user_role/down.sql
@@ -1,0 +1,2 @@
+INSERT INTO user_roles (value)
+VALUES ('demoUser');

--- a/apps/hasura.planx.uk/migrations/default/1778202123936_delete_demo_user_role/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778202123936_delete_demo_user_role/up.sql
@@ -1,0 +1,2 @@
+DELETE FROM user_roles
+WHERE value = 'demoUser';


### PR DESCRIPTION
Noticed this while manually adding a team membership to the database per latest #planx-bugs question - I surprisingly still had the option to select `demoUser` even though we've removed this via the UI. 

It was due to a lingering `user_roles` enum value missed as part of #6419, now corrected!

<img width="1852" height="1013" alt="Screenshot from 2026-05-07 21-00-36" src="https://github.com/user-attachments/assets/09642abc-3809-4cf6-b634-3769228b65ee" />
