### PR TITLE
feat(editor): Capture OS error state mocks

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
@@ -6,6 +6,7 @@ import Editor from "../Editor";
 import FindProperty from ".";
 import fetchBLPUCodesMock from "./mocks/findAddressReturnMock";
 import localAuthorityMock from "./mocks/localAuthorityMock";
+import osDatastoreErrorMock from "./mocks/osDatastoreErrorMock";
 
 /** FindProperty relies on a custom web component that cannot be shown by React Storybook. Find additional docs here: https://oslmap.netlify.app/ */
 export default {
@@ -30,6 +31,24 @@ export const EmptyForm: StoryObj = {
     <FindProperty
       title="Find your property"
       description="For example, SE5 0HU"
+    />
+  ),
+};
+
+export const OSDatastoreError: StoryObj = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/proxy/ordnance-survey/search/places/v1/postcode", () =>
+          HttpResponse.json(osDatastoreErrorMock, { status: 500 }),
+        ),
+      ],
+    },
+  },
+  render: () => (
+    <FindProperty
+      title="Enter the postcode of the property"
+      description="For example, HP9 2HA"
     />
   ),
 };

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/osDatastoreErrorMock.ts
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/mocks/osDatastoreErrorMock.ts
@@ -1,0 +1,15 @@
+/**
+ * Body returned by the OS Data Hub Places API (via our `/proxy/ordnance-survey`
+ * endpoint) when it responds with a 500. The `<address-autocomplete />` web
+ * component surfaces `fault.faultstring` to the user, e.g. "Warning Datastore Error".
+ */
+const osDatastoreErrorMock = {
+  fault: {
+    faultstring: "Datastore Error",
+    detail: {
+      errorcode: "Internal Server Error",
+    },
+  },
+};
+
+export default osDatastoreErrorMock;

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/PropertyInformation.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/PropertyInformation.stories.tsx
@@ -1,7 +1,9 @@
 import Wrapper from "@planx/components/fixtures/Wrapper";
 import { Meta, StoryObj } from "@storybook/tanstack-react";
+import { http, HttpResponse } from "msw";
 
 import Editor from "./Editor";
+import { osTileError } from "./mocks/osTileError";
 import { presentationalPropsMock } from "./mocks/propsMock";
 import { Presentational, PresentationalProps } from "./Public";
 
@@ -21,6 +23,24 @@ export const Basic: StoryObj = {
 };
 
 export const WithPropertyTypeOverride: StoryObj = {
+  render: () => (
+    <Presentational
+      {...defaultPresentationalProps}
+      showPropertyTypeOverride={true}
+    />
+  ),
+};
+
+export const OSTileError: StoryObj = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/proxy/ordnance-survey/maps/vector/v1/", () =>
+          HttpResponse.json(osTileError, { status: 500 }),
+        ),
+      ],
+    },
+  },
   render: () => (
     <Presentational
       {...defaultPresentationalProps}

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/mocks/osTileError.ts
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/mocks/osTileError.ts
@@ -1,0 +1,14 @@
+/**
+ * Error state returned by the OS VectorTiles API (via our `/proxy/ordnance-survey`
+ * endpoint) when it responds with a 500.
+ */
+export const osTileError = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <ExceptionReport version="1.1.0" xmlns="http://www.opengis.net/ows/1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
+    <Exception exceptionCode="SourceMessageNotAvailable">
+      <ExceptionText>service.config.transaction-counts message is not available for ExtractVariable: IdentifyTransactionCost</ExceptionText>
+    </Exception>
+  </ExceptionReport>
+`;


### PR DESCRIPTION
Trying to make the best of a bad situation...! 😅 

This PR adds two new stories, which cover error states when OS APIs go down. 

The aim here would be to improve over time how we handle this visually - for example a more meaningful error in `FindProperty` and maybe an OpenStreetMap tile fallback for the `<my-map/>` component (right now I think this kicks in if keys/proxy endpoints are missing, not in the case of 500s).