### PR TITLE
[fix] pin docker build platform

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -310,7 +310,7 @@ jobs:
 
       - if: steps.create.outputs.ip_address != null
         name: Create commands
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ env.FULL_DOMAIN }}
           username: root
@@ -346,7 +346,7 @@ jobs:
 
       - if: steps.create.outputs.ip_address == null
         name: Update commands
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ env.FULL_DOMAIN }}
           username: root
@@ -390,7 +390,7 @@ jobs:
           path: ./${{ env.EDITOR_DIRECTORY }}/build
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: upload built editor
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ env.FULL_DOMAIN }}
           username: root
@@ -411,7 +411,7 @@ jobs:
 
       - name: upload built localplanning.services
         continue-on-error: true
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ env.FULL_DOMAIN }}
           username: root

--- a/ci/caddy/Dockerfile
+++ b/ci/caddy/Dockerfile
@@ -1,9 +1,12 @@
+# check=skip=FromPlatformFlagConstDisallowed
+# ^ we build caddy for Vultr instances (i.e. Alpine), so we suppress warnings re hardcoding the platform
+
 # XXX: if updating this file, also update the image on Vultr CR (see README)
 # build Caddy with the Vultr DNS-01 challenge provider
 # see https://caddyserver.com/docs/modules/dns.providers.vultr
-FROM caddy:2.11-builder-alpine AS builder
+FROM --platform=linux/amd64 caddy:2.11-builder-alpine AS builder
 RUN xcaddy build --with github.com/caddy-dns/vultr@v0.0.0-20250723121531-55bf3e9768be
 
 # copy only the custom binary into a minimal runtime image
-FROM caddy:2.11-alpine
+FROM --platform=linux/amd64 caddy:2.11-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -4,6 +4,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   api:
+    platform: linux/amd64
     build:
       target: production
     volumes:
@@ -13,6 +14,15 @@ services:
       NODE_ENV: "pizza"
       AIRBRAKE_PROJECT_ID: ${AIRBRAKE_PROJECT_ID}
       AIRBRAKE_PROJECT_KEY: ${AIRBRAKE_PROJECT_KEY}
+
+  sharedb:
+    platform: linux/amd64
+
+  hasura:
+    platform: linux/amd64
+
+  hasura-proxy:
+    platform: linux/amd64
 
   editor:
     container_name: editor
@@ -36,6 +46,7 @@ services:
     entrypoint: "/goStatic -port 8044 -fallback /index.html"
 
   caddy:
+    platform: linux/amd64
     image: lhr.vultrcr.com/planx/caddy-vultr:latest
     # default to pulling image from private Vultr registry (if not available)
     pull_policy: missing

--- a/docker-compose.pizza.yml
+++ b/docker-compose.pizza.yml
@@ -25,6 +25,7 @@ services:
     platform: linux/amd64
 
   editor:
+    platform: linux/amd64
     container_name: editor
     image: pierrezemb/gostatic
     volumes:
@@ -32,6 +33,7 @@ services:
     entrypoint: "/goStatic -fallback /index.html"
 
   localplanning:
+    platform: linux/amd64
     container_name: localplanning
     image: pierrezemb/gostatic
     volumes:
@@ -39,6 +41,7 @@ services:
     entrypoint: "/goStatic -fallback /404.html"
 
   storybook:
+    platform: linux/amd64
     container_name: storybook
     image: pierrezemb/gostatic
     volumes:


### PR DESCRIPTION
Various fixes/improvements for the CI pizza build.

Prompted by all pizza builds (that is, runs of `pull-request.yml` GHA workflow) suddenly failing. Careful read of logs revealed the following line:

```
Error response from daemon: no matching manifest for linux/arm64 in the manifest list entries: no match for platform in manifest: not found
```

We conject that this is a result of Vultr bumping their Alpine build to latest (i.e. 3.23, or perhaps applying a more recent security patch thereof), which includes a [major version upgrade](https://gitlab.alpinelinux.org/alpine/apk-tools/-/releases/v3.0.0?__goaway_challenge=cookie&__goaway_id=d71abc4027187129922685ad0389d226&__goaway_referer=https%3A%2F%2Fwiki.alpinelinux.org%2F) (to v3) of the `apk` package manager, which is somehow more fussy about having the correct manifest/being on right platform? Unsure of cause but could be e.g. something to do with Alpine no longer being able to emulate it's way out of wrong platform build (see [here](https://github.com/moby/buildkit/issues/6400#issuecomment-3670695463))...

Alternatively it could be that the default github runners have been swapped out for `arm64` when they were previously `amd64`, and are therefore building for the former by default without being told otherwise? Although that would be weird because we do explicitly request [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) 🤔 