### PR TITLE
fix: Question options & Autocomplete 

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -490,4 +490,77 @@ describe("Checklist editor component", () => {
     expect(screen.getByDisplayValue("Coconut")).toBeVisible();
     expect(screen.getByDisplayValue("Date")).toBeVisible();
   });
+
+  describe("data field", () => {
+    it("clears option val fields when the data field is cleared (flat options)", async () => {
+      const { user } = await setup(
+        <DndProvider backend={HTML5Backend}>
+          <ChecklistEditor
+            node={{ data: { fn: "my.data.field", text: "A checklist" } }}
+            options={[
+              { id: "opt1", data: { text: "Yes", val: "yes" } },
+              { id: "opt2", data: { text: "No", val: "no" } },
+            ]}
+          />
+        </DndProvider>,
+      );
+
+      const checklistDataField = screen.getByTestId("checklist-data-field");
+
+      await user.click(within(checklistDataField).getByTitle("Clear"));
+
+      // Set a new fn value so option val fields become visible again
+      await user.click(within(checklistDataField).getByRole("combobox"));
+      await user.paste("new.data.field");
+      await user.keyboard("{Enter}");
+
+      const optionValFields = screen.getAllByTestId(
+        /data-field-autocomplete-option-/,
+      );
+      for (const field of optionValFields) {
+        expect(within(field).getByRole("combobox")).toHaveValue("");
+      }
+    });
+
+    it("clears option val fields when the data field is cleared (grouped options)", async () => {
+      const groupedOptions: Group<Option>[] = [
+        {
+          title: "Group A",
+          children: [
+            { id: "opt1", data: { text: "Apple", val: "apple" } },
+            { id: "opt2", data: { text: "Banana", val: "banana" } },
+          ],
+        },
+        {
+          title: "Group B",
+          children: [{ id: "opt3", data: { text: "Cherry", val: "cherry" } }],
+        },
+      ];
+
+      const { user } = await setup(
+        <DndProvider backend={HTML5Backend}>
+          <ChecklistEditor
+            node={{ data: { fn: "my.data.field", text: "A checklist" } }}
+            groupedOptions={groupedOptions}
+          />
+        </DndProvider>,
+      );
+
+      const checklistDataField = screen.getByTestId("checklist-data-field");
+
+      await user.click(within(checklistDataField).getByTitle("Clear"));
+
+      // Set a new fn value so option val fields become visible again
+      await user.click(within(checklistDataField).getByRole("combobox"));
+      await user.paste("new.data.field");
+      await user.keyboard("{Enter}");
+
+      const optionValFields = screen.getAllByTestId(
+        /data-field-autocomplete-option-/,
+      );
+      for (const field of optionValFields) {
+        expect(within(field).getByRole("combobox")).toHaveValue("");
+      }
+    });
+  });
 });

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -509,7 +509,7 @@ describe("Checklist editor component", () => {
 
       await user.click(within(checklistDataField).getByTitle("Clear"));
 
-      // Set a new fn value so option val fields become visible again
+      // Set a new data field value so option val fields become visible again
       await user.click(within(checklistDataField).getByRole("combobox"));
       await user.paste("new.data.field");
       await user.keyboard("{Enter}");
@@ -550,7 +550,7 @@ describe("Checklist editor component", () => {
 
       await user.click(within(checklistDataField).getByTitle("Clear"));
 
-      // Set a new fn value so option val fields become visible again
+      // Set a new data field value so option val fields become visible again
       await user.click(within(checklistDataField).getByRole("combobox"));
       await user.paste("new.data.field");
       await user.keyboard("{Enter}");

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -26,6 +26,42 @@ it("displays the options editor when the 'Add option' button is clicked", async 
 
   const optionsEditor = await screen.findByPlaceholderText("Option");
   expect(optionsEditor).toBeInTheDocument();
+});
+
+describe("data field", () => {
+  it("clears option val fields when the question data field is cleared", async () => {
+    const { user } = await setup(
+      <DndProvider backend={HTML5Backend}>
+        <Question
+          node={{ data: { fn: "my.data.field", text: "A question" } }}
+          options={[
+            { id: "opt1", data: { text: "Yes", val: "yes" } },
+            { id: "opt2", data: { text: "No", val: "no" } },
+          ]}
+        />
+      </DndProvider>,
+    );
+
+    const questionDataField = screen.getByTestId("question-data-field");
+
+    await user.click(within(questionDataField).getByTitle("Clear"));
+
+    // Set a new fn value so option val fields become visible again
+    await user.click(within(questionDataField).getByRole("combobox"));
+    await user.paste("new.data.field");
+    await user.keyboard("{Enter}");
+
+    expect(
+      within(screen.getByTestId("data-field-autocomplete-option-0")).getByRole(
+        "combobox",
+      ),
+    ).toHaveValue("");
+    expect(
+      within(screen.getByTestId("data-field-autocomplete-option-1")).getByRole(
+        "combobox",
+      ),
+    ).toHaveValue("");
+  });
 });
 
 describe("validation", () => {

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -46,7 +46,7 @@ describe("data field", () => {
 
     await user.click(within(questionDataField).getByTitle("Clear"));
 
-    // Set a new fn value so option val fields become visible again
+    // Set a new data field value so option val fields become visible again
     await user.click(within(questionDataField).getByRole("combobox"));
     await user.paste("new.data.field");
     await user.keyboard("{Enter}");

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
@@ -14,6 +14,7 @@ import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
 import { ICONS } from "../../icons";
+import { clearOptionsDataFields } from "../../utils";
 import { TypeNarrowedExpandableSwitch as ExpandableSwitch } from "./components/ExpandableSwitch";
 import { TypeNarrowedModalFooter as ModalFooter } from "./components/ModalFooter";
 import { TypeNarrowedOptions as Options } from "./components/Options";
@@ -83,7 +84,26 @@ export const BaseChecklistComponent: React.FC<Props> = (props) => {
               <DataFieldAutocomplete
                 data-testid="checklist-data-field"
                 value={formik.values.fn}
-                onChange={(value) => formik.setFieldValue("fn", value)}
+                onChange={(value) => {
+                  formik.setFieldValue("fn", value);
+                  if (!value) {
+                    if (formik.values.options) {
+                      formik.setFieldValue(
+                        "options",
+                        clearOptionsDataFields(formik.values.options),
+                      );
+                    }
+                    if (formik.values.groupedOptions) {
+                      formik.setFieldValue(
+                        "groupedOptions",
+                        formik.values.groupedOptions.map((group) => ({
+                          ...group,
+                          children: clearOptionsDataFields(group.children),
+                        })),
+                      );
+                    }
+                  }
+                }}
                 disabled={props.disabled}
               />
             </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -23,7 +23,7 @@ import { Switch } from "ui/shared/Switch";
 import { InternalNotes } from "../../../../../ui/editor/InternalNotes";
 import { DataFieldAutocomplete } from "../../DataFieldAutocomplete";
 import { ICONS } from "../../icons";
-import { getOptionsSchemaByFn } from "../../utils";
+import { clearOptionsDataFields, getOptionsSchemaByFn } from "../../utils";
 import MoreInformation from "./MoreInformation";
 import TemplatedNodeConfiguration from "./TemplatedNodeConfiguration";
 import { Props } from "./types";
@@ -105,10 +105,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
                   if (!value) {
                     formik.setFieldValue(
                       "options",
-                      formik.values.options?.map((option) => ({
-                        ...option,
-                        data: { ...option.data, val: "" },
-                      })),
+                      clearOptionsDataFields(formik.values.options ?? []),
                     );
                   }
                 }}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -97,9 +97,21 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
             </InputRow>
             <ErrorWrapper error={formik.errors.fn}>
               <DataFieldAutocomplete
+                data-testid="question-data-field"
                 schema={schema?.nodes}
                 value={formik.values.fn}
-                onChange={(value) => formik.setFieldValue("fn", value)}
+                onChange={(value) => {
+                  formik.setFieldValue("fn", value);
+                  if (!value) {
+                    formik.setFieldValue(
+                      "options",
+                      formik.values.options?.map((option) => ({
+                        ...option,
+                        data: { ...option.data, val: "" },
+                      })),
+                    );
+                  }
+                }}
                 disabled={props.disabled}
               />
             </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.test.tsx
@@ -1,0 +1,97 @@
+import { screen, within } from "@testing-library/react";
+import React, { useState } from "react";
+import { setup } from "test/utils";
+
+import { DataFieldAutocomplete } from "./DataFieldAutocomplete";
+
+const schema = ["my.existing.field", "another.field"];
+
+const StatefulDataFieldAutocomplete: React.FC<{
+  onChange: (v: string | null) => void;
+}> = ({ onChange }) => {
+  const [value, setValue] = useState<string | undefined>("");
+  return (
+    <DataFieldAutocomplete
+      schema={schema}
+      value={value}
+      onChange={(v) => {
+        setValue(v ?? "");
+        onChange(v);
+      }}
+    />
+  );
+};
+
+it("auto-commits a typed value that exists in the schema when the input loses focus", async () => {
+  const onChange = vi.fn();
+
+  const { user } = await setup(
+    <DataFieldAutocomplete schema={schema} value="" onChange={onChange} />,
+  );
+
+  const input = screen.getByRole("combobox");
+  await user.click(input);
+  await user.paste("my.existing.field");
+  await user.tab();
+
+  expect(onChange).toHaveBeenCalledWith("my.existing.field");
+});
+
+it("auto-commits a new value when the input loses focus", async () => {
+  const onChange = vi.fn();
+
+  const { user } = await setup(
+    <DataFieldAutocomplete schema={schema} value="" onChange={onChange} />,
+  );
+
+  const input = screen.getByRole("combobox");
+  await user.click(input);
+  await user.paste("my.new.custom.field");
+  await user.tab();
+
+  expect(onChange).toHaveBeenCalledWith("my.new.custom.field");
+});
+
+it("does not commit when the input loses focus without a change", async () => {
+  const onChange = vi.fn();
+
+  const { user } = await setup(
+    <DataFieldAutocomplete
+      schema={schema}
+      value="my.existing.field"
+      onChange={onChange}
+    />,
+  );
+
+  const input = screen.getByRole("combobox");
+  await user.click(input);
+  await user.tab();
+
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+it("auto-commits a typed value after the field has been cleared", async () => {
+  const onChange = vi.fn();
+
+  const { user, container } = await setup(
+    <StatefulDataFieldAutocomplete onChange={onChange} />,
+  );
+
+  // Type a value and blur to commit it
+  const input = screen.getByRole("combobox");
+  await user.click(input);
+  await user.paste("my.existing.field");
+  await user.tab();
+  expect(onChange).toHaveBeenLastCalledWith("my.existing.field");
+
+  // Clear the committed value
+  const clearButton = within(container).getByTitle("Clear");
+  await user.click(clearButton);
+  expect(onChange).toHaveBeenLastCalledWith(null);
+
+  // Type a new value and blur — this was the failing case
+  await user.click(screen.getByRole("combobox"));
+  await user.paste("another.field");
+  await user.tab();
+  expect(onChange).toHaveBeenLastCalledWith("another.field");
+});

--- a/apps/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/DataFieldAutocomplete.tsx
@@ -58,7 +58,10 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
   }, [value]);
 
   const handleChange = (_event: React.SyntheticEvent, value: string | null) => {
-    skipBlurRef.current = true;
+    // Only skip the blur handler when a real value is committed
+    if (value !== null) {
+      skipBlurRef.current = true;
+    }
 
     // Adding a new option via the "Add" button
     if (
@@ -83,8 +86,8 @@ export const DataFieldAutocomplete: React.FC<Props> = (props) => {
     if (!allowCustomValues) return;
     const trimmed = inputValue.trim();
 
-    // Auto-commit a typed value on blur if it's new and not already set
-    if (trimmed && trimmed !== value && !options.includes(trimmed)) {
+    // Auto-commit a typed value on blur if it differs from the current value
+    if (trimmed && trimmed !== value) {
       props.onChange(trimmed);
     }
   };

--- a/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -65,6 +65,11 @@ export const getPreviouslySubmittedData = ({
   return data;
 };
 
+export const clearOptionsDataFields = <T extends { data: { val?: string } }>(
+  options: T[],
+): T[] =>
+  options.map((option) => ({ ...option, data: { ...option.data, val: "" } }));
+
 export const getOptionsSchemaByFn = (
   fn?: string,
   defaultOptionsSchema?: string[],


### PR DESCRIPTION
### What's in this PR?
Two separate fixes but closely related, in response to [this Slack thread](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1780482734978799)
1. Clear 'Data Field' values on question & checklist options when the data field value for the question is cleared
2. Always persist the entered option in `DataFieldAutocomplete` when the input field loses focus

Tests added for both as well.

I'm expecting that this will fix George's issue in which it was possible to Update a Question node, as the Question looked like it had a Data Field selected, but really it didn't, because it hadn't persisted when the input lost focus.