### PR TITLE
fix(editor): Fallback to relative links within Editor sidebar and Storybook

### DIFF
--- a/apps/editor.planx.uk/src/hooks/usePublicRouteContext.ts
+++ b/apps/editor.planx.uk/src/hooks/usePublicRouteContext.ts
@@ -1,4 +1,4 @@
-import { notFound, useMatches } from "@tanstack/react-router";
+import { useMatches } from "@tanstack/react-router";
 import { useMemo } from "react";
 
 type PublicRoutePattern =
@@ -12,15 +12,18 @@ type PublicRoutePattern =
  * Returns the correct route pattern for public links based on current domain context.
  * Custom domains use "/$flow" pattern, while editor.planx.uk uses "/$team/$flow/{mode}" pattern.
  *
+ * Returns undefined when called outside a public route context (e.g. Editor sidebar, Storybook).
+ * In those cases links will degrade to (broken) relative links - this will have no external user impact.
+ *
  * Must be used to ensure type-safety and accuracy on any internal links within the _public route structure
  */
-export const usePublicRouteContext = (): PublicRoutePattern => {
+export const usePublicRouteContext = (): PublicRoutePattern | undefined => {
   const matches = useMatches();
 
   return useMemo(() => {
     const currentRoute = matches.at(-1);
 
-    if (!currentRoute?.routeId) throw notFound();
+    if (!currentRoute?.routeId) return undefined;
 
     const { routeId } = currentRoute;
 
@@ -37,6 +40,6 @@ export const usePublicRouteContext = (): PublicRoutePattern => {
       if (routeId.includes("/download-application")) return "/$team/$flow";
     }
 
-    throw notFound();
+    return undefined;
   }, [matches]);
 };

--- a/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
@@ -4,15 +4,8 @@ import Container from "@mui/material/Container";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import {
-  notFound,
-  useLocation,
-  useNavigate,
-  useRouter,
-} from "@tanstack/react-router";
-import { usePublicRouteContext } from "hooks/usePublicRouteContext";
+import { notFound, useLocation, useNavigate } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
 import { FOOTER_ITEMS } from "types";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 


### PR DESCRIPTION
## What's the problem?
Components that rely on the `usePublicContext()` hook throw an error anywhere outside the "public" context (`/_planXDomain` or `/_customSubdomain` routes). This means certain components cannot render within the Editor sidebar or Storybook

Exaple here - https://storybook.planx.uk/?path=/docs/planx-components-feedback--docs

The `Feedback` component just throws a `notFound()` error, and does not render.

Seen here in Airbrake - https://planx.airbrake.io/projects/329753/groups/4341880470066273589?tab=notice-detail

## What's the solution?
Degrate links in these contexts to being just relative ones, by passing an `undefined` `from` argument. This will mean links will be broken within the Editor sidebar and Storybook, but it's not a public-facing user error and is an improvement on the current situation.

## Context
This came up when working on https://github.com/theopensystemslab/planx-new/pull/6739 (now reverted). Once this PR has been merged I'll take another look at the above PR and move forward with it.