### PR TITLE
fix: ensure archived flows are not copiable or nestable

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromCopyFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromCopyFormSection.tsx
@@ -1,4 +1,3 @@
-import { gql, useQuery } from "@apollo/client";
 import MenuItem from "@mui/material/MenuItem";
 import { SelectChangeEvent } from "@mui/material/Select";
 import { useFormikContext } from "formik";
@@ -7,33 +6,13 @@ import InputLabel from "ui/public/InputLabel";
 import SelectInput from "ui/shared/SelectInput/SelectInput";
 import { slugify } from "utils";
 
+import { useGetCopiableFlows } from "./hooks/useGetCopiableFlows";
 import { CreateFlow } from "./types";
-
-interface CopiableFlow {
-  id: string;
-  slug: string;
-  name: string;
-  team: { name: string };
-}
 
 export const CreateFromCopyFormSection: React.FC = () => {
   const { values, setFieldValue } = useFormikContext<CreateFlow>();
 
-  const { data } = useQuery<{ copiableFlows: CopiableFlow[] }>(gql`
-    query GetCopiableFlows {
-      copiableFlows: flows(
-        where: { can_create_from_copy: { _eq: true } }
-        order_by: { team: { name: asc }, name: asc }
-      ) {
-        id
-        slug
-        name
-        team {
-          name
-        }
-      }
-    }
-  `);
+  const { data } = useGetCopiableFlows();
 
   if (values.mode !== "copy" || !data?.copiableFlows?.length) return null;
 

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useGetCopiableFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useGetCopiableFlows.ts
@@ -1,0 +1,38 @@
+import { gql, useQuery } from "@apollo/client";
+
+const GET_COPIABLE_FLOWS = gql`
+  query GetCopiableFlows {
+    copiableFlows: flows(
+      where: {
+        can_create_from_copy: { _eq: true }
+        archived_at: { _is_null: true }
+      }
+      order_by: { team: { name: asc }, name: asc }
+    ) {
+      id
+      slug
+      name
+      team {
+        name
+      }
+    }
+  }
+`;
+
+interface GetCopiableFlows {
+  copiableFlows: {
+    id: string;
+    slug: string;
+    name: string;
+    team: { name: string };
+  }[];
+}
+
+type GetCopiableFlowsVars = Record<string, never>;
+
+export const useGetCopiableFlows = () => {
+  return useQuery<GetCopiableFlows, GetCopiableFlowsVars>(
+    GET_COPIABLE_FLOWS,
+    {},
+  );
+};

--- a/apps/editor.planx.uk/src/utils/routeUtils/queryUtils.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/queryUtils.ts
@@ -172,7 +172,7 @@ export const getExternalPortals = async (
   const { data } = await client.query({
     query: gql`
       query GetFlows {
-        flows(order_by: { slug: asc }) {
+        flows(order_by: {slug: asc}, where: {archived_at: {_is_null: true}}) {
           id
           slug
           name


### PR DESCRIPTION
As reported [here](https://trello.com/c/T74ZBaOR).

The main change is adding an `{ _is_null: true }` check to `archived_at` in the query, but while I was here I refactored to use our [existing hook pattern](https://github.com/theopensystemslab/planx-new/blob/main/doc/guides/data-fetching-and-state-management.md). 

# Testing

1. Start creating a new flow from copy and check the list of copiable flows
2. Archive one of those flows
3. Start creating a new flow from copy and check the list again--the newly archived flow should no longer show up as an option