### PR TITLE
feat: Dashboard branded header

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ActivityWidget.tsx
@@ -44,6 +44,7 @@ export function ActivityWidget({
         sx={{
           minHeight: 36,
           borderBottom: 1,
+          paddingX: 1.25,
           borderColor: "divider",
           [`& .${tabsClasses.indicator}`]: { display: "none" },
         }}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -57,10 +57,10 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
         <Tabs
           value={tab}
           onChange={(_e, v) => setTab(v)}
-          sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main" }}
+          sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main", paddingX: 1.25, }}
         >
-          <StyledTab label="Recent flows" value="recent" fontSize="16px" />
-          <StyledTab label="Pinned flows" value="pinned" fontSize="16px" />
+          <StyledTab label="Recent flows" value="recent" />
+          <StyledTab label="Pinned flows" value="pinned" />
         </Tabs>
       </TabList>
       {loading ? (
@@ -95,8 +95,8 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
                 <ListItem
                   sx={{
                     position: "relative",
-                    px: 1.5,
-                    py: 1,
+                    px: 2,
+                    py: 1.25,
                     backgroundColor: isAnyTemplate
                       ? "template.light"
                       : "transparent",

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: "Editor Components/Dashboard/StatsBanner",
   component: StatsBanner,
   args: {
-    teamSlug: "test-council",
+    analyticsLink: "https://metabase.editor.planx.uk",
     loading: false,
     stats: {
       onlineFlows: 12,

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -1,8 +1,10 @@
 import Box from "@mui/material/Box";
-import { keyframes, styled } from "@mui/material/styles";
+import MuiLink from "@mui/material/Link";
+import { keyframes, styled, type Theme } from "@mui/material/styles";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { linkOptions } from "@tanstack/react-router";
-import { WidgetLink } from "ui/editor/DashboardWidget";
+import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import {
@@ -47,14 +49,31 @@ function formatDelta(delta: number): string {
   return delta >= 0 ? `+${delta}` : `${delta}`;
 }
 
+const analyticsLinkBase = (theme: Theme) => ({
+  fontSize: theme.typography.body2.fontSize,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+});
+
+const AnalyticsLink = styled(MuiLink)(({ theme }) => ({
+  ...analyticsLinkBase(theme),
+  color: theme.palette.text.primary,
+  "&:hover": { textDecorationThickness: "2px" },
+}));
+
+const AnalyticsLinkDisabled = styled(Typography)(({ theme }) => ({
+  ...analyticsLinkBase(theme),
+  color: theme.palette.text.disabled,
+  cursor: "default",
+}));
+
 interface StatsBannerProps {
-  teamSlug: string;
+  analyticsLink?: string;
   stats?: TeamDashboardStats;
   loading?: boolean;
 }
 
 export function StatsBanner({
-  teamSlug,
+  analyticsLink,
   stats,
   loading = false,
 }: StatsBannerProps) {
@@ -91,13 +110,22 @@ export function StatsBanner({
         <Typography variant="h4" component="h2">
           Last 30 days
         </Typography>
-        <WidgetLink
-          label="view analytics"
-          {...linkOptions({
-            to: "/app/$team",
-            params: { team: teamSlug },
-          })}
-        />
+        {analyticsLink ? (
+          <AnalyticsLink
+            href={analyticsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="always"
+          >
+            view analytics
+          </AnalyticsLink>
+        ) : (
+          <Tooltip title="Analytics unavailable" placement="bottom">
+            <AnalyticsLinkDisabled variant="body2">
+              view analytics
+            </AnalyticsLinkDisabled>
+          </Tooltip>
+        )}
       </Header>
       <StatsGrid>
         {tiles.map(({ label, value, delta }) => (
@@ -138,6 +166,7 @@ export default function ConnectedStatsBanner() {
   const teamSlug = useStore((state) => state.getTeam().slug);
   const { data, loading } = useTeamDashboardStats(teamSlug);
   const stats = data?.teamDashboardStats[0];
+  const analyticsLink = useTeamAnalyticsLink();
 
-  return <StatsBanner teamSlug={teamSlug} stats={stats} loading={loading} />;
+  return <StatsBanner analyticsLink={analyticsLink} stats={stats} loading={loading} />;
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -2,7 +2,6 @@ import Box from "@mui/material/Box";
 import { keyframes, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { linkOptions } from "@tanstack/react-router";
-import React from "react";
 import { WidgetLink } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../FlowEditor/lib/store";

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -16,18 +16,19 @@ const Root = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.light}`,
   position: "relative",
   padding: theme.spacing(1.5),
-  marginTop: theme.spacing(4),
-  marginBottom: theme.spacing(2),
   zIndex: 1,
+  borderRadius: theme.shape.borderRadius,
 }));
 
-const Header = styled(Box)({
+const Header = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "flex-start",
   gap: 16,
   alignItems: "baseline",
-  marginBottom: 12,
-});
+  marginBottom: theme.spacing(1),
+  paddingBottom: theme.spacing(1.5),
+  borderBottom: `1px solid ${theme.palette.border.light}`,
+}));
 
 const pulse = keyframes`
   0%, 100% { opacity: 1; }
@@ -88,7 +89,9 @@ export function StatsBanner({
   return (
     <Root>
       <Header>
-        <Typography variant="h3">Last 30 days</Typography>
+        <Typography variant="h4" component="h2">
+          Last 30 days
+        </Typography>
         <WidgetLink
           label="view analytics"
           {...linkOptions({

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -1,8 +1,9 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { linkOptions } from "@tanstack/react-router";
-import React from "react";
+import { DEFAULT_PRIMARY_COLOR } from "theme";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
@@ -14,14 +15,37 @@ import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
   const team = useStore((state) => state.getTeam());
+  const muiTheme = useTheme();
 
+  const mastheadBg = team.theme?.primaryColour ?? DEFAULT_PRIMARY_COLOR;
   return (
     <Box sx={{ bgcolor: "background.paper", flexGrow: 1 }}>
+      <Box sx={{ bgcolor: mastheadBg, py: 3 }}>
+        <Container
+          maxWidth="contentWide"
+          sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        >
+          {team.theme?.logo ? (
+            <Box
+              component="img"
+              src={team.theme.logo}
+              alt={team.name}
+              sx={{ maxWidth: 160, width: "100%", display: "block" }}
+            />
+          ) : (
+            <Typography
+              variant="h2"
+              component="h1"
+              gutterBottom
+              sx={{ color: muiTheme.palette.getContrastText(mastheadBg) }}
+            >
+              {team.name}
+            </Typography>
+          )}
+          <StatsBanner />
+        </Container>
+      </Box>
       <Container maxWidth="contentWide" sx={{ py: 4 }}>
-        <Typography variant="h2" component="h1" gutterBottom>
-          {team.name}
-        </Typography>
-        <StatsBanner />
         <Box
           sx={(theme) => ({
             display: "grid",

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -52,7 +52,11 @@ export default function Dashboard() {
           <StatsBanner />
         </Container>
       </Box>
-      <Container maxWidth="contentWide" sx={{ py: 4 }}>
+      <Container 
+        maxWidth="contentWide" 
+        // Override default container padding to align with widgets
+        sx={{ py: "30px !important" }}
+      >
         <Box
           sx={(theme) => ({
             display: "grid",

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -7,10 +7,10 @@ import { DEFAULT_PRIMARY_COLOR } from "theme";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
+import ActivityWidget from "./components/ActivityWidget";
+import FeedbackWidget from "./components/FeedbackWidget";
 import FlowsPanel from "./components/FlowsPanel";
 import ConnectedNotificationsWidget from "./components/NotificationsWidget";
-import FeedbackWidget from "./components/FeedbackWidget";
-import ActivityWidget from "./components/ActivityWidget";
 import StatsBanner from "./components/StatsBanner";
 
 export default function Dashboard() {
@@ -30,7 +30,14 @@ export default function Dashboard() {
               component="img"
               src={team.theme.logo}
               alt={team.name}
-              sx={{ maxWidth: 160, width: "100%", display: "block" }}
+              sx={{
+                maxWidth: 160,
+                width: "100%",
+                height: 60,
+                objectFit: "contain",
+                objectPosition: "left",
+                display: "block",
+              }}
             />
           ) : (
             <Typography

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts
@@ -58,10 +58,6 @@ export const teamStore: StateCreator<
       teamDomain: team.domain,
     });
 
-    if (team.theme?.favicon) {
-      const favicon = document.getElementById("favicon") as HTMLLinkElement;
-      favicon.href = team.theme.favicon;
-    }
   },
 
   getTeam: () => ({

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
 import Dashboard from "pages/Dashboard";
-import React from "react";
 
 export const Route = createFileRoute("/_authenticated/app/$team/dashboard")({
   beforeLoad: ({ params }) => {

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -36,6 +36,13 @@ export const Route = createFileRoute("/_authenticated/app/$team")({
             integrations {
               hasPlanningData: has_planning_data
             }
+            theme {
+              primaryColour: primary_colour
+              actionColour: action_colour
+              linkColour: link_colour
+              logo
+              favicon
+            }
             settings: team_settings {
               id
               boundaryUrl: boundary_url

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import { LinkOptions, RegisteredRouter } from "@tanstack/react-router";
 import { BadgeChip } from "components/EditorNavMenu/styles";
 import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
@@ -19,7 +20,7 @@ const Root = styled(Box)(({ theme }) => ({
   border: `1px solid ${theme.palette.border.light}`,
   display: "flex",
   flexDirection: "column",
-  height: "380px",
+  height: "400px",
   zIndex: 1,
 }));
 
@@ -27,12 +28,13 @@ const Header = styled(Box)(({ theme }) => ({
   display: "flex",
   alignItems: "baseline",
   justifyContent: "space-between",
-  padding: theme.spacing(1.5),
+  padding: theme.spacing(2),
 }));
 
 const StyledWidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
   color: theme.palette.text.primary,
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,  
   "&:hover": {
     textDecorationThickness: "2px",
   },

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -31,8 +31,8 @@ const Header = styled(Box)(({ theme }) => ({
 }));
 
 const StyledWidgetLink = styled(CustomLink)(({ theme }) => ({
-  fontSize: theme.typography.body3.fontSize,
-  color: theme.palette.text.secondary,
+  fontSize: theme.typography.body2.fontSize,
+  color: theme.palette.text.primary,
   "&:hover": {
     textDecorationThickness: "2px",
   },

--- a/apps/editor.planx.uk/src/utils/routeUtils/publicRouteHelpers.tsx
+++ b/apps/editor.planx.uk/src/utils/routeUtils/publicRouteHelpers.tsx
@@ -95,6 +95,11 @@ export const updateStoreWithPublicRouteData = (
   state.setFlowSettings(data.flow.settings);
   state.setTeam(data.flow.team);
 
+  if (data.flow.team?.theme?.favicon) {
+    const faviconEl = document.getElementById("favicon") as HTMLLinkElement;
+    faviconEl.href = data.flow.team.theme.favicon;
+  }
+
   // Only /published routes use the SaveAndReturn layout, but this needs to be resolved on beforeLoad()
   if (mode === "published") {
     const hasSendComponent = data.flow.publishedFlows[0]?.hasSendComponent;

--- a/apps/editor.planx.uk/src/utils/routeUtils/standaloneViewHelpers.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/standaloneViewHelpers.ts
@@ -87,4 +87,9 @@ export const setupStandaloneViewStore = (data: StandaloneViewData): void => {
   state.setGlobalSettings(globalSettings[0]);
   state.setFlowSettings(flowSettings);
   state.setTeam(team);
+
+  if (team.theme?.favicon) {
+    const faviconEl = document.getElementById("favicon") as HTMLLinkElement;
+    faviconEl.href = team.theme.favicon;
+  }
 };


### PR DESCRIPTION
## What does this PR do?

- Adds a team branded header/masthead to the dashboard page
  - If logo is present it is displayed, otherwise displays team name as text
  - Team theme colour is used as background
- Tidies up spacing and styling around the dashboard
- Hooks up analytics link in `StatsBanner` (uses same disabled/tooltip setup as `EditorNavMenu` if analytics link is not available

<img width="1728" height="893" alt="image" src="https://github.com/user-attachments/assets/29783277-30d7-4cd5-9d28-fe104656a7b5" />


**To test:**
- Toggle feature flag `Dashboard`
- Navigate to a team and select Dashboard from sidebar menu