### PR TITLE
[infra] minor fixes to smooth prod deploy

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -376,7 +376,7 @@ export = async () => {
   // note the mix of AWS and Cloudflare infra being provisioned here
   // TODO: should this be provisioned in the certs layer, or all consolidated here? should that be run in CI? etc.
   const editorSslCert = new aws.acm.Certificate(
-    `sslCert-editor`,
+    `sslCert`,
     {
       domainName: cloudfrontDomains[0],
       validationMethod: "DNS",
@@ -388,9 +388,9 @@ export = async () => {
   );
 
   // here we control the nameserver, so handle the DNS validation ourselves
-  const cloudfrontValidationRecords = cloudfrontDomains.map((_domain, index) => {
+  const editorCloudfrontValidationRecords = cloudfrontDomains.map((_domain, index) => {
     return new cloudflare.DnsRecord(
-      `sslCertValidationRecord-editor-${index}`,
+      `sslCertValidationRecord-${index}`,
       {
         name: editorSslCert.domainValidationOptions[index].resourceRecordName,
         type: editorSslCert.domainValidationOptions[index].resourceRecordType,
@@ -402,11 +402,11 @@ export = async () => {
     );
   });
 
-  const sslCertValidation = new aws.acm.CertificateValidation(
-    `sslCertValidation-editor`,
+  const editorSslCertValidation = new aws.acm.CertificateValidation(
+    `sslCertValidation`,
     {
       certificateArn: editorSslCert.arn,
-      validationRecordFqdns: cloudfrontValidationRecords.map(record => record.name),
+      validationRecordFqdns: editorCloudfrontValidationRecords.map(record => record.name),
     },
     { provider: usEast1 }
   );
@@ -437,7 +437,7 @@ export = async () => {
   });
 
   // ----------------------- LocalPlanning.services
-  createLocalPlanningServices(sslCertValidation.certificateArn);
+  createLocalPlanningServices(editorSslCertValidation.certificateArn);
 
   return {
     legacyDistributions,

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -68,7 +68,6 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           name: "gloucester",
           domain: "planningservices.gloucester.gov.uk",
           cloudFrontState: "single-plus-validation",
-          certificateLocation: "pulumiConfig",
         },
         {
           name: "epsom-and-ewell",


### PR DESCRIPTION
As per title, I introduced some changes during infra work that may cause unnecessary problems at deploy (e.g. having to manually delete DNS records in Cloudflare). This should be merged before we roll prod deploy #6681.

Also Gloucester somehow got left with Pulumi creds when it's now on AWS secrets, so this corrects that too.