### PR TITLE
fix: camelCase team slug for A4 `.caz` data fields

### DIFF
--- a/apps/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/apps/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -39,6 +39,7 @@ import * as stoke from "./local_authorities/metadata/stoke.js";
 import * as tewkesbury from "./local_authorities/metadata/tewkesbury.js";
 import * as torbay from "./local_authorities/metadata/torbay.js";
 import * as westBerkshire from "./local_authorities/metadata/westBerkshire.js";
+import { camelCase } from "lodash";
 
 export interface LocalAuthorityMetadata {
   planningConstraints: {
@@ -323,15 +324,8 @@ async function go(
     }
 
     // rename `articleFour.caz` to reflect localAuthority if applicable, ensuring `councilName` segment matches other A4 values (not always same as team-slug)
-    const customTeamSlugs: Record<string, string> = {
-      "barking-and-dagenham": "barkingAndDagenham",
-      "epsom-and-ewell": "epsomAndEwell",
-      "st-albans": "stAlbans",
-      "west-berkshire": "westBerkshire",
-    };
-    const localCaz = Object.keys(customTeamSlugs).includes(localAuthority)
-      ? `articleFour.${customTeamSlugs[localAuthority]}.caz`
-      : `articleFour.${localAuthority}.caz`;
+    const localCaz = `articleFour.${localAuthority.includes("-") ? camelCase(localAuthority) : localAuthority}.caz`;
+
     if (formattedResult["articleFour.caz"]) {
       formattedResult[localCaz] = formattedResult["articleFour.caz"];
       delete formattedResult["articleFour.caz"];

--- a/apps/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/apps/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -7,8 +7,9 @@ import {
 } from "@opensystemslab/planx-core/types";
 import { gql } from "graphql-request";
 import fetch from "isomorphic-fetch";
-import { addDesignatedVariable } from "./helpers.js";
+import camelCase from "lodash/camelCase.js";
 import { $api } from "../../../client/index.js";
+import { addDesignatedVariable } from "./helpers.js";
 
 import * as adurAndWorthing from "./local_authorities/metadata/adurAndWorthing.js";
 import * as barkingAndDagenham from "./local_authorities/metadata/barkingAndDagenham.js";
@@ -39,7 +40,6 @@ import * as stoke from "./local_authorities/metadata/stoke.js";
 import * as tewkesbury from "./local_authorities/metadata/tewkesbury.js";
 import * as torbay from "./local_authorities/metadata/torbay.js";
 import * as westBerkshire from "./local_authorities/metadata/westBerkshire.js";
-import { camelCase } from "lodash";
 
 export interface LocalAuthorityMetadata {
   planningConstraints: {


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1779803353067779

Testing:
- Proceed through planning constraints for any address (doens't matter if caz is true or false)
- Staging returns `articleFour.south-gloucestershire.caz` 
- This pizza returns `articleFour.southGloucestershire.caz` 