### PR TITLE
feat: only record `govUkPayment` on redirect to Gov Pay, reconcile if landed on Pay only

### DIFF
--- a/apps/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
@@ -33,9 +33,15 @@ export async function validateSession(
   const sessionUpdatedAt = fetchedSession.updated_at!;
   const flowId = fetchedSession.flow_id!;
 
-  // if a user has paid, skip reconciliation
+  // If a user has at least redirected away to Gov Pay, skip reconciliation
   // Docs: https://docs.payments.service.gov.uk/api_reference/#payment-status-meanings
-  const paymentStartedStatuses = ["created", "submitted", "success"];
+  const paymentStartedStatuses = [
+    "created",
+    "started",
+    "capturable",
+    "submitted",
+    "success",
+  ];
   const userStatus = sessionData?.govUkPayment?.state?.status;
   const userHasPaid = userStatus && paymentStartedStatuses.includes(userStatus);
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -22,6 +22,7 @@ export type Props = PublicProps<Pay>;
 
 type ComponentState =
   | { status: "indeterminate"; displayText?: string }
+  | { status: "no_payment_found" } // landed on Pay, has not redirected to Gov Pay to initiate payment
   | { status: "init" }
   | { status: "redirecting"; displayText?: string }
   | { status: "fetching_payment"; displayText?: string }
@@ -77,7 +78,7 @@ function Component(props: Props) {
       case Action.NoFeeFound:
         return { status: "undefined_fee" };
       case Action.NoPaymentFound:
-        return { status: "init" };
+        return { status: "no_payment_found" };
       case Action.IncompletePaymentFound:
         return {
           status: "fetching_payment",
@@ -285,13 +286,14 @@ function Component(props: Props) {
       fee === 0 || props.hidePay || state.status === "unsupported_team";
 
     if (shouldContinueWithoutPaying) continueWithoutPaying();
-    if (state.status === "init") startNewPayment();
+    if (["no_payment_found", "init"].includes(state.status)) startNewPayment();
     if (state.status === "retry") resumeExistingPayment();
   };
 
   return (
     <>
-      {state.status === "init" ||
+      {state.status === "no_payment_found" ||
+      state.status === "init" ||
       state.status === "retry" ||
       state.status === "unsupported_team" ||
       state.status === "undefined_fee" ||
@@ -301,9 +303,9 @@ function Component(props: Props) {
           fee={fee}
           onConfirm={onConfirm}
           buttonTitle={
-            state.status === "init"
-              ? "Pay now using GOV.UK Pay"
-              : "Retry payment"
+            state.status === "retry"
+              ? "Retry payment"
+              : "Pay now using GOV.UK Pay"
           }
           error={
             (state.status === "unsupported_team" &&


### PR DESCRIPTION
See https://trello.com/c/9WipbaSY/3624-do-not-skip-reconciliation-if-a-payment-has-been-created

**Currently / on staging:**
- As soon as you _land on_ the Pay node, we initiate a payment and store `lowcal_sessions.data.govUkPayment`
- This means that if you "Save" before ever redirecting to Gov Pay, we'll still _skip_ reconciliation when you return (even if fees or any other key content have changed)

**Now / changes here:**
- Only initiate payment once the user has clicked the button to redirect away to Gov Pay
- This allows us to still do reconciliation as usual for any scenarios where a user has landed on and saved from the Pay node (_before_ redirecting away or inviting someone else to pay)

**Testing notes:**
- Go to this editor flow: https://6749.planx.pizza/app/lambeth/pay-test
- Start a session on the `/published` link, proceed to Pay component, click save
- Go back to the editor, update the Calculate node to a new amount (formula), publish
- Resume your session and confirm updated amount is now shown, begin a payment by clicking "Pay now using Gov Pay", click "cancel" on the Gov Pay page, redirect back to PlanX (should _not_ be prompted for email on redirect), the button should now read "Retry [payment]", click save again
- Update and republish the flow once more with a new amount
- Resume your session again and confirm updated amount is now shown (this is because last recorded payment status is "cancelled", _not_ "created" or "started"), complete payment using mock card details, redirect back to PlanX and reach Confirmation page as normal

**Future options / level two:**
- Arguably, we still want to do reconcilation in scenarios where someone has redirected away to Gov Pay but then let the tab expire/timeout. This would require following additional API changes:
  - `validateSession` relies on a `userStatus` which it reads from `lowcal_sessions.data.govUkPayment`, but we'd need to query Gov UK Pay directly to get latest status (not simply what we last recorded)
    - If Gov Pay's status is any not categorised as "finished", then we could "force" a cancellation by removing `lowcal_sessions.data.govUkPayment` key, Pay node breadcrumb on our side, and corresponding `payment_status` record (??)
  - Then we could proceed with reconciliation "as normal" for a session without payment initiation, capturing any changes to fees or other content
- I have _not_ gone for this full change yet because I think there's still some uncertainty / edge cases here around Gov UK payment URLs created on redirect. If a user duplicates this tab, they could still have an "active" form for that payment reference. I think we'd need to very carefully test this if going this route and find more concrete Gov Pay info on link expiry (eg is "forcing the cancellation" on our side actually safe/sufficient) ! 
- There's also the BIG question of how to handle (and communicate to user) over invite to pay time window

For now, I think this first step of "do reconciliation for anyone who lands on Pay only" (or has explicitly cancelled a prior payment) is still a solid improvement / would correct most submission cases we've seen before ! 