### PR TITLE
feat: try rendering flattened flow in preview tab only

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PreviewBrowser/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/PreviewBrowser/index.tsx
@@ -5,13 +5,10 @@ import {
   ThemeProvider,
   useTheme,
 } from "@mui/material/styles";
-import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import { isEmpty } from "lodash";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useMemo } from "react";
 import Reset from "ui/icons/Reset";
-
-import Questions from "../../../../Preview/Questions";
+import { FlattenedFlow } from "utils/routeUtils/FlattenedFlow";
 
 const ResetToggle = styled(Button)(({ theme }) => ({
   position: "absolute",
@@ -23,12 +20,10 @@ const ResetToggle = styled(Button)(({ theme }) => ({
 }));
 
 export const PreviewBrowser: React.FC = () => {
-  const [resetPreview, flow, currentCard] = useStore((state) => [
+  const [resetPreview, flowId] = useStore((state) => [
     state.resetPreview,
-    state.flow,
-    state.currentCard,
+    state.id,
   ]);
-  const isLoading = isEmpty(flow);
 
   const theme = useTheme();
   const mobileTheme = useMemo(
@@ -58,14 +53,7 @@ export const PreviewBrowser: React.FC = () => {
         <Reset fontSize="small" />
         Restart
       </ResetToggle>
-      {isLoading ? (
-        <DelayedLoadingIndicator
-          msDelayBeforeVisible={50}
-          text="Loading flow data..."
-        />
-      ) : (
-        <Questions previewEnvironment="editor" key={currentCard?.id} />
-      )}
+      <FlattenedFlow previewEnvironment="editor" mode="draft" flowId={flowId} />
     </ThemeProvider>
   );
 };

--- a/apps/editor.planx.uk/src/utils/routeUtils/FlattenedFlow.tsx
+++ b/apps/editor.planx.uk/src/utils/routeUtils/FlattenedFlow.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { getFlattenedFlowData } from "lib/api/flow/requests";
 import { type Store } from "pages/FlowEditor/lib/store";
+import { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
 import Questions from "pages/Preview/Questions";
 import React from "react";
 import { updateStoreWithFlowData } from "utils/routeUtils/publicRouteHelpers";
@@ -9,6 +10,7 @@ import { updateStoreWithFlowData } from "utils/routeUtils/publicRouteHelpers";
 interface Props {
   mode: "preview" | "draft";
   flowId: string;
+  previewEnvironment?: PreviewEnvironment;
 }
 
 /**
@@ -20,7 +22,11 @@ interface Props {
  * Should always be accompanied by a prefetch (non-awaited) request on the route `loader()` function
  * to ensure we always kick off this long-running request immediately in the background
  */
-export const FlattenedFlow: React.FC<Props> = ({ mode, flowId }) => {
+export const FlattenedFlow: React.FC<Props> = ({
+  mode,
+  flowId,
+  previewEnvironment,
+}) => {
   const { data, isPending, error } = useQuery({
     queryKey: ["flattenedFlowData", mode, flowId],
     queryFn: () =>
@@ -37,5 +43,5 @@ export const FlattenedFlow: React.FC<Props> = ({ mode, flowId }) => {
 
   updateStoreWithFlowData(data as Store.Flow);
 
-  return <Questions previewEnvironment="standalone" />;
+  return <Questions previewEnvironment={previewEnvironment ?? "standalone"} />;
 };


### PR DESCRIPTION
does _not_ work, just trying to get a few different options up for dev call chat/demo ~wednesday ! 

open questions: 
- do we need to instantiate + run separate/parallel stores if side tab is reading from different data than the graph? `<Questions />` is a gnarly component heavily coupled to many navigation state methods