### PR TITLE
fix: Notification createdBy and time formatting

### DIFF
--- a/apps/api.planx.uk/modules/notifications/service.ts
+++ b/apps/api.planx.uk/modules/notifications/service.ts
@@ -25,7 +25,7 @@ export const resolveNotification = async (
         mutation UpdateNotifications(
           $flowId: uuid!
           $type: notification_type_enum_enum!
-          $resolvedAt: timestamp!
+          $resolvedAt: timestamptz!
           $resolvedBy: Int
         ) {
           notifications: update_notifications_many(

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -127,7 +127,7 @@ const NotificationsPanel = ({
             size="small"
             title={
               tab === 0
-                ? "No active notifications"
+                ? "No notifications, you're all up to date"
                 : "No resolved notifications"
             }
             sx={{ mx: 2 }}

--- a/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
@@ -19,7 +19,7 @@ const NOTIFICATION_FIELDS = gql`
     type
     createdAt: created_at
     resolvedAt: resolved_at
-    resolvedBy: user {
+    resolvedByUser: user {
       firstName: first_name
       lastName: last_name
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
@@ -68,7 +68,7 @@ export const Notifications = ({ notifications }: NotificationProps) => {
             size="small"
             title={
               tab === 0
-                ? "No active notifications"
+                ? "No notifications, you're all up to date"
                 : "No resolved notifications"
             }
             sx={{ mt: 0 }}

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/notifications.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/notifications.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/_authenticated/app/$team/notifications")(
               type
               createdAt: created_at
               resolvedAt: resolved_at
-              resolvedBy: user {
+              resolvedByUser: user {
                 firstName: first_name
                 lastName: last_name
               }

--- a/apps/hasura.planx.uk/migrations/default/1779223924522_alter_table_public_notifications_use_timestamptz/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779223924522_alter_table_public_notifications_use_timestamptz/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."notifications"
+  ALTER COLUMN "created_at" TYPE timestamp,
+  ALTER COLUMN "resolved_at" TYPE timestamp;

--- a/apps/hasura.planx.uk/migrations/default/1779223924522_alter_table_public_notifications_use_timestamptz/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779223924522_alter_table_public_notifications_use_timestamptz/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."notifications"
+  ALTER COLUMN "created_at" TYPE timestamptz,
+  ALTER COLUMN "resolved_at" TYPE timestamptz;


### PR DESCRIPTION
## What does this PR do?

Tidy up tasks and fixes with notifications:
- Ensure timestamp is formatted the same as FlowCard/table
- Ensure ResolvedBy is populated correctly
- Update copy for "no notifications"