### PR TITLE
fix(api): Supress CORS error logging

### DIFF
--- a/apps/api.planx.uk/cors.ts
+++ b/apps/api.planx.uk/cors.ts
@@ -15,7 +15,7 @@ const checkAllowedOrigins: CorsOptions["origin"] = (origin, callback) => {
 
   isTest || isDevelopment || isAllowed || isMapDocs
     ? callback(null, true)
-    : callback(new Error(`Not allowed by CORS. Origin: ${origin}`));
+    : callback(null, false);
 };
 
 const apiCors = cors({


### PR DESCRIPTION
Another noisy Airbrake error we can tidy up 🗑️ 🧹 

When somebody hits a CORS issue, we should not throw an error - it's the "correct" response and not an application error we can action and fix.

By just responding here with `callback(null, false)` we omit the `Access-Control-Allow-Origin` header and block the request.