### PR TITLE
fix: Reduce debounce delay when using SearchBox

### DIFF
--- a/apps/editor.planx.uk/src/ui/shared/constants.ts
+++ b/apps/editor.planx.uk/src/ui/shared/constants.ts
@@ -1,1 +1,1 @@
-export const SEARCH_DEBOUNCE_MS = 500;
+export const SEARCH_DEBOUNCE_MS = 100;


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Reduces search debounce value from 500ms to 100ms for a more immediate interaction when filtering

**To test:**
- Use the search in either team select or filtering flows