### PR TITLE
fix: persist templated node props when flattening nested flows

### DIFF
--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -418,6 +418,8 @@ const flattenedParentFlow: FlowGraph = {
     edges: ["nested-a"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   "nested-a": {
@@ -463,6 +465,8 @@ const flattenedParentFlow: FlowGraph = {
     edges: ["nested-b"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   "nested-b": {
@@ -490,6 +494,8 @@ const flattenedParentFlow: FlowGraph = {
     edges: ["nested-a"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   f6zoaYuboI: {
@@ -534,6 +540,8 @@ const flattenedParentFlowDraftOnly: FlowGraph = {
     edges: ["nested-a"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   "nested-a": {
@@ -576,6 +584,8 @@ const flattenedParentFlowDraftOnly: FlowGraph = {
     edges: ["nested-b"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   "nested-b": {
@@ -600,6 +610,8 @@ const flattenedParentFlowDraftOnly: FlowGraph = {
     edges: ["nested-a"],
     data: {
       flattenedFromExternalPortal: true,
+      isTemplatedNode: false,
+      areTemplatedNodeInstructionsRequired: false,
     },
   },
   f6zoaYuboI: {

--- a/apps/api.planx.uk/shared/dataMerged.ts
+++ b/apps/api.planx.uk/shared/dataMerged.ts
@@ -116,6 +116,10 @@ const fetchAndMergeStack = async (
           edges: [node.data?.flowId],
           data: {
             flattenedFromExternalPortal: true,
+            // Persist templated node fields for publish validation checks
+            isTemplatedNode: node.data?.isTemplatedNode,
+            areTemplatedNodeInstructionsRequired:
+              node.data?.areTemplatedNodeInstructionsRequired,
           },
         };
 


### PR DESCRIPTION
See bug report here: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1780055732310229

The FOI source template was recently updated and there are two new required customisations - specifically nested flow / external portal type nodes. 

The graph's "Customise" sidebar tab immediately recognised these as outstanding because the nodes in the live flow `data` have templated node props. 

But the "Publish" modal was failing identify these and throw a validation error. When nested flow node types are _flattened_ on preview (which is the data shape publish checks read from), we were failing to persist these templated node props. 

This has always been overlooked/missed since templates introduced from what I can tell, not a recent regression from `dataMerged` refactor.

**Testing:** 
- Open publish dialog on the following link and confirm that there is now a failing publish validation check: https://6764.planx.pizza/app/barnet/find-out-if-you-need-planning-permission (for same flow on prod/staging all checks are passing)
<img width="1858" height="1121" alt="Screenshot from 2026-05-29 09-04-41" src="https://github.com/user-attachments/assets/c59d5d52-8953-45b0-a975-b6908ec6392b" />