### PR TITLE
feat: handle teamAdmin subscription page access

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -183,7 +183,7 @@ function EditorNavMenu() {
             title: "Subscription",
             Icon: CurrencyPoundIcon,
             route: `/app/${teamSlug}/subscription`,
-            accessibleBy: ["platformAdmin", "teamAdmin", "teamEditor"],
+            accessibleBy: ["platformAdmin", "teamAdmin"],
             isNew: true,
           },
         ],

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
 import { Subscription } from "pages/FlowEditor/components/Subscription/Subscription";
@@ -7,10 +7,15 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
-  loader: async ({ params }) => {
-    const isAuthorised = useStore.getState().canUserEditTeam(params.team);
+  loader: async ({ params, context }) => {
+    const isAuthorised =
+      context.user?.isPlatformAdmin ||
+      useStore.getState().getUserRoleForCurrentTeam() === "teamAdmin";
+
     if (!isAuthorised) {
-      throw notFound();
+      throw new Error(
+        "You do not have the necessary permissions to view this page. Please contact a platform administrator if you think this is an error.",
+      );
     }
 
     const {

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_service_charges.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_service_charges.yaml
@@ -28,7 +28,7 @@ select_permissions:
         - session_id
       filter: {}
     comment: ""
-  - role: teamEditor
+  - role: teamAdmin
     permission:
       columns:
         - fiscal_year
@@ -47,7 +47,7 @@ select_permissions:
           members:
             _and:
               - user_id:
-                  _eq: x-hasura-user-id
+                  _eq: X-Hasura-User-Id
               - role:
-                  _eq: teamEditor
+                  _eq: teamAdmin
     comment: ""


### PR DESCRIPTION
# What does this PR do?
- Removes `teamEditor` from the subscription page `accessibleBy` list in `EditorNavMenu`
- Updates roles that the `/subscription` route will load for (`isPlatformAdmin` and relevant `teamAdmin` only)
- Updates Hasura permissions accordingly (I isolated / tested the Hasura permissions also and `teamEditor` cannot select, as expected, and `teamAdmin` can only select for the team for which they have admin privileges. 

# Testing
- As a `platformAdmin` I can view any team's subscription pages
- As a `teamAdmin` I can view the subscription page for my own team only; I see an error when I try to view another
    - ^ The `EditorNavMenu` will not show the option, visit `/app/$team/subscription` to check
- As a `teamEditor` I cannot view any subscription pages

To update the JWT for testing purposes, you'll have to log out and back in again!

Error view:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9caa1570-1ef5-476f-aa24-6d72894894de" />