### PR TITLE
feat: dashboard notifications panel

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useRecentNotifications.ts
@@ -53,22 +53,22 @@ const GET_RESOLVED_NOTIFICATIONS = gql`
 export const useRecentNotifications = (): {
   active: Notification[];
   resolved: Notification[];
+  loading: boolean;
 } => {
   const teamId = useStore((state) => state.teamId);
   const skip = !teamId;
 
-  const { data: activeData } = useSubscription<{ active: Notification[] }>(
-    GET_ACTIVE_NOTIFICATIONS,
-    { variables: { teamId }, skip },
-  );
+  const { data: activeData, loading: activeLoading } = useSubscription<{
+    active: Notification[];
+  }>(GET_ACTIVE_NOTIFICATIONS, { variables: { teamId }, skip });
 
-  const { data: resolvedData } = useSubscription<{ resolved: Notification[] }>(
-    GET_RESOLVED_NOTIFICATIONS,
-    { variables: { teamId }, skip },
-  );
+  const { data: resolvedData, loading: resolvedLoading } = useSubscription<{
+    resolved: Notification[];
+  }>(GET_RESOLVED_NOTIFICATIONS, { variables: { teamId }, skip });
 
   return {
     active: activeData?.active ?? [],
     resolved: resolvedData?.resolved ?? [],
+    loading: activeLoading || resolvedLoading,
   };
 };

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/tanstack-react";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/tanstack-react";
 import { Notification } from "pages/FlowEditor/components/Notifications/types";
 
 import { NotificationsWidget } from "./NotificationsWidget";

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.stories.tsx
@@ -1,0 +1,74 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Notification } from "pages/FlowEditor/components/Notifications/types";
+
+import { NotificationsWidget } from "./NotificationsWidget";
+
+const mockNotifications: Notification[] = [
+  {
+    id: 1,
+    flow: {
+      name: "Apply for planning permission",
+      slug: "apply-for-planning-permission",
+    },
+    team: { name: "Test Council", slug: "test-council" },
+    type: "template_flow_updated",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+    resolvedAt: null,
+    resolvedByUser: null,
+  },
+  {
+    id: 2,
+    flow: {
+      name: "Apply for a lawful development certificate",
+      slug: "apply-for-ldc",
+    },
+    team: { name: "Test Council", slug: "test-council" },
+    type: "template_flow_updated",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    resolvedAt: null,
+    resolvedByUser: null,
+  },
+  {
+    id: 3,
+    flow: {
+      name: "Prior approval: larger home extension",
+      slug: "prior-approval-larger-home-extension",
+    },
+    team: { name: "Test Council", slug: "test-council" },
+    type: "template_flow_updated",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+    resolvedAt: null,
+    resolvedByUser: null,
+  },
+];
+
+const meta = {
+  title: "Editor Components/Dashboard/NotificationsWidget",
+  component: NotificationsWidget,
+  args: {
+    teamSlug: "test-council",
+    notifications: mockNotifications,
+    totalCount: mockNotifications.length,
+  },
+} satisfies Meta<typeof NotificationsWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithNotifications: Story = {};
+
+export const NoNotifications: Story = {
+  args: {
+    notifications: [],
+    totalCount: 0,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    notifications: [],
+    totalCount: 0,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -27,6 +27,7 @@ export function NotificationsWidget({
     return (
       <DashboardWidget
         title="Notifications"
+        count={totalCount}
         link={{
           to: "/app/$team/notifications",
           params: { team: teamSlug },

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -1,6 +1,8 @@
 import Stack from "@mui/material/Stack";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useRecentNotifications } from "hooks/data/useRecentNotifications";
 import NotificationCardItem from "pages/FlowEditor/components/Notifications/NotificationCard";
+import { Notification } from "pages/FlowEditor/components/Notifications/types";
 import { partitionBySuperseded } from "pages/FlowEditor/components/Notifications/utils";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
@@ -8,36 +10,81 @@ import { EmptyState } from "ui/editor/EmptyState";
 
 const WIDGET_LIMIT = 3;
 
-export const NotificationsWidget = () => {
-  const team = useStore((state) => state.getTeam());
-  const { active } = useRecentNotifications();
-  const { current: activeNotifications } = partitionBySuperseded(active);
-  const visibleNotifications = activeNotifications.slice(0, WIDGET_LIMIT);
+interface NotificationsWidgetProps {
+  notifications: Notification[];
+  totalCount: number;
+  teamSlug: string;
+  loading?: boolean;
+}
 
-  return (
-    <DashboardWidget
-      title="Notifications"
-      count={activeNotifications.length}
-      linkTarget={`/app/${team.slug}/notifications`}
-      linkText="view all notifications"
-    >
-      {visibleNotifications.length === 0 ? (
+export function NotificationsWidget({
+  notifications,
+  totalCount,
+  teamSlug,
+  loading = false,
+}: NotificationsWidgetProps) {
+  if (loading) {
+    return (
+      <DashboardWidget
+        title="Notifications"
+        count={totalCount}
+        linkTarget={`/app/${teamSlug}/notifications`}
+        linkText="view all notifications"
+      >
+        <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+      </DashboardWidget>
+    );
+  }
+
+  if (notifications.length === 0) {
+    return (
+      <DashboardWidget
+        title="Notifications"
+        count={totalCount}
+        linkTarget={`/app/${teamSlug}/notifications`}
+        linkText="view all notifications"
+      >
         <EmptyState
           size="small"
           title="No notifications, you're all up to date"
           sx={{ mx: 2 }}
         />
-      ) : (
-        <Stack component="ul" sx={{ overflowY: "auto", flex: 1, m: 0, p: 0 }}>
-          {visibleNotifications.map((notification) => (
-            <NotificationCardItem
-              key={notification.id}
-              notification={notification}
-              compact
-            />
-          ))}
-        </Stack>
-      )}
+      </DashboardWidget>
+    );
+  }
+
+  return (
+    <DashboardWidget
+      title="Notifications"
+      count={totalCount}
+      linkTarget={`/app/${teamSlug}/notifications`}
+      linkText="view all notifications"
+    >
+      <Stack component="ul" sx={{ overflowY: "auto", flex: 1, m: 0, p: 0 }}>
+        {notifications.map((notification) => (
+          <NotificationCardItem
+            key={notification.id}
+            notification={notification}
+            compact
+          />
+        ))}
+      </Stack>
     </DashboardWidget>
   );
-};
+}
+
+export default function ConnectedNotificationsWidget() {
+  const team = useStore((state) => state.getTeam());
+  const { active, loading } = useRecentNotifications();
+  const { current: activeNotifications } = partitionBySuperseded(active);
+  const visibleNotifications = activeNotifications.slice(0, WIDGET_LIMIT);
+
+  return (
+    <NotificationsWidget
+      notifications={visibleNotifications}
+      totalCount={activeNotifications.length}
+      teamSlug={team.slug}
+      loading={loading}
+    />
+  );
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -27,7 +27,6 @@ export function NotificationsWidget({
     return (
       <DashboardWidget
         title="Notifications"
-        count={totalCount}
         link={{
           to: "/app/$team/notifications",
           params: { team: teamSlug },

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -1,0 +1,43 @@
+import Stack from "@mui/material/Stack";
+import { useRecentNotifications } from "hooks/data/useRecentNotifications";
+import NotificationCardItem from "pages/FlowEditor/components/Notifications/NotificationCard";
+import { partitionBySuperseded } from "pages/FlowEditor/components/Notifications/utils";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+import { EmptyState } from "ui/editor/EmptyState";
+
+const WIDGET_LIMIT = 3;
+
+export const NotificationsWidget = () => {
+  const team = useStore((state) => state.getTeam());
+  const { active } = useRecentNotifications();
+  const { current: activeNotifications } = partitionBySuperseded(active);
+  const visibleNotifications = activeNotifications.slice(0, WIDGET_LIMIT);
+
+  return (
+    <DashboardWidget
+      title="Notifications"
+      count={activeNotifications.length}
+      linkTarget={`/app/${team.slug}/notifications`}
+      linkText="view all notifications"
+    >
+      {visibleNotifications.length === 0 ? (
+        <EmptyState
+          size="small"
+          title="No notifications, you're all up to date"
+          sx={{ mx: 2 }}
+        />
+      ) : (
+        <Stack component="ul" sx={{ overflowY: "auto", flex: 1, m: 0, p: 0 }}>
+          {visibleNotifications.map((notification) => (
+            <NotificationCardItem
+              key={notification.id}
+              notification={notification}
+              compact
+            />
+          ))}
+        </Stack>
+      )}
+    </DashboardWidget>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -28,8 +28,11 @@ export function NotificationsWidget({
       <DashboardWidget
         title="Notifications"
         count={totalCount}
-        linkTarget={`/app/${teamSlug}/notifications`}
-        linkText="view all notifications"
+        link={{
+          to: "/app/$team/notifications",
+          params: { team: teamSlug },
+          label: "view all notifications",
+        }}
       >
         <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
       </DashboardWidget>
@@ -41,8 +44,11 @@ export function NotificationsWidget({
       <DashboardWidget
         title="Notifications"
         count={totalCount}
-        linkTarget={`/app/${teamSlug}/notifications`}
-        linkText="view all notifications"
+        link={{
+          to: "/app/$team/notifications",
+          params: { team: teamSlug },
+          label: "view all notifications",
+        }}
       >
         <EmptyState
           size="small"
@@ -57,8 +63,11 @@ export function NotificationsWidget({
     <DashboardWidget
       title="Notifications"
       count={totalCount}
-      linkTarget={`/app/${teamSlug}/notifications`}
-      linkText="view all notifications"
+      link={{
+        to: "/app/$team/notifications",
+        params: { team: teamSlug },
+        label: "view all notifications",
+      }}
     >
       <Stack component="ul" sx={{ overflowY: "auto", flex: 1, m: 0, p: 0 }}>
         {notifications.map((notification) => (

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -7,6 +7,7 @@ import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import FlowsPanel from "./components/FlowsPanel";
+import ConnectedNotificationsWidget from "./components/NotificationsWidget";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
@@ -46,6 +47,7 @@ export default function Dashboard() {
           >
             <i>notifications content</i>
           </DashboardWidget>
+          <ConnectedNotificationsWidget />
           <DashboardWidget
             title="Feedback"
             link={linkOptions({

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -2,11 +2,13 @@ import Box from "@mui/material/Box";
 import { styled, SxProps, Theme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { LinkOptions, RegisteredRouter } from "@tanstack/react-router";
+import { BadgeChip } from "components/EditorNavMenu/styles";
 import React from "react";
 import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
   title: string;
+  count?: number;
   link?: LinkOptions<RegisteredRouter> & { label: string };
   children: React.ReactNode;
   sx?: SxProps<Theme>;
@@ -48,15 +50,21 @@ export const WidgetLink = ({ label, ...linkProps }: WidgetLinkProps) => (
 
 export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   title,
+  count,
   link,
   children,
   sx,
 }) => (
   <Root sx={sx}>
     <Header>
-      <Typography variant="h3" component="h2">
-        {title}
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Typography variant="h3" component="h2">
+          {title}
+        </Typography>
+        {count !== undefined && count > 0 && (
+          <BadgeChip label={count} color="info" />
+        )}
+      </Box>
       {link && <WidgetLink {...link} />}
     </Header>
     {children}


### PR DESCRIPTION
### What's in this PR?
Adds the 'notifications' panel for the dashboard page. Fairly straightforward as we already have this data displayed in a very similar format.

This one doesn't match the designs exactly, as I re-used the whole `NotificationCard` component that's already being used and is very close. The only difference I could spot is the button styling, where there is a separate button rather than just the whole card being clickable. For now I think it's fine to keep as it, when we introduce more notification types that have multiple actions associated with them, we will want to re-design this card component both for the sidebar and the panel.