### PR TITLE
feat: Feature flag toggles in global settings

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -4,6 +4,7 @@ import CurrencyPoundIcon from "@mui/icons-material/CurrencyPound";
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import ExploreIcon from "@mui/icons-material/Explore";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
+import FlagIcon from "@mui/icons-material/Flag";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import GroupIcon from "@mui/icons-material/Group";
 import LayersIcon from "@mui/icons-material/Layers";
@@ -24,7 +25,7 @@ import {
 import AccountMenu from "components/AccountMenu";
 import { useFlowAnalyticsLink } from "hooks/analyticsLinks/useFlowAnalyticsLink";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
-import { hasFeatureFlag } from "lib/featureFlags";
+import { AVAILABLE_FEATURE_FLAGS, hasFeatureFlag } from "lib/featureFlags";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useMemo, useRef, useState } from "react";
 import EditorIcon from "ui/icons/Editor";
@@ -419,6 +420,20 @@ function EditorNavMenu() {
             );
           })}
         </MenuWrap>
+        {!isFlowRoute && role === "platformAdmin" && (
+          <Box sx={(theme) => ({ padding: theme.spacing(0, 0.5, 1) })}>
+            <NavMenuItem
+              title="Feature flags"
+              Icon={FlagIcon}
+              badgeCount={AVAILABLE_FEATURE_FLAGS.filter(hasFeatureFlag).length}
+              isActive={isActive("/app/global-settings/feature-flags")}
+              isExternal={false}
+              compact={compact}
+              onClick={() => handleClick("/app/global-settings/feature-flags")}
+              sx={{ minHeight: 44 }}
+            />
+          </Box>
+        )}
         {isTeamRoute && (role === "platformAdmin" || role === "teamEditor") && (
           <Box sx={(theme) => ({ padding: theme.spacing(0, 0.5, 1) })}>
             <Box ref={notificationsRef}>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -75,7 +75,7 @@ function EditorNavMenu() {
     const currentPath = pathname;
 
     // Factor in nested routes when determining active state
-    if (route.includes("/settings")) {
+    if (route.includes("settings")) {
       return currentPath.startsWith(route);
     }
 

--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,7 +1,7 @@
 // add/edit/remove feature flags in array below
-const AVAILABLE_FEATURE_FLAGS = ["DASHBOARD", "EXPLORE"] as const;
+export const AVAILABLE_FEATURE_FLAGS = ["DASHBOARD", "EXPLORE"] as const;
 
-type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
+export type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 
 /**
  * get list of feature flags that have been enabled for this session

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
@@ -48,7 +48,7 @@ const SettingsLayout: React.FC<Props> = ({
 
   const activeTab =
     filteredLinks.find((link) =>
-      pathname.href?.includes(`/settings${link.path}`),
+      pathname.href?.includes(getNavigationPath(link.path)),
     )?.path || filteredLinks[0]?.path;
 
   const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
@@ -77,17 +77,25 @@ const SettingsLayout: React.FC<Props> = ({
           </Typography>
           {settingsLinks && (
             <TabList>
-              <Tabs onChange={handleChange} value={activeTab} aria-label={title}>
-                {filteredLinks ? filteredLinks.map(({ label, path, icon: Icon }) => (
-                  <StyledTab
-                    size="large"
-                    key={path}
-                    value={path}
-                    label={label}
-                    icon={Icon ? <Icon /> : undefined}
-                    iconPosition="start"
-                  />
-                )) : <></>}
+              <Tabs
+                onChange={handleChange}
+                value={activeTab}
+                aria-label={title}
+              >
+                {filteredLinks ? (
+                  filteredLinks.map(({ label, path, icon: Icon }) => (
+                    <StyledTab
+                      size="large"
+                      key={path}
+                      value={path}
+                      label={label}
+                      icon={Icon ? <Icon /> : undefined}
+                      iconPosition="start"
+                    />
+                  ))
+                ) : (
+                  <></>
+                )}
               </Tabs>
             </TabList>
           )}

--- a/apps/editor.planx.uk/src/pages/GlobalSettings/FeatureFlags.tsx
+++ b/apps/editor.planx.uk/src/pages/GlobalSettings/FeatureFlags.tsx
@@ -1,0 +1,99 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import {
+  AVAILABLE_FEATURE_FLAGS,
+  type FeatureFlag,
+  hasFeatureFlag,
+  toggleFeatureFlag,
+} from "lib/featureFlags";
+import { useMemo, useState } from "react";
+import InputLegend from "ui/editor/InputLegend";
+import NewSettingsSection from "ui/editor/NewSettingsSection";
+import SettingsDescription from "ui/editor/SettingsDescription";
+import { Switch } from "ui/shared/Switch";
+
+function FeatureFlagsSettings() {
+  const savedFlags = useMemo(
+    () =>
+      Object.fromEntries(
+        AVAILABLE_FEATURE_FLAGS.map((flag) => [flag, hasFeatureFlag(flag)]),
+      ) as Record<FeatureFlag, boolean>,
+    [],
+  );
+
+  const [workingFlags, setWorkingFlags] =
+    useState<Record<FeatureFlag, boolean>>(savedFlags);
+
+  const dirty = AVAILABLE_FEATURE_FLAGS.some(
+    (flag) => workingFlags[flag] !== savedFlags[flag],
+  );
+
+  const handleToggle = (flag: FeatureFlag) => {
+    setWorkingFlags((prev) => ({ ...prev, [flag]: !prev[flag] }));
+  };
+
+  const handleSave = () => {
+    AVAILABLE_FEATURE_FLAGS.forEach((flag) => {
+      if (workingFlags[flag] !== savedFlags[flag]) {
+        toggleFeatureFlag(flag, false);
+      }
+    });
+    window.location.reload();
+  };
+
+  const handleReset = () => {
+    setWorkingFlags(savedFlags);
+  };
+
+  return (
+    <NewSettingsSection>
+      <Grid container spacing={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
+          <InputLegend>Feature flags</InputLegend>
+          <SettingsDescription>
+            Enable experimental features in this environment. Changes take
+            effect after saving (the page will auto-refresh).
+          </SettingsDescription>
+        </Grid>
+        <Grid size={{ xs: 12, md: 8 }}>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+              paddingTop: 0.25,
+            }}
+          >
+            {AVAILABLE_FEATURE_FLAGS.map((flag) => (
+              <Switch
+                key={flag}
+                label={flag.charAt(0) + flag.slice(1).toLowerCase()}
+                name={flag}
+                variant="editorPage"
+                capitalize
+                checked={workingFlags[flag]}
+                onChange={() => handleToggle(flag)}
+              />
+            ))}
+          </Box>
+          <Box sx={{ mt: 2.5, display: "flex", gap: 1.5 }}>
+            <Button variant="contained" disabled={!dirty} onClick={handleSave}>
+              Save
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              disabled={!dirty}
+              onClick={handleReset}
+            >
+              Reset changes
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+    </NewSettingsSection>
+  );
+}
+
+export default FeatureFlagsSettings;

--- a/apps/editor.planx.uk/src/pages/GlobalSettings/FeatureFlags.tsx
+++ b/apps/editor.planx.uk/src/pages/GlobalSettings/FeatureFlags.tsx
@@ -8,6 +8,7 @@ import {
   toggleFeatureFlag,
 } from "lib/featureFlags";
 import { useMemo, useState } from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import InputLegend from "ui/editor/InputLegend";
 import NewSettingsSection from "ui/editor/NewSettingsSection";
 import SettingsDescription from "ui/editor/SettingsDescription";
@@ -57,39 +58,49 @@ function FeatureFlagsSettings() {
           </SettingsDescription>
         </Grid>
         <Grid size={{ xs: 12, md: 8 }}>
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1,
-              paddingTop: 0.25,
-            }}
-          >
-            {AVAILABLE_FEATURE_FLAGS.map((flag) => (
-              <Switch
-                key={flag}
-                label={flag.charAt(0) + flag.slice(1).toLowerCase()}
-                name={flag}
-                variant="editorPage"
-                capitalize
-                checked={workingFlags[flag]}
-                onChange={() => handleToggle(flag)}
-              />
-            ))}
-          </Box>
-          <Box sx={{ mt: 2.5, display: "flex", gap: 1.5 }}>
-            <Button variant="contained" disabled={!dirty} onClick={handleSave}>
-              Save
-            </Button>
-            <Button
-              variant="contained"
-              color="secondary"
-              disabled={!dirty}
-              onClick={handleReset}
-            >
-              Reset changes
-            </Button>
-          </Box>
+          {(AVAILABLE_FEATURE_FLAGS.length as number) === 0 ? (
+            <EmptyState title="No feature flags available" />
+          ) : (
+            <>
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1,
+                  paddingTop: 0.25,
+                }}
+              >
+                {AVAILABLE_FEATURE_FLAGS.map((flag) => (
+                  <Switch
+                    key={flag}
+                    label={flag.charAt(0) + flag.slice(1).toLowerCase()}
+                    name={flag}
+                    variant="editorPage"
+                    capitalize
+                    checked={workingFlags[flag]}
+                    onChange={() => handleToggle(flag)}
+                  />
+                ))}
+              </Box>
+              <Box sx={{ mt: 2.5, display: "flex", gap: 1.5 }}>
+                <Button
+                  variant="contained"
+                  disabled={!dirty}
+                  onClick={handleSave}
+                >
+                  Save
+                </Button>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  disabled={!dirty}
+                  onClick={handleReset}
+                >
+                  Reset changes
+                </Button>
+              </Box>
+            </>
+          )}
         </Grid>
       </Grid>
     </NewSettingsSection>

--- a/apps/editor.planx.uk/src/pages/GlobalSettings/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/GlobalSettings/Layout.tsx
@@ -1,4 +1,5 @@
 import ArticleIcon from "@mui/icons-material/Article";
+import FlagIcon from "@mui/icons-material/Flag";
 import React, { PropsWithChildren } from "react";
 
 import SettingsLayout, {
@@ -8,6 +9,7 @@ import SettingsLayout, {
 const GlobalSettingsLayout: React.FC<PropsWithChildren> = ({ children }) => {
   const settingsLinks: SettingsLink[] = [
     { label: "Footer elements", path: "/footer", icon: ArticleIcon },
+    { label: "Feature flags", path: "/feature-flags", icon: FlagIcon },
   ];
 
   return (

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './route
 import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
 import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
 import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
+import { Route as AuthenticatedAppGlobalSettingsFeatureFlagsRouteImport } from './routes/_authenticated/app/global-settings/feature-flags'
 import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
 import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
 import { Route as AuthenticatedAppTeamSubmissionsRouteImport } from './routes/_authenticated/app/$team/submissions'
@@ -210,6 +211,12 @@ const AuthenticatedAppGlobalSettingsFooterRoute =
   AuthenticatedAppGlobalSettingsFooterRouteImport.update({
     id: '/footer',
     path: '/footer',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppGlobalSettingsFeatureFlagsRoute =
+  AuthenticatedAppGlobalSettingsFeatureFlagsRouteImport.update({
+    id: '/feature-flags',
+    path: '/feature-flags',
     getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
   } as any)
 const AuthenticatedAppTeamTutorialsRoute =
@@ -688,6 +695,7 @@ export interface FileRoutesByFullPath {
   '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
+  '/app/global-settings/feature-flags': typeof AuthenticatedAppGlobalSettingsFeatureFlagsRoute
   '/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
   '/$flow/view-application': typeof PublicCustomDomainFlowViewApplicationRoute
   '/app/$team/': typeof AuthenticatedAppTeamIndexRoute
@@ -774,6 +782,7 @@ export interface FileRoutesByTo {
   '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
+  '/app/global-settings/feature-flags': typeof AuthenticatedAppGlobalSettingsFeatureFlagsRoute
   '/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
   '/$flow/view-application': typeof PublicCustomDomainFlowViewApplicationRoute
   '/app/$team': typeof AuthenticatedAppTeamIndexRoute
@@ -864,6 +873,7 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/_authenticated/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/_authenticated/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
+  '/_authenticated/app/global-settings/feature-flags': typeof AuthenticatedAppGlobalSettingsFeatureFlagsRoute
   '/_authenticated/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
   '/_public/_customDomain/$flow/view-application': typeof PublicCustomDomainFlowViewApplicationRoute
   '/_authenticated/app/$team/': typeof AuthenticatedAppTeamIndexRoute
@@ -960,6 +970,7 @@ export interface FileRouteTypes {
     | '/app/$team/submissions'
     | '/app/$team/subscription'
     | '/app/$team/tutorials'
+    | '/app/global-settings/feature-flags'
     | '/app/global-settings/footer'
     | '/$flow/view-application'
     | '/app/$team/'
@@ -1046,6 +1057,7 @@ export interface FileRouteTypes {
     | '/app/$team/submissions'
     | '/app/$team/subscription'
     | '/app/$team/tutorials'
+    | '/app/global-settings/feature-flags'
     | '/app/global-settings/footer'
     | '/$flow/view-application'
     | '/app/$team'
@@ -1135,6 +1147,7 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/submissions'
     | '/_authenticated/app/$team/subscription'
     | '/_authenticated/app/$team/tutorials'
+    | '/_authenticated/app/global-settings/feature-flags'
     | '/_authenticated/app/global-settings/footer'
     | '/_public/_customDomain/$flow/view-application'
     | '/_authenticated/app/$team/'
@@ -1354,6 +1367,13 @@ declare module '@tanstack/react-router' {
       path: '/footer'
       fullPath: '/app/global-settings/footer'
       preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    }
+    '/_authenticated/app/global-settings/feature-flags': {
+      id: '/_authenticated/app/global-settings/feature-flags'
+      path: '/feature-flags'
+      fullPath: '/app/global-settings/feature-flags'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFeatureFlagsRouteImport
       parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
     }
     '/_authenticated/app/$team/tutorials': {
@@ -2093,12 +2113,15 @@ const AuthenticatedAppTeamRouteRouteWithChildren =
   )
 
 interface AuthenticatedAppGlobalSettingsRouteRouteChildren {
+  AuthenticatedAppGlobalSettingsFeatureFlagsRoute: typeof AuthenticatedAppGlobalSettingsFeatureFlagsRoute
   AuthenticatedAppGlobalSettingsFooterRoute: typeof AuthenticatedAppGlobalSettingsFooterRoute
   AuthenticatedAppGlobalSettingsIndexRoute: typeof AuthenticatedAppGlobalSettingsIndexRoute
 }
 
 const AuthenticatedAppGlobalSettingsRouteRouteChildren: AuthenticatedAppGlobalSettingsRouteRouteChildren =
   {
+    AuthenticatedAppGlobalSettingsFeatureFlagsRoute:
+      AuthenticatedAppGlobalSettingsFeatureFlagsRoute,
     AuthenticatedAppGlobalSettingsFooterRoute:
       AuthenticatedAppGlobalSettingsFooterRoute,
     AuthenticatedAppGlobalSettingsIndexRoute:

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/global-settings/feature-flags.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/global-settings/feature-flags.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import FeatureFlagsSettings from "pages/GlobalSettings/FeatureFlags";
+
+export const Route = createFileRoute(
+  "/_authenticated/app/global-settings/feature-flags",
+)({
+  component: FeatureFlagsSettings,
+});


### PR DESCRIPTION
## What does this PR do?

- Enables feature flags to be toggled in global settings
- Feature flags are added/removed from local storage
- Auto-refresh happens after saving so that the feature flag takes immediate effect

<img width="744" height="403" alt="image" src="https://github.com/user-attachments/assets/25b51c03-d9aa-4d9e-b374-75d5d0081bda" />


**Testing:**
https://6810.planx.pizza/app/global-settings/feature-flags