### PR TITLE
fix(editor): Guard ShareDB connection using unique flow ID, not shared flow slug

### DIFF
--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.test.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.test.tsx
@@ -1,0 +1,122 @@
+import { type FullStore, useStore } from "pages/FlowEditor/lib/store";
+import {
+  getBasicFlowData,
+  getFlowEditorData,
+} from "utils/routeUtils/queryUtils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { connectToFlowRoute } from "./-route.utils";
+
+vi.mock("pages/FlowEditor/lib/store", () => ({
+  useStore: {
+    getState: vi.fn(),
+    setState: vi.fn(),
+  },
+}));
+
+vi.mock("utils/routeUtils/queryUtils", () => ({
+  getBasicFlowData: vi.fn(),
+  getFlowEditorData: vi.fn(),
+}));
+
+const mockDisconnectFromFlow = vi.fn();
+const mockConnectToFlow = vi.fn().mockResolvedValue(undefined);
+const mockGetFlowInformation = vi.fn();
+
+const makeStore = (overrides: Partial<FullStore> = {}): FullStore =>
+  ({
+    id: "",
+    disconnectFromFlow: mockDisconnectFromFlow,
+    connectToFlow: mockConnectToFlow,
+    getFlowInformation: mockGetFlowInformation,
+    setOrderedFlow: vi.fn(),
+    ...overrides,
+  }) as unknown as FullStore;
+
+describe("connectToFlowRoute (ShareDB connection guard)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFlowEditorData).mockResolvedValue({
+      id: "flow-uuid",
+      flowStatus: "online",
+      isFlowPublished: false,
+      isTemplate: false,
+      templatedFrom: "template-uuid",
+      template: undefined,
+    });
+  });
+
+  /**
+   * Routes from lambeth/someFlow → berks/someFlow
+   */
+  it("reconnects when the same slug resolves to a different document on another team", async () => {
+    vi.mocked(useStore.getState).mockReturnValue(
+      makeStore({ id: "lambeth-someFlow-uuid" }),
+    );
+    vi.mocked(getBasicFlowData).mockResolvedValue({
+      id: "berks-someFlow-uuid",
+      name: "Some Flow",
+    });
+
+    await connectToFlowRoute("berks", "someFlow");
+
+    expect(mockDisconnectFromFlow).toHaveBeenCalledOnce();
+    expect(mockConnectToFlow).toHaveBeenCalledWith("berks-someFlow-uuid");
+  });
+
+  /**
+   * Routes from lambeth/confirmation-pages → /lambeth → /barnet → barnet/confirmation-pages
+   */
+  it("reconnects after visiting the team dashboard", async () => {
+    vi.mocked(useStore.getState).mockReturnValue(
+      makeStore({ id: "lambeth-confirmation-pages-uuid" }),
+    );
+    vi.mocked(getBasicFlowData).mockResolvedValue({
+      id: "barnet-confirmation-pages-uuid",
+      name: "Confirmation Pages",
+    });
+
+    await connectToFlowRoute("barnet", "confirmation-pages");
+
+    expect(mockDisconnectFromFlow).toHaveBeenCalledOnce();
+    expect(mockConnectToFlow).toHaveBeenCalledWith(
+      "barnet-confirmation-pages-uuid",
+    );
+  });
+
+  /**
+   * Routes from lambeth/someFlow → lambeth/someFlow,nestedFlowId
+   */
+  it("does not reconnect when already subscribed to the same document", async () => {
+    vi.mocked(useStore.getState).mockReturnValue(
+      makeStore({ id: "lambeth-someFlow-uuid" }),
+    );
+    vi.mocked(getBasicFlowData).mockResolvedValue({
+      id: "lambeth-someFlow-uuid",
+      name: "Some Flow",
+    });
+
+    await connectToFlowRoute("lambeth", "someFlow");
+
+    expect(mockDisconnectFromFlow).not.toHaveBeenCalled();
+    expect(mockConnectToFlow).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Routes from lambeth/flow-a → lambeth/flow-b
+   */
+  it("reconnects when navigating to a different flow on the same team", async () => {
+    vi.mocked(useStore.getState).mockReturnValue(
+      makeStore({ id: "lambeth-flow-a-uuid" }),
+    );
+    vi.mocked(getBasicFlowData).mockResolvedValue({
+      id: "lambeth-flow-b-uuid",
+      name: "Flow B",
+    });
+
+    await connectToFlowRoute("lambeth", "flow-b");
+
+    expect(mockDisconnectFromFlow).toHaveBeenCalledOnce();
+    expect(mockConnectToFlow).toHaveBeenCalledWith("lambeth-flow-b-uuid");
+  });
+});

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.utils.ts
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.utils.ts
@@ -1,0 +1,45 @@
+import { notFound } from "@tanstack/react-router";
+import { useStore } from "pages/FlowEditor/lib/store";
+import {
+  getBasicFlowData,
+  getFlowEditorData,
+} from "utils/routeUtils/queryUtils";
+
+export async function connectToFlowRoute(teamSlug: string, rootFlow: string) {
+  const store = useStore.getState();
+
+  try {
+    const flow = await getBasicFlowData(rootFlow, teamSlug);
+
+    // ShareDB is already subscribed to this exact flow
+    if (store.id === flow.id) return;
+
+    // Ensure we only have a single active connection
+    store.disconnectFromFlow();
+
+    await store.connectToFlow(flow.id);
+    useStore.setState({
+      flowName: flow.name,
+      flowSlug: rootFlow,
+    });
+
+    const flowEditorData = await getFlowEditorData(rootFlow, teamSlug);
+
+    useStore.setState({
+      id: flowEditorData.id,
+      flowStatus: flowEditorData.flowStatus,
+      isFlowPublished: flowEditorData.isFlowPublished,
+      isTemplate: flowEditorData.isTemplate,
+      isTemplatedFrom: Boolean(flowEditorData.templatedFrom),
+      template: flowEditorData.template,
+    });
+
+    if (flowEditorData.templatedFrom) {
+      store.setOrderedFlow();
+    }
+
+    store.getFlowInformation(rootFlow, teamSlug);
+  } catch (error) {
+    throw notFound();
+  }
+}

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
@@ -1,22 +1,16 @@
 import {
   createFileRoute,
-  notFound,
   Outlet,
   stripSearchParams,
 } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import ErrorFallback from "components/Error/ErrorFallback";
 import FlowSkeleton from "pages/FlowEditor/FlowSkeleton";
-import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { CatchAllComponent } from "routes/$";
-import {
-  getBasicFlowData,
-  getFlowEditorData,
-} from "utils/routeUtils/queryUtils";
 
-import { useStore } from "../../../../../pages/FlowEditor/lib/store";
 import { teamSearchSchema } from "..";
+import { connectToFlowRoute } from "./-route.utils";
 
 export const Route = createFileRoute("/_authenticated/app/$team/$flow")({
   pendingComponent: FlowSkeleton,
@@ -38,44 +32,8 @@ export const Route = createFileRoute("/_authenticated/app/$team/$flow")({
 
     return { rootFlow, folderIds };
   },
-  beforeLoad: async ({ params, context: { rootFlow } }) => {
-    const { team: teamSlug } = params;
-    const store = useStore.getState();
-
-    // Don't re-connect to document when navigating to nested flows
-    if (store.flowSlug === rootFlow) return;
-
-    try {
-      // Ensure we only have a single active connection
-      store.disconnectFromFlow();
-
-      const flow = await getBasicFlowData(rootFlow, teamSlug);
-      await store.connectToFlow(flow.id);
-      useStore.setState({
-        flowName: flow.name,
-        flowSlug: rootFlow,
-      });
-
-      const flowEditorData = await getFlowEditorData(rootFlow, teamSlug);
-
-      useStore.setState({
-        id: flowEditorData.id,
-        flowStatus: flowEditorData.flowStatus,
-        isFlowPublished: flowEditorData.isFlowPublished,
-        isTemplate: flowEditorData.isTemplate,
-        isTemplatedFrom: Boolean(flowEditorData.templatedFrom),
-        template: flowEditorData.template,
-      });
-
-      if (flowEditorData.templatedFrom) {
-        store.setOrderedFlow();
-      }
-
-      store.getFlowInformation(rootFlow, teamSlug);
-    } catch (error) {
-      throw notFound();
-    }
-  },
+  beforeLoad: async ({ params: { team }, context: { rootFlow } }) =>
+    connectToFlowRoute(team, rootFlow),
   component: RouteComponent,
   notFoundComponent: CatchAllComponent,
 });


### PR DESCRIPTION
## What's the problem?
When navigating from one flow to another with a shared `flowSlug` (e.g. `/lambeth/article-4` → `/barnet-article-4`), ShareDB does not re-connect. This means that operations carried out in the Editor are applied to the previous flow, not the current flow.

Reported here (OSL Slack) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1779969708981659

## What's the solution?
Rather than compare on `flow.slug` (shared), compare on `flow.id` (unique). The small tradeoff here is an additional fetch on navigation but this is pretty minor and will often return a result from the Apollo cache anyway.

## Testing

**On staging / production**
 - Navigate to `/lambeth/confirmation-pages`
 - See ShareDB connection established in dev console
 - Navigate to `/barnet/confirmation-pages`
 - No new ShareDB connection ❌ 
 - Any operations made are applied to `/lambeth/confirmation-pages` 😬 

**On Pizza**
 - Navigate to `/lambeth/confirmation-pages`
 - See ShareDB connection established in dev console
 - Navigate to `/barnet/confirmation-pages`
 - New ShareDB connection established ✅ 
 - Any operations made are applied to `/barnet/confirmation-pages` ✅ 

I've also added a basic test suite here for the `connectToFlowRoute()` helper.