### PR TITLE
feat: dashboard activity panel

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
@@ -1,0 +1,82 @@
+import { gql, useQuery } from "@apollo/client";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+const GET_ACTIVITY_BY_SERVICE = gql`
+  query GetActivityByService($teamId: Int!) {
+    flows(
+      where: { team_id: { _eq: $teamId }, deleted_at: { _is_null: true } }
+    ) {
+      name
+      sessions: lowcal_sessions_aggregate(
+        where: { deleted_at: { _is_null: true } }
+      ) {
+        aggregate {
+          count
+        }
+      }
+      submissions: lowcal_sessions_aggregate(
+        where: {
+          deleted_at: { _is_null: true }
+          submitted_at: { _is_null: false }
+        }
+      ) {
+        aggregate {
+          count
+        }
+      }
+    }
+  }
+`;
+
+type FlowActivity = {
+  name: string;
+  sessions: { aggregate: { count: number } | null };
+  submissions: { aggregate: { count: number } | null };
+};
+
+type GetActivityByServiceQuery = {
+  flows: FlowActivity[];
+};
+
+export type ActivityItem = {
+  name: string;
+  count: number;
+};
+
+const TOP_LIMIT = 5;
+
+export const useActivityData = (): {
+  sessions: ActivityItem[];
+  submissions: ActivityItem[];
+  loading: boolean;
+} => {
+  const teamId = useStore((state) => state.teamId);
+
+  const { data, loading } = useQuery<GetActivityByServiceQuery>(
+    GET_ACTIVITY_BY_SERVICE,
+    {
+      variables: { teamId },
+      skip: !teamId,
+    },
+  );
+
+  const flows = data?.flows ?? [];
+
+  const sessions = flows
+    .map(({ name, sessions }) => ({
+      name,
+      count: sessions.aggregate?.count ?? 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_LIMIT);
+
+  const submissions = flows
+    .map(({ name, submissions }) => ({
+      name,
+      count: submissions.aggregate?.count ?? 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, TOP_LIMIT);
+
+  return { sessions, submissions, loading };
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
@@ -9,11 +9,7 @@ const meta = {
   component: ActivityWidget,
   decorators: [
     (Story) => (
-      <DashboardWidget
-        title="Activity"
-        linkTarget="/app/test-team/activity"
-        linkText="view analytics"
-      >
+      <DashboardWidget title="Activity">
         <Story />
       </DashboardWidget>
     ),

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/tanstack-react";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { ActivityWidget } from "./ActivityWidget";
+
+const meta = {
+  title: "Editor Components/Dashboard/ActivityWidget",
+  component: ActivityWidget,
+  decorators: [
+    (Story) => (
+      <DashboardWidget
+        title="Activity"
+        linkTarget="/app/test-team/activity"
+        linkText="view analytics"
+      >
+        <Story />
+      </DashboardWidget>
+    ),
+  ],
+  args: {
+    loading: false,
+    sessions: [
+      { name: "Apply for planning permission", count: 312 },
+      { name: "Apply for a lawful development certificate", count: 198 },
+      { name: "Report a planning breach", count: 134 },
+      { name: "Prior approval: larger home extension", count: 79 },
+      { name: "Apply for listed building consent", count: 22 },
+    ],
+    submissions: [
+      { name: "Apply for planning permission", count: 204 },
+      { name: "Apply for a lawful development certificate", count: 97 },
+      { name: "Report a planning breach", count: 88 },
+      { name: "Prior approval: larger home extension", count: 41 },
+      { name: "Apply for listed building consent", count: 11 },
+    ],
+  },
+} satisfies Meta<typeof ActivityWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithData: Story = {};
+
+export const NoData: Story = {
+  args: {
+    sessions: [],
+    submissions: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
@@ -1,0 +1,41 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Tabs, { tabsClasses } from "@mui/material/Tabs";
+import { useActivityData } from "hooks/data/useActivityData";
+import React, { useState } from "react";
+import StyledTab from "ui/editor/StyledTab";
+
+import ServiceListWithCount from "./ServiceListWithCount";
+
+const Content = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  justifyContent: "flex-end",
+  overflow: "hidden",
+});
+
+export default function ActivityWidget() {
+  const [tab, setTab] = useState(0);
+  const { sessions, submissions } = useActivityData();
+
+  return (
+    <Content>
+      <Tabs
+        value={tab}
+        onChange={(_, value: number) => setTab(value)}
+        sx={{
+          minHeight: 36,
+          borderBottom: 1,
+          borderColor: "divider",
+          [`& .${tabsClasses.indicator}`]: { display: "none" },
+        }}
+      >
+        <StyledTab label="Sessions by service" />
+        <StyledTab label="Submissions by service" />
+      </Tabs>
+      {tab === 0 && <ServiceListWithCount items={sessions} />}
+      {tab === 1 && <ServiceListWithCount items={submissions} />}
+    </Content>
+  );
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
@@ -1,7 +1,8 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
-import { useActivityData } from "hooks/data/useActivityData";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { ActivityItem, useActivityData } from "hooks/data/useActivityData";
 import React, { useState } from "react";
 import StyledTab from "ui/editor/StyledTab";
 
@@ -15,9 +16,25 @@ const Content = styled(Box)({
   overflow: "hidden",
 });
 
-export default function ActivityWidget() {
+const LoadingArea = styled(Box)({
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+interface ActivityWidgetProps {
+  sessions: ActivityItem[];
+  submissions: ActivityItem[];
+  loading: boolean;
+}
+
+export function ActivityWidget({
+  sessions,
+  submissions,
+  loading,
+}: ActivityWidgetProps) {
   const [tab, setTab] = useState(0);
-  const { sessions, submissions } = useActivityData();
 
   return (
     <Content>
@@ -34,8 +51,27 @@ export default function ActivityWidget() {
         <StyledTab label="Sessions by service" />
         <StyledTab label="Submissions by service" />
       </Tabs>
-      {tab === 0 && <ServiceListWithCount items={sessions} />}
-      {tab === 1 && <ServiceListWithCount items={submissions} />}
+      {loading ? (
+        <LoadingArea>
+          <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+        </LoadingArea>
+      ) : (
+        <>
+          {tab === 0 && <ServiceListWithCount items={sessions} />}
+          {tab === 1 && <ServiceListWithCount items={submissions} />}
+        </>
+      )}
     </Content>
+  );
+}
+
+export default function ConnectedActivityWidget() {
+  const { sessions, submissions, loading } = useActivityData();
+  return (
+    <ActivityWidget
+      sessions={sessions}
+      submissions={submissions}
+      loading={loading}
+    />
   );
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
@@ -47,6 +47,22 @@ export default function ServiceListWithCount({
   const activeItems = items.filter((item) => item.count > 0);
   const maxCount = activeItems[0]?.count ?? 1;
 
+  if (activeItems.length === 0) {
+    return (
+      <ServiceList
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          No activity to show
+        </Typography>
+      </ServiceList>
+    );
+  }
+
   return (
     <ServiceList>
       {activeItems.map((item) => (

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
@@ -1,0 +1,69 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { ActivityItem } from "hooks/data/useActivityData";
+import React from "react";
+
+const ServiceList = styled(Box)(({ theme }) => ({
+  overflowY: "auto",
+  flex: 1,
+  padding: theme.spacing(0, 1.5),
+}));
+
+const ServiceRow = styled(Box)(({ theme }) => ({
+  paddingTop: theme.spacing(1.5),
+  paddingBottom: theme.spacing(1.5),
+  borderBottom: `1px solid ${theme.palette.border.light}`,
+  "&:last-child": {
+    borderBottom: "none",
+  },
+}));
+
+const ServiceMeta = styled(Box)({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "baseline",
+  marginBottom: 6,
+});
+
+const ProgressTrack = styled(Box)(({ theme }) => ({
+  height: 6,
+  borderRadius: 2,
+  backgroundColor: theme.palette.secondary.dark,
+  overflow: "hidden",
+}));
+
+const ProgressFill = styled(Box)(({ theme }) => ({
+  height: "100%",
+  backgroundColor: theme.palette.primary.main,
+  borderRadius: 50,
+}));
+
+export default function ServiceListWithCount({
+  items,
+}: {
+  items: ActivityItem[];
+}) {
+  const activeItems = items.filter((item) => item.count > 0);
+  const maxCount = activeItems[0]?.count ?? 1;
+
+  return (
+    <ServiceList>
+      {activeItems.map((item) => (
+        <ServiceRow key={item.name}>
+          <ServiceMeta>
+            <Typography variant="body3" sx={{ fontWeight: "bold" }}>
+              {item.name}
+            </Typography>
+            <Typography variant="body3" sx={{ fontWeight: "bold" }}>
+              {item.count}
+            </Typography>
+          </ServiceMeta>
+          <ProgressTrack>
+            <ProgressFill sx={{ width: `${(item.count / maxCount) * 100}%` }} />
+          </ProgressTrack>
+        </ServiceRow>
+      ))}
+    </ServiceList>
+  );
+}

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -9,6 +9,7 @@ import { useStore } from "../../pages/FlowEditor/lib/store";
 import FlowsPanel from "./components/FlowsPanel";
 import ConnectedNotificationsWidget from "./components/NotificationsWidget";
 import FeedbackWidget from "./components/FeedbackWidget";
+import ActivityWidget from "./components/ActivityWidget";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
@@ -60,7 +61,7 @@ export default function Dashboard() {
             <FeedbackWidget />
           </DashboardWidget>
           <DashboardWidget title="Activity">
-            <i>activity content</i>
+            <ActivityWidget />
           </DashboardWidget>
         </Box>
       </Container>

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_lowcal_sessions.yaml
@@ -89,6 +89,7 @@ select_permissions:
         - system_status
         - user_status
       filter: {}
+      allow_aggregations: true
     comment: ""
   - role: public
     permission:
@@ -137,6 +138,7 @@ select_permissions:
             members:
               user_id:
                 _eq: x-hasura-user-id
+      allow_aggregations: true
     comment: TeamEditor can select sessions from teams they're a member of. Required to view submissions.
 update_permissions:
   - role: api


### PR DESCRIPTION
### What's in this PR?
Adds the 'activity' panel for the dashboard page. Needed a new gql query & hook, and needed to allow aggregations on lowcal sessions in order to fetch it, so you'll need to make sure metadata is re-applied to test this locally.