### PR TITLE
chore: re-build editor when running pnpm tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,6 +25,11 @@ Run `pnpm test` to run the full end-to-end suite.
 
 Running tests requires a clean DB which can be set up with `../scripts/start-containers-for-tests.sh`
 
+This script also builds the editor automatically (skipping the build if nothing has changed). If you make changes to `apps/editor.planx.uk` after the containers are already running, you must re-build the editor, with one of:
+- `cd apps/editor.planx.uk && pnpm build` - if just the editor code has changed
+- `e2e/tests/ui-driven/build-editor.sh` - if the editor code and dependencies have changed
+- `pnpm tests` (from root) - if other containers also need to be restarted
+
 ## Debugging
 
 run `DEBUG_LOG=true pnpm test` to run with debug logging (useful for setup and teardown issues)

--- a/scripts/start-containers-for-tests.sh
+++ b/scripts/start-containers-for-tests.sh
@@ -21,6 +21,12 @@ trap 'echo "Error detected! Saving logs..."; \
       echo "Logs saved to docker_compose_logs.txt"; \
       e2e_compose down --volumes --remove-orphans' ERR
 
+function buildEditor(){
+  echo "Building editor..."
+  bash e2e/tests/ui-driven/build-editor.sh
+  echo "Editor build complete."
+}
+
 function setupContainers(){
   # Bring down the dev environment containers
   # volumes are kept as they are a different docker project
@@ -44,4 +50,5 @@ function setupContainers(){
   echo "All containers ready."
 }
 
+buildEditor
 setupContainers


### PR DESCRIPTION
This behavour is kind of assumed to be done as part of the main set up step, but wasn't being done. Uses the existing `build-editor.sh` script to only rebuild if there are changes in the working tree. Also added a note to README to remind that it needs to be re-built in between changes.