### PR TITLE
fix(lps): Do not return deleted sessions in query

### DIFF
--- a/apps/api.planx.uk/modules/lps/middleware/validateSessionStatus.ts
+++ b/apps/api.planx.uk/modules/lps/middleware/validateSessionStatus.ts
@@ -28,6 +28,7 @@ export const validateSessionStatus: GenerateDownloadToken = async (
           where: {
             system_status: { _eq: "active" }
             user_status: { _eq: "submitted" }
+            deleted_at: { _is_null: true }
             id: { _eq: $sessionId }
             email: { _eq: $email }
           }

--- a/apps/api.planx.uk/modules/lps/service/generateDownloadToken.test.ts
+++ b/apps/api.planx.uk/modules/lps/service/generateDownloadToken.test.ts
@@ -47,6 +47,27 @@ describe("generating a download token", () => {
       });
   });
 
+  /**
+   * lowcal_sessions_user_status() gives precedent to "submitted" over "expired"
+   * This means we need to explicity check for deleted_at value
+   * Otherwise, users could try to access data for a session which does not have data
+   */
+  it("returns 403 for a submitted session that has been soft-deleted", async () => {
+    queryMock.mockQuery({
+      name: "CheckDownloadableSessionExists",
+      matchOnVariables: false,
+      data: { lowcalSessions: [] },
+    });
+
+    await supertest(app)
+      .post(ENDPOINT)
+      .send({ email: NOTIFY_TEST_EMAIL, sessionId: uuidV4() })
+      .expect(403)
+      .then((res) => {
+        expect(res.body.error).toMatch(/Unauthorised/);
+      });
+  });
+
   it("handles GraphQL errors", async () => {
     queryMock.mockQuery({
       name: "CheckDownloadableSessionExists",

--- a/apps/api.planx.uk/modules/lps/service/getApplications/mutation.ts
+++ b/apps/api.planx.uk/modules/lps/service/getApplications/mutation.ts
@@ -26,7 +26,9 @@ export const CONSUME_MAGIC_LINK_MUTATION = gql`
           where: {
             # Fetch non-expired sessions...
             user_status: { _neq: "expired" }
-            # ..for services which still exist
+            # ...which are not soft-deleted ("submitted" takes precedence over "expired")
+            deleted_at: { _is_null: true }
+            # ...for services which still exist
             flow: {
               _and: [
                 { id: { _is_null: false } }


### PR DESCRIPTION
## What's the problem?
Users on LPS are trying to access deleted sessions to view them, and then failing to generate the HTML (as they do not have access to this data via row-level permissions).

Airbrake issue - https://planx.airbrake.io/projects/329753/groups/4273014255948764619?tab=overview

## What's the cause?
Our `user_status` computed field gives precedence to "submitted" over "deleted" meaning our `_neq: "expired"` check can fail. It's possible for a session to be both submitted and deleted (e.g 28 days post-submission), but the `user_status` column will always return "submitted". This means the session is returned when building the full list of applications in LPS, but if a user clicks on one to view the application and error will be thrown.

The `user_status` computed field [was introduced here](https://github.com/theopensystemslab/planx-new/pull/5155), and we had [a discussion about this precedence here](https://github.com/theopensystemslab/planx-new/pull/5155#discussion_r2318373837).

## What's the solution?
Explicitly filter out deleted sessions, and do not display them in LPS. This was our original intention with the following clause, I just missed this edge case -

```gql
# Fetch non-expired sessions...
user_status: { _neq: "expired" }
```

This regression was introduced here - https://github.com/theopensystemslab/planx-new/pull/5176/changes#diff-cdcbbc75ea4a4dd6c900d6411c9888d24b384b1fd8528d48e8feb6fd7a9c4b75

## Motivation
I'm working to try and clean up and resolve Airbrake issues - I've neglected these for too long...! This one is currently live and has occurred 183 times (5 since last deploy).