### PR TITLE
feat: analytics_enhancements view

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_enhancements.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics_enhancements.yaml
@@ -1,0 +1,3 @@
+table:
+  name: analytics_enhancements
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -3,6 +3,7 @@
 - "!include public_ai_gateway_audit_log.yaml"
 - "!include public_analytics.yaml"
 - "!include public_analytics_action_nodes.yaml"
+- "!include public_analytics_enhancements.yaml"
 - "!include public_analytics_exits.yaml"
 - "!include public_analytics_first_used.yaml"
 - "!include public_analytics_journeys_aggregated.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1779179773017_create_analytics_enhancements_view/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779179773017_create_analytics_enhancements_view/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW "public"."analytics_enhancements";

--- a/apps/hasura.planx.uk/migrations/default/1779179773017_create_analytics_enhancements_view/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779179773017_create_analytics_enhancements_view/up.sql
@@ -1,0 +1,6 @@
+CREATE MATERIALIZED VIEW "public"."analytics_enhancements" AS 
+    SELECT analytics_id, (allow_list_answers -> '_enhancements' -> 'proposal.description' -> 'userAction') as user_action
+    FROM analytics_logs
+    WHERE allow_list_answers ? '_enhancements';
+
+GRANT SELECT ON "public"."analytics_enhancements" TO metabase_read_only; 

--- a/apps/hasura.planx.uk/migrations/default/1779180031759_refresh_analytics_enhancements/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779180031759_refresh_analytics_enhancements/down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('refresh_analytics_enhancements');

--- a/apps/hasura.planx.uk/migrations/default/1779180031759_refresh_analytics_enhancements/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779180031759_refresh_analytics_enhancements/up.sql
@@ -1,0 +1,5 @@
+SELECT cron.schedule(
+  'refresh_analytics_enhancements',
+  '35 3 * * *',
+  $$REFRESH MATERIALIZED VIEW analytics_enhancements$$
+);


### PR DESCRIPTION
Following the existing pattern of analytics materialized views, this PR creates a new view that unfurls the `analytics_logs.allow_list_answers._enhancements` jsonb into a new Metabase-digestible view for enhanced project description analytics.

# Questions
❓ Is it overkill to follow the existing pattern and make this a materialized view refreshed with a nightly cron job, when we don't have much data? I opted for this for the sake of consistency and the fact that it seemed more future-proof, but it could be adding more cron job cruft. 
❓ I also wondered if it might be more appropriate to create an additional column for the type of enhancements, again with a view to when we add additional enhancements in the future--but decided not to for now because of possible cruft. Please say if anyone thinks we should do otherwise here...