### PR TITLE
[infra] init shared cert/CloudFront for Northumberland

### DIFF
--- a/doc/how-to/how-to-setup-custom-domains.md
+++ b/doc/how-to/how-to-setup-custom-domains.md
@@ -109,6 +109,8 @@ Path: `validation-only` → `shared-final`
 
     When it's done, you can then verify in the [AWS console](https://us-east-1.console.aws.amazon.com/acm/certificates/list) (make sure you're in the `us-east-1` region). The status of the specific domain on the mining cert should have changed from `Pending validation` to `Success`.
 
+    NB. The mining certs will 'fail' after 72hrs of attempting to validate their assigned domains, in which case you cannot use it to verify a correct DNS record. However, they can be re-created by simply deploying `certificates` again, as in step 2. Note that when these certs fail, Pulumi loses track of them, so it will not clean them up on next deploy (i.e. we should do that manually).
+
 6. Advance the state of the domain to `shared-final` by updating the entry in `customDomains.ts`:
 
     ```diff

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -109,7 +109,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "northumberland",
           domain: "planningservices.northumberland.gov.uk",
-          cloudFrontState: "validation-only",
+          cloudFrontState: "shared-final",
         },
         {
           name: "coventry",

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -106,6 +106,11 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           domain: "planningservices.canterbury.gov.uk",
           cloudFrontState: "legacy-with-validation",
         },
+        {
+          name: "northumberland",
+          domain: "planningservices.northumberland.gov.uk",
+          cloudFrontState: "validation-only",
+        }
       ]
     : [
         // we keep one custom domain on staging to function as a canary (monitored by UptimeRobot)

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -110,6 +110,11 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           name: "northumberland",
           domain: "planningservices.northumberland.gov.uk",
           cloudFrontState: "validation-only",
+        },
+        {
+          name: "coventry",
+          domain: "planningservices.coventry.gov.uk",
+          cloudFrontState: "validation-only",
         }
       ]
     : [


### PR DESCRIPTION
We are onboarding the first council onto our new shared cert/CloudFront setup, as per [howto](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md)!

Northumberland emailed us on devops@ and we've responded with the validation record. Since they're the first, the shared CloudFront isn't spun up yet, so they need to add the DNS records in 2 steps, rather than simultaneously. I've explained this, deployed the changes here to `certificates` on prod, and provided them with the former. There's no particular need to merge this while we wait.