### PR TITLE
[infra] test migration of legacy custom domain to shared CDN

### DIFF
--- a/apps/editor.planx.uk/src/airbrake.ts
+++ b/apps/editor.planx.uk/src/airbrake.ts
@@ -31,6 +31,8 @@ function getEnvForAllowedHosts(host: string) {
     case "editor.planx.uk":
       return "production";
 
+    case "planningservices.planx.in":
+    case "planningserviceslegacy.planx.in":
     case "editor.planx.dev":
       return "staging";
 

--- a/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
@@ -32,6 +32,10 @@ export const computePath = (
 //
 // TODO: Retire this, update docs
 const PREVIEW_ONLY_DOMAINS = [
+  // staging
+  "planningservices.planx.in",
+  "planningserviceslegacy.planx.in",
+  // production
   "planningservices.barnet.gov.uk",
   "planningservices.birmingham.gov.uk",
   "planningservices.buckinghamshire.gov.uk",

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -113,7 +113,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "test-legacy",
           domain: "planningserviceslegacy.planx.in",
-          cloudFrontState: "single-plus-validation",
+          cloudFrontState: "single-plus-shared",
         },
         {
           name: "test-new",


### PR DESCRIPTION
Follow up to #6533, where we test step 10 of onboarding a new council with a custom domain (`test-new`) and step 2 of migrating an existing custom domain (`test-legacy`).

After this, both custom domains ([legacy](https://planningserviceslegacy.planx.in) and [new](https://planningservices.planx.in)) should be in full working order, and we can check that cutover from legacy -> new is smooth with both running.

(steps refer to the revised docs in #6660) 