### PR TITLE
feat(api): assign teamAdmin role to JWT

### DIFF
--- a/apps/api.planx.uk/modules/auth/middleware.ts
+++ b/apps/api.planx.uk/modules/auth/middleware.ts
@@ -319,9 +319,14 @@ export const useRoleAuth: UseRoleAuth =
 export const useTeamViewerAuth = useRoleAuth([
   "teamViewer",
   "teamEditor",
+  "teamAdmin",
   "platformAdmin",
 ]);
-export const useTeamEditorAuth = useRoleAuth(["teamEditor", "platformAdmin"]);
+export const useTeamEditorAuth = useRoleAuth([
+  "teamEditor",
+  "teamAdmin",
+  "platformAdmin",
+]);
 export const usePlatformAdminAuth = useRoleAuth(["platformAdmin"]);
 
 /**

--- a/apps/api.planx.uk/modules/auth/service/jwt.ts
+++ b/apps/api.planx.uk/modules/auth/service/jwt.ts
@@ -51,6 +51,9 @@ const getDefaultRoleForUser = (user: User): Role => {
   if (user.isPlatformAdmin) return "platformAdmin";
   if (user.isAnalyst) return "analyst";
 
+  const isTeamAdmin = user.teams.find((team) => team.role === "teamAdmin");
+  if (isTeamAdmin) return "teamAdmin";
+
   const isTeamEditor = user.teams.find((team) => team.role === "teamEditor");
   if (isTeamEditor) return "teamEditor";
 

--- a/apps/hasura.planx.uk/migrations/default/1779274544198_insert_into_public_user_roles/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779274544198_insert_into_public_user_roles/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."user_roles" WHERE "value" = 'teamAdmin';

--- a/apps/hasura.planx.uk/migrations/default/1779274544198_insert_into_public_user_roles/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779274544198_insert_into_public_user_roles/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."user_roles"("value") VALUES (E'teamAdmin');


### PR DESCRIPTION
- Creates a `teamAdmin` enum in I `user_role` (missed this in #6608)
- Assigns role in API

Permissions have been tested locally too and, as expected, `teamEditor` permissions are granted / inherited when I assign myself a `teamAmin` role in Hasura.