### PR TITLE
fix: Downtime banner styling snags

### DIFF
--- a/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import { useParams } from "@tanstack/react-router";
-import { MENU_WIDTH_COMPACT } from "components/EditorNavMenu/styles";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -15,9 +14,9 @@ const BreadcrumbsContainer = styled(Box)(({ theme }) => ({
   display: "flex",
   gap: theme.spacing(1.5),
   alignItems: "center",
-  position: "fixed",
+  position: "absolute",
   top: 0,
-  left: MENU_WIDTH_COMPACT,
+  left: 0,
   zIndex: theme.zIndex.appBar,
   backgroundColor: `rgba(255, 255, 255, 0.2)`,
   padding: theme.spacing(1, 1.25, 1, 2),

--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -323,7 +323,7 @@ const Header: React.FC = () => {
   const showDowntimeBanner = data?.downtimeBanner?.isVisible || false;
 
   return (
-    <>
+    <Box>
       {showDowntimeBanner && <DowntimeBanner />}
       <Root
         position="static"
@@ -338,7 +338,7 @@ const Header: React.FC = () => {
       >
         <Toolbar />
       </Root>
-    </>
+    </Box>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/index.tsx
@@ -28,6 +28,7 @@ const EditorContainer = styled(Box, {
   flexGrow: 1,
   maxHeight: "100vh",
   maxWidth: hasNavMenu ? `calc(100vw - ${MENU_WIDTH_COMPACT}px)` : "100vw",
+  position: "relative",
 }));
 
 const EditorVisualControls = styled(ButtonGroup)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
@@ -55,10 +55,10 @@ const Layout: React.FC<PropsWithChildren> = ({ children }) => {
     <>
       <LoadingOverlay />
       <Header />
-      <Breadcrumbs />
       <DashboardWrap>
         <EditorNavMenu />
         <DashboardContainer>
+          <Breadcrumbs />
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             <WatermarkBackground variant="dark" opacity={0.05} />
             <DndProvider backend={HTML5Backend}>{children}</DndProvider>


### PR DESCRIPTION
## What does this PR do?

- Addresses two issues caused by presence of downtime banner

### Breadcrumb overlap (editor)

**Before:**
<img width="1728" height="789" alt="image" src="https://github.com/user-attachments/assets/f9d8b7af-2559-4d95-b44e-485dbb91e1bd" />

**After:** 
<img width="1728" height="789" alt="image" src="https://github.com/user-attachments/assets/f9db7aeb-888b-4a49-8605-c0d35bfbbd2b" />


### Header expanding (public)

**Before:**
<img width="1728" height="789" alt="image" src="https://github.com/user-attachments/assets/c7d7d18e-3a84-4d03-aac7-ab38df69d882" />

**After:**
<img width="1728" height="789" alt="image" src="https://github.com/user-attachments/assets/2bf87063-2058-4981-8aba-4bf0d7bc3ab2" />