### PR TITLE
style: Standardised secondary button with border

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
@@ -222,7 +222,6 @@ export const OverrideEntitiesModal = ({
         <Button
           variant="contained"
           color="secondary"
-          sx={{ backgroundColor: "background.default" }}
           onClick={closeModal}
           data-testid="override-modal-cancel-button"
         >

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -172,7 +172,6 @@ export const UploadedFileCard: React.FC<Props> = ({
                   startIcon={changeIcon}
                   sx={{
                     minWidth: 120,
-                    backgroundColor: "white",
                   }}
                   size="small"
                   onClick={onChange}

--- a/apps/editor.planx.uk/src/components/ConfirmationDialog.tsx
+++ b/apps/editor.planx.uk/src/components/ConfirmationDialog.tsx
@@ -35,12 +35,7 @@ export const ConfirmationDialog: React.FC<
       </DialogTitle>
       <DialogContent dividers>{children}</DialogContent>
       <DialogActions>
-        <Button
-          onClick={onCancel}
-          variant="contained"
-          color="secondary"
-          sx={{ backgroundColor: "background.default" }}
-        >
+        <Button onClick={onCancel} variant="contained" color="secondary">
           {cancelText}
         </Button>
         <Button onClick={onConfirm} variant="contained" color="prompt">

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -152,7 +152,6 @@ const NotificationsPanel = ({
           size="small"
           variant="contained"
           color="secondary"
-          sx={{ backgroundColor: "background.default" }}
           fullWidth
         >
           View all notifications

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -60,7 +60,7 @@ export const NoChangesDialog = ({
     <DialogTitle variant="h3" component="h1" sx={{ px: 3, py: 2 }}>
       {`Check for changes to publish`}
     </DialogTitle>
-    <DialogContent sx={{ p: 3 }}>
+    <DialogContent sx={{ p: 3 }} dividers>
       <Typography variant="body2">{`No new changes to publish`}</Typography>
     </DialogContent>
     <DialogActions>
@@ -68,7 +68,6 @@ export const NoChangesDialog = ({
         onClick={() => setDialogOpen(false)}
         variant="contained"
         color="secondary"
-        sx={{ backgroundColor: "background.default" }}
       >
         Keep editing
       </Button>
@@ -149,7 +148,6 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
             onClick={() => setDialogOpen(false)}
             variant="contained"
             color="secondary"
-            sx={{ backgroundColor: "background.default" }}
           >
             Keep editing
           </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/ModalActions.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/ModalActions.tsx
@@ -24,7 +24,6 @@ export const ModalActions = ({
         type="reset"
         onClick={onCancel}
         data-testid="modal-cancel-button"
-        sx={{ backgroundColor: "background.default" }}
       >
         Cancel
       </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
@@ -61,7 +61,6 @@ export const RemoveUserModal: React.FC<RemoveUserModalProps> = ({
           variant="contained"
           color="secondary"
           type="reset"
-          sx={{ backgroundColor: "background.default" }}
           onClick={onClose}
           data-testid="modal-cancel-button"
         >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -508,7 +508,6 @@ const FormModal: React.FC<FormModalProps> = ({
             onClick={handleCancelClose}
             variant="contained"
             color="secondary"
-            sx={{ backgroundColor: "background.default" }}
           >
             Continue editing
           </Button>

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -133,7 +133,6 @@ export const AddFlow: React.FC = () => {
                     disabled={isSubmitting}
                     variant="contained"
                     color="secondary"
-                    sx={{ backgroundColor: "background.default" }}
                   >
                     Back
                   </Button>

--- a/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/CopyDialog.tsx
@@ -131,7 +131,6 @@ export const CopyDialog: React.FC<Props> = ({
                   disabled={isSubmitting}
                   variant="contained"
                   color="secondary"
-                  sx={{ backgroundColor: "background.default" }}
                 >
                   Back
                 </Button>

--- a/apps/editor.planx.uk/src/pages/Team/components/MoveDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/MoveDialog.tsx
@@ -151,7 +151,6 @@ export const MoveDialog: React.FC<Props> = ({
                   disabled={isSubmitting}
                   variant="contained"
                   color="secondary"
-                  sx={{ backgroundColor: "background.default" }}
                 >
                   Back
                 </Button>

--- a/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -148,7 +148,6 @@ export const AddTeamButton: React.FC = () => {
                     onClick={() => setDialogOpen(false)}
                     variant="contained"
                     color="secondary"
-                    sx={{ backgroundColor: "background.default" }}
                   >
                     Back
                   </Button>

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -286,6 +286,17 @@ const getThemeOptions = ({
       MuiButton: {
         variants: [
           {
+            props: { variant: "contained", color: "secondary" },
+            style: {
+              backgroundColor: palette.background.default,
+              boxShadow: `inset 0 0 0 1px ${palette.border.main}, inset 0 -2px 0 rgba(0,0,0,0.25)`,
+              "&:hover": {
+                backgroundColor: palette.background.paper,
+                boxShadow: `inset 0 0 0 1px ${palette.border.main}, inset 0 -2px 0 rgba(0,0,0,0.5)`,
+              },
+            },
+          },
+          {
             props: { variant: "help" },
             style: {
               color: palette.link.main,


### PR DESCRIPTION
## What does this PR do

Addresses a piece of UI debt where secondary buttons are low contrast and often overwritten with a white background when used on paper to increase contrast.

- Standardise background to white
- Introduce border for stronger contrast

**Before:**
<img width="365" height="82" alt="image" src="https://github.com/user-attachments/assets/7fd00a6b-36db-43bc-80f7-a10e622e1376" />

<img width="365" height="76" alt="image" src="https://github.com/user-attachments/assets/949ba35c-6efe-4b2b-bf76-1992de068967" />



**After:**
<img width="365" height="82" alt="image" src="https://github.com/user-attachments/assets/6245803e-8e79-4796-8e39-e61b554ff284" />

<img width="365" height="76" alt="image" src="https://github.com/user-attachments/assets/2bb916e3-7170-4f52-a125-12a9e58560c9" />
