### PR TITLE
fix: Hook up search for archived flows

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -1,18 +1,19 @@
+import { ApolloError } from "@apollo/client";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
-import { FlowCardView } from "../../FlowEditor/lib/store/editor";
+import { FlowCardView, FlowSummary } from "../../FlowEditor/lib/store/editor";
 import { FlowTable } from "../components/FlowTable";
 import { ShowingServicesHeader } from "../components/ShowingServicesHeader";
 import { DashboardList } from "./DashboardList";
 import FlowCard from "./FlowCard";
-import { useGetArchivedFlows } from "./hooks/useGetArchivedFlows";
 import { StyledToggleButton } from "./StyledToggleButton";
 
 type Props = {
@@ -23,6 +24,11 @@ type Props = {
   ) => void;
   teamId: number;
   slug: string;
+  archivedFlows: FlowSummary[] | null;
+  loading: boolean;
+  error: ApolloError | undefined;
+  isFiltered: boolean;
+  onClearSearch: () => void;
 };
 
 const Archive: React.FC<Props> = ({
@@ -30,14 +36,12 @@ const Archive: React.FC<Props> = ({
   handleViewChange,
   teamId,
   slug,
+  archivedFlows,
+  loading,
+  error,
+  isFiltered,
+  onClearSearch,
 }) => {
-  const {
-    data: archivedFlowsData,
-    loading,
-    error,
-  } = useGetArchivedFlows(teamId);
-  const archivedFlows = archivedFlowsData?.flows ?? null;
-
   if (error) {
     return (
       <Box sx={{ pt: 2 }}>
@@ -78,13 +82,20 @@ const Archive: React.FC<Props> = ({
             display: "flex",
             justifyContent: "flex-start",
             alignItems: "center",
+            gap: 2,
             minHeight: "50px",
           }}
         >
           <ShowingServicesHeader
             matchedFlowsCount={archivedFlows?.length || 0}
             isArchived
+            isFiltered={isFiltered}
           />
+          {isFiltered && (
+            <Button onClick={onClearSearch} variant="link">
+              Clear filters
+            </Button>
+          )}
         </Box>
         <ToggleButtonGroup
           value={flowCardView}

--- a/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ShowingServicesHeader.tsx
@@ -31,11 +31,18 @@ export const ShowingServicesHeader = ({
         : `Showing ${matchedFlowsCount} pinned flow`;
   }
 
-  if (isArchived) {
+  if (isArchived && !isFiltered) {
     message =
       matchedFlowsCount !== 1
         ? `Showing ${matchedFlowsCount} archived flows`
         : `Showing ${matchedFlowsCount} archived flow`;
+  }
+
+  if (isArchived && isFiltered) {
+    message =
+      matchedFlowsCount !== 1
+        ? `Showing ${matchedFlowsCount} filtered archived flows`
+        : `Showing ${matchedFlowsCount} filtered archived flow`;
   }
 
   return (

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetArchivedFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetArchivedFlows.ts
@@ -6,8 +6,9 @@ import {
   GetAnyFlowsVars,
 } from "../../queries";
 
-export const useGetArchivedFlows = (teamId: number) =>
+export const useGetArchivedFlows = (teamId: number, skip?: boolean) =>
   useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_ARCHIVED_FLOWS, {
     variables: { teamId },
     fetchPolicy: "cache-and-network",
+    skip,
   });

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -222,7 +222,7 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
             teamId={teamId}
             slug={slug}
             archivedFlows={displayedArchivedFlows}
-            loading={archivedFlowsLoading}
+            loading={archivedFlowsLoading && !displayedArchivedFlows}
             error={archivedFlowsError}
             isFiltered={archiveIsFiltered}
             onClearSearch={() => {

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -14,6 +14,7 @@ import Archive from "./components/Archive";
 import { DashboardList } from "./components/DashboardList";
 import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
+import { useGetArchivedFlows } from "./components/hooks/useGetArchivedFlows";
 import { useGetFlows } from "./components/hooks/useGetFlows";
 import { sortOptions } from "./helpers/sortAndFilterOptions";
 import TeamLayout from "./TeamLayout";
@@ -55,9 +56,19 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
   const flows = data?.flows ?? initialFlows.flows;
   const [flowView, setFlowView] = useState<FlowView>("flows");
 
+  const {
+    data: archivedFlowsData,
+    loading: archivedFlowsLoading,
+    error: archivedFlowsError,
+  } = useGetArchivedFlows(teamId, flowView !== "archive");
+  const archivedFlows = archivedFlowsData?.flows ?? null;
+
   const [searchedFlows, setSearchedFlows] = useState<FlowSummary[] | null>(
     null,
   );
+  const [searchedArchivedFlows, setSearchedArchivedFlows] = useState<
+    FlowSummary[] | null
+  >(null);
   const [shouldClearSearch, setShouldClearSearch] = useState<boolean>(false);
   const searchParams = useSearch({ from: "/_authenticated/app/$team/" });
 
@@ -142,6 +153,10 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
   const showAddFlowButton = teamHasFlows && canUserEditTeam(slug);
   const flowsHaveBeenFiltered = sortedFlows?.length !== flows?.length;
 
+  const displayedArchivedFlows = searchedArchivedFlows ?? archivedFlows;
+  const archiveIsFiltered =
+    displayedArchivedFlows?.length !== archivedFlows?.length;
+
   return (
     <Box sx={{ bgcolor: "background.paper", flexGrow: 1 }}>
       <Container maxWidth="contentWide">
@@ -170,10 +185,14 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
               {isTrial && <InfoChip label="Trial account" />}
               {showAddFlowButton && flowView === "flows" && <AddFlow />}
             </Box>
-            {teamHasFlows && (
+            {(teamHasFlows || (flowView === "archive" && archivedFlows)) && (
               <SearchBox<FlowSummary>
-                records={flows}
-                setRecords={setSearchedFlows}
+                records={flowView === "archive" ? (archivedFlows ?? []) : flows}
+                setRecords={
+                  flowView === "archive"
+                    ? setSearchedArchivedFlows
+                    : setSearchedFlows
+                }
                 searchKey={["name", "slug"]}
                 clearSearch={shouldClearSearch}
               />
@@ -202,6 +221,14 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
             handleViewChange={handleViewChange}
             teamId={teamId}
             slug={slug}
+            archivedFlows={displayedArchivedFlows}
+            loading={archivedFlowsLoading}
+            error={archivedFlowsError}
+            isFiltered={archiveIsFiltered}
+            onClearSearch={() => {
+              setSearchedArchivedFlows(null);
+              setShouldClearSearch(true);
+            }}
           />
         )}
 


### PR DESCRIPTION
## What does this PR do?

- Hooks up search to work when viewing the flow archive (currently only works with "flows" view)
- Maintains search term when switching between flows and archive