### PR TITLE
feat: dashboard / explore: layout and display components

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { linkOptions } from "@tanstack/react-router";
 import React from "react";
 import { WidgetLink } from "ui/editor/DashboardWidget";
 
@@ -47,9 +48,13 @@ export default function StatsBanner({ team }: StatsBannerProps) {
     <Root>
       <Header>
         <Typography variant="h3">Last 30 days</Typography>
-        <WidgetLink to="/app/$team" params={{ team }}>
-          view analytics
-        </WidgetLink>
+        <WidgetLink
+          label="view analytics"
+          {...linkOptions({
+            to: "/app/$team",
+            params: { team },
+          })}
+        />
       </Header>
       <StatsGrid>
         {STATS.map(({ label }) => (

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -16,11 +16,13 @@ interface StatsBannerProps {
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.paper,
+  backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
+  position: "relative",
   padding: theme.spacing(1.5),
   marginTop: theme.spacing(4),
   marginBottom: theme.spacing(2),
+  zIndex: 1,
 }));
 
 const Header = styled(Box)({

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -1,0 +1,71 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { CustomLink } from "ui/shared/CustomLink/CustomLink";
+
+const STATS = [
+  { label: "Total sessions" },
+  { label: "Submissions" },
+  { label: "Guidance sessions" },
+  { label: "Online flows" },
+];
+
+interface StatsBannerProps {
+  teamSlug: string;
+}
+
+export default function StatsBanner({ teamSlug }: StatsBannerProps) {
+  return (
+    <Box
+      sx={(theme) => ({
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.border.light}`,
+        padding: theme.spacing(1.5),
+        mt: 4,
+        mb: 2,
+      })}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-start",
+          gap: 2,
+          alignItems: "baseline",
+          mb: 1.5,
+        }}
+      >
+        <Typography variant="h3">Last 30 days</Typography>
+        <CustomLink
+          to={`/app/${teamSlug}/analytics`}
+          sx={(theme) => ({
+            fontSize: theme.typography.body3.fontSize,
+            color: theme.palette.text.secondary,
+          })}
+        >
+          view analytics
+        </CustomLink>
+      </Box>
+      <Box
+        sx={(theme) => ({
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: theme.spacing(2),
+          [theme.breakpoints.down("md")]: {
+            gridTemplateColumns: "repeat(2, 1fr)",
+          },
+        })}
+      >
+        {STATS.map(({ label }) => (
+          <Box key={label}>
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              {label}
+            </Typography>
+            <Typography variant="h1" component="p">
+              —
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -45,7 +45,9 @@ export default function StatsBanner({ team }: StatsBannerProps) {
     <Root>
       <Header>
         <Typography variant="h3">Last 30 days</Typography>
-        <WidgetLink to={`/app/${team}/analytics`}>view analytics</WidgetLink>
+        <WidgetLink to="/app/$team" params={{ team }}>
+          view analytics
+        </WidgetLink>
       </Header>
       <StatsGrid>
         {STATS.map(({ label }) => (

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -1,7 +1,8 @@
 import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { CustomLink } from "ui/shared/CustomLink/CustomLink";
+import { WidgetLink } from "ui/editor/DashboardWidget";
 
 const STATS = [
   { label: "Total sessions" },
@@ -11,50 +12,42 @@ const STATS = [
 ];
 
 interface StatsBannerProps {
-  teamSlug: string;
+  team: string;
 }
 
-export default function StatsBanner({ teamSlug }: StatsBannerProps) {
+const Root = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.light}`,
+  padding: theme.spacing(1.5),
+  marginTop: theme.spacing(4),
+  marginBottom: theme.spacing(2),
+}));
+
+const Header = styled(Box)({
+  display: "flex",
+  justifyContent: "flex-start",
+  gap: 16,
+  alignItems: "baseline",
+  marginBottom: 12,
+});
+
+const StatsGrid = styled(Box)(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "repeat(4, 1fr)",
+  gap: theme.spacing(2),
+  [theme.breakpoints.down("md")]: {
+    gridTemplateColumns: "repeat(2, 1fr)",
+  },
+}));
+
+export default function StatsBanner({ team }: StatsBannerProps) {
   return (
-    <Box
-      sx={(theme) => ({
-        backgroundColor: theme.palette.background.paper,
-        border: `1px solid ${theme.palette.border.light}`,
-        padding: theme.spacing(1.5),
-        mt: 4,
-        mb: 2,
-      })}
-    >
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "flex-start",
-          gap: 2,
-          alignItems: "baseline",
-          mb: 1.5,
-        }}
-      >
+    <Root>
+      <Header>
         <Typography variant="h3">Last 30 days</Typography>
-        <CustomLink
-          to={`/app/${teamSlug}/analytics`}
-          sx={(theme) => ({
-            fontSize: theme.typography.body3.fontSize,
-            color: theme.palette.text.secondary,
-          })}
-        >
-          view analytics
-        </CustomLink>
-      </Box>
-      <Box
-        sx={(theme) => ({
-          display: "grid",
-          gridTemplateColumns: "repeat(4, 1fr)",
-          gap: theme.spacing(2),
-          [theme.breakpoints.down("md")]: {
-            gridTemplateColumns: "repeat(2, 1fr)",
-          },
-        })}
-      >
+        <WidgetLink to={`/app/${team}/analytics`}>view analytics</WidgetLink>
+      </Header>
+      <StatsGrid>
         {STATS.map(({ label }) => (
           <Box key={label}>
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
@@ -65,7 +58,7 @@ export default function StatsBanner({ teamSlug }: StatsBannerProps) {
             </Typography>
           </Box>
         ))}
-      </Box>
-    </Box>
+      </StatsGrid>
+    </Root>
   );
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -1,10 +1,14 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import { DashboardWidget } from "ui/editor/DashboardWidget";
 import React from "react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { useStore } from "../../pages/FlowEditor/lib/store";
 
 export default function Dashboard() {
+  const team = useStore((state) => state.getTeam());
+
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Typography variant="h2" component="h1" gutterBottom>
@@ -19,28 +23,28 @@ export default function Dashboard() {
       >
         <DashboardWidget
           title="Flows"
-          linkTarget="/app/flows"
+          linkTarget={`/app/${team.slug}/flows`}
           linkText="view all flows"
         >
           <i>flows content</i>
         </DashboardWidget>
         <DashboardWidget
           title="Notifications"
-          linkTarget="/app/notifications"
+          linkTarget={`/app/${team.slug}/notifications`}
           linkText="view all notifications"
         >
           <i>notifications content</i>
         </DashboardWidget>
         <DashboardWidget
           title="Feedback"
-          linkTarget="/app/feedback"
+          linkTarget={`/app/${team.slug}/feedback`}
           linkText="view all feedback"
         >
           <i>feedback content</i>
         </DashboardWidget>
         <DashboardWidget
           title="Activity"
-          linkTarget="/app/activity"
+          linkTarget={`/app/${team.slug}/activity`}
           linkText="view analytics"
         >
           <i>activity content</i>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import { linkOptions } from "@tanstack/react-router";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
@@ -26,30 +27,35 @@ export default function Dashboard() {
         >
           <DashboardWidget
             title="Flows"
-            linkTarget={`/app/${team.slug}/flows`}
-            linkText="view all flows"
+            link={linkOptions({
+              to: "/app/$team",
+              params: { team: team.slug },
+              label: "view all flows",
+            })}
           >
             <i>flows content</i>
           </DashboardWidget>
           <DashboardWidget
             title="Notifications"
-            linkTarget={`/app/${team.slug}/notifications`}
-            linkText="view all notifications"
+            link={linkOptions({
+              to: "/app/$team/notifications",
+              params: { team: team.slug },
+              label: "view all notifications",
+            })}
           >
             <i>notifications content</i>
           </DashboardWidget>
           <DashboardWidget
             title="Feedback"
-            linkTarget={`/app/${team.slug}/feedback`}
-            linkText="view all feedback"
+            link={linkOptions({
+              to: "/app/$team/feedback",
+              params: { team: team.slug },
+              label: "view all feedback",
+            })}
           >
             <i>feedback content</i>
           </DashboardWidget>
-          <DashboardWidget
-            title="Activity"
-            linkTarget={`/app/${team.slug}/activity`}
-            linkText="view analytics"
-          >
+          <DashboardWidget title="Activity">
             <i>activity content</i>
           </DashboardWidget>
         </Box>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -1,13 +1,51 @@
+import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
 import React from "react";
 
 export default function Dashboard() {
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="lg" sx={{ py: 4 }}>
       <Typography variant="h2" component="h1" gutterBottom>
         Dashboard
       </Typography>
+      <Box
+        sx={(theme) => ({
+          display: "grid",
+          gap: theme.spacing(2),
+          gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+        })}
+      >
+        <DashboardWidget
+          title="Flows"
+          linkTarget="/app/flows"
+          linkText="view all flows"
+        >
+          <i>flows content</i>
+        </DashboardWidget>
+        <DashboardWidget
+          title="Notifications"
+          linkTarget="/app/notifications"
+          linkText="view all notifications"
+        >
+          <i>notifications content</i>
+        </DashboardWidget>
+        <DashboardWidget
+          title="Feedback"
+          linkTarget="/app/feedback"
+          linkText="view all feedback"
+        >
+          <i>feedback content</i>
+        </DashboardWidget>
+        <DashboardWidget
+          title="Activity"
+          linkTarget="/app/activity"
+          linkText="view analytics"
+        >
+          <i>activity content</i>
+        </DashboardWidget>
+      </Box>
     </Container>
   );
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -15,7 +15,7 @@ export default function Dashboard() {
       <Typography variant="h2" component="h1" gutterBottom>
         {team.name}
       </Typography>
-      <StatsBanner team={team} />
+      <StatsBanner team={team.slug} />
       <Box
         sx={(theme) => ({
           display: "grid",

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -11,47 +11,49 @@ export default function Dashboard() {
   const team = useStore((state) => state.getTeam());
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-      <Typography variant="h2" component="h1" gutterBottom>
-        {team.name}
-      </Typography>
-      <StatsBanner team={team.slug} />
-      <Box
-        sx={(theme) => ({
-          display: "grid",
-          gap: theme.spacing(2),
-          gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
-        })}
-      >
-        <DashboardWidget
-          title="Flows"
-          linkTarget={`/app/${team.slug}/flows`}
-          linkText="view all flows"
+    <Box sx={{ bgcolor: "background.paper", flexGrow: 1 }}>
+      <Container maxWidth="contentWide" sx={{ py: 4 }}>
+        <Typography variant="h2" component="h1" gutterBottom>
+          {team.name}
+        </Typography>
+        <StatsBanner team={team.slug} />
+        <Box
+          sx={(theme) => ({
+            display: "grid",
+            gap: theme.spacing(2),
+            gridTemplateColumns: "repeat(auto-fit, minmax(470px, 1fr))",
+          })}
         >
-          <i>flows content</i>
-        </DashboardWidget>
-        <DashboardWidget
-          title="Notifications"
-          linkTarget={`/app/${team.slug}/notifications`}
-          linkText="view all notifications"
-        >
-          <i>notifications content</i>
-        </DashboardWidget>
-        <DashboardWidget
-          title="Feedback"
-          linkTarget={`/app/${team.slug}/feedback`}
-          linkText="view all feedback"
-        >
-          <i>feedback content</i>
-        </DashboardWidget>
-        <DashboardWidget
-          title="Activity"
-          linkTarget={`/app/${team.slug}/activity`}
-          linkText="view analytics"
-        >
-          <i>activity content</i>
-        </DashboardWidget>
-      </Box>
-    </Container>
+          <DashboardWidget
+            title="Flows"
+            linkTarget={`/app/${team.slug}/flows`}
+            linkText="view all flows"
+          >
+            <i>flows content</i>
+          </DashboardWidget>
+          <DashboardWidget
+            title="Notifications"
+            linkTarget={`/app/${team.slug}/notifications`}
+            linkText="view all notifications"
+          >
+            <i>notifications content</i>
+          </DashboardWidget>
+          <DashboardWidget
+            title="Feedback"
+            linkTarget={`/app/${team.slug}/feedback`}
+            linkText="view all feedback"
+          >
+            <i>feedback content</i>
+          </DashboardWidget>
+          <DashboardWidget
+            title="Activity"
+            linkTarget={`/app/${team.slug}/activity`}
+            linkText="view analytics"
+          >
+            <i>activity content</i>
+          </DashboardWidget>
+        </Box>
+      </Container>
+    </Box>
   );
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -15,7 +15,7 @@ export default function Dashboard() {
       <Typography variant="h2" component="h1" gutterBottom>
         {team.name}
       </Typography>
-      <StatsBanner teamSlug={team.slug} />
+      <StatsBanner team={team} />
       <Box
         sx={(theme) => ({
           display: "grid",

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
+import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
   const team = useStore((state) => state.getTeam());
@@ -12,8 +13,9 @@ export default function Dashboard() {
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Typography variant="h2" component="h1" gutterBottom>
-        Dashboard
+        {team.name}
       </Typography>
+      <StatsBanner teamSlug={team.slug} />
       <Box
         sx={(theme) => ({
           display: "grid",

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -1,13 +1,35 @@
+import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 export default function Explore() {
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="lg" sx={{ py: 4 }}>
       <Typography variant="h2" component="h1" gutterBottom>
         Explore
       </Typography>
+      <Box
+        sx={(theme) => ({
+          display: "grid",
+          gap: theme.spacing(2),
+          gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
+        })}
+      >
+        <DashboardWidget title="Templates" linkText="view all templates">
+          <i>templates content</i>
+        </DashboardWidget>
+        <DashboardWidget title="What's happening">
+          <i>news content</i>
+        </DashboardWidget>
+        <DashboardWidget title="Help and resources">
+          <i>resources content</i>
+        </DashboardWidget>
+        <DashboardWidget title="Available content">
+          <i>available content</i>
+        </DashboardWidget>
+      </Box>
     </Container>
   );
 }

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import { linkOptions } from "@tanstack/react-router";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
@@ -21,25 +22,20 @@ export default function Explore() {
           gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
         })}
       >
-        <DashboardWidget
-          title="Templates"
-          linkText="view all templates"
-          linkTarget={`/app/${team.slug}/flows?templates=source+template`}
-        >
+        <DashboardWidget title="Templates">
           <i>templates content</i>
         </DashboardWidget>
         <DashboardWidget
           title="Help and resources"
-          linkText="view all help and resources"
-          linkTarget={`/app/${team.slug}/resources`}
+          link={linkOptions({
+            to: "/app/$team/resources",
+            params: { team: team.slug },
+            label: "view all help and resources",
+          })}
         >
           <i>resources content</i>
         </DashboardWidget>
-        <DashboardWidget
-          title="Available content"
-          linkText="view analytics"
-          linkTarget={`/app/${team.slug}/analytics`}
-        >
+        <DashboardWidget title="Available content">
           <i>available content</i>
         </DashboardWidget>
       </Box>

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -4,7 +4,11 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
+import { useStore } from "../../pages/FlowEditor/lib/store";
+
 export default function Explore() {
+  const team = useStore((state) => state.getTeam());
+
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Typography variant="h2" component="h1" gutterBottom>
@@ -17,16 +21,25 @@ export default function Explore() {
           gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
         })}
       >
-        <DashboardWidget title="Templates" linkText="view all templates">
+        <DashboardWidget
+          title="Templates"
+          linkText="view all templates"
+          linkTarget={`/app/${team.slug}/flows?templates=source+template`}
+        >
           <i>templates content</i>
         </DashboardWidget>
-        <DashboardWidget title="What's happening">
-          <i>news content</i>
-        </DashboardWidget>
-        <DashboardWidget title="Help and resources">
+        <DashboardWidget
+          title="Help and resources"
+          linkText="view all help and resources"
+          linkTarget={`/app/${team.slug}/resources`}
+        >
           <i>resources content</i>
         </DashboardWidget>
-        <DashboardWidget title="Available content">
+        <DashboardWidget
+          title="Available content"
+          linkText="view analytics"
+          linkTarget={`/app/${team.slug}/analytics`}
+        >
           <i>available content</i>
         </DashboardWidget>
       </Box>

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -28,7 +28,7 @@ const Header = styled(Box)({
   justifyContent: "space-between",
 });
 
-const WidgetLink = styled(CustomLink)(({ theme }) => ({
+export const WidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body3.fontSize,
   color: theme.palette.text.secondary,
   "&:hover": {

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -1,0 +1,57 @@
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import { styled, SxProps, Theme } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+interface DashboardWidgetProps {
+  title: string;
+  linkTarget?: string;
+  linkText?: string;
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+const Root = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.border.light}`,
+  padding: theme.spacing(1.5),
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing(2),
+  height: "400px",
+}));
+
+const Header = styled(Box)({
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+});
+
+const WidgetLink = styled(Link)(({ theme }) => ({
+  fontSize: theme.typography.body3.fontSize,
+  color: theme.palette.text.secondary,
+  "&:hover": {
+    textDecorationThickness: "2px",
+  },
+}));
+
+export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
+  title,
+  linkTarget,
+  linkText,
+  children,
+  sx,
+}) => (
+  <Root sx={sx}>
+    <Header>
+      <Typography variant="h3" component="h2">
+        {title}
+      </Typography>
+      {linkTarget && linkText && (
+        <WidgetLink href={linkTarget}>{linkText}</WidgetLink>
+      )}
+    </Header>
+    {children}
+  </Root>
+);

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -1,13 +1,13 @@
 import Box from "@mui/material/Box";
 import { styled, SxProps, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { LinkOptions, RegisteredRouter } from "@tanstack/react-router";
 import React from "react";
 import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
   title: string;
-  linkTarget?: string;
-  linkText?: string;
+  link?: LinkOptions<RegisteredRouter> & { label: string };
   children: React.ReactNode;
   sx?: SxProps<Theme>;
 }
@@ -28,7 +28,7 @@ const Header = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1.5),
 }));
 
-export const WidgetLink = styled(CustomLink)(({ theme }) => ({
+const StyledWidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body3.fontSize,
   color: theme.palette.text.secondary,
   "&:hover": {
@@ -36,10 +36,19 @@ export const WidgetLink = styled(CustomLink)(({ theme }) => ({
   },
 })) as typeof CustomLink;
 
+type WidgetLinkProps = LinkOptions<RegisteredRouter> & { label: string };
+
+export const WidgetLink = ({ label, ...linkProps }: WidgetLinkProps) => (
+  <StyledWidgetLink
+    {...(linkProps as React.ComponentProps<typeof StyledWidgetLink>)}
+  >
+    {label}
+  </StyledWidgetLink>
+);
+
 export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   title,
-  linkTarget,
-  linkText,
+  link,
   children,
   sx,
 }) => (
@@ -48,9 +57,7 @@ export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
       <Typography variant="h3" component="h2">
         {title}
       </Typography>
-      {linkTarget && linkText && (
-        <WidgetLink to={linkTarget}>{linkText}</WidgetLink>
-      )}
+      {link && <WidgetLink {...link} />}
     </Header>
     {children}
   </Root>

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -13,11 +13,12 @@ interface DashboardWidgetProps {
 }
 
 const Root = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.background.paper,
+  backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
   display: "flex",
   flexDirection: "column",
   height: "380px",
+  zIndex: 1,
 }));
 
 const Header = styled(Box)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -15,18 +15,18 @@ interface DashboardWidgetProps {
 const Root = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   border: `1px solid ${theme.palette.border.light}`,
-  padding: theme.spacing(1.5),
   display: "flex",
   flexDirection: "column",
   gap: theme.spacing(2),
   height: "400px",
 }));
 
-const Header = styled(Box)({
+const Header = styled(Box)(({ theme }) => ({
   display: "flex",
   alignItems: "baseline",
   justifyContent: "space-between",
-});
+  padding: theme.spacing(1.5),
+}));
 
 export const WidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body3.fontSize,

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -17,8 +17,7 @@ const Root = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.light}`,
   display: "flex",
   flexDirection: "column",
-  gap: theme.spacing(2),
-  height: "400px",
+  height: "380px",
 }));
 
 const Header = styled(Box)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -1,8 +1,8 @@
 import Box from "@mui/material/Box";
-import Link from "@mui/material/Link";
 import { styled, SxProps, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
   title: string;
@@ -28,13 +28,13 @@ const Header = styled(Box)({
   justifyContent: "space-between",
 });
 
-const WidgetLink = styled(Link)(({ theme }) => ({
+const WidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body3.fontSize,
   color: theme.palette.text.secondary,
   "&:hover": {
     textDecorationThickness: "2px",
   },
-}));
+})) as typeof CustomLink;
 
 export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   title,
@@ -49,7 +49,7 @@ export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
         {title}
       </Typography>
       {linkTarget && linkText && (
-        <WidgetLink href={linkTarget}>{linkText}</WidgetLink>
+        <WidgetLink to={linkTarget}>{linkText}</WidgetLink>
       )}
     </Header>
     {children}


### PR DESCRIPTION
### What's in this PR?
- `StatsBanner` component - ready for linking up to real stats
- `DashboardWidget` component - re-usable card-like component for the dashboard / explore grid items (perhaps this could do with a better name)
- layout presenting these

These should provide a good basis for developing the actual content that will go inside them.