### PR TITLE
feat: Optimise and tidy empty state views

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -124,7 +124,7 @@ const NotificationsPanel = ({
       <Box sx={{ overflowY: "auto", flex: 1 }}>
         {!visibleNotifications.length && (
           <EmptyState
-            compact
+            size="small"
             title={
               tab === 0
                 ? "No active notifications"

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -9,12 +9,12 @@ import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
-import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { useNavigate } from "@tanstack/react-router";
 import NotificationCard from "pages/FlowEditor/components/Notifications/NotificationCard";
 import { Notification } from "pages/FlowEditor/components/Notifications/types";
 import { partitionBySuperseded } from "pages/FlowEditor/components/Notifications/utils";
 import { useState } from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import StyledTab from "ui/editor/StyledTab";
 
 interface Props {
@@ -123,15 +123,15 @@ const NotificationsPanel = ({
       <Divider />
       <Box sx={{ overflowY: "auto", flex: 1 }}>
         {!visibleNotifications.length && (
-          <Box sx={{ px: 2 }}>
-            <WarningContainer>
-              <Typography variant="body2" color="textSecondary">
-                {tab === 0
-                  ? "No active notifications."
-                  : "No resolved notifications."}
-              </Typography>
-            </WarningContainer>
-          </Box>
+          <EmptyState
+            compact
+            title={
+              tab === 0
+                ? "No active notifications"
+                : "No resolved notifications"
+            }
+            sx={{ mx: 2 }}
+          />
         )}
         <Stack>
           {visibleNotifications.map((notification) => (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -3,12 +3,12 @@ import { BREADCRUMBS_HEIGHT } from "components/Breadcrumbs";
 import { format } from "date-fns";
 import capitalize from "lodash/capitalize";
 import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";
 import SettingsSection from "ui/editor/SettingsSection";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
 import { dateFormatter } from "ui/shared/DataTable/utils";
-import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { ChangeStatusTool } from "./components/ChangeStatusTool";
 import { ExpandableHelpText } from "./components/ExpandableHelpText";
@@ -154,15 +154,10 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({
         </Typography>
       </SettingsSection>
       {feedback.length === 0 ? (
-        <SettingsSection>
-          <ErrorSummary
-            format="info"
-            heading={`No feedback found for this ${
-              isFlowLevel ? "service" : "team"
-            }`}
-            message="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
-          />
-        </SettingsSection>
+        <EmptyState
+          title={`No feedback found for this ${isFlowLevel ? "service" : "team"}`}
+          description="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
+        />
       ) : (
         <DataTable
           rows={feedback}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
@@ -65,7 +65,7 @@ export const Notifications = ({ notifications }: NotificationProps) => {
       <Container maxWidth="formWrap">
         {!visibleNotifications.length && (
           <EmptyState
-            compact
+            size="small"
             title={
               tab === 0
                 ? "No active notifications"

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
@@ -4,8 +4,8 @@ import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
-import { WarningContainer } from "@planx/components/shared/Preview/WarningContainer";
 import { useState } from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import StyledTab from "ui/editor/StyledTab";
 
 import NotificationCard from "./NotificationCard";
@@ -64,13 +64,15 @@ export const Notifications = ({ notifications }: NotificationProps) => {
       </Box>
       <Container maxWidth="formWrap">
         {!visibleNotifications.length && (
-          <WarningContainer>
-            <Typography variant="body2">
-              {tab === 0
-                ? "No active notifications."
-                : "No resolved notifications."}
-            </Typography>
-          </WarningContainer>
+          <EmptyState
+            compact
+            title={
+              tab === 0
+                ? "No active notifications"
+                : "No resolved notifications"
+            }
+            sx={{ mt: 0 }}
+          />
         )}
         {visibleNotifications.length > 0 && (
           <Stack sx={{ borderTop: "1px solid", borderColor: "border.main" }}>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
@@ -4,7 +4,7 @@ import ErrorFallback from "components/Error/ErrorFallback";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import SettingsSection from "ui/editor/SettingsSection";
+import { EmptyState } from "ui/editor/EmptyState";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import { ColumnConfig, ColumnFilterType } from "ui/shared/DataTable/types";
 import {
@@ -12,7 +12,6 @@ import {
   dateFormatter,
   defaultStringFilterOperator,
 } from "ui/shared/DataTable/utils";
-import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import {
   submissionEventTypes,
@@ -48,15 +47,10 @@ const EventsLog: React.FC<EventsLogProps> = ({
 
   if (submissions.length === 0)
     return (
-      <SettingsSection>
-        <ErrorSummary
-          format="info"
-          heading={`No payment or send events found for this ${
-            filterByFlow ? "service" : "team"
-          }`}
-          message="If you're looking for events before 1st January 2024, please contact a PlanX developer"
-        />
-      </SettingsSection>
+      <EmptyState
+        title={`No payment or send events found for this ${filterByFlow ? "service" : "team"}`}
+        description="If you're looking for events before 1st January 2024, please contact a PlanX developer"
+      />
     );
 
   const rowData = submissions.map((submission, index) => ({

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -7,6 +7,7 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 
 import { FlowCardView, FlowSummary } from "../../FlowEditor/lib/store/editor";
@@ -66,6 +67,10 @@ const Archive: React.FC<Props> = ({
       </Box>
     );
   }
+  if (!isFiltered && archivedFlows !== null && archivedFlows.length === 0) {
+    return <EmptyState title="No archived flows found" />;
+  }
+
   return (
     <>
       <Box
@@ -86,11 +91,13 @@ const Archive: React.FC<Props> = ({
             minHeight: "50px",
           }}
         >
-          <ShowingServicesHeader
-            matchedFlowsCount={archivedFlows?.length || 0}
-            isArchived
-            isFiltered={isFiltered}
-          />
+          {archivedFlows && archivedFlows.length > 0 && (
+            <ShowingServicesHeader
+              matchedFlowsCount={archivedFlows.length}
+              isArchived
+              isFiltered={isFiltered}
+            />
+          )}
           {isFiltered && (
             <Button onClick={onClearSearch} variant="link">
               Clear filters

--- a/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Flows.tsx
@@ -60,8 +60,9 @@ const Flows: React.FC<Props> = ({
   teamId,
   handleViewChange,
   slug,
+  flows,
 }) => {
-  const teamHasFlows = sortedFlows ? true : false;
+  const teamHasFlows = Boolean(flows && flows.length);
   const navigate = useNavigate();
 
   const sortedPinnedFlows =
@@ -101,10 +102,12 @@ const Flows: React.FC<Props> = ({
               minHeight: "50px",
             }}
           >
-            <ShowingServicesHeader
-              matchedFlowsCount={sortedFlows?.length || 0}
-              isFiltered={flowsHaveBeenFiltered}
-            />
+            {sortedFlows && sortedFlows.length > 0 && (
+              <ShowingServicesHeader
+                matchedFlowsCount={sortedFlows.length}
+                isFiltered={flowsHaveBeenFiltered}
+              />
+            )}
             {flowsHaveBeenFiltered && (
               <Button
                 onClick={() => {

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import { useSearch } from "@tanstack/react-router";
 import { isEmpty, orderBy } from "lodash";
 import React, { useEffect, useMemo, useState } from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import { InfoChip } from "ui/editor/InfoChip";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
@@ -11,8 +12,6 @@ import { useStore } from "../FlowEditor/lib/store";
 import { FlowCardView, FlowSummary } from "../FlowEditor/lib/store/editor";
 import { AddFlow } from "./components/AddFlow";
 import Archive from "./components/Archive";
-import { DashboardList } from "./components/DashboardList";
-import { Card, CardContent } from "./components/FlowCard/styles";
 import Flows from "./components/Flows";
 import { useGetArchivedFlows } from "./components/hooks/useGetArchivedFlows";
 import { useGetFlows } from "./components/hooks/useGetFlows";
@@ -22,15 +21,11 @@ import TeamLayout from "./TeamLayout";
 export type FlowView = "flows" | "archive";
 
 const GetStarted: React.FC = () => (
-  <DashboardList sx={{ paddingTop: 2 }}>
-    <Card>
-      <CardContent>
-        <Typography variant="h3">No services found</Typography>
-        <Typography>Get started by creating your first service</Typography>
-        <AddFlow />
-      </CardContent>
-    </Card>
-  </DashboardList>
+  <EmptyState
+    title="No flows found"
+    description="Get started by creating your first flow"
+    action={<AddFlow />}
+  />
 );
 
 interface TeamProps {
@@ -168,7 +163,7 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
               flexDirection: { xs: "column", contentWrap: "row" },
               justifyContent: "space-between",
               alignItems: { xs: "flex-start", contentWrap: "center" },
-              gap: 2,
+              minHeight: (theme) => theme.spacing(6),
             }}
           >
             <Box
@@ -185,7 +180,10 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
               {isTrial && <InfoChip label="Trial account" />}
               {showAddFlowButton && flowView === "flows" && <AddFlow />}
             </Box>
-            {(teamHasFlows || (flowView === "archive" && archivedFlows)) && (
+            {((flowView === "flows" && teamHasFlows) ||
+              (flowView === "archive" &&
+                archivedFlows &&
+                archivedFlows.length > 0)) && (
               <SearchBox<FlowSummary>
                 records={flowView === "archive" ? (archivedFlows ?? []) : flows}
                 setRecords={
@@ -232,7 +230,7 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
           />
         )}
 
-        {flows && !flows.length && <GetStarted />}
+        {flowView === "flows" && flows && !flows.length && <GetStarted />}
       </Container>
     </Box>
   );

--- a/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
@@ -3,37 +3,41 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
+type EmptyStateSize = "medium" | "small";
+
 interface EmptyStateProps {
   title?: string;
   description?: string;
   action?: React.ReactNode;
-  compact?: boolean;
+  size?: EmptyStateSize;
   sx?: BoxProps["sx"];
 }
 
 const Root = styled(Box, {
-  shouldForwardProp: (prop) => prop !== "compact",
-})<{ compact?: boolean }>(({ theme, compact }) => ({
+  shouldForwardProp: (prop) => prop !== "size",
+})<{ size?: EmptyStateSize }>(({ theme, size }) => ({
   marginTop: theme.spacing(2),
-  padding: compact ? theme.spacing(1.5) : theme.spacing(2.5),
+  padding: size === "small" ? theme.spacing(1.5) : theme.spacing(2.5),
   border: `4px solid ${theme.palette.border.light}`,
   backgroundColor: theme.palette.background.default,
   display: "flex",
   flexDirection: "column",
-  gap: compact ? theme.spacing(0.5) : theme.spacing(1.5),
+  gap: size === "small" ? theme.spacing(0.5) : theme.spacing(1.5),
 }));
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   action,
-  compact = false,
+  size = "medium",
   sx,
 }) => (
-  <Root compact={compact} sx={sx}>
-    {title && <Typography variant={compact ? "h4" : "h3"}>{title}</Typography>}
+  <Root size={size} sx={sx}>
+    {title && (
+      <Typography variant={size === "small" ? "h4" : "h3"}>{title}</Typography>
+    )}
     {description && (
-      <Typography variant={compact ? "body2" : "body1"}>
+      <Typography variant={size === "small" ? "body2" : "body1"}>
         {description}
       </Typography>
     )}

--- a/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
@@ -1,0 +1,42 @@
+import Box, { BoxProps } from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+interface EmptyStateProps {
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  compact?: boolean;
+  sx?: BoxProps["sx"];
+}
+
+const Root = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "compact",
+})<{ compact?: boolean }>(({ theme, compact }) => ({
+  marginTop: theme.spacing(2),
+  padding: compact ? theme.spacing(1.5) : theme.spacing(2.5),
+  border: `4px solid ${theme.palette.border.light}`,
+  backgroundColor: theme.palette.background.default,
+  display: "flex",
+  flexDirection: "column",
+  gap: compact ? theme.spacing(0.5) : theme.spacing(1.5),
+}));
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  action,
+  compact = false,
+  sx,
+}) => (
+  <Root compact={compact} sx={sx}>
+    {title && <Typography variant={compact ? "h4" : "h3"}>{title}</Typography>}
+    {description && (
+      <Typography variant={compact ? "body2" : "body1"}>
+        {description}
+      </Typography>
+    )}
+    {action}
+  </Root>
+);


### PR DESCRIPTION
## What does this PR do?

Currently when views are empty (no flows, no feedback, no submissions, no notifications) we use a mixture of `FlowCard`, `WarningContainer` and `ErrorSummary` to display the message.

Additionally the team flows view is overly cluttered when no flows are present, and as this is one of the first screens a new council will see, we want to keep it as clean as possible (screenshots below).

**Summary of changes:**
- Create a new `EmptyState` component, with slots for `title`, `description` and `action`
- Add to (when empty):
  - Flows screen
  - Feedback table
  - Submissions table
  - Notifications (panel and page)
- Simplify flows screen when no flows are present:
  - Remove filters (on flows)
  - Remove search input (on archive)
  - Remove view toggle
  - Remove table header
  - Remove "View x flows" header
- Update wording to refer to flows rather than a mixture of flows and services

**Testing:**
https://6663.planx.pizza/app/a-brand-new-team-without-any-flows

**Before changes:**
<img width="3032" height="1188" alt="image" src="https://github.com/user-attachments/assets/3961cf8d-ee60-4f03-9b2a-ae84017dceaf" />

<img width="3032" height="1188" alt="image" src="https://github.com/user-attachments/assets/b812e007-02cd-423e-979b-6d4f3a5149c2" />

**After changes:**
<img width="3032" height="804" alt="image" src="https://github.com/user-attachments/assets/e722eb30-a1b4-4e5a-aa6b-31d3835b6daa" />

<img width="3032" height="648" alt="image" src="https://github.com/user-attachments/assets/10ba99d7-d0b2-4b1f-900f-b4ab14dad51a" />
