### PR TITLE
fix: Reduce notification lag

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/controller.ts
+++ b/apps/api.planx.uk/modules/flows/publish/controller.ts
@@ -2,14 +2,12 @@ import type { Node } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
 
 import { ServerError } from "../../../errors/index.js";
-import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { publishFlow } from "./service.js";
 
 interface PublishFlowResponse {
   message: string;
   alteredNodes?: Node[];
-  templatedFlowsScheduledEventsResponse?: CreateScheduledEventResponse[];
 }
 
 export const publishFlowSchema = z.object({
@@ -42,8 +40,6 @@ export const publishFlowController: PublishFlowController = async (
         ? "Changes published"
         : "No new changes to publish",
       alteredNodes: response?.alteredNodes,
-      templatedFlowsScheduledEventsResponse:
-        response?.templatedFlowsScheduledEventsResponse,
     });
   } catch (error) {
     return next(

--- a/apps/api.planx.uk/modules/flows/publish/controller.ts
+++ b/apps/api.planx.uk/modules/flows/publish/controller.ts
@@ -2,12 +2,14 @@ import type { Node } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
 
 import { ServerError } from "../../../errors/index.js";
+import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
 import { publishFlow } from "./service.js";
 
 interface PublishFlowResponse {
   message: string;
   alteredNodes?: Node[];
+  templatedFlowsScheduledEventsResponse?: CreateScheduledEventResponse[];
 }
 
 export const publishFlowSchema = z.object({
@@ -40,6 +42,8 @@ export const publishFlowController: PublishFlowController = async (
         ? "Changes published"
         : "No new changes to publish",
       alteredNodes: response?.alteredNodes,
+      templatedFlowsScheduledEventsResponse:
+        response?.templatedFlowsScheduledEventsResponse,
     });
   } catch (error) {
     return next(

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -10,6 +10,7 @@ import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
 import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
 import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import { userContext } from "../../auth/middleware.js";
+import { resolveNotification } from "../../notifications/service.js";
 import { buildNodeTypeSet, createFlowTypeMap } from "../validate/helpers.js";
 
 interface PublishFlow {
@@ -32,7 +33,7 @@ export const publishFlow = async (
 ): Promise<{
   alteredNodes: Node[];
   templatedFlowsScheduledEventsResponse?: CreateScheduledEventResponse[];
-  resolveNotificationsScheduledEventResponse?: CreateScheduledEventResponse;
+  resolvedNotificationIds?: { id: number }[];
 } | null> => {
   const userId = userContext.getStore()?.user?.sub;
   if (!userId) throw Error("User details missing from request");
@@ -130,8 +131,8 @@ export const publishFlow = async (
         createScheduledEvent({
           webhook: `{{HASURA_PLANX_API_URL}}/flows/${flowId}/update-templated-flow/${templatedFlowId}`,
           schedule_at: new Date(
-            new Date().getTime() + (i > 0 ? i * 10 : 0) * 1000,
-          ), // Stagger events by 10 seconds starting at "now"
+            new Date().getTime() + (i > 0 ? i * 2 : 0) * 1000,
+          ), // Stagger events by 2 seconds starting at "now"
           payload: {
             sourceFlowId: flowId,
             templatedFlowId: templatedFlowId,
@@ -142,25 +143,18 @@ export const publishFlow = async (
     );
   }
 
-  // If we're publishing a templated flow, queue up an event to resolve any of its' active publish notifications
-  let resolveNotificationsScheduledEventResponse:
-    | CreateScheduledEventResponse
-    | undefined;
+  // If we're publishing a templated flow, directly resolve any of its' active publish notifications
+  let resolvedNotificationIds: { id: number }[] | undefined;
   if (response?.publishedFlow?.flow?.templatedFrom) {
-    resolveNotificationsScheduledEventResponse = await createScheduledEvent({
-      webhook: `{{HASURA_PLANX_API_URL}}/resolve-notification`,
-      schedule_at: new Date(), // now
-      payload: {
-        flowId: flowId,
-        type: "updated_templated_flow",
-      },
-      comment: `resolve_notification_on_templated_flow_publish_${flowId}`,
-    });
+    resolvedNotificationIds = await resolveNotification(
+      flowId,
+      "updated_templated_flow",
+    );
   }
 
   return {
     alteredNodes,
     templatedFlowsScheduledEventsResponse,
-    resolveNotificationsScheduledEventResponse,
+    resolvedNotificationIds,
   };
 };

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -130,8 +130,8 @@ export const publishFlow = async (
         createScheduledEvent({
           webhook: `{{HASURA_PLANX_API_URL}}/flows/${flowId}/update-templated-flow/${templatedFlowId}`,
           schedule_at: new Date(
-            new Date().getTime() + (i > 0 ? i * 2 : 0) * 1000,
-          ), // Stagger events by 2 seconds starting at "now"
+            new Date().getTime() + (i > 0 ? i * 5 : 0) * 1000,
+          ), // Stagger events by 5 seconds starting at "now"
           payload: {
             sourceFlowId: flowId,
             templatedFlowId: templatedFlowId,

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -7,9 +7,9 @@ import { gql } from "graphql-request";
 import * as jsondiffpatch from "jsondiffpatch";
 import { getClient } from "../../../client/index.js";
 import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
+import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
+import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import { userContext } from "../../auth/middleware.js";
-import { resolveNotification } from "../../notifications/service.js";
-import { updateTemplatedFlow } from "../updateTemplatedFlow/service.js";
 import { buildNodeTypeSet, createFlowTypeMap } from "../validate/helpers.js";
 
 interface PublishFlow {
@@ -31,7 +31,8 @@ export const publishFlow = async (
   templatedFlowIds?: string[],
 ): Promise<{
   alteredNodes: Node[];
-  resolvedNotificationIds?: { id: number }[];
+  templatedFlowsScheduledEventsResponse?: CreateScheduledEventResponse[];
+  resolveNotificationsScheduledEventResponse?: CreateScheduledEventResponse;
 } | null> => {
   const userId = userContext.getStore()?.user?.sub;
   if (!userId) throw Error("User details missing from request");
@@ -119,31 +120,47 @@ export const publishFlow = async (
     ...publishedFlow[key],
   }));
 
-  // If we're publishing a source flow, directly update each templated flow without blocking the response
-  if (templatedFlowIds && templatedFlowIds.length > 0) {
-    Promise.all(
-      templatedFlowIds.map((templatedFlowId) =>
-        updateTemplatedFlow(flowId, templatedFlowId).catch((err) =>
-          console.error(
-            `Failed to update templated flow ${templatedFlowId}:`,
-            err,
-          ),
-        ),
+  // If we're publishing a source flow, queue up events to additionally update each of its' templated flows
+  let templatedFlowsScheduledEventsResponse:
+    | CreateScheduledEventResponse[]
+    | undefined;
+  if (templatedFlowIds && templatedFlowIds?.length > 0) {
+    templatedFlowsScheduledEventsResponse = await Promise.all(
+      templatedFlowIds.map((templatedFlowId, i) =>
+        createScheduledEvent({
+          webhook: `{{HASURA_PLANX_API_URL}}/flows/${flowId}/update-templated-flow/${templatedFlowId}`,
+          schedule_at: new Date(
+            new Date().getTime() + (i > 0 ? i * 2 : 0) * 1000,
+          ), // Stagger events by 2 seconds starting at "now"
+          payload: {
+            sourceFlowId: flowId,
+            templatedFlowId: templatedFlowId,
+          },
+          comment: `update_templated_flow_${templatedFlowId}`,
+        }),
       ),
     );
   }
 
-  // If we're publishing a templated flow, directly resolve any of its' active publish notifications
-  let resolvedNotificationIds: { id: number }[] | undefined;
+  // If we're publishing a templated flow, queue up an event to resolve any of its' active publish notifications
+  let resolveNotificationsScheduledEventResponse:
+    | CreateScheduledEventResponse
+    | undefined;
   if (response?.publishedFlow?.flow?.templatedFrom) {
-    resolvedNotificationIds = await resolveNotification(
-      flowId,
-      "updated_templated_flow",
-    );
+    resolveNotificationsScheduledEventResponse = await createScheduledEvent({
+      webhook: `{{HASURA_PLANX_API_URL}}/resolve-notification`,
+      schedule_at: new Date(), // now
+      payload: {
+        flowId: flowId,
+        type: "updated_templated_flow",
+      },
+      comment: `resolve_notification_on_templated_flow_publish_${flowId}`,
+    });
   }
 
   return {
     alteredNodes,
-    resolvedNotificationIds,
+    templatedFlowsScheduledEventsResponse,
+    resolveNotificationsScheduledEventResponse,
   };
 };

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -7,10 +7,9 @@ import { gql } from "graphql-request";
 import * as jsondiffpatch from "jsondiffpatch";
 import { getClient } from "../../../client/index.js";
 import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
-import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
-import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
 import { userContext } from "../../auth/middleware.js";
 import { resolveNotification } from "../../notifications/service.js";
+import { updateTemplatedFlow } from "../updateTemplatedFlow/service.js";
 import { buildNodeTypeSet, createFlowTypeMap } from "../validate/helpers.js";
 
 interface PublishFlow {
@@ -32,7 +31,6 @@ export const publishFlow = async (
   templatedFlowIds?: string[],
 ): Promise<{
   alteredNodes: Node[];
-  templatedFlowsScheduledEventsResponse?: CreateScheduledEventResponse[];
   resolvedNotificationIds?: { id: number }[];
 } | null> => {
   const userId = userContext.getStore()?.user?.sub;
@@ -121,24 +119,16 @@ export const publishFlow = async (
     ...publishedFlow[key],
   }));
 
-  // If we're publishing a source flow, queue up events to additionally update each of its' templated flows
-  let templatedFlowsScheduledEventsResponse:
-    | CreateScheduledEventResponse[]
-    | undefined;
-  if (templatedFlowIds && templatedFlowIds?.length > 0) {
-    templatedFlowsScheduledEventsResponse = await Promise.all(
-      templatedFlowIds.map((templatedFlowId, i) =>
-        createScheduledEvent({
-          webhook: `{{HASURA_PLANX_API_URL}}/flows/${flowId}/update-templated-flow/${templatedFlowId}`,
-          schedule_at: new Date(
-            new Date().getTime() + (i > 0 ? i * 2 : 0) * 1000,
-          ), // Stagger events by 2 seconds starting at "now"
-          payload: {
-            sourceFlowId: flowId,
-            templatedFlowId: templatedFlowId,
-          },
-          comment: `update_templated_flow_${templatedFlowId}`,
-        }),
+  // If we're publishing a source flow, directly update each templated flow without blocking the response
+  if (templatedFlowIds && templatedFlowIds.length > 0) {
+    Promise.all(
+      templatedFlowIds.map((templatedFlowId) =>
+        updateTemplatedFlow(flowId, templatedFlowId).catch((err) =>
+          console.error(
+            `Failed to update templated flow ${templatedFlowId}:`,
+            err,
+          ),
+        ),
       ),
     );
   }
@@ -154,7 +144,6 @@ export const publishFlow = async (
 
   return {
     alteredNodes,
-    templatedFlowsScheduledEventsResponse,
     resolvedNotificationIds,
   };
 };

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -95,9 +95,9 @@ function EditorNavMenu() {
 
   const teamAnalyticsLink = useTeamAnalyticsLink();
   const flowAnalyticsLink = useFlowAnalyticsLink();
-  const notificationsCount = useNotificationsCount(teamSlug);
+  const notificationsCount = useNotificationsCount();
   const { active: activeNotifications, resolved: resolvedNotifications } =
-    useRecentNotifications(teamSlug);
+    useRecentNotifications();
 
   const globalLayoutSections: MenuSection[] = [
     {

--- a/apps/editor.planx.uk/src/hooks/data/useNotificationsCount.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useNotificationsCount.ts
@@ -1,13 +1,11 @@
-import { gql, useQuery } from "@apollo/client";
+import { gql, useSubscription } from "@apollo/client";
 import { hasFeatureFlag } from "lib/featureFlags";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 const GET_UNRESOLVED_NOTIFICATIONS = gql`
-  query GetUnresolvedNotificationsForTeam($teamSlug: String!) {
+  subscription GetUnresolvedNotificationsForTeam($teamId: Int!) {
     notifications(
-      where: {
-        team: { slug: { _eq: $teamSlug } }
-        resolved_at: { _is_null: true }
-      }
+      where: { team_id: { _eq: $teamId }, resolved_at: { _is_null: true } }
       distinct_on: flow_id
     ) {
       id
@@ -19,10 +17,12 @@ interface QueryResult {
   notifications: { id: number }[];
 }
 
-export const useNotificationsCount = (teamSlug?: string): number => {
-  const { data } = useQuery<QueryResult>(GET_UNRESOLVED_NOTIFICATIONS, {
-    variables: { teamSlug },
-    skip: !teamSlug || !hasFeatureFlag("NOTIFICATIONS"),
+export const useNotificationsCount = (): number => {
+  const teamId = useStore((state) => state.teamId);
+
+  const { data } = useSubscription<QueryResult>(GET_UNRESOLVED_NOTIFICATIONS, {
+    variables: { teamId },
+    skip: !teamId || !hasFeatureFlag("NOTIFICATIONS"),
   });
 
   return data?.notifications?.length ?? 0;

--- a/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
@@ -1,6 +1,7 @@
-import { gql, useQuery } from "@apollo/client";
+import { gql, useSubscription } from "@apollo/client";
 import { hasFeatureFlag } from "lib/featureFlags";
 import { Notification } from "pages/FlowEditor/components/Notifications/types";
+import { useStore } from "pages/FlowEditor/lib/store";
 
 const NOTIFICATION_FIELDS = gql`
   fragment NotificationFields on notifications {
@@ -21,23 +22,23 @@ const NOTIFICATION_FIELDS = gql`
   }
 `;
 
-const GET_PANEL_NOTIFICATIONS = gql`
+const GET_ACTIVE_NOTIFICATIONS = gql`
   ${NOTIFICATION_FIELDS}
-  query GetPanelNotificationsForTeam($teamSlug: String!) {
+  subscription GetActiveNotificationsForTeam($teamId: Int!) {
     active: notifications(
-      where: {
-        team: { slug: { _eq: $teamSlug } }
-        resolved_at: { _is_null: true }
-      }
+      where: { team_id: { _eq: $teamId }, resolved_at: { _is_null: true } }
       order_by: { created_at: desc }
     ) {
       ...NotificationFields
     }
+  }
+`;
+
+const GET_RESOLVED_NOTIFICATIONS = gql`
+  ${NOTIFICATION_FIELDS}
+  subscription GetResolvedNotificationsForTeam($teamId: Int!) {
     resolved: notifications(
-      where: {
-        team: { slug: { _eq: $teamSlug } }
-        resolved_at: { _is_null: false }
-      }
+      where: { team_id: { _eq: $teamId }, resolved_at: { _is_null: false } }
       order_by: { created_at: desc }
       limit: 5
     ) {
@@ -46,21 +47,25 @@ const GET_PANEL_NOTIFICATIONS = gql`
   }
 `;
 
-interface QueryResult {
+export const useRecentNotifications = (): {
   active: Notification[];
   resolved: Notification[];
-}
+} => {
+  const teamId = useStore((state) => state.teamId);
+  const skip = !teamId || !hasFeatureFlag("NOTIFICATIONS");
 
-export const useRecentNotifications = (
-  teamSlug?: string,
-): { active: Notification[]; resolved: Notification[] } => {
-  const { data } = useQuery<QueryResult>(GET_PANEL_NOTIFICATIONS, {
-    variables: { teamSlug },
-    skip: !teamSlug || !hasFeatureFlag("NOTIFICATIONS"),
-  });
+  const { data: activeData } = useSubscription<{ active: Notification[] }>(
+    GET_ACTIVE_NOTIFICATIONS,
+    { variables: { teamId }, skip },
+  );
+
+  const { data: resolvedData } = useSubscription<{ resolved: Notification[] }>(
+    GET_RESOLVED_NOTIFICATIONS,
+    { variables: { teamId }, skip },
+  );
 
   return {
-    active: data?.active ?? [],
-    resolved: data?.resolved ?? [],
+    active: activeData?.active ?? [],
+    resolved: resolvedData?.resolved ?? [],
   };
 };


### PR DESCRIPTION
## What does this PR do?

Feature flag:
```
window.featureFlags.toggle("NOTIFICATIONS")
```

Currently notifications are running on a Hasura scheduled event, causing a significant lag to notification updates.

Switching to `useSubscription` allows near instant updates.