### PR TITLE
feat: dashboard feedback panel

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/tanstack-react";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
@@ -18,8 +18,11 @@ const meta = {
     (Story) => (
       <DashboardWidget
         title="Feedback"
-        linkTarget="/app/test-council/feedback"
-        linkText="view all feedback"
+        link={{
+          to: "/app/$team/feedback",
+          params: { team: "test-council" },
+          label: "view all feedback",
+        }}
       >
         <Story />
       </DashboardWidget>

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { FeedbackWidget } from "./FeedbackWidget";
+
+const mockFlows = [
+  { flowName: "Apply for planning permission", count: 14 },
+  { flowName: "Apply for a lawful development certificate", count: 7 },
+  { flowName: "Report a planning breach", count: 3 },
+  { flowName: "Prior approval: larger home extension", count: 1 },
+];
+
+const meta = {
+  title: "Editor Components/Dashboard/FeedbackWidget",
+  component: FeedbackWidget,
+  decorators: [
+    (Story) => (
+      <DashboardWidget
+        title="Feedback"
+        linkTarget="/app/test-council/feedback"
+        linkText="view all feedback"
+      >
+        <Story />
+      </DashboardWidget>
+    ),
+  ],
+  args: {
+    flows: mockFlows,
+    total: mockFlows.reduce((sum, { count }) => sum + count, 0),
+    loading: false,
+  },
+} satisfies Meta<typeof FeedbackWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithFeedback: Story = {};
+
+export const NoFeedback: Story = {
+  args: {
+    flows: [],
+    total: 0,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
@@ -1,0 +1,51 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import { useUnreadFeedback } from "./useUnreadFeedback";
+
+interface FeedbackWidgetProps {
+  teamSlug: string;
+}
+
+export default function FeedbackWidget({ teamSlug }: FeedbackWidgetProps) {
+  const { flows, total } = useUnreadFeedback(teamSlug);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 1,
+          px: 1.5,
+          pb: 1,
+        }}
+      >
+        <Typography variant="h1" component="p">
+          {total}
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          unread items across all flows
+        </Typography>
+      </Box>
+      <Divider />
+      <Box sx={{ overflowY: "auto" }}>
+        {flows.map(({ flowName, count }) => (
+          <React.Fragment key={flowName}>
+            <Box sx={{ px: 1.5, py: 1 }}>
+              <Typography variant="body2">
+                <strong>{flowName}</strong>
+              </Typography>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                {count} unread {count === 1 ? "item" : "items"}
+              </Typography>
+            </Box>
+            <Divider />
+          </React.Fragment>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
@@ -1,16 +1,37 @@
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import React from "react";
 
-import { useUnreadFeedback } from "./useUnreadFeedback";
+import { useStore } from "../../FlowEditor/lib/store";
+import { FlowSummary, useUnreadFeedback } from "./useUnreadFeedback";
 
 interface FeedbackWidgetProps {
-  teamSlug: string;
+  flows: FlowSummary[];
+  total: number;
+  loading?: boolean;
 }
 
-export default function FeedbackWidget({ teamSlug }: FeedbackWidgetProps) {
-  const { flows, total } = useUnreadFeedback(teamSlug);
+export function FeedbackWidget({
+  flows,
+  total,
+  loading = false,
+}: FeedbackWidgetProps) {
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -48,4 +69,11 @@ export default function FeedbackWidget({ teamSlug }: FeedbackWidgetProps) {
       </Box>
     </Box>
   );
+}
+
+export default function ConnectedFeedbackWidget() {
+  const teamSlug = useStore((state) => state.getTeam().slug);
+  const { flows, total, loading } = useUnreadFeedback(teamSlug);
+
+  return <FeedbackWidget flows={flows} total={total} loading={loading} />;
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const GET_UNREAD_FEEDBACK_SUMMARY = gql`
+  query GetUnreadFeedbackByTeam($teamSlug: String!) {
+    feedback_summary(
+      where: { team_slug: { _eq: $teamSlug }, status: { _eq: "unread" } }
+    ) {
+      flowName: service_name
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 
 import { GET_UNREAD_FEEDBACK_SUMMARY } from "./queries";
 
-interface FlowSummary {
+export interface FlowSummary {
   flowName: string;
   count: number;
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from "@apollo/client";
+
+import { GET_UNREAD_FEEDBACK_SUMMARY } from "./queries";
+
+interface FlowSummary {
+  flowName: string;
+  count: number;
+}
+
+export const useUnreadFeedback = (teamSlug: string) => {
+  const { data, loading, error } = useQuery<{
+    feedback_summary: { flowName: string }[];
+  }>(GET_UNREAD_FEEDBACK_SUMMARY, {
+    variables: { teamSlug },
+  });
+
+  const counts = (data?.feedback_summary ?? []).reduce<Record<string, number>>(
+    (acc, { flowName }) => {
+      acc[flowName] = (acc[flowName] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+
+  const flows: FlowSummary[] = Object.entries(counts)
+    .map(([flowName, count]) => ({ flowName, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const total = flows.reduce((sum, { count }) => sum + count, 0);
+
+  return { flows, total, loading, error };
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -8,6 +8,7 @@ import { DashboardWidget } from "ui/editor/DashboardWidget";
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import FlowsPanel from "./components/FlowsPanel";
 import ConnectedNotificationsWidget from "./components/NotificationsWidget";
+import FeedbackWidget from "./components/FeedbackWidget";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
@@ -56,7 +57,7 @@ export default function Dashboard() {
               label: "view all feedback",
             })}
           >
-            <i>feedback content</i>
+            <FeedbackWidget teamSlug={team.slug} />
           </DashboardWidget>
           <DashboardWidget title="Activity">
             <i>activity content</i>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -57,7 +57,7 @@ export default function Dashboard() {
               label: "view all feedback",
             })}
           >
-            <FeedbackWidget teamSlug={team.slug} />
+            <FeedbackWidget />
           </DashboardWidget>
           <DashboardWidget title="Activity">
             <i>activity content</i>


### PR DESCRIPTION
### What's in this PR?
Adds the 'feedback' panel for the dashboard page.

I looked into making the list items link to specific feedback entries on the feedback page but I don't think its possible as the route just renders a table, and the table filters do not persist in the URL. 

Decided to write a new query rather than using the existing one on the feedback page because there's a lot less information required for this table and we'll want it to load as fast as possible, being a landing page summary.