### PR TITLE
fix(editor): Default value of `SelectMultiple` must be array

### DIFF
--- a/apps/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SelectMultiple.tsx
@@ -55,6 +55,7 @@ export function SelectMultiple<T>(props: Props<T>) {
   // MUI doesn't pass the Autocomplete value along to the TextField automatically
   const isSelectEmpty = !props.value?.length;
   const placeholder = isSelectEmpty ? props.placeholder : undefined;
+  const value = props.value || [];
 
   return (
     <FormControl sx={{ display: "flex", flexDirection: "column" }}>
@@ -95,6 +96,7 @@ export function SelectMultiple<T>(props: Props<T>) {
           },
         }}
         {...props}
+        value={value}
       />
     </FormControl>
   );


### PR DESCRIPTION
## What's the problem?
In MUI v9, `useAutocomplete` no longer gracefully handles `value={undefined}` when `multiple={true}`. It seems to read `selectedValues.length` directly without a fallback in place. MUI actually has this prop type set at `any` which is why this isn't caught by the type system - https://mui.com/material-ui/api/select/#select-prop-value

No real user impact here, just Airbrake noise I'm trying to work on.

This resolves the following Airbrake error - https://planx.airbrake.io/projects/329753/groups/4330870364369425909?tab=overview

## What's the solution?
Ensure we always pass an array be default here. 

## Testing
On staging - 
 - open a `NextSteps` component (I'm sure others trigger this also - I just hit this one first)
 - fill out the form (don't set any tags e.g. `To review`)
 - close modal
 - error logged in console
 
 Repeat on Pizza, no issue! ✅ 
