### PR TITLE
fix(api): Supress missing JWT errors

### DIFF
--- a/apps/api.planx.uk/errors/requestHandlers.ts
+++ b/apps/api.planx.uk/errors/requestHandlers.ts
@@ -22,6 +22,34 @@ export const expiredJWTHandler: ErrorRequestHandler = (
 };
 
 /**
+ * Handle missing JWTs from autheneticated routes - likely requests from bots, frontend errors, or frontend race conditions
+ * Log request context for debugging but do not send to Airbrake
+ */
+export const noTokenHandler: ErrorRequestHandler = (
+  errorObject,
+  req,
+  res,
+  next,
+) => {
+  const isMissingTokenError =
+    errorObject?.name === "UnauthorizedError" &&
+    errorObject?.message === "No authorization token was found";
+
+  if (!isMissingTokenError) return next(errorObject);
+
+  console.debug({
+    message: "Request missing auth token",
+    method: req.method,
+    path: req.path,
+    userAgent: req.headers["user-agent"],
+    referer: req.headers["referer"],
+    ip: req.ip,
+  });
+
+  return res.status(401).send({ error: "No authorization token was found" });
+};
+
+/**
  * Fallback error handler
  * Must be final Express middleware
  */

--- a/apps/api.planx.uk/server.ts
+++ b/apps/api.planx.uk/server.ts
@@ -11,7 +11,11 @@ import { pinoHttp } from "pino-http";
 
 import { defaultCors } from "./cors.js";
 import { useSwaggerDocs } from "./docs/index.js";
-import { errorHandler, expiredJWTHandler } from "./errors/requestHandlers.js";
+import {
+  errorHandler,
+  expiredJWTHandler,
+  noTokenHandler,
+} from "./errors/requestHandlers.js";
 import adminRoutes from "./modules/admin/routes.js";
 import aiRoutes from "./modules/ai/routes.js";
 import analyticsRoutes from "./modules/analytics/routes.js";
@@ -132,6 +136,7 @@ app.use(webhookRoutes);
 
 // Handle any server errors that were passed with next(err)
 // Order is significant, these should be the final app.use()
+app.use(noTokenHandler);
 app.use(expiredJWTHandler);
 app.use(errorHandler);
 


### PR DESCRIPTION
Follow up to #6669, this PR stops us logging an Airbrake error for invalid / missing JWT.

This isn't really a bug but the expected behaviour for unauthenticated requests - there's no action we can take here to resolve these, and the errors just cause noise in Airbrake (222 occurrences, 13 since last deploy).

Just logging these out is sufficient if we want to debug issues around these requests.

The middleware pattern implemented here follows the suggestion in the `express-jwt` `README.md` here - https://github.com/auth0/express-jwt#error-handling