### PR TITLE
feat: add and populate `notifications.resolved_by`

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -154,6 +154,7 @@ export const publishFlow = async (
       payload: {
         flowId: flowId,
         type: "updated_templated_flow",
+        resolvedBy: parseInt(userId),
       },
       comment: `resolve_notification_on_templated_flow_publish_${flowId}`,
     });

--- a/apps/api.planx.uk/modules/notifications/controller.ts
+++ b/apps/api.planx.uk/modules/notifications/controller.ts
@@ -9,6 +9,7 @@ export const resolveNotificationEventSchema = z.object({
     payload: z.object({
       flowId: z.string(),
       type: z.string(), // one of `notification_type_enum.value`
+      resolvedBy: z.number().optional(),
     }),
   }),
 });
@@ -25,10 +26,10 @@ export type ResolveNotificationController = ValidatedRequestHandler<
 
 export const resolveNotificationController: ResolveNotificationController =
   async (_req, res, next) => {
-    const { flowId, type } = res.locals.parsedReq.body.payload;
+    const { flowId, type, resolvedBy } = res.locals.parsedReq.body.payload;
 
     try {
-      const response = await resolveNotification(flowId, type);
+      const response = await resolveNotification(flowId, type, resolvedBy);
 
       res.status(200).send({
         message: `Successfully resolved ${type} notification(s) for flow ID ${flowId}`,

--- a/apps/api.planx.uk/modules/notifications/service.ts
+++ b/apps/api.planx.uk/modules/notifications/service.ts
@@ -12,7 +12,11 @@ interface UpdateNotifications {
 }
 
 // Currently only initiated via a Hasura event, so we don't have user context here and rely on $api client
-export const resolveNotification = async (flowId: string, type: string) => {
+export const resolveNotification = async (
+  flowId: string,
+  type: string,
+  resolvedBy?: number,
+) => {
   // If many unresolved notifications of the same "type" exist for this flow, resolve them all
   //   If no notifications match these conditions, it'll simply return [] and still "succeed"
   const resolveNotificationResponse =
@@ -22,6 +26,7 @@ export const resolveNotification = async (flowId: string, type: string) => {
           $flowId: uuid!
           $type: notification_type_enum_enum!
           $resolvedAt: timestamp!
+          $resolvedBy: Int
         ) {
           notifications: update_notifications_many(
             updates: {
@@ -30,7 +35,7 @@ export const resolveNotification = async (flowId: string, type: string) => {
                 type: { _eq: $type }
                 resolved_at: { _is_null: true }
               }
-              _set: { resolved_at: $resolvedAt }
+              _set: { resolved_at: $resolvedAt, resolved_by: $resolvedBy }
             }
           ) {
             returning {
@@ -43,6 +48,7 @@ export const resolveNotification = async (flowId: string, type: string) => {
         flowId: flowId,
         type: type,
         resolvedAt: new Date(),
+        resolvedBy: resolvedBy,
       },
     );
 

--- a/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
@@ -19,6 +19,10 @@ const NOTIFICATION_FIELDS = gql`
     type
     createdAt: created_at
     resolvedAt: resolved_at
+    resolvedBy: user {
+      firstName: first_name
+      lastName: last_name
+    }
   }
 `;
 

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/notifications.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/notifications.tsx
@@ -35,6 +35,10 @@ export const Route = createFileRoute("/_authenticated/app/$team/notifications")(
               type
               createdAt: created_at
               resolvedAt: resolved_at
+              resolvedBy: user {
+                firstName: first_name
+                lastName: last_name
+              }
             }
           }
         `,

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_notifications.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_notifications.yaml
@@ -23,34 +23,46 @@ object_relationships:
         remote_table:
           name: teams
           schema: public
+  - name: user
+    using:
+      manual_configuration:
+        column_mapping:
+          resolved_by: id
+        insertion_order: null
+        remote_table:
+          name: users
+          schema: public
 insert_permissions:
   - role: api
     permission:
       check: {}
       columns:
         - id
+        - resolved_by
+        - team_id
         - type
         - created_at
         - resolved_at
         - flow_id
-        - team_id
     comment: ""
 select_permissions:
   - role: api
     permission:
       columns:
         - id
+        - resolved_by
+        - team_id
         - type
         - created_at
         - resolved_at
         - flow_id
-        - team_id
       filter: {}
     comment: ""
   - role: platformAdmin
     permission:
       columns:
         - id
+        - resolved_by
         - team_id
         - type
         - created_at
@@ -62,6 +74,7 @@ select_permissions:
     permission:
       columns:
         - id
+        - resolved_by
         - team_id
         - type
         - created_at
@@ -81,6 +94,7 @@ update_permissions:
     permission:
       columns:
         - id
+        - resolved_by
         - team_id
         - type
         - created_at

--- a/apps/hasura.planx.uk/migrations/default/1778869440774_alter_table_public_notifications_add_column_resolved_by/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778869440774_alter_table_public_notifications_add_column_resolved_by/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."notifications" drop column "resolved_by";

--- a/apps/hasura.planx.uk/migrations/default/1778869440774_alter_table_public_notifications_add_column_resolved_by/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1778869440774_alter_table_public_notifications_add_column_resolved_by/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."notifications" add column "resolved_by" integer
+ null;


### PR DESCRIPTION
Please see https://github.com/theopensystemslab/planx-new/pull/6668#discussion_r3250096139

This is just backend piece, no UI! 

To test, "resolve" a notification via publishing then `notifications` table to confirm your user ID / relationship is populated. 
<img width="1855" height="1055" alt="Screenshot from 2026-05-15 14-38-54" src="https://github.com/user-attachments/assets/ad2d714b-511b-4d03-99cc-95c18277f7bc" />
