### PR TITLE
chore(ci): Update pulumi/actions to v7

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: planx_frontend_build
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-      - uses: pulumi/actions@v6
+      - uses: pulumi/actions@v7
         with:
           command: up
           refresh: true

--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -53,7 +53,7 @@ jobs:
           name: planx_frontend_build
           path: ./${{ env.EDITOR_DIRECTORY }}/build
 
-      - uses: pulumi/actions@v6
+      - uses: pulumi/actions@v7
         with:
           command: up
           refresh: true


### PR DESCRIPTION
Resolves the following GHA warning - 

<img width="1545" height="165" alt="image" src="https://github.com/user-attachments/assets/ea853e4a-ccc2-4be2-b1cc-83a2fd8bef40" />
