### PR TITLE
feat: conditionally render settings for flows vs services

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
@@ -14,6 +14,7 @@ import React from "react";
 import SettingsLayout from "../SettingsLayout";
 import { GET_FLOW_TEMPLATE_STATUS } from "./Template/queries";
 import type { GetFlowTemplateStatus } from "./Template/types";
+import { useGetIsService } from "./Visibility/IsService/queries";
 
 interface Props {
   children: React.ReactNode;
@@ -21,15 +22,17 @@ interface Props {
 
 const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
   const [flowId, flowSlug] = useStore((state) => [state.id, state.flowSlug]);
-
   const { team } = useParams({ from: "/_authenticated/app/$team" });
 
-  const { data } = useQuery<GetFlowTemplateStatus>(GET_FLOW_TEMPLATE_STATUS, {
+  const { data: templateData } = useQuery<GetFlowTemplateStatus>(GET_FLOW_TEMPLATE_STATUS, {
     variables: { flowId },
   });
+  
+  const { data: isServiceData } = useGetIsService(flowId)
+  const isService = isServiceData?.flow.isService
 
   // TODO: Make type-safe!
-  const settingsLinks = [
+  const serviceSettingsLinks = [
     { label: "Visibility", path: "/visibility", icon: VisibilityIcon },
     { label: "About", path: "/about", icon: InfoIcon },
     { label: "Legal disclaimer", path: "/legal-disclaimer", icon: GavelIcon },
@@ -39,7 +42,7 @@ const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
       label: "Templates",
       path: "/templates",
       icon: StarIcon,
-      condition: Boolean(data?.flow.templatedFrom),
+      condition: Boolean(templateData?.flow.templatedFrom),
     },
     { label: "Emails", path: "/emails", icon: EmailIcon },
   ];
@@ -47,7 +50,7 @@ const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
   return (
     <SettingsLayout
       title="Flow settings"
-      settingsLinks={settingsLinks}
+      settingsLinks={isService ? serviceSettingsLinks : []}
       getNavigationPath={(path) => `/app/${team}/${flowSlug}/settings${path}`}
       topOffset={BREADCRUMBS_HEIGHT}
     >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
@@ -17,7 +17,7 @@ import { validationSchema } from "./schema";
 import type {
   GetIsServiceResponse,
   IsServiceFormValues,
-  UpdateIsServiceVars,
+  IsServiceVars,
 } from "./types";
 
 const IsService: React.FC = () => {
@@ -30,7 +30,7 @@ const IsService: React.FC = () => {
   return (
     <SettingsFormContainer<
       GetIsServiceResponse,
-      UpdateIsServiceVars,
+      IsServiceVars,
       IsServiceFormValues
     >
       query={GET_IS_SERVICE}
@@ -38,7 +38,7 @@ const IsService: React.FC = () => {
       validationSchema={validationSchema}
       legend={"Is this flow a service?"}
       description={
-        "A service is user-facing and includes more customisable settings. Only services can accept responses."
+        "A service is user-facing and can accept responses when turned online. Only services can accept responses."
       }
       getInitialValues={({ flow: { isService } }) => ({ isService })}
       queryVariables={{ flowId }}
@@ -66,17 +66,22 @@ const IsService: React.FC = () => {
                 variant="body1"
                 sx={{ fontWeight: FONT_WEIGHT_BOLD, mr: 1, mb: 2 }}
               >
-                This is currently a {formik.values.isService === true ? "service" : "flow"}
+                {formik.values.isService === true ? "This is a service" : "This is currently a flow"}
               </Typography>
-              <Typography
-                variant="body1"
-              >
-                {formik.values.isService === true ? 
-                "A service is user-facing and can accept submissions" : 
-                "A flow is content that will be nested in other services, and cannot directly accept submissions"}
-                .
-              </Typography>
+              {formik.values.isService === true ? 
+                <Typography
+                  variant="body2"
+                >
+                  If this flow has been made a service in error, please contact an admin to revert it to a flow.
+                </Typography> :
+                <Typography
+                  variant="body1"
+                  >
+                  A flow is content that will be nested in other services, and cannot directly accept responses.
+                </Typography>
+              }
             </Box>
+              {formik.values.isService !== true &&
               <Box sx={{ display: "flex" }}>
                 <Button
                   id="set-is-service-button"
@@ -86,11 +91,9 @@ const IsService: React.FC = () => {
                   variant="contained"
                   onClick={() => setDialogOpen(true)}
                 >
-                  {formik.values.isService === false
-                    ? "Change to user-facing service"
-                    : "Change to flow"}
+                  {"Make this a user-facing service"}
                 </Button>
-              </Box>
+              </Box>}
               </>
             )}
             {isProduction && (
@@ -105,17 +108,11 @@ const IsService: React.FC = () => {
                     await formik.submitForm();
                 }
                 }
-                title="Confirm flow type change"
-                confirmText={
-                  formik.values.isService === false
-                    ? "Set to service"
-                    : "Set to flow"
-                }
+                title="Confirm change to service"
+                confirmText={"Set to service"}
                 cancelText="Cancel"
               >
-                {formik.values.isService === false 
-                ? "Are you sure you want to set this flow as a user-facing service?"
-                : "Are you sure you want to set this service as a flow? This should only be set if it is intended for use as a nested flow."}
+                Are you sure you want to set this flow as a user-facing service?
               </ConfirmationDialog>
             )}
           </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
@@ -1,0 +1,128 @@
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
+import { ConfirmationDialog } from "components/ConfirmationDialog";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import { FONT_WEIGHT_BOLD } from "theme";
+
+import SettingsFormContainer from "../../../shared/SettingsForm";
+import {
+  GET_IS_SERVICE,
+  UPDATE_IS_SERVICE,
+} from "./queries";
+import { validationSchema } from "./schema";
+import type {
+  GetIsServiceResponse,
+  IsServiceFormValues,
+  UpdateIsServiceVars,
+} from "./types";
+
+const IsService: React.FC = () => {
+  const [flowId] = useStore((state) => [state.id]);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const isProduction = import.meta.env.VITE_APP_ENV === "production";
+
+  return (
+    <SettingsFormContainer<
+      GetIsServiceResponse,
+      UpdateIsServiceVars,
+      IsServiceFormValues
+    >
+      query={GET_IS_SERVICE}
+      mutation={UPDATE_IS_SERVICE}
+      validationSchema={validationSchema}
+      legend={"Is this flow a service?"}
+      description={
+        "A service is user-facing and includes more customisable settings. Only services can accept responses."
+      }
+      getInitialValues={({ flow: { isService } }) => ({ isService })}
+      queryVariables={{ flowId }}
+      getMutationVariables={(values) => ({ flowId, ...values })}
+      showActionButtons={false}
+      defaultValues={{isService: false}}
+    >
+      {({ formik, data }) => {
+        const isTrial = data?.flow.team.settings.isTrial;
+
+        return (
+          <>
+            {isTrial && (
+              <WarningContainer>
+                <PendingActionsIcon sx={{ mr: 1 }} />
+                <Typography variant="body2">
+                  Trial accounts cannot create publicly-accessible services.
+                </Typography>
+              </WarningContainer>
+            )}
+          {isProduction && (
+            <>
+            <Box sx={{ display: "flex-col", alignItems: "center", mb: 2 }}>
+              <Typography
+                variant="body1"
+                sx={{ fontWeight: FONT_WEIGHT_BOLD, mr: 1, mb: 2 }}
+              >
+                This is currently a {formik.values.isService === true ? "service" : "flow"}
+              </Typography>
+              <Typography
+                variant="body1"
+              >
+                {formik.values.isService === true ? 
+                "A service is user-facing and can accept submissions" : 
+                "A flow is content that will be nested in other services, and cannot directly accept submissions"}
+                .
+              </Typography>
+            </Box>
+              <Box sx={{ display: "flex" }}>
+                <Button
+                  id="set-is-service-button"
+                  data-testid="set-is-service-button"
+                  sx={{ mb: 2 }}
+                  disabled={data?.flow.team.settings.isTrial}
+                  variant="contained"
+                  onClick={() => setDialogOpen(true)}
+                >
+                  {formik.values.isService === false
+                    ? "Change to user-facing service"
+                    : "Change to flow"}
+                </Button>
+              </Box>
+              </>
+            )}
+            {isProduction && (
+              <ConfirmationDialog
+                open={dialogOpen}
+                onClose={async () => {
+                    setDialogOpen(false);
+                    await formik.setFieldValue(
+                      "isService",
+                      !formik.values.isService,
+                    );
+                    await formik.submitForm();
+                }
+                }
+                title="Confirm flow type change"
+                confirmText={
+                  formik.values.isService === false
+                    ? "Set to service"
+                    : "Set to flow"
+                }
+                cancelText="Cancel"
+              >
+                {formik.values.isService === false 
+                ? "Are you sure you want to set this flow as a user-facing service?"
+                : "Are you sure you want to set this service as a flow? This should only be set if it is intended for use as a nested flow."}
+              </ConfirmationDialog>
+            )}
+          </>
+        );
+      }}
+    </SettingsFormContainer>
+  );
+};
+
+export default IsService;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
@@ -25,8 +25,6 @@ const IsService: React.FC = () => {
 
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const isProduction = import.meta.env.VITE_APP_ENV === "production";
-
   return (
     <SettingsFormContainer<
       GetIsServiceResponse,
@@ -59,8 +57,6 @@ const IsService: React.FC = () => {
                 </Typography>
               </WarningContainer>
             )}
-          {isProduction && (
-            <>
             <Box sx={{ display: "flex-col", alignItems: "center", mb: 2 }}>
               <Typography
                 variant="body1"
@@ -81,22 +77,18 @@ const IsService: React.FC = () => {
                 </Typography>
               }
             </Box>
-              {formik.values.isService !== true &&
               <Box sx={{ display: "flex" }}>
                 <Button
                   id="set-is-service-button"
                   data-testid="set-is-service-button"
                   sx={{ mb: 2 }}
-                  disabled={data?.flow.team.settings.isTrial}
+                  disabled={isTrial}
                   variant="contained"
                   onClick={() => setDialogOpen(true)}
                 >
                   {"Make this a user-facing service"}
                 </Button>
-              </Box>}
-              </>
-            )}
-            {isProduction && (
+              </Box>
               <ConfirmationDialog
                 open={dialogOpen}
                 onClose={async () => {
@@ -114,7 +106,6 @@ const IsService: React.FC = () => {
               >
                 Are you sure you want to set this flow as a user-facing service?
               </ConfirmationDialog>
-            )}
           </>
         );
       }}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/index.tsx
@@ -9,10 +9,7 @@ import React, { useState } from "react";
 import { FONT_WEIGHT_BOLD } from "theme";
 
 import SettingsFormContainer from "../../../shared/SettingsForm";
-import {
-  GET_IS_SERVICE,
-  UPDATE_IS_SERVICE,
-} from "./queries";
+import { GET_IS_SERVICE, UPDATE_IS_SERVICE } from "./queries";
 import { validationSchema } from "./schema";
 import type {
   GetIsServiceResponse,
@@ -42,7 +39,7 @@ const IsService: React.FC = () => {
       queryVariables={{ flowId }}
       getMutationVariables={(values) => ({ flowId, ...values })}
       showActionButtons={false}
-      defaultValues={{isService: false}}
+      defaultValues={{ isService: false }}
     >
       {({ formik, data }) => {
         const isTrial = data?.flow.team.settings.isTrial;
@@ -62,21 +59,23 @@ const IsService: React.FC = () => {
                 variant="body1"
                 sx={{ fontWeight: FONT_WEIGHT_BOLD, mr: 1, mb: 2 }}
               >
-                {formik.values.isService === true ? "This is a service" : "This is currently a flow"}
+                {formik.values.isService === true
+                  ? "This is a service"
+                  : "This is currently a flow"}
               </Typography>
-              {formik.values.isService === true ? 
-                <Typography
-                  variant="body2"
-                >
-                  If this flow has been made a service in error, please contact an admin to revert it to a flow.
-                </Typography> :
-                <Typography
-                  variant="body1"
-                  >
-                  A flow is content that will be nested in other services, and cannot directly accept responses.
+              {formik.values.isService === true ? (
+                <Typography variant="body2">
+                  If this flow has been made a service in error, please contact
+                  an admin to revert it to a flow.
                 </Typography>
-              }
+              ) : (
+                <Typography variant="body1">
+                  A flow is content that will be nested in other services, and
+                  cannot directly accept responses.
+                </Typography>
+              )}
             </Box>
+            {formik.values.isService === false && (
               <Box sx={{ display: "flex" }}>
                 <Button
                   id="set-is-service-button"
@@ -89,23 +88,23 @@ const IsService: React.FC = () => {
                   {"Make this a user-facing service"}
                 </Button>
               </Box>
-              <ConfirmationDialog
-                open={dialogOpen}
-                onClose={async () => {
-                    setDialogOpen(false);
-                    await formik.setFieldValue(
-                      "isService",
-                      !formik.values.isService,
-                    );
-                    await formik.submitForm();
-                }
-                }
-                title="Confirm change to service"
-                confirmText={"Set to service"}
-                cancelText="Cancel"
-              >
-                Are you sure you want to set this flow as a user-facing service?
-              </ConfirmationDialog>
+            )}
+            <ConfirmationDialog
+              open={dialogOpen}
+              onClose={async () => {
+                setDialogOpen(false);
+                await formik.setFieldValue(
+                  "isService",
+                  !formik.values.isService,
+                );
+                await formik.submitForm();
+              }}
+              title="Confirm change to service"
+              confirmText={"Set to service"}
+              cancelText="Cancel"
+            >
+              Are you sure you want to set this flow as a user-facing service?
+            </ConfirmationDialog>
           </>
         );
       }}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
@@ -1,48 +1,42 @@
-import { useMutation,useQuery } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 
-import { GetIsServiceResponse, IsServiceVars } from "./types"
+import { GetIsServiceResponse, IsServiceVars } from "./types";
 
 export const GET_IS_SERVICE = gql`
-query GetIsService($flowId: uuid!) {
-  flow: flows_by_pk(id: $flowId) {
-    isService: is_service
-    team {
-      settings: team_settings {
-        isTrial: is_trial
+  query GetIsService($flowId: uuid!) {
+    flow: flows_by_pk(id: $flowId) {
+      isService: is_service
+      team {
+        settings: team_settings {
+          isTrial: is_trial
+        }
       }
     }
   }
-}
-
 `;
 
 export const UPDATE_IS_SERVICE = gql`
   mutation SetIsService($flowId: uuid!) {
-    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: true}) {
+    update_flows_by_pk(
+      pk_columns: { id: $flowId }
+      _set: { is_service: true }
+    ) {
       id
       isService: is_service
     }
   }
 `;
 
-
 export const useGetIsService = (flowId: string) => {
-  return useQuery<GetIsServiceResponse, IsServiceVars>(
-    GET_IS_SERVICE,
-    {
-      variables: { flowId },
-    }
-  );
+  return useQuery<GetIsServiceResponse, IsServiceVars>(GET_IS_SERVICE, {
+    variables: { flowId },
+  });
 };
 
 export const useUpdateIsService = (flowId: string) => {
-  return useMutation<GetIsServiceResponse, IsServiceVars>(
-    UPDATE_IS_SERVICE,
-    {
-      variables: { flowId },
-      refetchQueries: [{ query: GET_IS_SERVICE, variables: { flowId } }],
-    }
-  );
+  return useMutation<GetIsServiceResponse, IsServiceVars>(UPDATE_IS_SERVICE, {
+    variables: { flowId },
+    refetchQueries: [{ query: GET_IS_SERVICE, variables: { flowId } }],
+  });
 };
-

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@apollo/client";
+import gql from "graphql-tag";
+
+export const GET_IS_SERVICE = gql`
+  query GetIsService($flowId: uuid!) {
+    flow: flows_by_pk(id: $flowId) {
+      isService: is_service
+    }
+  }
+`;
+
+export const UPDATE_IS_SERVICE = gql`
+  mutation SetIsService($flowId: uuid!, $isService: Boolean!) {
+    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: $isService}) {
+      isService: is_service
+    }
+  }
+`;
+
+type GetIsServiceVars = { flowId: string};
+type GetIsServiceResponse = { isService: boolean };
+type UpdateIsServiceVars = {flowId: string, isService: boolean};
+
+export const useGetIsService = (flowId: string) => {
+  return useQuery<GetIsServiceResponse, GetIsServiceVars>(
+    GET_IS_SERVICE,
+    {
+      variables: { flowId },
+    }
+  );
+};
+
+export const useUpdateIsService = (flowId: string, isService: boolean) => {
+  return useQuery<GetIsServiceResponse, UpdateIsServiceVars>(
+    UPDATE_IS_SERVICE,
+    {
+      variables: { flowId, isService },
+    }
+  );
+};
+

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
@@ -1,25 +1,31 @@
-import { useQuery } from "@apollo/client";
+import { useMutation,useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 
+import { GetIsServiceResponse, GetIsServiceVars, UpdateIsServiceVars } from "./types"
+
 export const GET_IS_SERVICE = gql`
-  query GetIsService($flowId: uuid!) {
-    flow: flows_by_pk(id: $flowId) {
-      isService: is_service
+query GetIsService($flowId: uuid!) {
+  flow: flows_by_pk(id: $flowId) {
+    isService: is_service
+    team {
+      settings: team_settings {
+        isTrial: is_trial
+      }
     }
   }
+}
+
 `;
 
 export const UPDATE_IS_SERVICE = gql`
   mutation SetIsService($flowId: uuid!, $isService: Boolean!) {
-    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: $isService}) {
+    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: $isService, status: offline}) {
+      id
       isService: is_service
     }
   }
 `;
 
-type GetIsServiceVars = { flowId: string};
-type GetIsServiceResponse = { isService: boolean };
-type UpdateIsServiceVars = {flowId: string, isService: boolean};
 
 export const useGetIsService = (flowId: string) => {
   return useQuery<GetIsServiceResponse, GetIsServiceVars>(
@@ -31,10 +37,11 @@ export const useGetIsService = (flowId: string) => {
 };
 
 export const useUpdateIsService = (flowId: string, isService: boolean) => {
-  return useQuery<GetIsServiceResponse, UpdateIsServiceVars>(
+  return useMutation<GetIsServiceResponse, UpdateIsServiceVars>(
     UPDATE_IS_SERVICE,
     {
       variables: { flowId, isService },
+      refetchQueries: [{ query: GET_IS_SERVICE, variables: { flowId } }],
     }
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/queries.ts
@@ -1,7 +1,7 @@
 import { useMutation,useQuery } from "@apollo/client";
 import gql from "graphql-tag";
 
-import { GetIsServiceResponse, GetIsServiceVars, UpdateIsServiceVars } from "./types"
+import { GetIsServiceResponse, IsServiceVars } from "./types"
 
 export const GET_IS_SERVICE = gql`
 query GetIsService($flowId: uuid!) {
@@ -18,8 +18,8 @@ query GetIsService($flowId: uuid!) {
 `;
 
 export const UPDATE_IS_SERVICE = gql`
-  mutation SetIsService($flowId: uuid!, $isService: Boolean!) {
-    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: $isService, status: offline}) {
+  mutation SetIsService($flowId: uuid!) {
+    update_flows_by_pk(pk_columns: {id: $flowId}, _set: {is_service: true}) {
       id
       isService: is_service
     }
@@ -28,7 +28,7 @@ export const UPDATE_IS_SERVICE = gql`
 
 
 export const useGetIsService = (flowId: string) => {
-  return useQuery<GetIsServiceResponse, GetIsServiceVars>(
+  return useQuery<GetIsServiceResponse, IsServiceVars>(
     GET_IS_SERVICE,
     {
       variables: { flowId },
@@ -36,11 +36,11 @@ export const useGetIsService = (flowId: string) => {
   );
 };
 
-export const useUpdateIsService = (flowId: string, isService: boolean) => {
-  return useMutation<GetIsServiceResponse, UpdateIsServiceVars>(
+export const useUpdateIsService = (flowId: string) => {
+  return useMutation<GetIsServiceResponse, IsServiceVars>(
     UPDATE_IS_SERVICE,
     {
-      variables: { flowId, isService },
+      variables: { flowId },
       refetchQueries: [{ query: GET_IS_SERVICE, variables: { flowId } }],
     }
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/schema.ts
@@ -1,0 +1,5 @@
+import { boolean, object } from "yup";
+
+export const validationSchema = object({
+  isService: boolean().required(),
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/types.ts
@@ -1,0 +1,14 @@
+export type GetIsServiceVars = { flowId: string};
+export type GetIsServiceResponse = 
+    {
+      flow: {
+        isService: boolean,
+        team: {
+          settings: {
+            isTrial: boolean;
+          }
+        }
+      }
+    }
+export type IsServiceFormValues = { isService: boolean };
+export type UpdateIsServiceVars = { flowId: string, isService: boolean };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/IsService/types.ts
@@ -1,4 +1,4 @@
-export type GetIsServiceVars = { flowId: string};
+export type IsServiceVars = { flowId: string};
 export type GetIsServiceResponse = 
     {
       flow: {
@@ -11,4 +11,3 @@ export type GetIsServiceResponse =
       }
     }
 export type IsServiceFormValues = { isService: boolean };
-export type UpdateIsServiceVars = { flowId: string, isService: boolean };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
@@ -9,12 +9,12 @@ import LPSListing from "./LPS";
 
 const VisibilitySettings: React.FC = () => {
   const flowId = useStore((state) => state.id);
-  const { data: isServiceData } = useGetIsService(flowId)
-  const isService = isServiceData?.flow.isService
+  const { data: isServiceData } = useGetIsService(flowId);
+  const isService = isServiceData?.flow.isService;
 
   return (
     <>
-      {!isService && <IsService />}
+      <IsService />
       {isService && <FlowStatus />}
       <FlowCopy />
       {isService && <LPSListing />}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
@@ -1,15 +1,23 @@
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import FlowCopy from "./FlowCopy";
 import FlowStatus from "./FlowStatus";
+import IsService from "./IsService";
+import { useGetIsService } from "./IsService/queries";
 import LPSListing from "./LPS";
 
 const VisibilitySettings: React.FC = () => {
+  const flowId = useStore((state) => state.id);
+  const { data: isServiceData } = useGetIsService(flowId)
+  const isService = isServiceData?.flow.isService
+
   return (
     <>
-      <FlowStatus />
+      <IsService />
+      {isService && <FlowStatus />}
       <FlowCopy />
-      <LPSListing />
+      {isService && <LPSListing />}
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Visibility/index.tsx
@@ -14,7 +14,7 @@ const VisibilitySettings: React.FC = () => {
 
   return (
     <>
-      <IsService />
+      {!isService && <IsService />}
       {isService && <FlowStatus />}
       <FlowCopy />
       {isService && <LPSListing />}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
@@ -75,20 +75,22 @@ const SettingsLayout: React.FC<Props> = ({
           <Typography variant="h2" component="h1" gutterBottom>
             {title}
           </Typography>
-          <TabList>
-            <Tabs onChange={handleChange} value={activeTab} aria-label={title}>
-              {filteredLinks.map(({ label, path, icon: Icon }) => (
-                <StyledTab
-                  size="large"
-                  key={path}
-                  value={path}
-                  label={label}
-                  icon={Icon ? <Icon /> : undefined}
-                  iconPosition="start"
-                />
-              ))}
-            </Tabs>
-          </TabList>
+          {settingsLinks && (
+            <TabList>
+              <Tabs onChange={handleChange} value={activeTab} aria-label={title}>
+                {filteredLinks ? filteredLinks.map(({ label, path, icon: Icon }) => (
+                  <StyledTab
+                    size="large"
+                    key={path}
+                    value={path}
+                    label={label}
+                    icon={Icon ? <Icon /> : undefined}
+                    iconPosition="start"
+                  />
+                )) : <></>}
+              </Tabs>
+            </TabList>
+          )}
         </Container>
       </Box>
       <Container maxWidth="contentWrap">{children}</Container>

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -321,6 +321,7 @@ select_permissions:
         - email_template
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -376,17 +377,18 @@ select_permissions:
   - role: teamEditor
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - copied_from
         - created_at
         - creator_id
         - data
-        - archived_at
         - description
         - email_template
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -464,6 +466,7 @@ update_permissions:
         - description
         - email_template
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -498,14 +501,15 @@ update_permissions:
   - role: teamEditor
     permission:
       columns:
+        - archived_at
         - can_create_from_copy
         - category
         - copied_from
         - data
-        - archived_at
         - description
         - email_template
         - is_listed_on_lps
+        - is_service
         - limitations
         - name
         - settings

--- a/apps/hasura.planx.uk/migrations/default/1778154943749_alter_table_public_flows_add_column_is_service/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778154943749_alter_table_public_flows_add_column_is_service/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."flows" drop column "is_service";

--- a/apps/hasura.planx.uk/migrations/default/1778154943749_alter_table_public_flows_add_column_is_service/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778154943749_alter_table_public_flows_add_column_is_service/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."flows" add column "is_service" boolean
+ not null default 'false';
+
+UPDATE "public"."flows" SET is_service = true
+    WHERE "public"."flows"."status" = 'online';

--- a/e2e/tests/ui-driven/.eslintrc
+++ b/e2e/tests/ui-driven/.eslintrc
@@ -4,7 +4,7 @@
     "playwright/expect-expect": [
       "error",
       {
-        "additionalAssertFunctionNames": ["expectSections", "publishService", "turnServiceOnline"]
+        "additionalAssertFunctionNames": ["expectSections", "publishService", "turnServiceOnline", "makeFlowAService"]
       }
     ],
     "playwright/no-networkidle": "warn"

--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -8,7 +8,9 @@ import { getTeamPage } from "./helpers/getPage.js";
 import { answerQuestion, clickContinue } from "./helpers/userActions.js";
 import { PlaywrightEditor } from "./pages/Editor.js";
 import {
+  makeFlowAService,
   navigateToService,
+  navigateToFlowSettings,
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
@@ -117,6 +119,8 @@ test.describe("Flow creation, publish and preview", () => {
     await expect(previewLink).toBeVisible();
 
     await navigateToService(page, serviceProps.slug);
+    await navigateToFlowSettings(page);
+    await makeFlowAService(page);
     await turnServiceOnline(page);
 
     // Exit back to main Editor page

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -12,7 +12,9 @@ import {
   selectedFlag,
 } from "./helpers/globalHelpers.js";
 import {
+  makeFlowAService,
   navigateToService,
+  navigateToFlowSettings,
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
@@ -132,6 +134,18 @@ test.describe("Flow creation, publish and preview", () => {
     ).toBeVisible();
   });
 
+  test("Make a flow a service", async ({ browser }) => {
+    const page = await createAuthenticatedSession({
+      browser,
+      userId: context.user!.id!,
+    });
+
+    await page.goto(`/${context.team.slug}/${serviceProps.slug}`);
+    await navigateToFlowSettings(page);
+    await makeFlowAService(page);
+    await expect(page.getByTestId("set-is-service-button")).toBeHidden();
+  });
+
   test("Turn a flow online", async ({ browser }) => {
     const page = await createAuthenticatedSession({
       browser,
@@ -139,6 +153,7 @@ test.describe("Flow creation, publish and preview", () => {
     });
 
     await navigateToService(page, serviceProps.slug);
+    await navigateToFlowSettings(page);
     await turnServiceOnline(page);
 
     // Exit back to main Editor page
@@ -179,6 +194,8 @@ test.describe("Flow creation, publish and preview", () => {
 
     // We are publishing the Ext Portal service and turning it online
     await publishService(page);
+    await navigateToFlowSettings(page);
+    await makeFlowAService(page);
     await turnServiceOnline(page);
 
     // We switch back to the original service

--- a/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
+++ b/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
@@ -38,8 +38,18 @@ export const publishService = async (page: Page) => {
   ).toBeVisible();
 };
 
-export const turnServiceOnline = async (page: Page) => {
+export const navigateToFlowSettings = async (page: Page) => {
   await page.locator('[aria-label="Flow settings"]').click();
+};
+
+export const makeFlowAService = async (page: Page) => {
+  await page.getByText("Make this a user-facing service").click();
+  await page.getByText("Set to service").click();
+
+  await expect(page.getByText("Settings updated successfully")).toBeVisible();
+};
+
+export const turnServiceOnline = async (page: Page) => {
   await page.getByRole("tab", { name: "Visibility" }).click();
   await page.getByTestId("set-status-button").click();
 

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -7,7 +7,9 @@ import {
 } from "./helpers/context.js";
 import { getTeamPage } from "./helpers/getPage.js";
 import {
+  makeFlowAService,
   navigateToService,
+  navigateToFlowSettings,
   navigateToTeamPage,
   publishService,
   turnServiceOnline,
@@ -99,8 +101,8 @@ test.describe("Templates", () => {
       ).toBeVisible();
 
       // check "require edits" control and instructions are not initially visible
-      await expect(page.getByLabel("Require edits")).not.toBeVisible();
-      await expect(page.getByText("Instructions")).not.toBeVisible();
+      await expect(page.getByLabel("Require edits")).toBeHidden();
+      await expect(page.getByText("Instructions")).toBeHidden();
 
       // check "allow edits" control is visible then click it
       const allowEditsControl = page.getByLabel("Allow edits");
@@ -260,9 +262,20 @@ test.describe("Templates", () => {
         .click();
       await expect(
         page.getByRole("option", { name: SOURCE_TEMPLATE_NAME }),
-      ).not.toBeVisible();
+      ).toBeHidden();
 
       await page.keyboard.press("Escape");
+    });
+
+    test("can set the source template to be a Service", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+      await navigateToFlowSettings(page);
+      await makeFlowAService(page);
     });
 
     test("can set the source template online", async ({ browser }) => {
@@ -272,7 +285,7 @@ test.describe("Templates", () => {
         teamName: context.team.name,
       });
       await navigateToService(page, SOURCE_TEMPLATE_SLUG);
-
+      await navigateToFlowSettings(page);
       await turnServiceOnline(page);
     });
 
@@ -319,7 +332,7 @@ test.describe("Templates", () => {
       await page.getByRole("option", { name: "Source template" }).click();
 
       await expect(page.getByText(SOURCE_TEMPLATE_NAME)).toBeVisible();
-      await expect(page.getByText(REGULAR_FLOW_NAME)).not.toBeVisible();
+      await expect(page.getByText(REGULAR_FLOW_NAME)).toBeHidden();
     });
   });
 
@@ -400,7 +413,7 @@ test.describe("Templates", () => {
       // The source template should not appear in the filtered results
       await expect(
         page.getByText(SOURCE_TEMPLATE_NAME, { exact: true }),
-      ).not.toBeVisible();
+      ).toBeHidden();
     });
 
     test("non-templated node is read-only in the templated flow", async ({
@@ -447,7 +460,7 @@ test.describe("Templates", () => {
       await page.getByRole("dialog").waitFor();
       await expect(
         page.locator('button[form="modal"][type="submit"]'),
-      ).not.toBeDisabled();
+      ).toBeEnabled();
       await page.locator('button[aria-label="close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 


### PR DESCRIPTION
# What does this PR do?
- Adds a boolean `flows.is_service` column, allows select and update permissions to `platformAdmin` and `teamEditor`
- Conditionally renders most of the settings depending on whether a flow `isService` or not
- New `IsService` component to make the change (which is one way with a warning modal, see discussion with [August about this](https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1778245685599309?thread_ts=1778067730.871219&cid=C04DZ1NBUMR). We don't anticipate this will change back and forth, can handle edge cases, and this also seemed useful to distinguish this functionality from online / offline status)

https://github.com/user-attachments/assets/d0c71917-6b48-4dd6-9db6-4460d95f1f6f

# Testing
- Open a flow that is currently offline
- It should be a flow
- Change to a service
- Other settings should now be visible and change cannot be reverted

# Next steps
- [X] Tests
- [ ] Make sure `is_service` propagates from source template, if templated
- [ ] When this merges, we'll have to update sync scripts! 
- [x] Tidy up where we use the term 'service' vs 'flow' elsewhere
<img width="600" alt="Screenshot 2026-05-08 173905" src="https://github.com/user-attachments/assets/3ed717c7-e924-4821-9801-eb623aeafb22" />

# Questions
- Should this be behind a feature flag or okay to merge as is? 
