### PR TITLE
feat(editor): Autofocus `TeamSelect` on open

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.stories.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { TeamSummary } from "pages/FlowEditor/lib/store/team";
-import { Route as AuthenticatedAppRoute } from "routes/_authenticated/app/route";
 
 import TeamSelect from "./TeamSelect";
 
@@ -46,29 +52,29 @@ const mockTeams: TeamSummary[] = [
 ] as TeamSummary[];
 
 export const Basic = {
-  parameters: {
-    tanstack: {
-      router: {
-        route: AuthenticatedAppRoute,
-        routeOverrides: {
-          "/_authenticated/app": {
-            loader: () => ({ teams: mockTeams }),
-            beforeLoad: () => {},
-          },
-        },
-      },
-    },
-  },
   render: () => {
     useStore.setState({
       canUserEditTeam: (slug: string) => slug === "open-systems-lab",
     });
 
-    return (
-      <TeamSelect
-        currentTeamSlug="open-systems-lab"
-        onTeamSelect={(teamSlug) => console.log(`Navigating to ${teamSlug}`)}
-      />
-    );
+    const rootRoute = createRootRoute();
+    const authenticatedAppRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: "/_authenticated/app",
+      loader: () => ({ teams: mockTeams }),
+      component: () => (
+        <TeamSelect
+          currentTeamSlug="open-systems-lab"
+          onTeamSelect={(teamSlug) => console.log(`Navigating to ${teamSlug}`)}
+        />
+      ),
+    });
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([authenticatedAppRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+
+    return <RouterProvider router={router} />;
   },
 } satisfies Story;

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -13,7 +13,7 @@ import ButtonBase from "@planx/components/shared/Buttons/ButtonBase";
 import { useLoaderData } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { TeamSummary } from "pages/FlowEditor/lib/store/team";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
@@ -80,6 +80,7 @@ export const TeamSelect: React.FC<Props> = ({
     null,
   );
   const [clearSearch, setClearSearch] = useState<boolean>(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const viewOnlyTeams = useMemo(
     () => teams.filter((team) => !canUserEditTeam(team.slug)),
@@ -173,6 +174,10 @@ export const TeamSelect: React.FC<Props> = ({
         onClose={handleClose}
         maxWidth="xs"
         slotProps={{
+          transition: {
+            // Auto-focus search box
+            onEntered: () => searchInputRef.current?.focus(),
+          },
           paper: {
             sx: {
               position: "absolute",
@@ -207,6 +212,7 @@ export const TeamSelect: React.FC<Props> = ({
             clearSearch={clearSearch}
             hideLabel={true}
             compact={true}
+            inputRef={searchInputRef}
           />
           <Stack sx={{ gap: 2, pt: 2 }}>
             {displayEditableTeams.length > 0 && (

--- a/apps/editor.planx.uk/src/hooks/useSearch.ts
+++ b/apps/editor.planx.uk/src/hooks/useSearch.ts
@@ -47,10 +47,12 @@ export const useSearch = <T extends object>({
   );
 
   useEffect(() => {
-    const fuseResults =
-      searchType === "include-match"
-        ? fuse.search(formatSearchPattern(pattern))
-        : fuse.search(pattern);
+    const query =
+      searchType === "include-match" ? formatSearchPattern(pattern) : pattern;
+
+    if (!query) return setResults([]);
+
+    const fuseResults = fuse.search(query);
     setResults(
       fuseResults.map((result) => {
         // Required type narrowing for FuseResult

--- a/apps/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -23,6 +23,7 @@ interface SearchBoxProps<T> {
   clearSearch?: boolean;
   hideLabel?: boolean;
   compact?: boolean;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 export const SearchBox = <T extends object>({
@@ -32,6 +33,7 @@ export const SearchBox = <T extends object>({
   clearSearch = false,
   hideLabel = false,
   compact = false,
+  inputRef,
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();
@@ -102,6 +104,7 @@ export const SearchBox = <T extends object>({
                   padding: (theme) => theme.spacing(0.25, 0.5, 0.25, 1.25),
                 }),
               }}
+              ref={inputRef}
               name="search"
               id="search"
               aria-describedby="search-label"


### PR DESCRIPTION
Small issue which has bugged me for a while...! 😅 

When the `TeamSelect` is now opened, the search box is immediately focussed which allows the user to type right away.

Test it out here - https://storybook.6806.planx.pizza/?path=/docs/design-system-molecules-teamselect--docs