### PR TITLE
feat: dashboard flows panel

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
@@ -75,8 +75,11 @@ const meta = {
     (Story) => (
       <DashboardWidget
         title="Flows"
-        linkTarget="/app/test-council"
-        linkText="view all flows"
+        link={{
+          to: "/app/$team",
+          params: { team: "test-council" },
+          label: "view all flows",
+        }}
       >
         <Story />
       </DashboardWidget>

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
@@ -84,6 +84,7 @@ const meta = {
   ],
   args: {
     flows: mockFlows,
+    teamSlug: "test-council",
     loading: false,
   },
 } satisfies Meta<typeof FlowsPanel>;

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
@@ -1,0 +1,107 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
+import React from "react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { FlowsPanel } from "./FlowsPanel";
+
+const mockFlows: FlowSummary[] = [
+  {
+    id: "1",
+    name: "Apply for planning permission",
+    slug: "apply-for-planning-permission",
+    status: "online",
+    updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    summary: "",
+    operations: [],
+    publishedFlows: [],
+    templatedFrom: null,
+    isTemplate: false,
+    isListedOnLPS: false,
+    pinnedFlows: [{ flowId: "1" }],
+    template: { team: { name: "Test Council" } },
+  },
+  {
+    id: "2",
+    name: "Apply for a lawful development certificate",
+    slug: "apply-for-ldc",
+    status: "online",
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+    summary: "",
+    operations: [],
+    publishedFlows: [],
+    templatedFrom: null,
+    isTemplate: false,
+    isListedOnLPS: false,
+    pinnedFlows: [],
+    template: { team: { name: "Test Council" } },
+  },
+  {
+    id: "3",
+    name: "Prior approval: larger home extension",
+    slug: "prior-approval-larger-home-extension",
+    status: "offline",
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    summary: "",
+    operations: [],
+    publishedFlows: [],
+    templatedFrom: "some-template-id",
+    isTemplate: false,
+    isListedOnLPS: false,
+    pinnedFlows: [{ flowId: "3" }],
+    template: { team: { name: "Test Council" } },
+  },
+  {
+    id: "4",
+    name: "Report a planning breach",
+    slug: "report-a-planning-breach",
+    status: "offline",
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+    summary: "",
+    operations: [],
+    publishedFlows: [],
+    templatedFrom: null,
+    isTemplate: false,
+    isListedOnLPS: false,
+    pinnedFlows: [],
+    template: { team: { name: "Test Council" } },
+  },
+];
+
+const meta = {
+  title: "Editor Components/Dashboard/FlowsPanel",
+  component: FlowsPanel,
+  decorators: [
+    (Story) => (
+      <DashboardWidget
+        title="Flows"
+        linkTarget="/app/test-council"
+        linkText="view all flows"
+      >
+        <Story />
+      </DashboardWidget>
+    ),
+  ],
+  args: {
+    flows: mockFlows,
+    loading: false,
+  },
+} satisfies Meta<typeof FlowsPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithFlows: Story = {};
+
+export const NoFlows: Story = {
+  args: {
+    flows: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -9,7 +9,7 @@ import Typography from "@mui/material/Typography";
 import { Link } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
-import React, { useState } from "react";
+import React from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 import StyledTab from "ui/editor/StyledTab";
@@ -22,8 +22,6 @@ const TabList = styled(Box)(() => ({
     display: "none",
   },
 }));
-
-type Tab = "recent" | "pinned";
 
 const MAX_FLOWS = 5;
 
@@ -38,7 +36,8 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
   teamSlug,
   loading = false,
 }) => {
-  const [tab, setTab] = useState<Tab>("recent");
+  const tab = useStore((state) => state.dashboardFlowsTab);
+  const setTab = useStore((state) => state.setDashboardFlowsTab);
 
   const recentFlows = [...flows]
     .sort(

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -4,6 +4,8 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { useState } from "react";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
@@ -16,12 +18,16 @@ type Tab = "recent" | "pinned";
 
 const MAX_FLOWS = 5;
 
-export const FlowsPanel: React.FC = () => {
-  const [tab, setTab] = useState<Tab>("recent");
-  const teamId = useStore((state) => state.getTeam().id);
-  const { data } = useGetFlows(teamId);
+interface FlowsPanelProps {
+  flows: FlowSummary[];
+  loading?: boolean;
+}
 
-  const flows = data?.flows ?? [];
+export const FlowsPanel: React.FC<FlowsPanelProps> = ({
+  flows,
+  loading = false,
+}) => {
+  const [tab, setTab] = useState<Tab>("recent");
 
   const recentFlows = [...flows]
     .sort(
@@ -44,53 +50,76 @@ export const FlowsPanel: React.FC = () => {
         <StyledTab label="Recent flows" value="recent" fontSize="16px" />
         <StyledTab label="Pinned flows" value="pinned" fontSize="16px" />
       </Tabs>
-      <List disablePadding sx={{ overflowY: "auto", flex: 1 }}>
-        {displayed.map((flow, i) => {
-          const isOnline = flow.status === "online";
-          const isAnyTemplate = flow.isTemplate || Boolean(flow.templatedFrom);
-          return (
-            <React.Fragment key={flow.id}>
-              {i > 0 && <Divider />}
-              <ListItem
-                sx={{
-                  px: 1.5,
-                  py: 1,
-                  backgroundColor: isAnyTemplate
-                    ? "template.light"
-                    : "transparent",
-                }}
-              >
-                <ListItemText
-                  primary={
-                    <Typography variant="body1" sx={{ fontWeight: "bold" }}>
-                      {flow.name}
-                    </Typography>
-                  }
-                />
-                <FlowTag
-                  tagType={FlowTagType.Status}
-                  statusVariant={
-                    isOnline ? StatusVariant.Online : StatusVariant.Offline
-                  }
+      {loading ? (
+        <List
+          disablePadding
+          sx={{
+            display: "flex",
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+        </List>
+      ) : (
+        <List disablePadding sx={{ overflowY: "auto", flex: 1 }}>
+          {displayed.map((flow, i) => {
+            const isOnline = flow.status === "online";
+            const isAnyTemplate =
+              flow.isTemplate || Boolean(flow.templatedFrom);
+            return (
+              <React.Fragment key={flow.id}>
+                {i > 0 && <Divider />}
+                <ListItem
+                  sx={{
+                    px: 1.5,
+                    py: 1,
+                    backgroundColor: isAnyTemplate
+                      ? "template.light"
+                      : "transparent",
+                  }}
                 >
-                  {isOnline ? "Online" : "Offline"}
-                </FlowTag>
-              </ListItem>
-            </React.Fragment>
-          );
-        })}
-        {displayed.length === 0 && (
-          <ListItem sx={{ px: 1.5, py: 1 }}>
-            <ListItemText
-              primary={
-                <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                  {tab === "pinned" ? "No pinned flows" : "No flows yet"}
-                </Typography>
-              }
-            />
-          </ListItem>
-        )}
-      </List>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+                        {flow.name}
+                      </Typography>
+                    }
+                  />
+                  <FlowTag
+                    tagType={FlowTagType.Status}
+                    statusVariant={
+                      isOnline ? StatusVariant.Online : StatusVariant.Offline
+                    }
+                  >
+                    {isOnline ? "Online" : "Offline"}
+                  </FlowTag>
+                </ListItem>
+              </React.Fragment>
+            );
+          })}
+          {displayed.length === 0 && (
+            <ListItem sx={{ px: 1.5, py: 1 }}>
+              <ListItemText
+                primary={
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    {tab === "pinned" ? "No pinned flows" : "No flows yet"}
+                  </Typography>
+                }
+              />
+            </ListItem>
+          )}
+        </List>
+      )}
     </>
   );
 };
+
+export default function ConnectedFlowsPanel() {
+  const teamId = useStore((state) => state.getTeam().id);
+  const { data, loading } = useGetFlows(teamId);
+  const flows = data?.flows ?? [];
+
+  return <FlowsPanel flows={flows} loading={loading} />;
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -1,0 +1,96 @@
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
+import StyledTab from "ui/editor/StyledTab";
+
+import { useStore } from "../../FlowEditor/lib/store";
+import { useGetFlows } from "../../Team/components/hooks/useGetFlows";
+
+type Tab = "recent" | "pinned";
+
+const MAX_FLOWS = 5;
+
+export const FlowsPanel: React.FC = () => {
+  const [tab, setTab] = useState<Tab>("recent");
+  const teamId = useStore((state) => state.getTeam().id);
+  const { data } = useGetFlows(teamId);
+
+  const flows = data?.flows ?? [];
+
+  const recentFlows = [...flows]
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    )
+    .slice(0, MAX_FLOWS);
+
+  const pinnedFlows = flows.filter((f) => f.pinnedFlows.length > 0);
+
+  const displayed = tab === "recent" ? recentFlows : pinnedFlows;
+
+  return (
+    <>
+      <Tabs
+        value={tab}
+        onChange={(_e, v) => setTab(v)}
+        sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main" }}
+      >
+        <StyledTab label="Recent flows" value="recent" />
+        <StyledTab label="Pinned flows" value="pinned" />
+      </Tabs>
+      <List disablePadding sx={{ overflowY: "auto", flex: 1 }}>
+        {displayed.map((flow, i) => {
+          const isOnline = flow.status === "online";
+          const isAnyTemplate = flow.isTemplate || Boolean(flow.templatedFrom);
+          return (
+            <React.Fragment key={flow.id}>
+              {i > 0 && <Divider />}
+              <ListItem
+                sx={{
+                  px: 1.5,
+                  py: 1,
+                  backgroundColor: isAnyTemplate
+                    ? "template.light"
+                    : "transparent",
+                }}
+              >
+                <ListItemText
+                  primary={
+                    <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+                      {flow.name}
+                    </Typography>
+                  }
+                />
+                <FlowTag
+                  tagType={FlowTagType.Status}
+                  statusVariant={
+                    isOnline ? StatusVariant.Online : StatusVariant.Offline
+                  }
+                >
+                  {isOnline ? "Online" : "Offline"}
+                </FlowTag>
+              </ListItem>
+            </React.Fragment>
+          );
+        })}
+        {displayed.length === 0 && (
+          <ListItem sx={{ px: 1.5, py: 1 }}>
+            <ListItemText
+              primary={
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {tab === "pinned" ? "No pinned flows" : "No flows yet"}
+                </Typography>
+              }
+            />
+          </ListItem>
+        )}
+      </List>
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -1,9 +1,12 @@
+import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import Tabs from "@mui/material/Tabs";
+import { styled } from "@mui/material/styles";
+import Tabs, { tabsClasses } from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
+import { Link } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React, { useState } from "react";
@@ -14,17 +17,25 @@ import StyledTab from "ui/editor/StyledTab";
 import { useStore } from "../../FlowEditor/lib/store";
 import { useGetFlows } from "../../Team/components/hooks/useGetFlows";
 
+const TabList = styled(Box)(() => ({
+  [`& .${tabsClasses.indicator}`]: {
+    display: "none",
+  },
+}));
+
 type Tab = "recent" | "pinned";
 
 const MAX_FLOWS = 5;
 
 interface FlowsPanelProps {
   flows: FlowSummary[];
+  teamSlug: string;
   loading?: boolean;
 }
 
 export const FlowsPanel: React.FC<FlowsPanelProps> = ({
   flows,
+  teamSlug,
   loading = false,
 }) => {
   const [tab, setTab] = useState<Tab>("recent");
@@ -42,14 +53,16 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
 
   return (
     <>
-      <Tabs
-        value={tab}
-        onChange={(_e, v) => setTab(v)}
-        sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main" }}
-      >
-        <StyledTab label="Recent flows" value="recent" fontSize="16px" />
-        <StyledTab label="Pinned flows" value="pinned" fontSize="16px" />
-      </Tabs>
+      <TabList>
+        <Tabs
+          value={tab}
+          onChange={(_e, v) => setTab(v)}
+          sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main" }}
+        >
+          <StyledTab label="Recent flows" value="recent" fontSize="16px" />
+          <StyledTab label="Pinned flows" value="pinned" fontSize="16px" />
+        </Tabs>
+      </TabList>
       {loading ? (
         <List
           disablePadding
@@ -70,16 +83,32 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
               flow.isTemplate || Boolean(flow.templatedFrom);
             return (
               <React.Fragment key={flow.id}>
-                {i > 0 && <Divider />}
+                {i > 0 && <Divider sx={{ borderColor: "border.main" }} />}
                 <ListItem
                   sx={{
+                    position: "relative",
                     px: 1.5,
                     py: 1,
                     backgroundColor: isAnyTemplate
                       ? "template.light"
                       : "transparent",
+                    "&:hover": {
+                      backgroundColor: isAnyTemplate
+                        ? "template.main"
+                        : "background.paper",
+                    },
                   }}
                 >
+                  <Link
+                    to="/app/$team/$flow"
+                    params={{ team: teamSlug, flow: flow.slug }}
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      zIndex: 1,
+                    }}
+                    aria-label={flow.name}
+                  />
                   <ListItemText
                     primary={
                       <Typography variant="body1" sx={{ fontWeight: "bold" }}>
@@ -117,9 +146,9 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
 };
 
 export default function ConnectedFlowsPanel() {
-  const teamId = useStore((state) => state.getTeam().id);
-  const { data, loading } = useGetFlows(teamId);
+  const team = useStore((state) => state.getTeam());
+  const { data, loading } = useGetFlows(team.id);
   const flows = data?.flows ?? [];
 
-  return <FlowsPanel flows={flows} loading={loading} />;
+  return <FlowsPanel flows={flows} teamSlug={team.slug} loading={loading} />;
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -16,6 +16,7 @@ import StyledTab from "ui/editor/StyledTab";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import { useGetFlows } from "../../Team/components/hooks/useGetFlows";
+import { NoFlowsGetStarted } from "../../Team/index";
 
 const TabList = styled(Box)(() => ({
   [`& .${tabsClasses.indicator}`]: {
@@ -144,9 +145,13 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
                 justifyContent: "center",
               }}
             >
-              <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                {tab === "pinned" ? "No pinned flows" : "No flows yet"}
-              </Typography>
+              {tab === "pinned" ? (
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  No pinned flows
+                </Typography>
+              ) : (
+                <NoFlowsGetStarted />
+              )}
             </ListItem>
           )}
         </List>

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -41,8 +41,8 @@ export const FlowsPanel: React.FC = () => {
         onChange={(_e, v) => setTab(v)}
         sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main" }}
       >
-        <StyledTab label="Recent flows" value="recent" />
-        <StyledTab label="Pinned flows" value="pinned" />
+        <StyledTab label="Recent flows" value="recent" fontSize="16px" />
+        <StyledTab label="Pinned flows" value="pinned" fontSize="16px" />
       </Tabs>
       <List disablePadding sx={{ overflowY: "auto", flex: 1 }}>
         {displayed.map((flow, i) => {

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -76,7 +76,15 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
           <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
         </List>
       ) : (
-        <List disablePadding sx={{ overflowY: "auto", flex: 1 }}>
+        <List
+          disablePadding
+          sx={{
+            overflowY: "auto",
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           {displayed.map((flow, i) => {
             const isOnline = flow.status === "online";
             const isAnyTemplate =
@@ -129,14 +137,17 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
             );
           })}
           {displayed.length === 0 && (
-            <ListItem sx={{ px: 1.5, py: 1 }}>
-              <ListItemText
-                primary={
-                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                    {tab === "pinned" ? "No pinned flows" : "No flows yet"}
-                  </Typography>
-                }
-              />
+            <ListItem
+              sx={{
+                display: "flex",
+                flex: 1,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                {tab === "pinned" ? "No pinned flows" : "No flows yet"}
+              </Typography>
             </ListItem>
           )}
         </List>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
-import { FlowsPanel } from "./components/FlowsPanel";
+import FlowsPanel from "./components/FlowsPanel";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
+import { FlowsPanel } from "./components/FlowsPanel";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
@@ -33,7 +34,7 @@ export default function Dashboard() {
               label: "view all flows",
             })}
           >
-            <i>flows content</i>
+            <FlowsPanel />
           </DashboardWidget>
           <DashboardWidget
             title="Notifications"

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -63,6 +63,8 @@ export interface EditorUIStore {
   setLoadingCompleteCallback: (callback: (() => void) | undefined) => void;
   flowCardView: FlowCardView;
   setFlowCardView: (view: FlowCardView) => void;
+  dashboardFlowsTab: "recent" | "pinned";
+  setDashboardFlowsTab: (tab: "recent" | "pinned") => void;
   showTags: boolean;
   toggleShowTags: () => void;
   showImages: boolean;
@@ -120,6 +122,12 @@ export const editorUIStore: StateCreator<
 
     setFlowCardView: (view: FlowCardView) => {
       set({ flowCardView: view });
+    },
+
+    dashboardFlowsTab: "recent",
+
+    setDashboardFlowsTab: (tab) => {
+      set({ dashboardFlowsTab: tab });
     },
 
     showTags: true,
@@ -198,6 +206,7 @@ export const editorUIStore: StateCreator<
     partialize: (state) => ({
       showSidebar: state.showSidebar,
       flowCardView: state.flowCardView,
+      dashboardFlowsTab: state.dashboardFlowsTab,
       showTags: state.showTags,
       showImages: state.showImages,
       showNotes: state.showNotes,

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
@@ -2,8 +2,10 @@ import { useQuery } from "@apollo/client";
 
 import { GET_FLOWS, GetAnyFlowsQuery, GetAnyFlowsVars } from "../../queries";
 
-export const useGetFlows = (teamId: number) =>
-  useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_FLOWS, {
-    variables: { teamId },
-    fetchPolicy: "cache-and-network",
-  });
+export const useGetFlows = (teamId: number) => {
+  const { data, loading } = useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(
+    GET_FLOWS,
+    { variables: { teamId }, fetchPolicy: "cache-and-network" },
+  );
+  return { data, loading };
+};

--- a/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/hooks/useGetFlows.ts
@@ -2,10 +2,8 @@ import { useQuery } from "@apollo/client";
 
 import { GET_FLOWS, GetAnyFlowsQuery, GetAnyFlowsVars } from "../../queries";
 
-export const useGetFlows = (teamId: number) => {
-  const { data, loading } = useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(
-    GET_FLOWS,
-    { variables: { teamId }, fetchPolicy: "cache-and-network" },
-  );
-  return { data, loading };
-};
+export const useGetFlows = (teamId: number) =>
+  useQuery<GetAnyFlowsQuery, GetAnyFlowsVars>(GET_FLOWS, {
+    variables: { teamId },
+    fetchPolicy: "cache-and-network",
+  });

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -20,7 +20,7 @@ import TeamLayout from "./TeamLayout";
 
 export type FlowView = "flows" | "archive";
 
-const GetStarted: React.FC = () => (
+export const NoFlowsGetStarted: React.FC = () => (
   <EmptyState
     title="No flows found"
     description="Get started by creating your first flow"
@@ -230,7 +230,9 @@ const Team: React.FC<TeamProps> = (initialFlows) => {
           />
         )}
 
-        {flowView === "flows" && flows && !flows.length && <GetStarted />}
+        {flowView === "flows" && flows && !flows.length && (
+          <NoFlowsGetStarted />
+        )}
       </Container>
     </Box>
   );

--- a/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
@@ -5,6 +5,7 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface StyledTabProps extends TabProps {
   size?: "default" | "large";
+  fontSize?: string;
 }
 
 const TabLabel = styled("span")(() => ({
@@ -34,7 +35,7 @@ const StyledTab = styled(
   {
     shouldForwardProp: (prop) => prop !== "size",
   },
-)<StyledTabProps>(({ theme, size = "default" }) => ({
+)<StyledTabProps>(({ theme, size = "default", fontSize }) => ({
   position: "relative",
   zIndex: 1,
   textTransform: "none",
@@ -45,7 +46,7 @@ const StyledTab = styled(
   minHeight: size === "large" ? "48px" : "36px",
   margin: theme.spacing(0, size === "large" ? 1 : 0.5),
   padding: "0.75em",
-  fontSize: size === "large" ? "1rem" : undefined,
+  fontSize: fontSize ?? (size === "large" ? "1rem" : undefined),
   "& svg": {
     marginRight: "7px !important",
     fontSize: 18,


### PR DESCRIPTION
### What's in this PR?
Adds the 'flows' panel for the dashboard page. Fairly straightforward as we already have this data displayed in a very similar format.

Also added `fontSize` parameter to our `StyledTabs` - but some of other sizing here is still slightly off from the designs so perhaps it would be better to make a whole new variant? 