### PR TITLE
fix: Focus outline on cloned template nodes

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -95,11 +95,15 @@ $fontMonospace: "Source Code Pro", monospace;
 
     a:focus,
     a:active {
+      // Apply focus outline
       outline: 4px solid $focus;
       outline-offset: 0;
-      // Make focussed link outline more visible
-      z-index: 1;
     }
+  }
+
+  // Ensure focus outline is visible above visited outline when both are applied
+  .card-wrapper:not(.template-card) a:focus {
+    position: relative;
   }
 
   ol:empty {


### PR DESCRIPTION
## What does this PR do?

- Addresses issue raised by Jonny, where focusing on a cloned template node causes the clone marker to obscure the rest of the node


https://github.com/user-attachments/assets/941d44b3-0a3c-444c-9505-14bdb535a2b3



### Solution

- Ensure the styling to make the focus outline appear over the visited online is applied to only non-templated nodes (templated node visited outline wraps the entire node rather than just the link)

### Testing
https://6708.planx.pizza/app/testing/template-clone-nodes