### PR TITLE
chore: re-organise `dataMerged` and improve test coverage

### DIFF
--- a/apps/api.planx.uk/helpers.test.ts
+++ b/apps/api.planx.uk/helpers.test.ts
@@ -1,16 +1,5 @@
-import { ComponentType } from "@opensystemslab/planx-core/types";
-import {
-  dataMerged,
-  getFlowData,
-  getFormattedEnvironment,
-  isLiveEnv,
-} from "./helpers.js";
+import { getFlowData, getFormattedEnvironment, isLiveEnv } from "./helpers.js";
 import { queryMock } from "./tests/graphqlQueryMock.js";
-import {
-  childFlow,
-  draftParentFlow,
-  flattenedParentFlow,
-} from "./tests/mocks/validateAndPublishMocks.js";
 
 describe("getFormattedEnvironment() function", () => {
   const OLD_ENV = process.env;
@@ -68,111 +57,6 @@ describe("isLiveEnv() function", () => {
       process.env.NODE_ENV = env;
       expect(isLiveEnv()).toBe(false);
     });
-  });
-});
-
-describe("dataMerged() function", () => {
-  beforeEach(() => {
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: true,
-      variables: {
-        id: "parent-flow-with-external-portal",
-      },
-      data: {
-        flow: {
-          data: draftParentFlow,
-          slug: "parent-flow",
-          team_id: 1,
-          team: {
-            slug: "testing",
-          },
-          publishedFlows: [{ data: flattenedParentFlow }],
-        },
-      },
-    });
-  });
-
-  it("flattens published external portal nodes by overwriting their type", async () => {
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: true,
-      variables: {
-        id: "child-flow-id",
-      },
-      data: {
-        flow: {
-          data: childFlow,
-          slug: "child-flow",
-          team_id: 1,
-          team: {
-            slug: "testing",
-          },
-          publishedFlows: [{ data: childFlow }],
-        },
-      },
-    });
-
-    const result = await dataMerged("parent-flow-with-external-portal");
-    const nodeTypes = Object.values(result).map((node) =>
-      "type" in node ? node.type : undefined,
-    );
-
-    expect(nodeTypes.includes(ComponentType.ExternalPortal)).toBe(false);
-  });
-
-  it("throws an error when an external portal is not published", async () => {
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: true,
-      variables: {
-        id: "child-flow-id",
-      },
-      data: {
-        flow: {
-          data: childFlow,
-          slug: "child-flow",
-          team_id: 1,
-          team: {
-            slug: "testing",
-          },
-          publishedFlows: [],
-        },
-      },
-    });
-
-    await expect(
-      dataMerged("parent-flow-with-external-portal"),
-    ).rejects.toThrow();
-  });
-
-  it("flattens any published or draft external portal nodes when isDraftData only is set to true", async () => {
-    queryMock.mockQuery({
-      name: "GetFlowData",
-      matchOnVariables: true,
-      variables: {
-        id: "child-flow-id",
-      },
-      data: {
-        flow: {
-          data: childFlow,
-          slug: "child-flow",
-          team_id: 1,
-          team: {
-            slug: "testing",
-          },
-          publishedFlows: [],
-        },
-      },
-    });
-
-    const result = await dataMerged(
-      "parent-flow-with-external-portal",
-      {},
-      false,
-      true,
-    );
-    expect(result).toEqual(flattenedParentFlow);
   });
 });
 

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -1,5 +1,4 @@
-import type { FlowGraph, FlowStatus } from "@opensystemslab/planx-core/types";
-import { ComponentType } from "@opensystemslab/planx-core/types";
+import type { FlowStatus } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
 import capitalize from "lodash/capitalize.js";
 
@@ -377,97 +376,6 @@ export const getTemplatedFlowEdits = async (flowId: string) => {
 };
 
 /**
- * Flatten a flow to create a single JSON representation of the main flow data and any external portals
- *   By default, requires that any external portals are published and flattens their latest published version
- *   When draftDataOnly = true, flattens the draft data of the main flow and the draft data of any external portals published or otherwise
- */
-const dataMerged = async (
-  id: string,
-  ob: { [key: string]: Node } = {},
-  isPortal = false,
-  draftDataOnly = false,
-): Promise<FlowGraph> => {
-  // get the primary draft flow data, including its' latest published version
-  const response = await getFlowData(id);
-  const { slug, team, publishedFlows } = response;
-  let { data } = response;
-
-  // only flatten external portals that are published, unless we're loading draftDataOnly
-  if (isPortal && !draftDataOnly) {
-    if (publishedFlows?.[0]?.data) {
-      data = publishedFlows[0].data;
-    } else {
-      throw new Error(
-        `Publish flow ${team.slug}/${slug} before proceeding. All flows used as external portals must be published.`,
-      );
-    }
-  }
-
-  // recursively get and flatten external portals
-  for (const [nodeId, node] of Object.entries(data)) {
-    const isExternalPortalRoot =
-      nodeId === "_root" && Object.keys(ob).length > 0;
-    const isExternalPortal = node.type === ComponentType.ExternalPortal;
-    const isMerged = ob[node.data?.flowId];
-
-    // merge external portal _root node as a new node in the graph using its' flowId as nodeId
-    if (isExternalPortalRoot) {
-      ob[id] = {
-        ...node, // includes _root edges for navigation to all child nodes in this portal
-        type: ComponentType.InternalPortal,
-        data: {
-          text: `${team.slug}/${slug}`,
-          flattenedFromExternalPortal: true,
-          templatedFrom: response.templatedFrom,
-          // add extra metadata about latest published version when applicable
-          ...(!draftDataOnly && {
-            publishedFlowId: publishedFlows?.[0]?.id,
-            publishedAt: publishedFlows?.[0]?.created_at,
-            publishedBy: publishedFlows?.[0]?.publisher_id,
-            summary: publishedFlows?.[0]?.summary,
-          }),
-        },
-      };
-    }
-
-    // merge external portal type node as an internal portal type node, with an edge pointing to flowId (to navigate to the externalPortalRoot set above)
-    else if (isExternalPortal) {
-      ob[nodeId] = {
-        type: ComponentType.InternalPortal,
-        edges: [node.data?.flowId],
-        data: {
-          flattenedFromExternalPortal: true,
-        },
-      };
-
-      // recursively merge flow
-      if (!isMerged) {
-        await dataMerged(node.data?.flowId, ob, true, draftDataOnly);
-      }
-    }
-
-    // merge all other nodes
-    else ob[nodeId] = node;
-  }
-
-  // for every external portal that has been merged, confirm its' latest version was merged. If not, overwrite older snapshot with newest version
-  //   ** this is a final/separate step because older snapshots can be nested in _already_ flattened data (eg not picked up as ComponentType.ExternalPortal above)
-  if (!draftDataOnly) {
-    for (const [nodeId, node] of Object.entries(ob).filter(
-      ([_nodeId, node]) => node.data?.publishedFlowId,
-    )) {
-      const mostRecentPublishedFlowId =
-        await getMostRecentPublishedFlowVersion(nodeId);
-      if (mostRecentPublishedFlowId !== node.data?.publishedFlowId) {
-        await dataMerged(nodeId, ob, true, draftDataOnly);
-      }
-    }
-  }
-
-  return ob as FlowGraph;
-};
-
-/**
  * For any node with edges, recursively find all of its' children nodes and return them as their own flow-like data structure
  */
 const getChildren = (
@@ -537,13 +445,12 @@ const getFormattedEnvironment = (): string => {
 };
 
 export {
+  createFlow,
+  getChildren,
   getFlowData,
+  getFormattedEnvironment,
   getMostRecentPublishedFlow,
   getMostRecentPublishedFlowVersion,
-  dataMerged,
-  getChildren,
-  makeUniqueFlow,
-  createFlow,
   isLiveEnv,
-  getFormattedEnvironment,
+  makeUniqueFlow,
 };

--- a/apps/api.planx.uk/modules/flows/flattenFlow/controller.ts
+++ b/apps/api.planx.uk/modules/flows/flattenFlow/controller.ts
@@ -1,8 +1,8 @@
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { z } from "zod";
 import { ServerError } from "../../../errors/index.js";
+import { dataMerged } from "../../../shared/dataMerged.js";
 import type { ValidatedRequestHandler } from "../../../shared/middleware/validate.js";
-import { dataMerged } from "../../../helpers.js";
 
 type FlattenFlowDataResponse = FlowGraph;
 

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -6,9 +6,10 @@ import {
 import { gql } from "graphql-request";
 import * as jsondiffpatch from "jsondiffpatch";
 import { getClient } from "../../../client/index.js";
-import { dataMerged, getMostRecentPublishedFlow } from "../../../helpers.js";
+import { getMostRecentPublishedFlow } from "../../../helpers.js";
 import { createScheduledEvent } from "../../../lib/hasura/metadata/index.js";
 import type { CreateScheduledEventResponse } from "../../../lib/hasura/metadata/types.js";
+import { dataMerged } from "../../../shared/dataMerged.js";
 import { userContext } from "../../auth/middleware.js";
 import { buildNodeTypeSet, createFlowTypeMap } from "../validate/helpers.js";
 

--- a/apps/api.planx.uk/modules/flows/validate/service/index.ts
+++ b/apps/api.planx.uk/modules/flows/validate/service/index.ts
@@ -7,18 +7,18 @@ import type {
 import * as jsondiffpatch from "jsondiffpatch";
 
 import {
-  dataMerged,
   getHistory,
   getMostRecentPublishedFlow,
   getTemplatedFlows,
   type FlowHistoryEntry,
 } from "../../../../helpers.js";
+import { dataMerged } from "../../../../shared/dataMerged.js";
 import { validateFees } from "./fees.js";
 import { validateInviteToPay } from "./inviteToPay.js";
 import { validatePlanningConstraints } from "./planningConstraints.js";
 import { validateSections } from "./sections.js";
-import { validateTemplatedNodes } from "./templatedNodes.js";
 import { validateSend } from "./send.js";
+import { validateTemplatedNodes } from "./templatedNodes.js";
 
 type AlteredNode = {
   id: string;

--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -1,0 +1,644 @@
+import {
+  ComponentType,
+  type FlowGraph,
+  type Value,
+} from "@opensystemslab/planx-core/types";
+
+import { queryMock } from "../tests/graphqlQueryMock.js";
+import { dataMerged } from "./dataMerged.js";
+
+describe("dataMerged() function", () => {
+  beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "parent-flow",
+      },
+      data: {
+        flow: {
+          data: draftParentFlow,
+          slug: "parent-flow",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [{ data: flattenedParentFlow }],
+        },
+      },
+    });
+  });
+
+  it("flattens published nested flows by default", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowA,
+          slug: "nested-a",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowA,
+            },
+          ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowB,
+          slug: "nested-b",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowB,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await dataMerged("parent-flow");
+    expect(result).toEqual(flattenedParentFlow);
+  });
+
+  it("flattens draft nested flows when draftDataOnly is set to true", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowA,
+          slug: "nested-a",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [{ data: publishedNestedFlowA }],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowB,
+          slug: "nested-b",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [{ data: publishedNestedFlowB }],
+        },
+      },
+    });
+
+    const result = await dataMerged("parent-flow", {}, false, true);
+    expect(result).toEqual(flattenedParentFlowDraftOnly);
+  });
+
+  it("only fetches a unique flow reference once even if it is nested in multiple locations", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowA,
+          slug: "nested-a",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowA,
+            },
+          ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowB,
+          slug: "nested-b",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowB,
+            },
+          ],
+        },
+      },
+    });
+
+    await dataMerged("parent-flow");
+    expect(queryMock.getCalls().length).toEqual(3); // 3 = 1x parent-flow, 1x nested-a (even though nested 2 unique locations), 1x nested-b
+  });
+
+  it("converts all external portal node types to internal types on flatten", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowA,
+          slug: "nested-a",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowA,
+            },
+          ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowB,
+          slug: "nested-b",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [
+            {
+              data: publishedNestedFlowB,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await dataMerged("parent-flow");
+    const nodeTypes = Object.values(result).map((node) =>
+      "type" in node ? node.type : undefined,
+    );
+
+    expect(nodeTypes.includes(ComponentType.ExternalPortal)).toBe(false);
+    expect(nodeTypes.includes(ComponentType.InternalPortal)).toBe(true);
+  });
+
+  it("throws an error when an external portal is not published and draftDataOnly is falsey", async () => {
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowA,
+          slug: "nested-a",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [], // a is not published, but b is
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetFlowData",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          data: draftNestedFlowB,
+          slug: "nested-b",
+          team_id: 1,
+          team: {
+            slug: "testing",
+          },
+          publishedFlows: [{ data: publishedNestedFlowB }],
+        },
+      },
+    });
+
+    await expect(dataMerged("parent-flow")).rejects.toThrow();
+  });
+});
+
+/**
+ * Draft parent flow data which includes 3 nested flow nodes (2 unique flows) and 1 folder
+ */
+const draftParentFlow: FlowGraph = {
+  _root: {
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+  },
+  "45vie6vizK": {
+    data: {
+      content: "<h1>Folder</h1><p>This is content in a folder</p>",
+      resetButton: false,
+      tags: [],
+    },
+    type: ComponentType.Content,
+  },
+  DQRnJfTvkq: {
+    data: {
+      tags: [],
+      text: "Which branch?",
+      neverAutoAnswer: false,
+      alwaysAutoAnswerBlank: false,
+    },
+    type: ComponentType.Question,
+    edges: ["jTi25P1WkE", "xwVz9s9ZVQ", "f6zoaYuboI"],
+  },
+  f6zoaYuboI: {
+    data: {
+      text: "C",
+    },
+    type: ComponentType.Answer,
+  },
+  jTi25P1WkE: {
+    data: {
+      text: "A",
+    },
+    type: ComponentType.Answer,
+    edges: ["0ND9E0ov0D"],
+  },
+  xwVz9s9ZVQ: {
+    data: {
+      text: "B",
+    },
+    type: ComponentType.Answer,
+    edges: ["UZWjLKDsBv"],
+  },
+  r6ZeA1GFpU: {
+    type: ComponentType.InternalPortal,
+    data: {
+      text: "Folder",
+    },
+    edges: ["45vie6vizK"],
+  },
+  "0ND9E0ov0D": {
+    type: ComponentType.ExternalPortal,
+    data: {
+      flow: {
+        id: "nested-a",
+        name: "Nested A",
+        slug: "nested-a",
+        team: "API",
+      },
+      flowId: "nested-a",
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
+    },
+  },
+  UZWjLKDsBv: {
+    type: ComponentType.ExternalPortal,
+    data: {
+      flow: {
+        id: "nested-a",
+        name: "Nested A",
+        slug: "nested-a",
+        team: "API",
+      },
+      flowId: "nested-a",
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
+    },
+  },
+  JtWhixLQQD: {
+    type: ComponentType.ExternalPortal,
+    data: {
+      flow: {
+        id: "nested-b",
+        name: "Nested B",
+        slug: "nested-b",
+        team: "API",
+      },
+      flowId: "nested-b",
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
+    },
+  },
+};
+
+/**
+ * Flattened parent flow
+ *  - Published versions of each nested flow by default, draft version of parent flow
+ *  - External portals (aka nested flows) have been converted to internal portals (folders)
+ *  - Repeated references to the same nested flow are de-duplicated (eg each unique flow is only flattened once)
+ */
+const flattenedParentFlow: FlowGraph = {
+  _root: {
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+  },
+  "0ND9E0ov0D": {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-a"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  "nested-a": {
+    edges: ["P3bEBTSeQd"],
+    type: ComponentType.InternalPortal,
+    data: {
+      text: "testing/nested-a",
+      flattenedFromExternalPortal: true,
+      templatedFrom: undefined as unknown as Value,
+    },
+  },
+  P3bEBTSeQd: {
+    data: {
+      content: "<h1>Nested A</h1><p>This is nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  "45vie6vizK": {
+    data: {
+      tags: [],
+      content: "<h1>Folder</h1><p>This is content in a folder</p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  DQRnJfTvkq: {
+    data: {
+      tags: [],
+      text: "Which branch?",
+      neverAutoAnswer: false,
+      alwaysAutoAnswerBlank: false,
+    },
+    type: ComponentType.Question,
+    edges: ["jTi25P1WkE", "xwVz9s9ZVQ", "f6zoaYuboI"],
+  },
+  JtWhixLQQD: {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-b"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  "nested-b": {
+    edges: ["g4fB7FE0cz"],
+    type: ComponentType.InternalPortal,
+    data: {
+      text: "testing/nested-b",
+      flattenedFromExternalPortal: true,
+      templatedFrom: undefined as unknown as Value,
+    },
+  },
+  g4fB7FE0cz: {
+    data: {
+      content: "<h1>Nested B</h1><p>This is nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  UZWjLKDsBv: {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-a"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  f6zoaYuboI: {
+    data: {
+      text: "C",
+    },
+    type: ComponentType.Answer,
+  },
+  jTi25P1WkE: {
+    data: {
+      text: "A",
+    },
+    type: ComponentType.Answer,
+    edges: ["0ND9E0ov0D"],
+  },
+  r6ZeA1GFpU: {
+    data: {
+      text: "Folder",
+    },
+    type: ComponentType.InternalPortal,
+    edges: ["45vie6vizK"],
+  },
+  xwVz9s9ZVQ: {
+    data: {
+      text: "B",
+    },
+    type: ComponentType.Answer,
+    edges: ["UZWjLKDsBv"],
+  },
+};
+
+/**
+ * Flattened parent flow
+ *  - Draft flows all the way down, otherwise same as above
+ */
+const flattenedParentFlowDraftOnly: FlowGraph = {
+  _root: {
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+  },
+  "0ND9E0ov0D": {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-a"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  "nested-a": {
+    edges: ["P3bEBTSeQd"],
+    type: ComponentType.InternalPortal,
+    data: {
+      text: "testing/nested-a",
+      flattenedFromExternalPortal: true,
+      templatedFrom: undefined as unknown as Value,
+    },
+  },
+  P3bEBTSeQd: {
+    data: {
+      content:
+        "<h1>Nested A</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  "45vie6vizK": {
+    data: {
+      tags: [],
+      content: "<h1>Folder</h1><p>This is content in a folder</p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  DQRnJfTvkq: {
+    data: {
+      tags: [],
+      text: "Which branch?",
+      neverAutoAnswer: false,
+      alwaysAutoAnswerBlank: false,
+    },
+    type: ComponentType.Question,
+    edges: ["jTi25P1WkE", "xwVz9s9ZVQ", "f6zoaYuboI"],
+  },
+  JtWhixLQQD: {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-b"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  "nested-b": {
+    edges: ["g4fB7FE0cz"],
+    type: ComponentType.InternalPortal,
+    data: {
+      text: "testing/nested-b",
+      flattenedFromExternalPortal: true,
+      templatedFrom: undefined as unknown as Value,
+    },
+  },
+  g4fB7FE0cz: {
+    data: {
+      content:
+        "<h1>Nested B</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+  UZWjLKDsBv: {
+    type: ComponentType.InternalPortal,
+    edges: ["nested-a"],
+    data: {
+      flattenedFromExternalPortal: true,
+    },
+  },
+  f6zoaYuboI: {
+    data: {
+      text: "C",
+    },
+    type: ComponentType.Answer,
+  },
+  jTi25P1WkE: {
+    data: {
+      text: "A",
+    },
+    type: ComponentType.Answer,
+    edges: ["0ND9E0ov0D"],
+  },
+  r6ZeA1GFpU: {
+    data: {
+      text: "Folder",
+    },
+    type: ComponentType.InternalPortal,
+    edges: ["45vie6vizK"],
+  },
+  xwVz9s9ZVQ: {
+    data: {
+      text: "B",
+    },
+    type: ComponentType.Answer,
+    edges: ["UZWjLKDsBv"],
+  },
+};
+
+const draftNestedFlowA: FlowGraph = {
+  _root: {
+    edges: ["P3bEBTSeQd"],
+  },
+  P3bEBTSeQd: {
+    data: {
+      content:
+        "<h1>Nested A</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+};
+
+const publishedNestedFlowA: FlowGraph = {
+  _root: {
+    edges: ["P3bEBTSeQd"],
+  },
+  P3bEBTSeQd: {
+    data: {
+      content: "<h1>Nested A</h1><p>This is nested flow content</p><p></p>",
+      resetButton: false,
+    },
+    type: ComponentType.Content,
+  },
+};
+
+const draftNestedFlowB: FlowGraph = {
+  _root: {
+    edges: ["g4fB7FE0cz"],
+  },
+  g4fB7FE0cz: {
+    type: 250,
+    data: {
+      content:
+        "<h1>Nested B</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
+      resetButton: false,
+    },
+  },
+};
+
+const publishedNestedFlowB: FlowGraph = {
+  _root: {
+    edges: ["g4fB7FE0cz"],
+  },
+  g4fB7FE0cz: {
+    type: 250,
+    data: {
+      content: "<h1>Nested B</h1><p>This is nested flow content</p><p></p>",
+      resetButton: false,
+    },
+  },
+};

--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -47,8 +47,25 @@ describe("dataMerged() function", () => {
           publishedFlows: [
             {
               data: publishedNestedFlowA,
+              created_at: "2026-05-15T02:12:32.889893+00:00",
+              publisher_id: 1,
+              id: 9,
+              summary: "Testing a",
             },
           ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetMostRecentPublishedFlowVersion",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-a",
+      },
+      data: {
+        flow: {
+          publishedFlows: [{ id: 9 }],
         },
       },
     });
@@ -70,8 +87,25 @@ describe("dataMerged() function", () => {
           publishedFlows: [
             {
               data: publishedNestedFlowB,
+              created_at: "2026-05-15T02:12:48.760153+00:00",
+              publisher_id: 1,
+              id: 10,
+              summary: "Testing b",
             },
           ],
+        },
+      },
+    });
+
+    queryMock.mockQuery({
+      name: "GetMostRecentPublishedFlowVersion",
+      matchOnVariables: true,
+      variables: {
+        id: "nested-b",
+      },
+      data: {
+        flow: {
+          publishedFlows: [{ id: 10 }],
         },
       },
     });
@@ -393,6 +427,10 @@ const flattenedParentFlow: FlowGraph = {
       text: "testing/nested-a",
       flattenedFromExternalPortal: true,
       templatedFrom: undefined as unknown as Value,
+      publishedAt: "2026-05-15T02:12:32.889893+00:00",
+      publishedBy: 1,
+      publishedFlowId: 9,
+      summary: "Testing a",
     },
   },
   P3bEBTSeQd: {
@@ -434,6 +472,10 @@ const flattenedParentFlow: FlowGraph = {
       text: "testing/nested-b",
       flattenedFromExternalPortal: true,
       templatedFrom: undefined as unknown as Value,
+      publishedAt: "2026-05-15T02:12:48.760153+00:00",
+      publishedBy: 1,
+      publishedFlowId: 10,
+      summary: "Testing b",
     },
   },
   g4fB7FE0cz: {
@@ -621,7 +663,7 @@ const draftNestedFlowB: FlowGraph = {
     edges: ["g4fB7FE0cz"],
   },
   g4fB7FE0cz: {
-    type: 250,
+    type: ComponentType.Content,
     data: {
       content:
         "<h1>Nested B</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
@@ -635,7 +677,7 @@ const publishedNestedFlowB: FlowGraph = {
     edges: ["g4fB7FE0cz"],
   },
   g4fB7FE0cz: {
-    type: 250,
+    type: ComponentType.Content,
     data: {
       content: "<h1>Nested B</h1><p>This is nested flow content</p><p></p>",
       resetButton: false,

--- a/apps/api.planx.uk/shared/dataMerged.ts
+++ b/apps/api.planx.uk/shared/dataMerged.ts
@@ -1,0 +1,96 @@
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
+
+import { getFlowData, getMostRecentPublishedFlowVersion } from "../helpers.js";
+import type { Flow, Node } from "../types.js";
+
+/**
+ * Flatten a flow to create a single JSON representation of the main flow data and any external portals
+ *   By default, requires that any external portals are published and flattens their latest published version
+ *   When draftDataOnly = true, flattens the draft data of the main flow and the draft data of any external portals published or otherwise
+ */
+export const dataMerged = async (
+  id: string,
+  ob: { [key: string]: Node } = {},
+  isPortal = false,
+  draftDataOnly = false,
+): Promise<FlowGraph> => {
+  // get the primary draft flow data, including its' latest published version
+  const response = await getFlowData(id);
+  const { slug, team, publishedFlows } = response;
+  let { data } = response;
+
+  // only flatten external portals that are published, unless we're loading draftDataOnly
+  if (isPortal && !draftDataOnly) {
+    if (publishedFlows?.[0]?.data) {
+      data = publishedFlows[0].data;
+    } else {
+      throw new Error(
+        `Publish flow ${team.slug}/${slug} before proceeding. All flows used as external portals must be published.`,
+      );
+    }
+  }
+
+  // recursively get and flatten external portals
+  for (const [nodeId, node] of Object.entries(data)) {
+    const isExternalPortalRoot =
+      nodeId === "_root" && Object.keys(ob).length > 0;
+    const isExternalPortal = node.type === ComponentType.ExternalPortal;
+    const isMerged = ob[node.data?.flowId];
+
+    // merge external portal _root node as a new node in the graph using its' flowId as nodeId
+    if (isExternalPortalRoot) {
+      ob[id] = {
+        ...node, // includes _root edges for navigation to all child nodes in this portal
+        type: ComponentType.InternalPortal,
+        data: {
+          text: `${team.slug}/${slug}`,
+          flattenedFromExternalPortal: true,
+          templatedFrom: response.templatedFrom,
+          // add extra metadata about latest published version when applicable
+          ...(!draftDataOnly && {
+            publishedFlowId: publishedFlows?.[0]?.id,
+            publishedAt: publishedFlows?.[0]?.created_at,
+            publishedBy: publishedFlows?.[0]?.publisher_id,
+            summary: publishedFlows?.[0]?.summary,
+          }),
+        },
+      };
+    }
+
+    // merge external portal type node as an internal portal type node, with an edge pointing to flowId (to navigate to the externalPortalRoot set above)
+    else if (isExternalPortal) {
+      ob[nodeId] = {
+        type: ComponentType.InternalPortal,
+        edges: [node.data?.flowId],
+        data: {
+          flattenedFromExternalPortal: true,
+        },
+      };
+
+      // recursively merge flow
+      if (!isMerged) {
+        await dataMerged(node.data?.flowId, ob, true, draftDataOnly);
+      }
+    }
+
+    // merge all other nodes
+    else ob[nodeId] = node;
+  }
+
+  // for every external portal that has been merged, confirm its' latest version was merged. If not, overwrite older snapshot with newest version
+  //   ** this is a final/separate step because older snapshots can be nested in _already_ flattened data (eg not picked up as ComponentType.ExternalPortal above)
+  if (!draftDataOnly) {
+    for (const [nodeId, node] of Object.entries(ob).filter(
+      ([_nodeId, node]) => node.data?.publishedFlowId,
+    )) {
+      const mostRecentPublishedFlowId =
+        await getMostRecentPublishedFlowVersion(nodeId);
+      if (mostRecentPublishedFlowId !== node.data?.publishedFlowId) {
+        await dataMerged(nodeId, ob, true, draftDataOnly);
+      }
+    }
+  }
+
+  return ob as FlowGraph;
+};


### PR DESCRIPTION
https://trello.com/c/cD2Fpav1/3155-make-preview-panel-match-position-in-the-graph

Building out continuous preview panel navigation is going to rely on flattened `draftDataOnly` flow data. Currently it's slow and expensive to fetch. Motivated to try to optimise existing methods a bit first! 

**Changes:**
- [x] Moves `dataMerged` out of `helpers.ts` to its' own file under `shared/`
- [x] Updates `dataMerged` test mocks and scenarios to cover more complex cases (eg multiple nested flows, same nested flow referenced in multiple locations while only fetched + flattened once, etc)

**Next PR:**
- [ ] Refactor recursive `dataMerged` function to use a linear stack instead (would be too hard to review in this diff)
  - Record some baseline `/flatten-data` loading times here, should be faster :crossed_fingers: 
 