### PR TITLE
fix: stagger `update-templated-flow` events further

### DIFF
--- a/apps/api.planx.uk/lib/hasura/metadata/index.ts
+++ b/apps/api.planx.uk/lib/hasura/metadata/index.ts
@@ -57,6 +57,7 @@ export const createScheduledEvent = async (
         ],
         retry_conf: {
           num_retries: 1,
+          retry_interval_seconds: 30,
         },
       },
     });

--- a/apps/api.planx.uk/lib/hasura/metadata/types.ts
+++ b/apps/api.planx.uk/lib/hasura/metadata/types.ts
@@ -18,7 +18,8 @@ export interface ScheduledEventRequestBody {
 export interface CreateScheduledEventArgs {
   headers: Record<string, string>[];
   retry_conf: {
-    num_retries: number;
+    num_retries: number; // default 0
+    retry_interval_seconds?: number; // default 10
   };
   webhook: string;
   schedule_at: Date;

--- a/apps/api.planx.uk/modules/flows/publish/service.ts
+++ b/apps/api.planx.uk/modules/flows/publish/service.ts
@@ -131,8 +131,8 @@ export const publishFlow = async (
         createScheduledEvent({
           webhook: `{{HASURA_PLANX_API_URL}}/flows/${flowId}/update-templated-flow/${templatedFlowId}`,
           schedule_at: new Date(
-            new Date().getTime() + (i > 0 ? i * 5 : 0) * 1000,
-          ), // Stagger events by 5 seconds starting at "now"
+            new Date().getTime() + (i > 0 ? i * 15 : 0) * 1000,
+          ), // Stagger events by 15 seconds starting at "now"
           payload: {
             sourceFlowId: flowId,
             templatedFlowId: templatedFlowId,


### PR DESCRIPTION
See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1781020983863579

This was recently _reduced from 10s to 5s_ when we introduced notifications here https://github.com/theopensystemslab/planx-new/pull/6667 (I believe mostly for ease of UI testing, council editors are surely not logging in this frequently and noticing a "tardy" notification!)

The first occurances of `Failed to update templated flow...` begin on Airbrake in late May, right around merge of that reduction :dart: 

Based on errors here, we're overwhelming Hasura at point of event creation which is resulting in errors like `One-off Scheduled event timed out while processing`, _before_ it's even able to attempt to hit an API endpoint. 

I've also chosen to bump the retry interval from 10s to 30s here across the board (everywhere we use scheduled events including send, not just updating templated flows). Again, no functional change just hopefully giving Hasura and the API a bit more recovery room if needed.

See Slack thread for most robust ideas / investigation points! This increased stagger intends to immediately ease issues, but recognise not necessarily sustainable ! 

