### PR TITLE
infra: bump ShareDB and Hasura `memory` on staging

### DIFF
--- a/apps/editor.planx.uk/src/lib/graphql/links.ts
+++ b/apps/editor.planx.uk/src/lib/graphql/links.ts
@@ -70,6 +70,8 @@ const getWsLink = () => {
       uri: import.meta.env.VITE_APP_HASURA_WEBSOCKET!,
       options: {
         reconnect: true,
+        lazy: true,
+        inactivityTimeout: 30000, // 30s
         connectionParams: async () => {
           const jwt = await getJWT();
           return {

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -45,12 +45,12 @@ config:
     secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
   application:hasura-admin-secret:
     secure: AAABACnU/Z5aGH2DaNQ29YkJqx8bKKRYFEdXvJm0yswo0pK2Iqnz09j7H2kOaZOzY2fSfEDu8rU=
-  application:hasura-cpu: "1024"
-  application:hasura-memory: "2048"
+  application:hasura-cpu: "2048"
+  application:hasura-memory: "4096"
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
-  application:hasura-proxy-cpu: "512"
-  application:hasura-proxy-memory: "1024"
+  application:hasura-proxy-cpu: "1024"
+  application:hasura-proxy-memory: "2048"
   application:hasura-service-scaling-maximum: "2"
   application:hasura-service-scaling-minimum: "1"
   application:idox-nexus-client:

--- a/infrastructure/application/services/sharedb.ts
+++ b/infrastructure/application/services/sharedb.ts
@@ -64,7 +64,7 @@ export const createSharedbService = async ({
       name: "sharedb",
       image: sharedbImage.imageUri,
       essential: true,
-      memory: 512 /*MB*/,
+      memory: 1024 /*MB*/,
       portMappings: [{ targetGroup: sharedbTargetGroup }],
       environment: [
         { name: "PORT", value: String(SHAREDB_PORT) },


### PR DESCRIPTION
More attempts at resolving https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1781094283435389?thread_ts=1781020983.863579&cid=C088K9ZL8EA

See notes from this specific comment:
> In trying to pinpoint what's different about GDPO source template, I'm comparing unflattened flow size (flows.data which ShareDB & Hasura operate on) by simply counting number of nodes:
> - HPP = 68
> - LDC = 146
> - FOI source template = 169
> - A4 = 793 (more customisable nodes than GDPO)
> - GDPO = 4,408 :melting_face: 
>   - Non-source-template osl/permitteddevelopment =  14,171 for comparison though which ShareDB typically connects to fine (eg no "Page not found" issue)
>
> Is this literally just a much larger source template data structure than we've had to operate on before? Can we "just" allocate more memory/larger containers/($$) to the situation until we better understand how to optimise data operations?

There won't be any noticable difference on pizza here, we'll have to test this via Pulumi/AWS staging infra. Our API `memory` is already at `4096` so I haven't bumped that any further here.