### PR TITLE
fix: do not queue up send events when using Editor side panel

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Send/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Public.tsx
@@ -20,9 +20,11 @@ const SendComponent: React.FC<Props> = ({
   ...props
 }) => {
   const fullProps = { destinations: destinations, ...props };
+  const environment = useStore((state) => state.previewEnvironment);
   if (
     window.location.pathname.endsWith("/draft") ||
-    window.location.pathname.endsWith("/preview")
+    window.location.pathname.endsWith("/preview") ||
+    environment !== "standalone" // editor Preview panel
   ) {
     return <SkipSendWarning {...fullProps} />;
   } else {


### PR DESCRIPTION
Will clear up this Airbrake error: https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1779884128133599

> **: Failed to create send events for session . Error: Request failed with status code 404

<img width="1103" height="616" alt="Screenshot from 2026-05-27 08-39-46" src="https://github.com/user-attachments/assets/6749cee2-f2a5-4fd2-922f-1bdb516c9e56" />

When we click through to Airbrake, we can see this occured from a graph URL:
- We _expect_ send event creation to fail on a graph URL because there is _not_ database session storage. It's intentional that Pay & Send integrations can only be tested via published routes
- We can't filter for this in the same `endsWith()` way because graph URLs end the same as published flows on custom subdomains. The "Preview" tab of the graph's side panel is notably _not_ a "standalone" environment though