### PR TITLE
feat: inherit or write isService value on flow creation

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -13,6 +13,7 @@ export interface GetFlowDataResponse {
   data: Flow["data"];
   summary: string | null;
   description: string | null;
+  isService: boolean;
   limitations: string | null;
   team_id: number;
   team: { slug: string };
@@ -41,6 +42,7 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
           name
           summary
           description
+          isService: is_service
           limitations
           team_id
           team {
@@ -79,6 +81,7 @@ const createFlow = async ({
   summary,
   description,
   limitations,
+  isService,
 }: {
   teamId: number;
   slug: string;
@@ -90,6 +93,7 @@ const createFlow = async ({
   summary?: string;
   description?: string;
   limitations?: string;
+  isService?: boolean;
 }) => {
   const { client: $client } = getClient();
   const userId = userContext.getStore()?.user?.sub;
@@ -112,6 +116,7 @@ const createFlow = async ({
           $summary: String
           $description: String
           $limitations: String
+          $is_service: Boolean
         ) {
           insertFlow: insert_flows_one(
             object: {
@@ -126,6 +131,7 @@ const createFlow = async ({
               summary: $summary
               description: $description
               limitations: $limitations
+              is_service: $is_service
             }
           ) {
             id
@@ -143,6 +149,7 @@ const createFlow = async ({
         summary: summary,
         description: description,
         limitations: limitations,
+        is_service: isService,
       },
     );
 

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -15,16 +15,16 @@ export interface GetFlowDataResponse {
   description: string | null;
   isService: boolean;
   limitations: string | null;
-  team_id: number;
+  teamId: number;
   team: { slug: string };
   templatedFrom: string | null;
   publishedFlows:
     | {
         data: Flow["data"];
         id: number;
-        created_at: string;
+        createdAt: string;
         summary: string;
-        publisher_id: number;
+        publisherId: number;
       }[]
     | [];
 }
@@ -44,7 +44,7 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
           description
           isService: is_service
           limitations
-          team_id
+          teamId: team_id
           team {
             slug
           }
@@ -55,9 +55,9 @@ const getFlowData = async (id: string): Promise<GetFlowDataResponse> => {
           ) {
             data
             id
-            created_at
+            createdAt: created_at
             summary
-            publisher_id
+            publisherId: publisher_id
           }
         }
       }

--- a/apps/api.planx.uk/modules/flows/copyFlow/service.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/service.ts
@@ -25,6 +25,7 @@ const copyFlow = async ({
       isTemplate: false,
       flowData: uniqueFlowData,
       copiedFrom: flowId,
+      isService: flow.isService,
     });
   }
 

--- a/apps/api.planx.uk/modules/flows/createFlow/controller.ts
+++ b/apps/api.planx.uk/modules/flows/createFlow/controller.ts
@@ -17,6 +17,7 @@ export const createFlowSchema = z.object({
     slug: z.string(),
     name: z.string().trim(),
     isTemplate: z.boolean().optional().default(false),
+    isService: z.boolean().optional().default(false),
   }),
 });
 
@@ -31,7 +32,8 @@ export const createFlowController: CreateFlowController = async (
   next,
 ) => {
   try {
-    const { teamId, slug, name, isTemplate } = res.locals.parsedReq.body;
+    const { teamId, slug, name, isTemplate, isService } =
+      res.locals.parsedReq.body;
     const flowData: FlowGraph = { _root: { edges: [] } };
 
     // createFlow automatically handles the associated operation and initial publish
@@ -40,6 +42,7 @@ export const createFlowController: CreateFlowController = async (
       slug,
       name,
       isTemplate,
+      isService,
       flowData,
     });
 

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -28,6 +28,7 @@ const createFlowFromTemplate = async (
     limitations: isNull(sourceTemplate.limitations)
       ? undefined
       : sourceTemplate.limitations,
+    isService: sourceTemplate.isService,
   });
 
   return { id, slug };

--- a/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
+++ b/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
@@ -36,9 +36,9 @@ export const updateTemplatedFlow = async (
   templatedFlowId: string,
 ) => {
   const { data: sourceData, publishedFlows } = await getFlowData(sourceFlowId);
-  const { publisher_id: sourcePublisher, summary } = publishedFlows[0];
+  const { publisherId: sourcePublisher, summary } = publishedFlows[0];
 
-  const { team_id: templatedFlowTeamId } = await getFlowData(templatedFlowId);
+  const { teamId: templatedFlowTeamId } = await getFlowData(templatedFlowId);
 
   // Get templated flow edits (aka "customisations")
   //   Since initiated via a Hasura event, we don't have user context here and rely on $api client

--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -19,7 +19,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftParentFlow,
           slug: "parent-flow",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -40,15 +40,15 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowA,
           slug: "nested-a",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
           publishedFlows: [
             {
               data: publishedNestedFlowA,
-              created_at: "2026-05-15T02:12:32.889893+00:00",
-              publisher_id: 1,
+              createdAt: "2026-05-15T02:12:32.889893+00:00",
+              publisherId: 1,
               id: 9,
               summary: "Testing a",
             },
@@ -80,15 +80,15 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowB,
           slug: "nested-b",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
           publishedFlows: [
             {
               data: publishedNestedFlowB,
-              created_at: "2026-05-15T02:12:48.760153+00:00",
-              publisher_id: 1,
+              createdAt: "2026-05-15T02:12:48.760153+00:00",
+              publisherId: 1,
               id: 10,
               summary: "Testing b",
             },
@@ -125,7 +125,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowA,
           slug: "nested-a",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -144,7 +144,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowB,
           slug: "nested-b",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -168,7 +168,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowA,
           slug: "nested-a",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -191,7 +191,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowB,
           slug: "nested-b",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -219,7 +219,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowA,
           slug: "nested-a",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -242,7 +242,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowB,
           slug: "nested-b",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -275,7 +275,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowA,
           slug: "nested-a",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },
@@ -294,7 +294,7 @@ describe("dataMerged() function", () => {
         flow: {
           data: draftNestedFlowB,
           slug: "nested-b",
-          team_id: 1,
+          teamId: 1,
           team: {
             slug: "testing",
           },

--- a/apps/api.planx.uk/shared/dataMerged.ts
+++ b/apps/api.planx.uk/shared/dataMerged.ts
@@ -103,8 +103,8 @@ const fetchAndMergeStack = async (
             // Add extra metadata about latest published version when applicable
             ...(!draftDataOnly && {
               publishedFlowId: publishedFlows?.[0]?.id,
-              publishedAt: publishedFlows?.[0]?.created_at,
-              publishedBy: publishedFlows?.[0]?.publisher_id,
+              publishedAt: publishedFlows?.[0]?.createdAt,
+              publishedBy: publishedFlows?.[0]?.publisherId,
               summary: publishedFlows?.[0]?.summary,
             }),
           },

--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import FormControlLabel, {
   FormControlLabelProps,
 } from "@mui/material/FormControlLabel";
@@ -6,8 +7,9 @@ import Radio from "@mui/material/Radio";
 import React from "react";
 
 export interface Props {
-  id?: string;
+  id?: string | boolean;
   label: FormControlLabelProps["label"];
+  description?: string;
   onChange: FormControlLabelProps["onChange"];
   variant?: "default" | "compact";
   value?: string;
@@ -18,6 +20,7 @@ const BasicRadio: React.FC<Props> = ({
   id,
   onChange,
   label,
+  description,
   variant = "default",
   disabled,
 }) => (
@@ -25,7 +28,16 @@ const BasicRadio: React.FC<Props> = ({
     value={id}
     onChange={onChange}
     control={<Radio variant={variant} />}
-    label={label}
+    label={
+      description ? (
+        <Box>
+          <Box sx={{ fontWeight: "bold", mb: 1 }}>{label}</Box>
+          <Box sx={{ color: "text.secondary" }}>{description}</Box>
+        </Box>
+      ) : (
+        label
+      )
+    }
     disabled={disabled}
     sx={(theme) => ({
       ml: theme.spacing(-1),

--- a/apps/editor.planx.uk/src/lib/api/flow/types.ts
+++ b/apps/editor.planx.uk/src/lib/api/flow/types.ts
@@ -4,6 +4,7 @@ export type NewFlow = {
   teamId: number;
   sourceId?: string;
   isTemplate?: boolean;
+  isService?: boolean;
 };
 
 export interface CreateFlowResponse {

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -67,16 +67,26 @@ export const BaseFormSection: React.FC = () => {
         />
       </InputLabel>
       {values.mode === "new" && (
-        <Permission.IsPlatformAdmin>
+        <>
+          <Permission.IsPlatformAdmin>
+            <Switch
+              name="isTemplate"
+              checked={values.flow.isTemplate}
+              onChange={() =>
+                setFieldValue("flow.isTemplate", !values.flow.isTemplate)
+              }
+              label={"Source template"}
+            />
+          </Permission.IsPlatformAdmin>
           <Switch
-            name="isTemplate"
-            checked={values.flow.isTemplate}
+            name="isService"
+            checked={values.flow.isService}
             onChange={() =>
-              setFieldValue("flow.isTemplate", !values.flow.isTemplate)
+              setFieldValue("flow.isService", !values.flow.isService)
             }
-            label={"Source template"}
+            label={"Is this a user-facing service?"}
           />
-        </Permission.IsPlatformAdmin>
+        </>
       )}
     </>
   );

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/BaseFormSection.tsx
@@ -1,4 +1,7 @@
 import MenuItem from "@mui/material/MenuItem";
+import RadioGroup from "@mui/material/RadioGroup";
+import Typography from "@mui/material/Typography";
+import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
 import { useFormikContext } from "formik";
 import React from "react";
 import Permission from "ui/editor/Permission";
@@ -11,12 +14,11 @@ import { slugify } from "utils";
 
 import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
 import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
-import { CREATE_FLOW_MODES, CreateFlow } from "./types";
+import { CREATE_FLOW_MODES, CreateFlow, FLOW_SERVICE_OPTIONS } from "./types";
 
 export const BaseFormSection: React.FC = () => {
   const { values, setFieldValue, getFieldProps, errors } =
     useFormikContext<CreateFlow>();
-
   return (
     <>
       <InputLabel
@@ -78,14 +80,27 @@ export const BaseFormSection: React.FC = () => {
               label={"Source template"}
             />
           </Permission.IsPlatformAdmin>
-          <Switch
-            name="isService"
-            checked={values.flow.isService}
-            onChange={() =>
-              setFieldValue("flow.isService", !values.flow.isService)
-            }
-            label={"Is this a user-facing service?"}
-          />
+          <Typography variant="h4">Is this a flow or a service?</Typography>
+          <RadioGroup
+            defaultValue={false}
+            value={values.flow.isService}
+            sx={{ gap: 1 }}
+          >
+            {FLOW_SERVICE_OPTIONS.map((option) => (
+              <BasicRadio
+                id={option.isService}
+                label={option.title}
+                description={option.description}
+                variant="compact"
+                onChange={(e) =>
+                  setFieldValue(
+                    "flow.isService",
+                    (e.target as HTMLInputElement).value === "true",
+                  )
+                }
+              />
+            ))}
+          </RadioGroup>
         </>
       )}
     </>

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useCreateFlow.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useCreateFlow.ts
@@ -24,7 +24,7 @@ export const useCreateFlow = () => {
       }[mode];
 
       await mutation(flow);
-      return { mode, flow };
+      return { mode, flow: flow };
     },
     onSuccess: ({ mode }) => {
       if (mode === "template") useStore.setState({ isTemplatedFrom: true });

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -87,7 +87,6 @@ export const AddFlow: React.FC = () => {
   };
 
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-
   return (
     <Box>
       <AddButton onClick={() => setDialogOpen(true)}>Add a new flow</AddButton>

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -36,6 +36,7 @@ export const AddFlow: React.FC = () => {
       sourceId: "",
       teamId,
       isTemplate: false,
+      isService: false,
     },
   };
 
@@ -45,6 +46,7 @@ export const AddFlow: React.FC = () => {
     values,
     { setFieldError, setStatus },
   ) => {
+    console.log({ values });
     setLoadingCompleteCallback(() => {
       toast.success("Flow created successfully");
       setLoadingCompleteCallback(undefined);

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -46,7 +46,6 @@ export const AddFlow: React.FC = () => {
     values,
     { setFieldError, setStatus },
   ) => {
-    console.log({ values });
     setLoadingCompleteCallback(() => {
       toast.success("Flow created successfully");
       setLoadingCompleteCallback(undefined);

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/types.ts
@@ -8,6 +8,7 @@ export const validationSchema = object().shape({
     name: string().required("Name is required"),
     teamId: number().integer().required("Team ID is required"),
     isTemplate: boolean(),
+    isService: boolean(),
     sourceId: string().when("$mode", {
       is: "new",
       then: string().notRequired(),
@@ -35,3 +36,16 @@ export const CREATE_FLOW_MODES = [
     title: "Copy an existing flow...",
   },
 ] as const;
+
+export const FLOW_SERVICE_OPTIONS = [
+  {
+    isService: false,
+    title: "Flow",
+    description: "Used as a modular building block within services",
+  },
+  {
+    isService: true,
+    title: "Service",
+    description: "A user-facing form that will be published and set online",
+  },
+];

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -147,6 +147,7 @@ insert_permissions:
         - description
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -179,6 +180,7 @@ insert_permissions:
         - description
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -218,6 +220,7 @@ insert_permissions:
         - description
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -286,6 +289,7 @@ select_permissions:
         - email_template
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name
@@ -354,6 +358,7 @@ select_permissions:
         - email_template
         - id
         - is_listed_on_lps
+        - is_service
         - is_template
         - limitations
         - name


### PR DESCRIPTION
# What does this PR do? 

When a new flow is a copy or template, inherit the `flows.is_service` value.
When a new flow is created from scratch, write a `flows.is_service` value using an editor-facing switch.

Practically speaking, this means
- Update Hasura permissions (for selecting, inserting `flows.is_service` column)
- New `Switch` in `BaseFormSection` only shown when `values.mode === "new"`
- API writes `isService` value

# Testing

Test on a pizza and check `flows.is_service` value in Hasura. I have tested:
- Create a new flow from scratch that is just a flow
- Create a new flow from scratch that is a service
- Create a flow copied from a flow
- Create a flow copied from a service
- Create a templated flow that is a service
    - Because the get query here filters for `status = online`, and only services can be online, then source templates that are services can be used to create new ones