### PR TITLE
feat(ci): Trigger regression tests via PR comment

### DIFF
--- a/.github/workflows/regression-tests-on-comment.yml
+++ b/.github/workflows/regression-tests-on-comment.yml
@@ -8,7 +8,8 @@ jobs:
   dispatch:
     if: |
       github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/regression-tests')
+      startsWith(github.event.comment.body, '/regression-tests') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -60,7 +61,6 @@ jobs:
               workflow_id: 'regression-tests.yml',
               ref: '${{ steps.pr.outputs.ref }}',
               inputs: {
-                pr_number: String(context.issue.number),
                 comment_id: String(${{ steps.comment.outputs.id }}),
               },
             });

--- a/.github/workflows/regression-tests-on-comment.yml
+++ b/.github/workflows/regression-tests-on-comment.yml
@@ -37,6 +37,19 @@ jobs:
             });
             core.setOutput('ref', pr.head.ref);
 
+      - name: Post pending comment
+        id: comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `⏳ Regression tests running on \`${{ steps.pr.outputs.ref }}\`...`,
+            });
+            core.setOutput('id', comment.id);
+
       - name: Dispatch regression-tests workflow
         uses: actions/github-script@v7
         with:
@@ -46,16 +59,8 @@ jobs:
               repo: context.repo.repo,
               workflow_id: 'regression-tests.yml',
               ref: '${{ steps.pr.outputs.ref }}',
-            });
-
-      - name: Post confirmation comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const runsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/regression-tests.yml`;
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Regression tests triggered on \`${{ steps.pr.outputs.ref }}\` - [view runs](${runsUrl}) :rocket:`,
+              inputs: {
+                pr_number: String(context.issue.number),
+                comment_id: String(${{ steps.comment.outputs.id }}),
+              },
             });

--- a/.github/workflows/regression-tests-on-comment.yml
+++ b/.github/workflows/regression-tests-on-comment.yml
@@ -1,0 +1,61 @@
+name: Regression Tests (comment trigger)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/regression-tests')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Add eyes reaction
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Get PR head ref
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('ref', pr.head.ref);
+
+      - name: Dispatch regression-tests workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'regression-tests.yml',
+              ref: '${{ steps.pr.outputs.ref }}',
+            });
+
+      - name: Post confirmation comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/regression-tests.yml`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Regression tests triggered on \`${{ steps.pr.outputs.ref }}\` - [view runs](${runsUrl}) :rocket:`,
+            });

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -8,10 +8,6 @@ on:
     - cron: "06 6 * * *"
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: PR number to update comment on
-        required: false
-        type: string
       comment_id:
         description: Comment ID to update with pass/fail result
         required: false

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -7,6 +7,15 @@ on:
     # Runs every morning at 06:06 (https://crontab.guru/#06_6_*_*_*)
     - cron: "06 6 * * *"
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to update comment on
+        required: false
+        type: string
+      comment_id:
+        description: Comment ID to update with pass/fail result
+        required: false
+        type: string
 
 env:
   EDITOR_DIRECTORY: apps/editor.planx.uk
@@ -105,6 +114,32 @@ jobs:
           name: playwright-report
           path: e2e/tests/ui-driven/test-results/
           retention-days: 3
+
+  notify_pr:
+    name: Update PR Comment
+    runs-on: ubuntu-24.04
+    needs: [integration_tests, api_tests, test_react, end_to_end_tests]
+    if: always() && inputs.comment_id != ''
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update PR comment with result
+        uses: actions/github-script@v7
+        env:
+          PASSED: ${{ needs.integration_tests.result == 'success' && needs.api_tests.result == 'success' && needs.test_react.result == 'success' && needs.end_to_end_tests.result == 'success' }}
+          COMMENT_ID: ${{ inputs.comment_id }}
+        with:
+          script: |
+            const passed = process.env.PASSED === 'true';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: parseInt(process.env.COMMENT_ID),
+              body: passed
+                ? `✅ Regression tests passed - [view run](${runUrl})`
+                : `❌ Regression tests failed - [view run](${runUrl})`,
+            });
 
   notify:
     name: Notify On Failure


### PR DESCRIPTION
Follow up to post-mortem doc here - https://www.notion.so/opensystemslab/Postmortem-35135d469ad180da8c60caf36ef81396

This PR creates a new GHA which allows regression tests to be triggered by commenting `/regression-tests` on a PR. The aim here is to lower the friction for kicking these off on a given branch.

### Workflow
1. Comment `/regression-tests` on a PR,  👀 reaction appears
2. A comment posts - "⏳ Regression tests running on `{{branch-name}}`..."
3. Tests run against branch
4. That same comment is edited to either -  
    - ✅ Regression tests passed + link to run
    - ❌ Regression tests failed + link to run
    
This cannot be tested on this branch, we'll need to merge to `main` and then test/debug unfortunately..!