### PR TITLE
chore(ci): Upgrade actions/setup-node to v6

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         version: ${{ inputs.pnpm-version }}
         
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"


### PR DESCRIPTION
Resolves the following GHA warning - 

<img width="1533" height="234" alt="image" src="https://github.com/user-attachments/assets/35f16d95-9839-4667-b65d-99bddb43a7c4" />
