### PR TITLE
feat(lps): Use Lambda@Edge to handle URL extensions

### DIFF
--- a/apps/localplanning.services/astro.config.mjs
+++ b/apps/localplanning.services/astro.config.mjs
@@ -51,8 +51,9 @@ export default defineConfig({
     },
   ],
   build: {
-    // AWS Cloudfront requires /about.html not /about/index.html
-    format: isCloudfrontBuild 
+    // Emit /about.html not /about/index.html for AWS Cloudfront
+    // The LPS URL rewrite Lambda@Edge function maps pretty URLs (/about) to *.html keys
+    format: isCloudfrontBuild
       ? "file"
       : "directory"
   }

--- a/infrastructure/application/aws/lambda/README.md
+++ b/infrastructure/application/aws/lambda/README.md
@@ -71,3 +71,61 @@ Key constraints:
 - Lambda@Edge functions must be created in `us-east-1`
 - Viewer-request triggers don't support environment variables — the Hasura URL is inlined by Pulumi at deploy time
 - The `__HASURA_URL__` placeholder in `flow_link_preview.js` is replaced per environment
+
+---
+
+# LPS URL Rewrite
+
+A [Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-the-edge.html) viewer-request function that maps the LPS site's pretty URLs to the real `*.html` S3 keys.
+
+## Overview
+
+LocalPlanning.Services (LPS) is a static [Astro](https://astro.build) site served from a private S3 bucket via a CloudFront REST origin (OAI). A REST origin performs no directory-index / pretty-URL resolution, so `/about` maps to an S3 key literally named `about`. Astro (`build.format: "file"`) outputs `about.html`.
+
+Previously the deploy script bridged this gap by stripping `.html` from keys on upload (`about.html` → `about`). That created a key-space mismatch between `dist/` and the bucket, so the static `aws s3 sync --delete` deleted every live page on each deploy and re-created it moments later — a window in which CloudFront served 403/404, recorded by UptimeRobot as downtime on every deploy.
+
+This function moves the mapping to the edge instead, so the site is deployed to S3 **verbatim** (keys === `dist` paths) and `sync --delete` only ever overwrites live objects atomically.
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant CF as CloudFront
+    participant Lambda as Lambda@Edge
+    participant S3
+
+    Browser->>CF: GET /about
+    CF->>Lambda: Viewer request trigger
+    Note over Lambda: /about → /about.html
+    Lambda->>CF: Forward rewritten URI
+    CF->>S3: GET /about.html
+    S3->>CF: about.html
+    CF->>Browser: 200 OK
+```
+
+Rewrite rules:
+
+- `/` → `/index.html`
+- `/about/` (trailing slash) → `/about.html`
+- `/about` (extensionless) → `/about.html`
+- Anything with an extension (`/_astro/*.js`, `/sitemap-index.xml`, `/favicon.ico`, an explicit `/about.html`) is passed through unchanged
+
+## Local testing
+
+```sh
+node --test lps_url_rewrite.test.js
+
+# Alternatively, run the following from project root -
+
+pnpm test
+```
+
+The tests assert the rewritten URI for the root, extensionless pages, trailing-slash pages, the error page key, and asset/`.xml`/`.ico` pass-throughs.
+
+## Deployment
+
+Deployed via Pulumi as a Lambda@Edge function attached to the LPS (`mode: "static"`) CloudFront distribution only.
+
+Key constraints:
+
+- Lambda@Edge functions must be created in `us-east-1`
+- The function is config-free, so no placeholder substitution is needed

--- a/infrastructure/application/aws/lambda/lps_url_rewrite.js
+++ b/infrastructure/application/aws/lambda/lps_url_rewrite.js
@@ -1,0 +1,24 @@
+exports.handler = async (event) => {
+  const request = event.Records[0].cf.request;
+  const uri = request.uri;
+
+  // Root → index document
+  if (uri === "/") {
+    request.uri = "/index.html";
+    return request;
+  }
+
+  // Trailing slash (e.g. /about/ → /about.html)
+  if (uri.endsWith("/")) {
+    request.uri = `${uri.slice(0, -1)}.html`;
+    return request;
+  }
+
+  // Extensionless path (e.g. /about → /about.html)
+  if (!uri.includes(".")) {
+    request.uri = `${uri}.html`;
+  }
+
+  // Pass everything else through unchanged
+  return request;
+};

--- a/infrastructure/application/aws/lambda/lps_url_rewrite.test.js
+++ b/infrastructure/application/aws/lambda/lps_url_rewrite.test.js
@@ -1,0 +1,63 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { handler } = require("./lps_url_rewrite");
+
+// Mock viewer-request event
+function makeEvent(uri) {
+  return { Records: [{ cf: { request: { uri, headers: {} } } }] };
+}
+
+const CASES = [
+  { 
+    description: "Root navigates to index document", 
+    uri: "/",
+    expected: "/index.html"
+  },
+  { 
+    description: "Extensionless page", 
+    uri: "/about",
+    expected: "/about.html"
+  },
+  { 
+    description: "Trailing slash", 
+    uri: "/about/",
+    expected: "/about.html"
+  },
+  { 
+    description: "Nested extensionless page", 
+    uri: "/nested/page",
+    expected: "/nested/page.html"
+  },
+  { 
+    description: "Error page key", 
+    uri: "/404",
+    expected: "/404.html"
+  },
+  { 
+    description: "Hashed assets are unchanged", 
+    uri: "/_astro/index.abc123.js",
+    expected: "/_astro/index.abc123.js"
+  },
+  { 
+    description: "XML files are unchanged", 
+    uri: "/sitemap-index.xml",
+    expected: "/sitemap-index.xml"
+  },
+  { 
+    description: "Icon files are unchanged", 
+    uri: "/favicon.ico",
+    expected: "/favicon.ico"
+  },
+  { 
+    description: "HTML files are unchanged", 
+    uri: "/about.html",
+    expected: "/about.html"
+  },
+];
+
+for (const { uri, expected, description } of CASES) {
+  test(description, async () => {
+    const result = await handler(makeEvent(uri));
+    assert.strictEqual(result.uri, expected);
+  });
+}

--- a/infrastructure/application/services/lps.ts
+++ b/infrastructure/application/services/lps.ts
@@ -2,7 +2,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as cloudflare from "@pulumi/cloudflare";
 
-import { createCdn, usEast1 } from "../utils";
+import { createCdn, createLpsUrlRewriteLambda, usEast1 } from "../utils";
 
 // The @pulumi/cloudflare package doesn't generate errors so this is here just to create a warning in case the Cloudflare API token is missing.
 new pulumi.Config("cloudflare").requireSecret("apiToken");
@@ -171,6 +171,8 @@ export const createLocalPlanningServices = (planXCertArn: pulumi.Output<string>)
 
   const acmCertificateArn = createLPSCertificates(domain, planXCertArn);
 
+  const urlRewriteLambda = createLpsUrlRewriteLambda();
+
   const cdn = createCdn({
     cdnName: domain,
     domains: [domain],
@@ -180,6 +182,10 @@ export const createLocalPlanningServices = (planXCertArn: pulumi.Output<string>)
     oai,
     mode: "static",
     includeWww: env === "production",
+    lambdaFunctionAssociation: {
+      lambdaArn: urlRewriteLambda.qualifiedArn,
+      eventType: "viewer-request",
+    },
   });
 
   createCNAMERecords(domain, cdn);

--- a/infrastructure/application/utils/createCDN.ts
+++ b/infrastructure/application/utils/createCDN.ts
@@ -18,12 +18,12 @@ const staticErrorResponses: aws.cloudfront.DistributionArgs["customErrorResponse
   {
     errorCode: 404,
     responseCode: 404,
-    responsePagePath: "/404",
+    responsePagePath: "/404.html",
   },
   {
     errorCode: 403,
     responseCode: 404,
-    responsePagePath: "/404",
+    responsePagePath: "/404.html",
   },
 ];
 
@@ -115,7 +115,7 @@ export const createCdn = ({
         },
       },
     ],
-    defaultRootObject: mode === "spa" ? "index.html" : "index",
+    defaultRootObject: "index.html",
 
     // A CloudFront distribution can configure different cache behaviors based on the request path.
     // Here we just specify a single, default cache behavior which is just read-only requests to S3.

--- a/infrastructure/application/utils/createLpsUrlRewriteLambda.ts
+++ b/infrastructure/application/utils/createLpsUrlRewriteLambda.ts
@@ -1,0 +1,56 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+
+import { usEast1 } from "./providers";
+
+/**
+ * Creates a Lambda@Edge function that rewrites LPS pretty URLs to the real
+ * *.html S3 keys at the edge (e.g. `/about` -> `/about.html`), so the static
+ * site can be deployed to S3 without rewriting keys on upload.
+ */
+export const createLpsUrlRewriteLambda = () => {
+  const config = new pulumi.Config();
+  const lambdaNodejsRuntime = config.require("lambda-nodejs-runtime");
+
+  const assumeRolePolicy = aws.iam.getPolicyDocumentOutput({
+    statements: [{
+      effect: "Allow",
+      principals: [{
+        type: "Service",
+        identifiers: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+      }],
+      actions: ["sts:AssumeRole"],
+    }],
+  }, { provider: usEast1 });
+
+  const role = new aws.iam.Role("lps-url-rewrite-role", {
+    assumeRolePolicy: assumeRolePolicy.json,
+  });
+
+  new aws.iam.RolePolicyAttachment("lps-url-rewrite-logs", {
+    role: role.name,
+    policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
+  });
+
+  const source = fs.readFileSync(
+    `${process.cwd()}/aws/lambda/lps_url_rewrite.js`,
+    "utf-8",
+  );
+
+  const lambda = new aws.lambda.Function(
+    "lps-url-rewrite",
+    {
+      runtime: lambdaNodejsRuntime,
+      handler: "lps_url_rewrite.handler",
+      role: role.arn,
+      code: new pulumi.asset.AssetArchive({
+        "lps_url_rewrite.js": new pulumi.asset.StringAsset(source),
+      }),
+      publish: true,
+    },
+    { provider: usEast1 },
+  );
+
+  return lambda;
+};

--- a/infrastructure/application/utils/index.ts
+++ b/infrastructure/application/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./createCloudflareIngressRule";
 export * from "./createCDN";
 export * from "./createFlowLinkPreviewLambda";
+export * from "./createLpsUrlRewriteLambda";
 export * from "./generateCORSAllowList";
 export * from "./generateTeamSecrets";
 export * from "./helpers";

--- a/scripts/deploy-lps.sh
+++ b/scripts/deploy-lps.sh
@@ -28,21 +28,8 @@ aws s3 sync $BUILD_DIR/_astro s3://$BUCKET_NAME/_astro \
 echo "Syncing static files..."
 aws s3 sync $BUILD_DIR s3://$BUCKET_NAME \
     --exclude "_astro/*" \
-    --exclude "*.html" \
     --cache-control "max-age=0,no-cache,no-store,must-revalidate" \
     --delete
-
-# Upload HTML files manually to strip extensions
-# Required for URL paths on AWS S3
-echo "Renaming and syncing HTML files..."
-find $BUILD_DIR -name "*.html" | while read -r filepath; do
-    rel_path=${filepath#$BUILD_DIR/}
-    s3_key="${rel_path%.html}"
-
-    aws s3 cp "$filepath" "s3://$BUCKET_NAME/$s3_key" \
-        --content-type "text/html" \
-        --cache-control "max-age=0,no-cache,no-store,must-revalidate"
-done
 
 echo "Invalidating CDN..."
 aws cloudfront create-invalidation \


### PR DESCRIPTION
## What does this PR do?
- Created a Lambda@Edge function to map URLs (see below)
- Configures this function as part of the Pulumi IAC setup
- Basic test coverage

## Context
LPS is a static Astro site served from a private S3 bucket via a CloudFront REST origin (OAI). A REST origin performs no directory-index / pretty-URL resolution, so `/about` maps to an S3 key literally named `about`. Astro (`build.format: "file"`) outputs `about.html`.

Previously the deploy script bridged this gap by stripping `.html` from keys on upload (`about.html` → `about`). That created a key-space mismatch between `dist/` and the bucket, so the static `aws s3 sync --delete` deleted every live page on each deploy and re-created it moments later. During this window CloudFront served 403/404 responses, recorded by UptimeRobot as downtime on every deploy.

This function moves the mapping to the edge instead, so the site is deployed to S3 as-is and running `s3 sync --delete`  on deploy only ever overwrites live objects.

## Testing
I'd love to merge this to `main` to test the Pulumi staging setup, usually hit a few issues at this stage as there's not an easy way to test this without merging. I've aimed to follow the pattern used by our other Lambda function, but I'd also like to see how builds are running here once in place so we can fix or revert this one.