### PR TITLE
fix: remove placeholder notifications widget

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -39,16 +39,6 @@ export default function Dashboard() {
           >
             <FlowsPanel />
           </DashboardWidget>
-          <DashboardWidget
-            title="Notifications"
-            link={linkOptions({
-              to: "/app/$team/notifications",
-              params: { team: team.slug },
-              label: "view all notifications",
-            })}
-          >
-            <i>notifications content</i>
-          </DashboardWidget>
           <ConnectedNotificationsWidget />
           <DashboardWidget
             title="Feedback"


### PR DESCRIPTION
Accidentally left this placeholder panel during a rebase.