### PR TITLE
feat: auto-suggest editor data values for `property.localAuthorityDistrict`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
@@ -7,6 +7,7 @@ import {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
+import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { getIn } from "formik";
 import React from "react";
@@ -39,6 +40,7 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
   isTemplatedNode,
 }: Props<T>) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
 
   return (
     <Box>
@@ -103,6 +105,7 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
                 formik.values.fn,
                 schema,
                 currentOptionVals,
+                localAuthorityDistrictSchema,
               ),
             }}
             isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
@@ -8,6 +8,7 @@ import type {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
+import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { FormikValues, getIn } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -39,6 +40,7 @@ export const GroupedOptions = <T extends AnyChecklist>({
   isTemplatedNode,
 }: Props<T>) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
 
   // Type-narrowing only - groupedOptions will be defined here
   if (!formik.values.groupedOptions)
@@ -153,6 +155,7 @@ export const GroupedOptions = <T extends AnyChecklist>({
                   formik.values.fn,
                   schema,
                   currentOptionVals,
+                  localAuthorityDistrictSchema,
                 ),
               }}
               isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
@@ -1,6 +1,7 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { AnyOption } from "@planx/components/Option/model";
 import { DEFAULT_RULE } from "@planx/components/ResponsiveChecklist/model";
+import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { partition } from "lodash";
 import React from "react";
@@ -33,6 +34,7 @@ export const Options = <T extends AnyChecklist>({
   const exclusiveOrOptionManagerShouldRender = nonExclusiveOptions.length > 0;
 
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
 
   return (
     <ModalSectionContent subtitle="Options">
@@ -77,6 +79,7 @@ export const Options = <T extends AnyChecklist>({
                 formik.values.fn,
                 schema,
                 currentOptionVals,
+                localAuthorityDistrictSchema,
               ),
             }}
             isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -22,6 +22,7 @@ import { Switch } from "ui/shared/Switch";
 
 import { InternalNotes } from "../../../../../ui/editor/InternalNotes";
 import { DataFieldAutocomplete } from "../../DataFieldAutocomplete";
+import { useLocalAuthorityDistricts } from "../../hooks";
 import { ICONS } from "../../icons";
 import { getOptionsSchemaByFn } from "../../utils";
 import MoreInformation from "./MoreInformation";
@@ -43,6 +44,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
   const currentOptionVals = formik.values.options?.map(
     (option) => option.data?.val,
   );
+  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
 
   const focusRef = useRef<HTMLInputElement | null>(null);
 
@@ -165,6 +167,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
                   formik.values.fn,
                   schema?.options,
                   currentOptionVals,
+                  localAuthorityDistrictSchema,
                 ),
               }}
               isTemplatedNode={props.node?.data?.isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
@@ -1,3 +1,5 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLocalAuthorityDistricts } from "lib/planningData/requests";
 import { useEffect, useState } from "react";
 
 export type UseFileUrlProps =
@@ -30,4 +32,15 @@ export const useFileUrl = (props: UseFileUrlProps) => {
   return {
     fileUrl,
   };
+};
+
+export const useLocalAuthorityDistricts = () => {
+  const query = useQuery({
+    queryKey: ["localAuthorityDistrictNames"],
+    queryFn: () => getLocalAuthorityDistricts(),
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+  });
+
+  return query;
 };

--- a/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -69,6 +69,7 @@ export const getOptionsSchemaByFn = (
   fn?: string,
   defaultOptionsSchema?: string[],
   currentOptions?: (string | undefined)[],
+  localAuthorityDistrictSchema?: string[] | undefined,
 ) => {
   let schema = defaultOptionsSchema;
 
@@ -78,6 +79,10 @@ export const getOptionsSchemaByFn = (
   if (fn === "proposal.projectType")
     schema = getValidSchemaValues("ProjectType");
   if (fn === "property.type") schema = getValidSchemaValues("PropertyType");
+
+  // For other data fields, suggest based on external data source like Planning Data
+  if (fn === "property.localAuthorityDistrict" && localAuthorityDistrictSchema)
+    schema = localAuthorityDistrictSchema;
 
   // Ensure that any initial values outside of ODP Schema enums will still be recognised/pre-populated when modal loads
   currentOptions?.forEach((option) => {

--- a/apps/editor.planx.uk/src/lib/planningData/requests.ts
+++ b/apps/editor.planx.uk/src/lib/planningData/requests.ts
@@ -1,6 +1,11 @@
 import axios from "axios";
 
-import { type Entity, SearchEntityParams, SearchEntityResponse } from "./types";
+import {
+  type Entity,
+  SearchEntityParams,
+  SearchEntityResponse,
+  SearchEntityResponseExcludeGeom,
+} from "./types";
 
 const PLANNING_DATA_URL = "https://www.planning.data.gov.uk" as const;
 
@@ -56,4 +61,27 @@ export const getEntity = async (
     baseURL: PLANNING_DATA_URL,
   });
   return data;
+};
+
+/**
+ * Get all records in a single dataset to autosuggest data values for `property.localAuthorityDistrict`
+ */
+export const getLocalAuthorityDistricts = async () => {
+  const { data } = await axios.get<SearchEntityResponseExcludeGeom>(
+    `/entity.json`,
+    {
+      baseURL: PLANNING_DATA_URL,
+      params: {
+        limit: 400, // ~344 local authority districts, this shouldn't change often (if anything will decrease with mergers)
+        entries: "all", // include "historic" ones
+        dataset: "local-authority-district",
+        exclude_field: "geometry,point", // don't return geometry for faster, lighter response
+      },
+      paramsSerializer: {
+        indexes: null,
+      },
+    },
+  );
+
+  return data.entities.map((entity) => entity.name).sort();
 };

--- a/apps/editor.planx.uk/src/lib/planningData/types.ts
+++ b/apps/editor.planx.uk/src/lib/planningData/types.ts
@@ -25,3 +25,11 @@ export type SearchEntityResponse = FeatureCollection<
 >;
 
 export type Entity = Feature<Polygon | MultiPolygon, Record<string, unknown>>;
+
+export interface SearchEntityResponseExcludeGeom {
+  entities: {
+    entity: number;
+    name: string;
+    dataset: string;
+  }[];
+}


### PR DESCRIPTION
Was mentioned during strat days updates that case-sensitivity of passport data fields still a big gotcha / editor pain point. 

`property.localAuthorityDistrict` is one that _every_ council needs to customise and is particularly odd casing ! 

We can fetch a list of valid values to suggest from https://www.planning.data.gov.uk/entity.json?limit=400&dataset=local-authority-district&exclude_field=geometry,point&entries=all

<img width="900" height="1055" alt="Screenshot from 2026-06-02 14-26-10" src="https://github.com/user-attachments/assets/615d65e8-4cca-49e2-957a-1f3a49929e2d" />


Because all our auto-suggests allow overwriting, templated node instructions & defaults are un-altered:
<img width="527" height="445" alt="image" src="https://github.com/user-attachments/assets/19a50c00-3ba6-4330-8ecb-327571c9955e" />