### PR TITLE
chore: bump planx core

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -12,7 +12,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@aws-sdk/s3-request-presigner": "^3.1000.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#a150756",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8071dbb",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.16",
     "ai": "^6.0.116",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^3.1000.0
         version: 3.1040.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#a150756
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#8071dbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1076,14 +1076,14 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@formatjs/fast-memoize@3.1.4':
-    resolution: {integrity: sha512-Lbke1aOrsygKKR09Ux0NrZgbTqpDmiwXOgzyDOJ8Owr1zd5qOKTauf62hH+Seeku3ju77rHWH9I5SfX2CN0vuA==}
+  '@formatjs/fast-memoize@3.1.3':
+    resolution: {integrity: sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==}
 
-  '@formatjs/intl-listformat@8.3.5':
-    resolution: {integrity: sha512-ibv9RLqPNlazmT2tXeA3WbZarc083JxY6OKaE6UYiJYrDTmDNR68CvHjpbqExEEWxH22u6tlxZl91ehWKXMbaQ==}
+  '@formatjs/intl-listformat@8.3.4':
+    resolution: {integrity: sha512-q7WskvO6C/Cyq7ryyM9maDL2FJzt6u39MMBrxmTHZtpTMZukG5Lw0kl9sZaCOR9tYP34xOdWp4JNUrfrkdLGXQ==}
 
-  '@formatjs/intl-localematcher@0.8.6':
-    resolution: {integrity: sha512-AZRgUxj0q93lyF7Z5lFS85bLINXuBLX4R3tCKicO6fSWo6cvh9GQfoR3B1WlsqQwefZ1QORTivhInx7gM6HUzQ==}
+  '@formatjs/intl-localematcher@0.8.5':
+    resolution: {integrity: sha512-TEW/NR367c3PcQ2AXfkNig9jC740+qbkM0LgKl7UCE7Xtv7C5Uk1mvlu86MjQZBmscUai8HSWjcEETpwaVvJ6A==}
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -1225,8 +1225,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389}
     version: 1.0.0
 
   '@opentelemetry/api@1.9.0':
@@ -5354,15 +5354,15 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
-  '@formatjs/fast-memoize@3.1.4': {}
+  '@formatjs/fast-memoize@3.1.3': {}
 
-  '@formatjs/intl-listformat@8.3.5':
+  '@formatjs/intl-listformat@8.3.4':
     dependencies:
-      '@formatjs/intl-localematcher': 0.8.6
+      '@formatjs/intl-localematcher': 0.8.5
 
-  '@formatjs/intl-localematcher@0.8.6':
+  '@formatjs/intl-localematcher@0.8.5':
     dependencies:
-      '@formatjs/fast-memoize': 3.1.4
+      '@formatjs/fast-memoize': 3.1.3
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
     dependencies:
@@ -5498,11 +5498,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@formatjs/intl-listformat': 8.3.5
+      '@formatjs/intl-listformat': 8.3.4
       '@mui/material': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -17,7 +17,7 @@
     "@mui/x-charts": "^9.0.0",
     "@mui/x-data-grid": "^9.0.0",
     "@opensystemslab/map": "1.0.0-alpha.11",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#a150756",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8071dbb",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-router-devtools": "^1.163.3",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#a150756
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#8071dbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.95.2(react@19.2.5)
@@ -1852,8 +1852,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.11':
     resolution: {integrity: sha512-ETACPCk5Coef1L2kNT3MhIzLxVPDpyopxsTNcgeRyEqL71HBfTklGyC5+t7HgEgxRkX5wlUXqmKPNL9DdpVj8g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389}
     version: 1.0.0
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -8649,7 +8649,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.4)

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.30.2",
   "dependencies": {
     "@cucumber/cucumber": "^11.3.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#a150756",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8071dbb",
     "axios": "^1.15.2",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.3.0
         version: 11.3.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#a150756
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#8071dbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.6)
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389}
     version: 1.0.0
 
   '@pkgjs/parseargs@0.11.0':
@@ -2156,7 +2156,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@19.2.4))(@types/react@19.2.6)(react@19.2.4)

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#a150756",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8071dbb",
     "axios": "^1.15.2",
     "dotenv": "^16.6.1",
     "eslint": "^8.57.1",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#a150756
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#8071dbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.6)
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -318,8 +318,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389}
     version: 1.0.0
 
   '@playwright/test@1.58.2':
@@ -1789,7 +1789,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@19.2.4))(@types/react@19.2.6)(react@19.2.4)

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@10.30.2",
   "keywords": [],
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#a150756",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#8071dbb",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3"
   },

--- a/scripts/encrypt/pnpm-lock.yaml
+++ b/scripts/encrypt/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#a150756
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#8071dbb
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -435,8 +435,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389}
     version: 1.0.0
 
   '@popperjs/core@2.11.8':
@@ -1627,7 +1627,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/a150756a65b788bf6a30d3014aebb32e7fcd44ca(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/8071dbb331843b44da338191d905ef8062409389(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
Missed this in the backend templates PR - email_template change is merged to planx-core main now so just bumping this accordingly.