### PR TITLE
test(editor): Drop redundant async on describe block

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -17,7 +17,7 @@ import { ResponsiveChecklist } from "./model";
 
 const { setState } = useStore;
 
-describe("Responsive Checklist editor component", async () => {
+describe("Responsive Checklist editor component", () => {
   beforeEach(() => {
     setState({
       user: {


### PR DESCRIPTION
Very minor syntax issue I spotted when looking at the performance of this test suite.

I don't think this will have any impact on timeouts or performance (the fix at #6644 is correct), but is just a small syntax cleanup - this `async` is not required anywhere so I've removed it.