### PR TITLE
feat: Modal UI for new component select

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.stories.tsx
@@ -1,0 +1,33 @@
+import Paper from "@mui/material/Paper";
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+
+import AddComponentModal, {
+  AddComponentModalContent,
+} from "./AddComponentModal";
+
+const meta: Meta<typeof AddComponentModal> = {
+  title: "Editor Components/Modal/AddComponentModal",
+  component: AddComponentModal,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AddComponentModal>;
+
+export const Default: Story = {
+  render: () => (
+    <Paper
+      sx={{
+        width: 300,
+        maxHeight: "min(480px, 85vh)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        border: 1,
+        borderColor: "divider",
+      }}
+    >
+      <AddComponentModalContent onSelect={() => {}} />
+    </Paper>
+  ),
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.tsx
@@ -1,0 +1,263 @@
+import Box from "@mui/material/Box";
+import Popover from "@mui/material/Popover";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { ICONS } from "@planx/components/shared/icons";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { hangerAnchor } from "pages/FlowEditor/lib/hangerAnchor";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { AiChip } from "ui/editor/AiChip";
+import { SearchBox } from "ui/shared/SearchBox/SearchBox";
+import { getNodeRoute } from "utils/routeUtils/utils";
+
+import {
+  ALL_CATEGORIES,
+  ALL_ITEMS,
+  type Category,
+  type ComponentItem,
+} from "./componentData";
+
+const POPOVER_WIDTH = 300;
+
+interface ComponentRowProps {
+  item: ComponentItem;
+  onClick: () => void;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const ComponentRow: React.FC<ComponentRowProps> = ({
+  item,
+  onClick,
+  scrollContainerRef,
+}) => {
+  const Icon = ICONS[item.type];
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const onScroll = () => setTooltipOpen(false);
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [scrollContainerRef]);
+
+  return (
+    <Tooltip
+      title={item.description}
+      placement="right"
+      arrow
+      open={tooltipOpen}
+      onOpen={() => setTooltipOpen(true)}
+      onClose={() => setTooltipOpen(false)}
+      slotProps={{ tooltip: { sx: { maxWidth: 240 } } }}
+    >
+      <Box
+        onClick={onClick}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.5,
+          py: 0.875,
+          cursor: "pointer",
+          "&:hover": {
+            backgroundColor: "action.hover",
+            "& .component-title": { fontWeight: FONT_WEIGHT_SEMI_BOLD },
+          },
+        }}
+      >
+        {Icon && (
+          <Box sx={{ flexShrink: 0, lineHeight: 0, color: "text.primary" }}>
+            <Icon sx={{ fontSize: 20 }} />
+          </Box>
+        )}
+        <Typography variant="body2" className="component-title">
+          {item.title}
+        </Typography>
+        {item.hasAiVariant && <AiChip sx={{ ml: "auto" }} />}
+      </Box>
+    </Tooltip>
+  );
+};
+
+interface AddComponentModalContentProps {
+  onSelect: (slug: string) => void;
+}
+
+export const AddComponentModalContent: React.FC<
+  AddComponentModalContentProps
+> = ({ onSelect }) => {
+  const [searchedItems, setSearchedItems] = useState<ComponentItem[] | null>(
+    null,
+  );
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filteredCategories = useMemo<Category[]>(() => {
+    if (!searchedItems) return ALL_CATEGORIES;
+    const visibleSlugs = new Set(searchedItems.map((item) => item.slug));
+    return ALL_CATEGORIES.map((cat) => ({
+      ...cat,
+      items: cat.items.filter((item) => visibleSlugs.has(item.slug)),
+    })).filter((cat) => cat.items.length > 0);
+  }, [searchedItems]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      (document.getElementById("search") as HTMLInputElement | null)?.focus();
+    }, 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1.25,
+          borderBottom: 1,
+          borderColor: "divider",
+          backgroundColor: "background.paper",
+        }}
+      >
+        <SearchBox<ComponentItem>
+          records={ALL_ITEMS}
+          setRecords={setSearchedItems}
+          searchKey={["title", "description"]}
+          compact
+          hideLabel
+          fullWidth
+          placeholder="Search components"
+        />
+      </Box>
+      <Box ref={listRef} sx={{ overflowY: "auto", pb: 2 }}>
+        {filteredCategories.length === 0 ? (
+          <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>
+            No components match your search.
+          </Typography>
+        ) : (
+          filteredCategories.map((cat) => (
+            <Box key={cat.label}>
+              <Typography
+                variant="body3"
+                sx={{
+                  fontWeight: FONT_WEIGHT_SEMI_BOLD,
+                  display: "block",
+                  p: 1.5,
+                  pb: 0.5,
+                  color: "text.primary",
+                }}
+              >
+                {cat.label}
+              </Typography>
+              {cat.items.map((item) => (
+                <ComponentRow
+                  key={item.slug}
+                  item={item}
+                  onClick={() => onSelect(item.slug)}
+                  scrollContainerRef={listRef}
+                />
+              ))}
+            </Box>
+          ))
+        )}
+      </Box>
+    </>
+  );
+};
+
+interface AddComponentModalProps {
+  parent?: string;
+  before?: string;
+}
+
+const AddComponentModal: React.FC<AddComponentModalProps> = ({
+  parent,
+  before,
+}) => {
+  const navigate = useNavigate();
+  const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
+
+  const handleSelect = useCallback(
+    (slug: string) => {
+      navigate({
+        to: getNodeRoute(parent, before),
+        params: {
+          team,
+          flow,
+          ...(parent && { parent }),
+          ...(before && { before }),
+        },
+        search: { type: slug as NodeSearchParams["type"] },
+      });
+    },
+    [navigate, team, flow, parent, before],
+  );
+
+  const handleClose = useCallback(() => {
+    navigate({ to: "/app/$team/$flow", params: { team, flow } });
+  }, [navigate, team, flow]);
+
+  // Position the popover anchored to the hanger that triggered navigation
+  const rect = hangerAnchor.get();
+  const spaceBelow = rect ? window.innerHeight - rect.bottom : 0;
+  const showBelow = !rect || spaceBelow >= 450;
+
+  const buttonCenterX = rect
+    ? Math.max(
+        POPOVER_WIDTH / 2 + 8,
+        Math.min(
+          rect.left + (rect.right - rect.left) / 2,
+          window.innerWidth - POPOVER_WIDTH / 2 - 8,
+        ),
+      )
+    : window.innerWidth / 2;
+
+  const anchorPosition = rect
+    ? { top: showBelow ? rect.bottom + 4 : rect.top - 4, left: buttonCenterX }
+    : { top: window.innerHeight / 2, left: window.innerWidth / 2 };
+
+  const transformOrigin = {
+    vertical: rect && !showBelow ? ("bottom" as const) : ("top" as const),
+    horizontal: "center" as const,
+  };
+
+  return (
+    <Popover
+      open
+      onClose={handleClose}
+      data-testid="add-component-modal"
+      anchorReference="anchorPosition"
+      anchorPosition={anchorPosition}
+      transformOrigin={transformOrigin}
+      disableScrollLock
+      slotProps={{
+        paper: {
+          sx: {
+            width: POPOVER_WIDTH,
+            maxHeight: "min(480px, 85vh)",
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            border: 1,
+            borderColor: "divider",
+          },
+        },
+        backdrop: {
+          sx: { backgroundColor: "rgba(0, 0, 0, 0.3)" },
+        },
+      }}
+    >
+      <AddComponentModalContent onSelect={handleSelect} />
+    </Popover>
+  );
+};
+
+export default AddComponentModal;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/componentData.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/componentData.ts
@@ -120,6 +120,17 @@ export const ALL_CATEGORIES: Category[] = [
         description: "Collect multiple inputs on a single page",
       },
       {
+        type: TYPES.Feedback,
+        slug: "feedback",
+        title: "Feedback",
+        description: "Collect user feedback",
+      },
+    ],
+  },
+  {
+    label: "Upload",
+    items: [
+      {
         type: TYPES.FileUpload,
         slug: "file-upload",
         title: "File upload",
@@ -130,18 +141,6 @@ export const ALL_CATEGORIES: Category[] = [
         slug: "file-upload-and-label",
         title: "Upload and label",
         description: "Upload and label files",
-      },
-      {
-        type: TYPES.MapAndLabel,
-        slug: "map-and-label",
-        title: "Map and label",
-        description: "Draw and label areas on a map",
-      },
-      {
-        type: TYPES.Feedback,
-        slug: "feedback",
-        title: "Feedback",
-        description: "Collect user feedback",
       },
     ],
   },
@@ -213,6 +212,12 @@ export const ALL_CATEGORIES: Category[] = [
         title: "Planning constraints",
         description: "Show planning constraints",
       },
+      {
+        type: TYPES.MapAndLabel,
+        slug: "map-and-label",
+        title: "Map and label",
+        description: "Draw and label areas on a map",
+      },
     ],
   },
   {
@@ -236,17 +241,17 @@ export const ALL_CATEGORIES: Category[] = [
         title: "Calculate",
         description: "Calculate a value or fee",
       },
+    ],
+  },
+  {
+    label: "Pay and send",
+    items: [
       {
         type: TYPES.SetFee,
         slug: "set-fee",
         title: "Set fees",
         description: "Define fee amounts",
       },
-    ],
-  },
-  {
-    label: "Pay and send",
-    items: [
       {
         type: TYPES.Pay,
         slug: "pay",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/hangerAnchor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/hangerAnchor.ts
@@ -1,0 +1,10 @@
+type Rect = { top: number; bottom: number; left: number; right: number };
+
+let _rect: Rect | null = null;
+
+export const hangerAnchor = {
+  set: (rect: Rect) => {
+    _rect = rect;
+  },
+  get: () => _rect,
+};

--- a/apps/editor.planx.uk/src/ui/editor/AiChip.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/AiChip.tsx
@@ -1,0 +1,31 @@
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import Box, { type BoxProps } from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+export const AiChip = ({ sx }: Pick<BoxProps, "sx">) => (
+  <Box
+    sx={[
+      {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.4,
+        px: 0.4,
+        py: 0.25,
+        borderRadius: 2,
+        backgroundColor: "info.dark",
+        color: "primary.contrastText",
+        flexShrink: 0,
+      },
+      ...(Array.isArray(sx) ? sx : [sx]),
+    ]}
+  >
+    <AutoAwesomeIcon sx={{ fontSize: 12 }} />
+    <Typography
+      variant="body3"
+      sx={{ lineHeight: 1, fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+    >
+      AI
+    </Typography>
+  </Box>
+);

--- a/apps/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SearchBox/SearchBox.tsx
@@ -24,6 +24,8 @@ interface SearchBoxProps<T> {
   hideLabel?: boolean;
   compact?: boolean;
   inputRef?: React.Ref<HTMLInputElement>;
+  fullWidth?: boolean;
+  placeholder?: string;
 }
 
 export const SearchBox = <T extends object>({
@@ -34,6 +36,8 @@ export const SearchBox = <T extends object>({
   hideLabel = false,
   compact = false,
   inputRef,
+  fullWidth = false,
+  placeholder = "",
 }: SearchBoxProps<T>) => {
   const [isSearching, setIsSearching] = useState(false);
   const [searchedTerm, setSearchedTerm] = useState<string>();
@@ -83,7 +87,7 @@ export const SearchBox = <T extends object>({
   }, [clearSearch, resetForm, submitForm]);
 
   return (
-    <Box sx={{ maxWidth: 360 }}>
+    <Box sx={{ maxWidth: fullWidth ? "100%" : 360 }}>
       <InputRow>
         <InputRowLabel
           inputProps={{
@@ -108,6 +112,7 @@ export const SearchBox = <T extends object>({
               name="search"
               id="search"
               aria-describedby="search-label"
+              placeholder={placeholder}
               value={values.pattern}
               onChange={(e) => {
                 setFieldValue("pattern", e.target.value);


### PR DESCRIPTION
## What does this PR do?

Sets up component UI and Storybook file for new component select

- New component `AddComponentModal` to present component list
- Storybook file for the above
- Dedicated AI chip to be standardised/reused
- Small change to `SearchBox` to allow for full-width and a placeholder prop

**Testing:**
https://storybook.6833.planx.pizza/?path=/docs/editor-components-modal-addcomponentmodal--docs