### PR TITLE
fix: overwrite existing help text with blank on paste

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -521,11 +521,10 @@ export const editorStore: StateCreator<
 
     const newData = {
       ...(node.data || {}),
-      info: payload.info ?? node.data?.info,
-      policyRef: payload.policyRef ?? node.data?.policyRef,
-      howMeasured: payload.howMeasured ?? node.data?.howMeasured,
-      definitionImg:
-        payload.definitionImg ?? node.data?.definitionImg ?? undefined,
+      info: payload.info,
+      policyRef: payload.policyRef,
+      howMeasured: payload.howMeasured,
+      definitionImg: payload.definitionImg,
     };
 
     try {


### PR DESCRIPTION
Previously we intentionally retained existing help text fields on paste if the payload for any of them was null. This turned out counterintuitive. On paste, all help text should be identical to the source it was copied from.