### PR TITLE
fix(ci): Handle pnpm install after cache hits

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: The pnpm version to use
     required: false
     default: 10.30.2
+  cache:
+    description: setup-node cache strategy
+    required: false
+    default: "pnpm"
 
 runs:
   using: composite
@@ -17,11 +21,11 @@ runs:
     - uses: pnpm/action-setup@v5.0.0
       with:
         version: ${{ inputs.pnpm-version }}
-        
+
     - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        cache: "pnpm"
+        cache: ${{ inputs.cache }}
         cache-dependency-path: "**/pnpm-lock.yaml"
         
     - name: Setup .gitconfig

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -146,6 +146,8 @@ jobs:
             ${{ runner.os }}-
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: ${{ steps.cache-localplanning-build-assets.outputs.cache-hit != 'true' && 'pnpm' || '' }}
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
@@ -170,6 +172,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: ${{ steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true' && 'pnpm' || '' }}
       - run: pnpm install --frozen-lockfile
         if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}


### PR DESCRIPTION
## What's the problem?
The GHA jobs `build_localplanning_services` and `build_planx_frontend` sometimes fail their post-job step with `Path Validation Error … do(es) not exist`, which means no cache is being saved.

Reported here (OSL Slack) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1780323406497859

<img width="1870" height="679" alt="image" src="https://github.com/user-attachments/assets/9ced8b0a-ce30-4e3d-a818-b30dec88f166" />

## What's the cause?
Both jobs skip `pnpm install` when there's a cache hit (this is the intended behaviour). But `actions/setup-node` was always setting `cache: "pnpm"` regardless of if there's an install or not. When the install is skipped, that store is never created so the save fails. This is why it's only happening intermittently - it's only after a cache hit.

Regression introduced here https://github.com/theopensystemslab/planx-new/pull/6539, and upgrading here I think surfaced this issue - https://github.com/theopensystemslab/planx-new/pull/6743

## What's the solution?
The `setup-node-pnpm` action now takes a `cache` input. These two jobs set it from the same `cache-hit` flag.

 - Cache miss → `pnpm install` runs → `cache: pnpm` (store gets created, caching works)
 - Cache hit → `pnpm install` skipped → `cache: ''` (no save attempted, no error)

This means pnpm caching stays where it's useful and is turned off only where it was breaking.