### PR TITLE
fix(api): Return 4XX for user file upload errors, not 5XX

### DIFF
--- a/apps/api.planx.uk/modules/file/docs.yaml
+++ b/apps/api.planx.uk/modules/file/docs.yaml
@@ -47,6 +47,16 @@ components:
               error:
                 type: string
                 example: "Unsupported file type. Mimetype: text/plain. Extension: .txt"
+    FileTooLarge:
+      description: The uploaded file exceeds the 30MB size limit
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: "File too large"
     DownloadFile:
       description: Successful response
       content:
@@ -76,7 +86,9 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/UploadFile"
-        "400":
+        "413":
+          $ref: "#/components/responses/FileTooLarge"
+        "415":
           $ref: "#/components/responses/UnsupportedFileType"
         "500":
           $ref: "#/components/responses/ErrorMessage"
@@ -93,7 +105,9 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/UploadFile"
-        "400":
+        "413":
+          $ref: "#/components/responses/FileTooLarge"
+        "415":
           $ref: "#/components/responses/UnsupportedFileType"
         "500":
           $ref: "#/components/responses/ErrorMessage"

--- a/apps/api.planx.uk/modules/file/docs.yaml
+++ b/apps/api.planx.uk/modules/file/docs.yaml
@@ -37,6 +37,16 @@ components:
             - type: "null"
         fileUrl:
           type: string
+    UnsupportedFileType:
+      description: The uploaded file has an unsupported MIME type or extension
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: "Unsupported file type. Mimetype: text/plain. Extension: .txt"
     DownloadFile:
       description: Successful response
       content:
@@ -66,6 +76,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/UploadFile"
+        "400":
+          $ref: "#/components/responses/UnsupportedFileType"
         "500":
           $ref: "#/components/responses/ErrorMessage"
   /file/public/upload:
@@ -81,6 +93,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/UploadFile"
+        "400":
+          $ref: "#/components/responses/UnsupportedFileType"
         "500":
           $ref: "#/components/responses/ErrorMessage"
   /file/public/{fileKey}/{fileName}:

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -54,7 +54,7 @@ describe("File upload", () => {
           .post(ENDPOINT)
           .field("filename", "")
           .attach("file", Buffer.from("some data"), "some_file.xlxs")
-          .expect(500)
+          .expect(400)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -69,7 +69,7 @@ describe("File upload", () => {
             filename: "invalid_file.txt", // Invalid file type
             contentType: "text/plain", // Invalid MIME type
           })
-          .expect(500)
+          .expect(400)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -84,7 +84,7 @@ describe("File upload", () => {
             filename: "invalid_file.png", // Valid file type
             contentType: "text/plain", // Invalid MIME type
           })
-          .expect(500)
+          .expect(400)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -99,7 +99,7 @@ describe("File upload", () => {
             filename: "invalid_file.txt", // Invalid file type
             contentType: "application/pdf", // Valid MIME type
           })
-          .expect(500)
+          .expect(400)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -141,7 +141,7 @@ describe("File upload", () => {
           filename: "my_file.jpg",
           contentType: "image/jpg",
         })
-        .expect(500)
+        .expect(400)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Unsupported file type/);
@@ -291,7 +291,7 @@ describe("File upload", () => {
           filename: "my_file.jpg",
           contentType: "image/jpg",
         })
-        .expect(500)
+        .expect(400)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Unsupported file type/);

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -47,6 +47,36 @@ describe("File upload", () => {
   });
 
   describe.each([PRIVATE_ENDPOINT, PUBLIC_ENDPOINT])(
+    "File size validation for %s",
+    (ENDPOINT) => {
+      it("should return 413 when file exceeds the 30MB limit", async () => {
+        const oversizedBuffer = Buffer.alloc(31 * 1024 * 1024); // 31MB
+        await supertest(app)
+          .post(ENDPOINT)
+          .field("filename", "")
+          .attach("file", oversizedBuffer, "large_file.pdf")
+          .expect(413)
+          .then((res) => {
+            expect(mockPutObject).not.toHaveBeenCalled();
+            expect(res.body.error).toMatch(/File too large/);
+          });
+      });
+
+      it("should return 400 when file is attached to an unexpected field", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .field("filename", "")
+          .attach("wrong_field", Buffer.from("some data"), "some_file.pdf")
+          .expect(400)
+          .then((res) => {
+            expect(mockPutObject).not.toHaveBeenCalled();
+            expect(res.body.error).toMatch(/Unexpected field/);
+          });
+      });
+    },
+  );
+
+  describe.each([PRIVATE_ENDPOINT, PUBLIC_ENDPOINT])(
     "File type validation for %s",
     (ENDPOINT) => {
       it("should not upload a file with an invalid extension", async () => {
@@ -54,7 +84,7 @@ describe("File upload", () => {
           .post(ENDPOINT)
           .field("filename", "")
           .attach("file", Buffer.from("some data"), "some_file.xlxs")
-          .expect(400)
+          .expect(415)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -69,7 +99,7 @@ describe("File upload", () => {
             filename: "invalid_file.txt", // Invalid file type
             contentType: "text/plain", // Invalid MIME type
           })
-          .expect(400)
+          .expect(415)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -84,7 +114,7 @@ describe("File upload", () => {
             filename: "invalid_file.png", // Valid file type
             contentType: "text/plain", // Invalid MIME type
           })
-          .expect(400)
+          .expect(415)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -99,7 +129,7 @@ describe("File upload", () => {
             filename: "invalid_file.txt", // Invalid file type
             contentType: "application/pdf", // Valid MIME type
           })
-          .expect(400)
+          .expect(415)
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
@@ -141,7 +171,7 @@ describe("File upload", () => {
           filename: "my_file.jpg",
           contentType: "image/jpg",
         })
-        .expect(400)
+        .expect(415)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Unsupported file type/);
@@ -291,7 +321,7 @@ describe("File upload", () => {
           filename: "my_file.jpg",
           contentType: "image/jpg",
         })
-        .expect(400)
+        .expect(415)
         .then((res) => {
           expect(mockPutObject).not.toHaveBeenCalled();
           expect(res.body.error).toMatch(/Unsupported file type/);

--- a/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -54,9 +54,13 @@ const upload = multer(multerOptions).single("file");
 
 export const useFileUpload: RequestHandler = (req, res, next) => {
   upload(req, res, (err) => {
-    if (err instanceof multer.MulterError || err instanceof Error) {
-      // User-facing validation failure, e.g. unsupported file type
-      return res.status(400).json({ error: err.message });
+    if (err instanceof multer.MulterError) {
+      const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
+      return res.status(status).json({ error: err.message });
+    }
+    if (err instanceof Error) {
+      // fileFilter rejection - unsupported file type
+      return res.status(415).json({ error: err.message });
     }
     // System error - log to Airbrake, return 5XX to user
     if (err) return next(err);

--- a/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -1,5 +1,6 @@
 import multer from "multer";
 import path from "path";
+import type { RequestHandler } from "express";
 
 /**
  * 30mb to match limit set in frontend
@@ -49,4 +50,16 @@ const multerOptions: multer.Options = {
   fileFilter,
 };
 
-export const useFileUpload = multer(multerOptions).single("file");
+const upload = multer(multerOptions).single("file");
+
+export const useFileUpload: RequestHandler = (req, res, next) => {
+  upload(req, res, (err) => {
+    if (err instanceof multer.MulterError || err instanceof Error) {
+      // User-facing validation failure, e.g. unsupported file type
+      return res.status(400).json({ error: err.message });
+    }
+    // System error - log to Airbrake, return 5XX to user
+    if (err) return next(err);
+    next();
+  });
+};

--- a/apps/api.planx.uk/vitest.config.ts
+++ b/apps/api.planx.uk/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       reporter: ["lcov", "html", "text-summary"],
       thresholds: {
         statements: 77.59,
-        branches: 60.41,
+        branches: 60.5,
         functions: 78.07,
         lines: 77.83,
         autoUpdate: true,


### PR DESCRIPTION
## What's the problem?
Currently if a user uploads an unsupported file type we log this to error and return a status 500 error (system error). This is noisy in Airbrake and semantically incorrect - this should be a 4XX (user error).

Airbrake error - https://planx.airbrake.io/projects/329753/groups/4305428642307087654?tab=overview

## What's the solution?
Update the `useFileUpload` middleware to support [413](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/413) and [415](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/415) statuses, update tests.

## Motivation
I'm trying to narrow down and resolve Airbrake issues as a bit of a side-quest so that the signal to noise ratio here is a little more meaningful - aiming to pick up one issue a day...!