### PR TITLE
style: Flow view toggle position

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -23,7 +23,7 @@ import { StyledToggleButton } from "./StyledToggleButton";
 
 const FiltersContainer = styled(Box)(({ theme }) => ({
   width: "100%",
-  margin: theme.spacing(0, 0, 2),
+  marginBottom: theme.spacing(1),
   padding: theme.spacing(1.5, 0),
   display: "flex",
   flexDirection: "row",
@@ -82,29 +82,13 @@ const Flows: React.FC<Props> = ({
               <SortControl<FlowSummary> sortOptions={sortOptions} />
             </Box>
           )}
-          <ToggleButtonGroup
-            value={flowCardView}
-            exclusive
-            onChange={handleViewChange}
-            size="small"
-          >
-            <Tooltip title="Card view" placement="bottom">
-              <StyledToggleButton value="grid" disableRipple>
-                <ViewModuleIcon />
-              </StyledToggleButton>
-            </Tooltip>
-            <Tooltip title="Table view" placement="bottom">
-              <StyledToggleButton value="row" disableRipple>
-                <TableRowsIcon />
-              </StyledToggleButton>
-            </Tooltip>
-          </ToggleButtonGroup>
         </FiltersContainer>
         <Box
           sx={{
             display: "flex",
             flexDirection: "row",
             alignItems: "center",
+            justifyContent: "space-between",
             gap: 2,
           }}
         >
@@ -145,6 +129,23 @@ const Flows: React.FC<Props> = ({
               </Button>
             )}
           </Box>
+          <ToggleButtonGroup
+            value={flowCardView}
+            exclusive
+            onChange={handleViewChange}
+            size="small"
+          >
+            <Tooltip title="Card view" placement="bottom">
+              <StyledToggleButton value="grid" disableRipple>
+                <ViewModuleIcon />
+              </StyledToggleButton>
+            </Tooltip>
+            <Tooltip title="Table view" placement="bottom">
+              <StyledToggleButton value="row" disableRipple>
+                <TableRowsIcon />
+              </StyledToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
         </Box>
         {flowCardView === "grid" ? (
           <>


### PR DESCRIPTION
## What does this PR do?

Quick one:

- Moves position of flow list toggle to prevent earlier wrapping of filters and inconsistent position:

**Current issue:**
<img width="1590" height="564" alt="image" src="https://github.com/user-attachments/assets/353e2df3-978a-4bd4-88f0-8990894e6006" />

**Updated:**
<img width="1590" height="564" alt="image" src="https://github.com/user-attachments/assets/82a9295f-31a1-4daf-ad08-a6a101d3bc1a" />

