### PR TITLE
feat: auto-suggest editor data values for all Planning Data fns

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
@@ -7,7 +7,7 @@ import {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
-import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
+import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { getIn } from "formik";
 import React from "react";
@@ -40,7 +40,9 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
   isTemplatedNode,
 }: Props<T>) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
-  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
+  const { data: planningDataSchema } = usePlanningDataEntityNames(
+    formik.values.fn || "",
+  );
 
   return (
     <Box>
@@ -103,9 +105,8 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
               optionPlaceholder: "Exclusive 'or' option",
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
-                schema,
+                planningDataSchema ?? schema,
                 currentOptionVals,
-                localAuthorityDistrictSchema,
               ),
             }}
             isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
@@ -8,7 +8,7 @@ import type {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
-import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
+import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { FormikValues, getIn } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -40,7 +40,9 @@ export const GroupedOptions = <T extends AnyChecklist>({
   isTemplatedNode,
 }: Props<T>) => {
   const { schema, currentOptionVals } = useCurrentOptions(formik);
-  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
+  const { data: planningDataSchema } = usePlanningDataEntityNames(
+    formik.values.fn || "",
+  );
 
   // Type-narrowing only - groupedOptions will be defined here
   if (!formik.values.groupedOptions)
@@ -153,9 +155,8 @@ export const GroupedOptions = <T extends AnyChecklist>({
                 groups: nonExclusiveOptionGroups.map((opt) => opt.title),
                 schema: getOptionsSchemaByFn(
                   formik.values.fn,
-                  schema,
+                  planningDataSchema ?? schema,
                   currentOptionVals,
-                  localAuthorityDistrictSchema,
                 ),
               }}
               isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
@@ -1,7 +1,7 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { AnyOption } from "@planx/components/Option/model";
 import { DEFAULT_RULE } from "@planx/components/ResponsiveChecklist/model";
-import { useLocalAuthorityDistricts } from "@planx/components/shared/hooks";
+import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { partition } from "lodash";
 import React from "react";
@@ -34,7 +34,9 @@ export const Options = <T extends AnyChecklist>({
   const exclusiveOrOptionManagerShouldRender = nonExclusiveOptions.length > 0;
 
   const { schema, currentOptionVals } = useCurrentOptions(formik);
-  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
+  const { data: planningDataSchema } = usePlanningDataEntityNames(
+    formik.values.fn || "",
+  );
 
   return (
     <ModalSectionContent subtitle="Options">
@@ -77,9 +79,8 @@ export const Options = <T extends AnyChecklist>({
               showValueField: !!formik.values.fn,
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
-                schema,
+                planningDataSchema ?? schema,
                 currentOptionVals,
-                localAuthorityDistrictSchema,
               ),
             }}
             isTemplatedNode={isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -22,7 +22,7 @@ import { Switch } from "ui/shared/Switch";
 
 import { InternalNotes } from "../../../../../ui/editor/InternalNotes";
 import { DataFieldAutocomplete } from "../../DataFieldAutocomplete";
-import { useLocalAuthorityDistricts } from "../../hooks";
+import { usePlanningDataEntityNames } from "../../hooks";
 import { ICONS } from "../../icons";
 import { getOptionsSchemaByFn } from "../../utils";
 import MoreInformation from "./MoreInformation";
@@ -44,7 +44,9 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
   const currentOptionVals = formik.values.options?.map(
     (option) => option.data?.val,
   );
-  const { data: localAuthorityDistrictSchema } = useLocalAuthorityDistricts();
+  const { data: planningDataSchema } = usePlanningDataEntityNames(
+    formik.values.fn || "",
+  );
 
   const focusRef = useRef<HTMLInputElement | null>(null);
 
@@ -165,9 +167,8 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
                 showValueField: !!formik.values.fn,
                 schema: getOptionsSchemaByFn(
                   formik.values.fn,
-                  schema?.options,
+                  planningDataSchema ?? schema?.options,
                   currentOptionVals,
-                  localAuthorityDistrictSchema,
                 ),
               }}
               isTemplatedNode={props.node?.data?.isTemplatedNode}

--- a/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getLocalAuthorityDistricts } from "lib/planningData/requests";
+import { getEntityNames } from "lib/planningData/requests";
 import { useEffect, useState } from "react";
 
 export type UseFileUrlProps =
@@ -34,10 +34,19 @@ export const useFileUrl = (props: UseFileUrlProps) => {
   };
 };
 
-export const useLocalAuthorityDistricts = () => {
+export const usePlanningDataEntityNames = (fn: string) => {
+  const fnToDataset: Record<string, string> = {
+    "property.localAuthorityDistrict": "local-authority-district",
+    "property.localPlanningAuthority": "local-planning-authority",
+    "property.region": "region",
+    "property.developmentCorporation": "development-corporation",
+    // "property.ward": "ward" // only 'turn on' once we setup query pagination and if UI is okay (current PD API limit = 500, but there's ~7k wards)
+  };
+
   const query = useQuery({
-    queryKey: ["localAuthorityDistrictNames"],
-    queryFn: () => getLocalAuthorityDistricts(),
+    queryKey: [fnToDataset[fn]],
+    queryFn: () => getEntityNames(fnToDataset[fn]),
+    enabled: Object.keys(fnToDataset).includes(fn),
     refetchOnWindowFocus: false,
     staleTime: Infinity,
   });

--- a/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -69,20 +69,16 @@ export const getOptionsSchemaByFn = (
   fn?: string,
   defaultOptionsSchema?: string[],
   currentOptions?: (string | undefined)[],
-  localAuthorityDistrictSchema?: string[] | undefined,
 ) => {
   let schema = defaultOptionsSchema;
 
   // For certain data fields, suggest based on full ODP Schema enums rather than current flow schema
+  //   Note that many `property.{}` fields which auto-suggest based on Planning Data entities set their schema one level up
   if (fn === "application.type")
     schema = getValidSchemaValues("ApplicationType");
   if (fn === "proposal.projectType")
     schema = getValidSchemaValues("ProjectType");
   if (fn === "property.type") schema = getValidSchemaValues("PropertyType");
-
-  // For other data fields, suggest based on external data source like Planning Data
-  if (fn === "property.localAuthorityDistrict" && localAuthorityDistrictSchema)
-    schema = localAuthorityDistrictSchema;
 
   // Ensure that any initial values outside of ODP Schema enums will still be recognised/pre-populated when modal loads
   currentOptions?.forEach((option) => {

--- a/apps/editor.planx.uk/src/lib/planningData/requests.ts
+++ b/apps/editor.planx.uk/src/lib/planningData/requests.ts
@@ -64,17 +64,17 @@ export const getEntity = async (
 };
 
 /**
- * Get all records in a single dataset to autosuggest data values for `property.localAuthorityDistrict`
+ * Get all named entities (omitting geometry) in a single dataset to autosuggest data values for `property.{dataset}`
  */
-export const getLocalAuthorityDistricts = async () => {
+export const getEntityNames = async (dataset: string) => {
   const { data } = await axios.get<SearchEntityResponseExcludeGeom>(
     `/entity.json`,
     {
       baseURL: PLANNING_DATA_URL,
       params: {
-        limit: 400, // ~344 local authority districts, this shouldn't change often (if anything will decrease with mergers)
-        entries: "all", // include "historic" ones
-        dataset: "local-authority-district",
+        limit: 500,
+        entries: "all", // include "historic" entities
+        dataset: dataset,
         exclude_field: "geometry,point", // don't return geometry for faster, lighter response
       },
       paramsSerializer: {


### PR DESCRIPTION
Follow-up to #6799 ! 

**Now covering:** 
- `property.localAuthorityDistrict`
- `property.localPlanningAuthority`
- `property.region`
- `property.developmentCorporation`
 
**Outstanding / next PR:** 
- `property.constraints.planning` including granular A4s