### PR TITLE
chore(api): Additional logging on `markSessionAsSubmitted()`

### DIFF
--- a/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -229,7 +229,9 @@ const markSessionAsSubmitted = async (sessionId: string) => {
     `;
     await $api.client.request(mutation, { sessionId });
   } catch (error) {
-    throw new Error(`Error marking session ${sessionId} as submitted`);
+    throw new Error(
+      `Error marking session ${sessionId} as submitted. Error: ${error}`,
+    );
   }
 };
 


### PR DESCRIPTION
Additional logging to help debug this issue - https://planx.airbrake.io/projects/329753/groups/4319191530410710700?tab=overview

The sessions in question _has_ been marked as submitted in the DB, so this error may be thrown due to a duplicate call or other issue.

Notes added to Airbrake, will revisit when next thrown.