### PR TITLE
fix(editor): Broken header layout when DowntimeBanner displayed

### DIFF
--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -323,7 +323,7 @@ const Header: React.FC = () => {
   const showDowntimeBanner = data?.downtimeBanner?.isVisible || false;
 
   return (
-    <>
+    <Box>
       {showDowntimeBanner && <DowntimeBanner />}
       <Root
         position="static"
@@ -338,7 +338,7 @@ const Header: React.FC = () => {
       >
         <Toolbar />
       </Root>
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## What's the problem?
The `DowntimeBanner` element can break the layout (dependent on other children). This shows up as an expanded header in places.

<img width="1364" height="954" alt="image" src="https://github.com/user-attachments/assets/2226257d-4352-46a8-8d82-1820a6e09758" />


## What's the cause?
This is a CSS Grid issue - we declare in `RootContainer` that there will be three rows, but `DowntimeBanner` makes it four children and breaks the layout - 

https://github.com/theopensystemslab/planx-new/blob/7f084798b072a5c111861e715dd308becbabddcb/apps/editor.planx.uk/src/pages/layout/PublicLayout.tsx#L21-L26

## What's the solution?
Just wrap in a `<Box/>` so the number of children stays consistent - there's a single `<Header/>` child instead of two breaking out from the fragment.

## Testing...
- Toggle downtime banner on staging, navigate through a few nodes, see expanded header ❌ 
- Toggle downtime banner on pizza, navigate through a few nodes, see correctly sized header ✅ 