### PR TITLE
fix: polyfill `at` for ITP users on old browsers

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -1,5 +1,3 @@
-import "core-js/stable/array/at"; // at polyfill
-
 import ErrorOutline from "@mui/icons-material/ErrorOutlined";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -1,3 +1,5 @@
+import "core-js/stable/array/at"; // at polyfill
+
 import ErrorOutline from "@mui/icons-material/ErrorOutlined";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";

--- a/apps/editor.planx.uk/src/index.tsx
+++ b/apps/editor.planx.uk/src/index.tsx
@@ -1,3 +1,5 @@
+import "core-js/actual/array/at"; // array.at polyfill
+import "core-js/actual/string/at"; // string.at polyfill
 import "core-js/actual/string/replace-all"; // replace-all polyfill
 import "react-toastify/dist/ReactToastify.css";
 import "./app.css";


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1780063916845819