### PR TITLE
feat: add userAction to enhancements analytics

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -85,6 +85,7 @@ describe("Passport generation", () => {
             "proposal.description": {
               original: ORIGINAL,
               enhanced: ENHANCED,
+              userAction: "Accepted the AI-enhanced description",
             },
           },
         },
@@ -140,6 +141,7 @@ describe("Passport generation", () => {
             "proposal.description": {
               original: ORIGINAL,
               enhanced: ENHANCED,
+              userAction: "Retained their original description",
             },
           },
         },
@@ -198,6 +200,7 @@ describe("Passport generation", () => {
             "proposal.description": {
               original: ORIGINAL,
               enhanced: ENHANCED,
+              userAction: "Re-wrote their description after AI feedback",
             },
           },
         },
@@ -253,6 +256,7 @@ describe("Passport generation", () => {
             "proposal.description": {
               original: ORIGINAL,
               enhanced: ENHANCED,
+              userAction: "Re-wrote their description after AI feedback",
             },
           },
         },
@@ -274,6 +278,7 @@ describe("navigating back to the EnhancedTextInput component", () => {
         "proposal.description": {
           original: "my first attempt",
           enhanced: "our LLM-enhanced suggestion",
+          userAction: "Re-wrote their description after AI feedback"
         },
       },
     },
@@ -393,6 +398,7 @@ describe("navigating back to the EnhancedTextInput component", () => {
             "proposal.description": {
               original: ORIGINAL,
               enhanced: ENHANCED,
+              userAction: "Accepted the AI-enhanced description",
             },
           },
         },

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
@@ -31,15 +31,16 @@ export const makeBreadcrumb = (
     );
 
   const { userInput, original } = values;
+  const userAction = getAction(values);
 
   const enhancement =
     values.status === "success"
-      ? { original, enhanced: values.enhanced }
-      : { original, error: values.error };
+      ? { original, enhanced: values.enhanced, userAction }
+      : { original, error: values.error, userAction };
 
   return {
     [fn]: userInput,
-    [`enhancedTextInput.${fn}.action`]: getAction(values),
+    [`enhancedTextInput.${fn}.action`]: userAction,
     // TODO: Ensure we deep merge this
     _enhancements: {
       [fn]: enhancement,

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
@@ -7,6 +7,7 @@ import type { PublicProps } from "../shared/types";
 export interface EnhancementData {
   original: string;
   enhanced: string;
+  userAction: TaskActionDescription;
 }
 
 export const TaskActionMap = {


### PR DESCRIPTION
So that the `_enhancements` object in analytics shows a `userAction` key too, and not just original / enhanced descriptions
<img width="571" height="275" alt="Screenshot 2026-05-08 142150" src="https://github.com/user-attachments/assets/78333a6d-9a9c-45c9-86f4-ea762de5c91d" />

❓ I know `enhancedTextInput.proposal.description.action` could be added to the `ALLOW_LIST` instead but I thought it was neater to add a `userAction` key--let me know if intentionally not included in `_enhancements` or if I should just change the `ALLOW_LIST` instead?
