### PR TITLE
fix[tests]: add mock for resend call

### DIFF
--- a/apps/api.planx.uk/modules/send/email/index.test.ts
+++ b/apps/api.planx.uk/modules/send/email/index.test.ts
@@ -31,6 +31,10 @@ vi.mock("../utils/exportZip", () => {
   };
 });
 
+vi.mock("../../../lib/resend/index.js", () => ({
+  sendEmail: vi.fn().mockResolvedValue({ message: "submit email sent successfully" }),
+}));
+
 describe(`sending an application by email to a planning office`, () => {
   beforeEach(() => {
     queryMock.mockQuery({

--- a/apps/api.planx.uk/modules/send/email/index.test.ts
+++ b/apps/api.planx.uk/modules/send/email/index.test.ts
@@ -32,7 +32,9 @@ vi.mock("../utils/exportZip", () => {
 });
 
 vi.mock("../../../lib/resend/index.js", () => ({
-  sendEmail: vi.fn().mockResolvedValue({ message: "submit email sent successfully" }),
+  sendEmail: vi
+    .fn()
+    .mockResolvedValue({ message: "submit email sent successfully" }),
 }));
 
 describe(`sending an application by email to a planning office`, () => {


### PR DESCRIPTION
Noticed some API tests were failing for me locally and on CI - this mock for the resend endpoint seems to fix things.