### PR TITLE
fix: store redirectTo in sessionStorage so it works after oauth

### DIFF
--- a/apps/editor.planx.uk/src/routes/(auth)/login.tsx
+++ b/apps/editor.planx.uk/src/routes/(auth)/login.tsx
@@ -36,6 +36,6 @@ export const Route = createFileRoute("/(auth)/login")({
   pendingComponent: DelayedLoadingIndicator,
 });
 
-function isValidRedirect(path: string | null): path is string {
+function isValidRedirect(path: string | null): boolean {
   return Boolean(path && path.startsWith("/") && !path.startsWith("//"));
 }

--- a/apps/editor.planx.uk/src/routes/(auth)/login.tsx
+++ b/apps/editor.planx.uk/src/routes/(auth)/login.tsx
@@ -1,7 +1,10 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { useStore } from "pages/FlowEditor/lib/store";
 import Login from "pages/Login/Login";
 import { z } from "zod";
+
+const REDIRECT_KEY = "planx_redirect_after_login";
 
 const loginSearchSchema = z.object({
   redirectTo: z.string().optional(),
@@ -9,6 +12,30 @@ const loginSearchSchema = z.object({
 
 export const Route = createFileRoute("/(auth)/login")({
   validateSearch: loginSearchSchema,
+  beforeLoad: async ({ search }) => {
+    // store redirectTo in sessionStorage so we can access it after oauth returns
+    if (search.redirectTo) {
+      sessionStorage.setItem(REDIRECT_KEY, search.redirectTo);
+    }
+
+    const { authStatus, initAuthStore } = useStore.getState();
+    if (authStatus === "idle") {
+      await initAuthStore();
+    }
+
+    if (useStore.getState().authStatus === "authenticated") {
+      const pendingRedirect = sessionStorage.getItem(REDIRECT_KEY);
+      sessionStorage.removeItem(REDIRECT_KEY);
+      throw redirect({
+        to: isValidRedirect(pendingRedirect) ? pendingRedirect! : "/app",
+        replace: true,
+      });
+    }
+  },
   component: Login,
   pendingComponent: DelayedLoadingIndicator,
 });
+
+function isValidRedirect(path: string | null): path is string {
+  return Boolean(path && path.startsWith("/") && !path.startsWith("//"));
+}

--- a/apps/editor.planx.uk/src/routes/(auth)/login.tsx
+++ b/apps/editor.planx.uk/src/routes/(auth)/login.tsx
@@ -2,9 +2,11 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
 import Login from "pages/Login/Login";
+import {
+  isSecureLocalRedirect,
+  REDIRECT_KEY,
+} from "utils/routeUtils/redirectUtils";
 import { z } from "zod";
-
-const REDIRECT_KEY = "planx_redirect_after_login";
 
 const loginSearchSchema = z.object({
   redirectTo: z.string().optional(),
@@ -27,7 +29,7 @@ export const Route = createFileRoute("/(auth)/login")({
       const pendingRedirect = sessionStorage.getItem(REDIRECT_KEY);
       sessionStorage.removeItem(REDIRECT_KEY);
       throw redirect({
-        to: isValidRedirect(pendingRedirect) ? pendingRedirect! : "/app",
+        to: isSecureLocalRedirect(pendingRedirect) ? pendingRedirect! : "/app",
         replace: true,
       });
     }
@@ -35,7 +37,3 @@ export const Route = createFileRoute("/(auth)/login")({
   component: Login,
   pendingComponent: DelayedLoadingIndicator,
 });
-
-function isValidRedirect(path: string | null): boolean {
-  return Boolean(path && path.startsWith("/") && !path.startsWith("//"));
-}

--- a/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
@@ -20,6 +20,19 @@ export const Route = createFileRoute("/_authenticated")({
         replace: true,
       });
     }
+
+    const pendingRedirect = sessionStorage.getItem(
+      "planx_redirect_after_login",
+    );
+    if (
+      pendingRedirect &&
+      pendingRedirect.startsWith("/") &&
+      !pendingRedirect.startsWith("//") &&
+      location.pathname !== pendingRedirect
+    ) {
+      sessionStorage.removeItem("planx_redirect_after_login");
+      throw redirect({ to: pendingRedirect, replace: true });
+    }
   },
   head: () => ({
     meta: [

--- a/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { REDIRECT_KEY } from "utils/routeUtils/redirectUtils";
 
 import { validateDomain } from "./-loader";
 
@@ -21,16 +22,14 @@ export const Route = createFileRoute("/_authenticated")({
       });
     }
 
-    const pendingRedirect = sessionStorage.getItem(
-      "planx_redirect_after_login",
-    );
+    const pendingRedirect = sessionStorage.getItem(REDIRECT_KEY);
     if (
       pendingRedirect &&
       pendingRedirect.startsWith("/") &&
       !pendingRedirect.startsWith("//") &&
       location.pathname !== pendingRedirect
     ) {
-      sessionStorage.removeItem("planx_redirect_after_login");
+      sessionStorage.removeItem(REDIRECT_KEY);
       throw redirect({ to: pendingRedirect, replace: true });
     }
   },

--- a/apps/editor.planx.uk/src/utils/routeUtils/redirectUtils.test.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/redirectUtils.test.ts
@@ -1,0 +1,44 @@
+import { isSecureLocalRedirect } from "./redirectUtils";
+
+// jsdom sets window.location.origin to "http://localhost"
+
+describe("isSecureLocalRedirect()", () => {
+  describe("accepts relative paths", () => {
+    it("accepts the root path", () => {
+      expect(isSecureLocalRedirect("/")).toBe(true);
+    });
+
+    it("accepts valid local paths", () => {
+      expect(isSecureLocalRedirect("/app")).toBe(true);
+      expect(isSecureLocalRedirect("/app/some-team/some-flow")).toBe(true);
+    });
+
+    it("accepts paths with a query string", () => {
+      expect(isSecureLocalRedirect("/app?foo=bar")).toBe(true);
+    });
+  });
+
+  describe("rejects invalid and external URLs", () => {
+    it("rejects null", () => {
+      expect(isSecureLocalRedirect(null)).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      expect(isSecureLocalRedirect("")).toBe(false);
+    });
+
+    it("rejects absolute external URLs", () => {
+      expect(isSecureLocalRedirect("https://evil.com")).toBe(false);
+      expect(isSecureLocalRedirect("http://evil.com")).toBe(false);
+      expect(isSecureLocalRedirect("https://evil.com/path")).toBe(false);
+    });
+
+    it("rejects protocol URLs (//evil.com)", () => {
+      expect(isSecureLocalRedirect("//evil.com")).toBe(false);
+    });
+
+    it("rejects javascript: URIs", () => {
+      expect(isSecureLocalRedirect("javascript:alert(1)")).toBe(false);
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/utils/routeUtils/redirectUtils.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/redirectUtils.ts
@@ -1,0 +1,13 @@
+export const REDIRECT_KEY = "planx_redirect_after_login";
+
+// Ensures the path is a relative path by resolving it against the current origin
+// if path is absolute e.g. "https://evil.com", URL() will adopt that, and return false
+export function isSecureLocalRedirect(path: string | null): boolean {
+  if (!path) return false;
+  try {
+    const url = new URL(path, window.location.origin);
+    return url.origin === window.location.origin && !path.startsWith("//");
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
I noticed that the redirectTo query param was getting discarded throughout the google oauth process (probably the same with the Microsoft flow as well). Storing the url in SessionStorage and retrieving it before accessing the app should be a pretty robust fix for this.