### PR TITLE
feat(editor): Fix error logging for ShareDB issues

### DIFF
--- a/apps/editor.planx.uk/src/components/Error/ErrorFallback.tsx
+++ b/apps/editor.planx.uk/src/components/Error/ErrorFallback.tsx
@@ -7,10 +7,21 @@ import type { FallbackProps } from "react-error-boundary";
 
 import { GraphErrorComponent, isGraphError } from "./GraphError";
 
+const normalizeError = (error: unknown): Error => {
+  if (error instanceof Error) return error;
+  if (typeof error === "string") return new Error(error);
+  try {
+    return new Error(JSON.stringify(error));
+  } catch {
+    return new Error(String(error));
+  }
+};
+
 const ErrorFallback: React.FC<FallbackProps> = ({ error }) => {
   if (isGraphError(error)) return <GraphErrorComponent error={error} />;
 
-  logger.notify(error);
+  const normalizedError = normalizeError(error);
+  logger.notify(normalizedError);
 
   return (
     <Card>
@@ -19,9 +30,9 @@ const ErrorFallback: React.FC<FallbackProps> = ({ error }) => {
           Something went wrong
         </Typography>
         <Typography>
-          {(error as Error).message && (
+          {normalizedError.message && (
             <pre style={{ color: "#E91B0C", whiteSpace: "pre-line" }}>
-              {(error as Error).message}
+              {normalizedError.message}
             </pre>
           )}
         </Typography>

--- a/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
+++ b/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
@@ -18,6 +18,10 @@ const ThrowError: React.FC = () => {
   throw new Error("Something broke");
 };
 
+const ThrowPlainObject: React.FC = () => {
+  throw { ops: [{ p: ["nodeId", "data"], oi: { title: "new" } }] };
+};
+
 const ThrowGraphError: React.FC = () => {
   throw new GraphError("nodeMustFollowFindProperty");
 };
@@ -56,6 +60,24 @@ it("renders if a child throws an error", async () => {
 
   expect(queryByText(/Something went wrong/)).not.toBeInTheDocument();
   expect(getByRole("heading", { name: /Invalid graph/ })).toBeInTheDocument();
+});
+
+it("normalises a plain object error and calls Airbrake with a proper Error", async () => {
+  const loggerSpy = vi.spyOn(logger, "notify");
+
+  await setup(
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <ThrowPlainObject />
+    </ErrorBoundary>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalled();
+
+  // All calls should receive a proper Error instance (not a plain object)
+  for (const [notifiedError] of loggerSpy.mock.calls) {
+    expect(notifiedError).toBeInstanceOf(Error);
+    expect((notifiedError as Error).message).toContain("ops");
+  }
 });
 
 it("does not call Airbrake", async () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -23,6 +23,7 @@ import {
 } from "@planx/graph";
 import { OT } from "@planx/graph/types";
 import type { RegisteredRouter } from "@tanstack/react-router";
+import { logger } from "airbrake";
 import { client } from "lib/graphql";
 import debounce from "lodash/debounce";
 import { type } from "ot-json0";
@@ -45,7 +46,11 @@ let doc: Doc;
 const send = (ops: Array<any>) => {
   if (ops.length > 0) {
     console.log({ ops });
-    doc.submitOp(ops);
+    doc.submitOp(ops, {}, (err) => {
+      if (err) {
+        console.error("[ShareDB] Failed to submit operation:", err);
+      }
+    });
   }
 };
 
@@ -386,6 +391,11 @@ export const editorStore: StateCreator<
     doc.on("op", (_op: any, isLocalOp?: boolean) =>
       isLocalOp ? cloneStateFromLocalOps() : cloneStateFromRemoteOps(),
     );
+
+    doc.on("error", (err: unknown) => {
+      console.error("[ShareDB] Document error:", err);
+      logger.notify(err instanceof Error ? err : new Error(String(err)));
+    });
   },
 
   disconnectFromFlow: () => {


### PR DESCRIPTION
## What's the problem?
Airbrake is logging a number of issues as simply `[Object object]` (please see https://planx.airbrake.io/projects/329753/groups/4331653999003538228?tab=overview)

I believe that these are the ShareDB issues mentioned in this thread (the timing and locations seem to match up pretty well) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1779446296118569

## What's the cause?
This is logging `[Object object]` because Airbrake is being invoked with a plain object instead of an `Error` instance. This is happening because there's no listener for ShareDB `error` events, so they're just getting thrown and caught by the error boundary.

## What's the solution?
- Add a listener, throw as an `Error` instance
- Add additional guards (error normalisation) to catch other instances of this - this should ensure we always pass an `Error` to Airbrake

## What's the underlying ShareDB error here?
Currently, I'm not sure...!

This originates from this diff (by Airbrake's estimate) - https://github.com/theopensystemslab/planx-new/compare/aee9a1d423ecd6c086c3a910bddaf813e9fff156...34d042f8eb79eeeed136067ad003dbb961a2b771 . No clear smoking guns here that I can spot relating to ShareDB.

We only have screenshots of the errors in Slack so it's a little hard to get to the underlying issue without progressing this to prod, and capturing more detail on the underlying error.
