### PR TITLE
fix(sharedb): Resolve off-by-one error with operations

### DIFF
--- a/apps/sharedb.planx.uk/sharedb-postgresql.js
+++ b/apps/sharedb.planx.uk/sharedb-postgresql.js
@@ -227,8 +227,9 @@ PostgresDB.prototype.getOps = function (
       return;
     }
     client.query(
-      // "SELECT version, operation FROM operations WHERE collection = $1 AND doc_id = $2 AND version >= $3 AND version < $4",
-      "SELECT version, data FROM operations WHERE flow_id = $1 AND version >= $2 AND version < $3",
+      // Ops are stored keyed by their resulting version (snapshot.v = op.v + 1)
+      // See PostgresDB.prototype.commit above (INSERT INTO operations)
+      "SELECT version, data FROM operations WHERE flow_id = $1 AND version > $2 AND version <= $3",
       [id, from, to],
       (err, res) => {
         done();


### PR DESCRIPTION
## What's the problem?
The editor intermittently throws `Op submit failed. Versions mismatched during op transform` in production. This is surfaced [via Airbrake here](https://planx.airbrake.io/projects/329753/groups/4333149767543658180?tab=overview), and raised [via OSL Slack here](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1779446296118569).

When this error is triggered, the user's in-flight edit is rejected by the ShareDB server and a silent failure is experienced. The error has been recurring frequently over the past few weeks, but has been observed [many times before](https://github.com/theopensystemslab/planx-new/pull/839).

This appears to be a genuine "day 1" error, see SQL queries here - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1780054419865069?thread_ts=1779446296.118569&cid=C088K9ZL8EA

## What's the cause?
The error only happens when a client submits a **stale operation** - one based on an older version of the flow than the server currently has (usually two people editing the same flow at once, or an edit made just before the client reconnected at a guess!). In that case ShareDB tries to "catch the operation up" by replaying everything the client missed, and that replay is where it's failing.

The bug is an off-by-one in how we read those missed operations back.

### How operations are stored
Each operation carries its own base version inside the JSONB `data` field (`data ->> 'v'`). But the row it's saved in is numbered one *higher* - the `INSERT` in `PostgresDB.prototype.commit` writes `version = snapshot.v`, which is always `op.v + 1`. So an operation that says `v = 5` lives in the row `version = 6`.

https://github.com/theopensystemslab/planx-new/blob/bc1c66b9c704576fd5f79fae92ce61261a02b774/apps/sharedb.planx.uk/sharedb-postgresql.js#L132-L133

Prod data confirms this - `operations.version` is always one greater than `data ->> 'v'`:

<img width="1288" height="1452" alt="image" src="https://github.com/user-attachments/assets/2a4b3dd0-8c33-47be-a3a6-e2176b822fa1" />

### How we read them back
To replay, ShareDB asks `getOps` for "every operation from version `from` onward." Because the rows are numbered one higher than the version inside them, our query's bounds are off by one and it returns a window starting one operation too early. ShareDB checks that the first operation it gets back is exactly version `from`, sees it's one behind, and rejects the whole submission with "Versions mismatched during op transform."

## What's the solution?
A one-line change to the `getOps` query bounds in the custom ShareDB Postgres adapter, so the read window matches how ops are actually keyed in storage.

```js
// Before
"SELECT version, data FROM operations WHERE flow_id = $1 AND version >= $2 AND version < $3",

// After
"SELECT version, data FROM operations WHERE flow_id = $1 AND version > $2 AND version <= $3",
```

The one-character-per-bound change shifts the window to the rows that actually match, and then the replay with a stale operation succeeds.

### Do we need a data migration?
No, because the proposed solution is a read-path fix only. It reads existing rows correctly (old and new), and leaves the `PostgresDB.prototype.commit` condition untouched. The fix only shifts which rows are read - the number of operations returned is unchanged (`to - from`), so the separate `missingOpsError` guard still passes. It just reads the correct rows.

An alternative fix would be to migrate all the data and change the write path instead - riskier and a lot more work for basically the same outcome.

## What I ruled out / how I got here
- **Frequent ShareDB deploys / frequent reconnections** - investigated and rejected as the trigger. The Airbrake occurrence timestamps don't line up with the deploy schedules at all -
  - Errors arrive in tight same-day bursts, each from a single IP
  - The two largest bursts of errors (May 15, May 19) had no deploy anywhere near them
  - Today's burst of errors (09:32–09:58) finished before today's deploy (~10:00) - cause can't follow effect.

  The real signature is session-local as far as I can tell - one editing session repeatedly generating stale ops over 20–30 min (concurrent edits to the same node, or a flaky connection causing issues).

- **CPU / resource pressure** - also ruled out. AWS CPU is sat at ~10%, spiking to ~25%, no noticeable recent changes. This spiky-max/low-average pattern looks just like short bursts of activity, not sustained load on the server.

The off-by-one has always been present (see above), the error volume just tracks how often a stale operation is submitted. This server fix should resolve this regardless of what triggers the stale operation.

## Testing
1. Reproduce on staging/production by making near-simultaneous edits to the same node in two tabs (monitor console for ShareDB reconnections, or this error being thrown)
2. Repeat the process on pizza

## Next steps...
We've previously ruled out showing ShareDB status in the Editor (e.g. a "Reconnecting..." spinner) and I still think that's right, it's just noise. The right behaviour on any disconnect is a silent reconnection, operations queued in memory, and ShareDB reconciling everything once the connection is back.

Happy to discuss or revisit this. One thing worth considering separately maybe - warning the user before they close the tab / navigate away while operations are still pending.