### PR TITLE
fix[tests]: bump API test timeout for `modules/gis/serivce/findLpa` and add mock for Resend

### DIFF
--- a/apps/api.planx.uk/modules/gis/service/findLpa/index.test.ts
+++ b/apps/api.planx.uk/modules/gis/service/findLpa/index.test.ts
@@ -56,6 +56,6 @@ describe("checking several points against local planning authority lookup API", 
             ),
           ).toEqual(location.lpas);
         });
-    });
+    }, 20_000); // 20s request timeout
   });
 });

--- a/apps/api.planx.uk/modules/gis/service/findLpa/index.test.ts
+++ b/apps/api.planx.uk/modules/gis/service/findLpa/index.test.ts
@@ -56,6 +56,6 @@ describe("checking several points against local planning authority lookup API", 
             ),
           ).toEqual(location.lpas);
         });
-    }, 20_000); // 20s request timeout
+    }, 30_000); // 30s request timeout
   });
 });

--- a/apps/api.planx.uk/modules/send/email/index.test.ts
+++ b/apps/api.planx.uk/modules/send/email/index.test.ts
@@ -31,6 +31,12 @@ vi.mock("../utils/exportZip", () => {
   };
 });
 
+vi.mock("../../../lib/resend/index.js", () => ({
+  sendEmail: vi
+    .fn()
+    .mockResolvedValue({ message: "submit email sent successfully" }),
+}));
+
 describe(`sending an application by email to a planning office`, () => {
   beforeEach(() => {
     queryMock.mockQuery({


### PR DESCRIPTION
This has been regularly timing out on nightly regression test runs and local branches lately. Eg https://github.com/theopensystemslab/planx-new/actions/runs/26148104122

Timeout added here is consistent with a pre-existing similar one in main GIS module  (`modules/gis/service/index.test.ts`).