### PR TITLE
feat: add 'Not relevant' feedback status

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/ChangeStatusTool.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/ChangeStatusTool.test.tsx
@@ -227,6 +227,7 @@ describe("ChangeStatusTool — changing status (the reported bug)", () => {
     ["Urgent", "urgent"],
     ["In progress", "in_progress"],
     ["Actioned", "actioned"],
+    ["Not relevant", "not_relevant"],
   ] as const)(
     "calls the mutation with status '%s' when '%s' menu item is clicked",
     async (label, status) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.test.tsx
@@ -32,6 +32,7 @@ describe("StatusChip", () => {
     ["urgent", "Urgent", "MuiChip-colorError"],
     ["in_progress", "In progress", "MuiChip-colorWarning"],
     ["actioned", "Actioned", "MuiChip-colorSuccess"],
+    ["not_relevant", "Not relevant", "MuiChip-colorSecondary"],
   ] as const)(
     "renders '%s' label with correct colour class for status '%s'",
     async (status, label, colourClass) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/components/StatusChip.tsx
@@ -10,6 +10,7 @@ export const FEEDBACK_COLOURS = {
   urgent: "error",
   in_progress: "warning",
   actioned: "success",
+  not_relevant: "secondary",
 } as const;
 
 export const StatusChip = (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/mocks/mockFeedback.ts
@@ -303,7 +303,7 @@ export const mockFeedback: Feedback[] = [
     nodeId: "5SuQhstVL5",
     nodeText: null,
     projectType: null,
-    status: "in_progress",
+    status: "not_relevant",
     editorNotes: "No action needed",
   },
   {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/types.ts
@@ -10,6 +10,7 @@ export const FEEDBACK_STATUS = [
   "actioned",
   "in_progress",
   "urgent",
+  "not_relevant",
 ] as const;
 export type FeedbackStatus = (typeof FEEDBACK_STATUS)[number];
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.test.ts
@@ -28,6 +28,7 @@ describe("feedbackStatusText", () => {
     ["urgent", "Urgent"],
     ["actioned", "Actioned"],
     ["in_progress", "In progress"],
+    ["not_relevant", "Not relevant"],
   ] as const)("maps '%s' to '%s'", (status, expected) => {
     expect(feedbackStatusText[status]).toBe(expected);
   });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/utils.tsx
@@ -32,6 +32,7 @@ export const feedbackStatusText: Record<FeedbackStatus, string> = {
   urgent: "Urgent",
   actioned: "Actioned",
   in_progress: "In progress",
+  not_relevant: "Not relevant",
 };
 
 export const getCombinedHelpText = (feedback: Feedback) => {

--- a/apps/hasura.planx.uk/migrations/default/1779978551959_add_feedback_status_not_relevant/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779978551959_add_feedback_status_not_relevant/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."feedback_status_enum" WHERE value = 'not_relevant';

--- a/apps/hasura.planx.uk/migrations/default/1779978551959_add_feedback_status_not_relevant/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1779978551959_add_feedback_status_not_relevant/up.sql
@@ -1,0 +1,3 @@
+INSERT INTO "public"."feedback_status_enum"("value", "comment") 
+VALUES 
+  (E'not_relevant', E'This feedback has been deemed not relevant');


### PR DESCRIPTION
Uses `secondary` light grey. 