### PR TITLE
chore: batch `updateTemplatedFlow` mutations into single request

### DIFF
--- a/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
+++ b/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
@@ -71,7 +71,7 @@ export const updateTemplatedFlow = async (
   const updateTemplatedFlowTransactionResponse =
     await $api.client.request<UpdateTemplatedFlowTransactionResponse>(
       gql`
-        mutation UpdateTemplatedFlowTransation(
+        mutation UpdateTemplatedFlowTransaction(
           $data: jsonb!
           $flowId: uuid!
           $comment: String!

--- a/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
+++ b/apps/api.planx.uk/modules/flows/updateTemplatedFlow/service.ts
@@ -31,6 +31,10 @@ interface InsertNotification {
   };
 }
 
+type UpdateTemplatedFlowTransactionResponse = UpdateTemplatedFlowData &
+  InsertComment &
+  InsertNotification;
+
 export const updateTemplatedFlow = async (
   sourceFlowId: string,
   templatedFlowId: string,
@@ -60,73 +64,53 @@ export const updateTemplatedFlow = async (
   // Apply templated flow edits on top of source data using Lodash's mergeWith (order of args matters!)
   const data = customMerge(sourceData, edits);
 
-  // Set merged data as `flows.data` for templatedFlowId
-  const updateFlowResponse = await $api.client.request<UpdateTemplatedFlowData>(
-    gql`
-      mutation UpdateTemplatedFlowData($data: jsonb!, $id: uuid!) {
-        flow: update_flows_by_pk(
-          pk_columns: { id: $id }
-          _set: { data: $data }
-        ) {
-          data
-        }
-      }
-    `,
-    {
-      data: data,
-      id: templatedFlowId,
-    },
-  );
-
-  // Insert a "History" comment for templatedFlowId to denote update with source summary & author
-  const insertCommentResponse = await $api.client.request<InsertComment>(
-    gql`
-      mutation InsertComment(
-        $flow_id: uuid!
-        $comment: String!
-        $actor_id: Int!
-      ) {
-        comment: insert_flow_comments_one(
-          object: { flow_id: $flow_id, comment: $comment, actor_id: $actor_id }
-        ) {
-          id
-        }
-      }
-    `,
-    {
-      flow_id: templatedFlowId,
-      comment: `Source template published: "${summary}"`,
-      actor_id: sourcePublisher,
-    },
-  );
-
-  // Insert a new "Notification" that the templatedFlowId is ready to review & publish
-  const insertNotificationResponse =
-    await $api.client.request<InsertNotification>(
+  // Batch updates into a single transaction to minimise number of network requests
+  //   1) Set merged data as `flows.data` for templatedFlowId
+  //   2) Insert a "History" comment for templatedFlowId to denote update with source summary & author
+  //   3) Insert a new "Notification" that the templatedFlowId is ready to review & publish
+  const updateTemplatedFlowTransactionResponse =
+    await $api.client.request<UpdateTemplatedFlowTransactionResponse>(
       gql`
-        mutation InsertNotification(
-          $flow_id: uuid!
-          $team_id: Int!
+        mutation UpdateTemplatedFlowTransation(
+          $data: jsonb!
+          $flowId: uuid!
+          $comment: String!
+          $actorId: Int!
+          $teamId: Int!
           $type: notification_type_enum_enum!
         ) {
+          flow: update_flows_by_pk(
+            pk_columns: { id: $flowId }
+            _set: { data: $data }
+          ) {
+            data
+          }
+          comment: insert_flow_comments_one(
+            object: { flow_id: $flowId, comment: $comment, actor_id: $actorId }
+          ) {
+            id
+          }
           notification: insert_notifications_one(
-            object: { flow_id: $flow_id, team_id: $team_id, type: $type }
+            object: { flow_id: $flowId, team_id: $teamId, type: $type }
           ) {
             id
           }
         }
       `,
       {
-        flow_id: templatedFlowId,
-        team_id: templatedFlowTeamId,
+        flowId: templatedFlowId,
+        data: data,
+        comment: `Source template published: "${summary}"`,
+        actorId: sourcePublisher,
+        teamId: templatedFlowTeamId,
         type: "updated_templated_flow",
       },
     );
 
   return {
-    templatedFlowData: updateFlowResponse.flow.data,
-    commentId: insertCommentResponse.comment.id,
-    notificationId: insertNotificationResponse.notification.id,
+    templatedFlowData: updateTemplatedFlowTransactionResponse.flow.data,
+    commentId: updateTemplatedFlowTransactionResponse.comment.id,
+    notificationId: updateTemplatedFlowTransactionResponse.notification.id,
   };
 };
 

--- a/apps/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
@@ -101,7 +101,7 @@ describe("success", () => {
     });
 
     queryMock.mockQuery({
-      name: "UpdateTemplatedFlowTransation",
+      name: "UpdateTemplatedFlowTransaction",
       matchOnVariables: false,
       data: {
         flow: {
@@ -145,7 +145,7 @@ describe("success", () => {
 
     // Without edits to merge or "reconcile", then the templated flow is updated to exactly match the source data
     queryMock.mockQuery({
-      name: "UpdateTemplatedFlowTransation",
+      name: "UpdateTemplatedFlowTransaction",
       matchOnVariables: false,
       data: {
         flow: {

--- a/apps/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/updateTemplatedFlow/updateTemplatedFlow.test.ts
@@ -87,26 +87,6 @@ describe("success", () => {
         },
       },
     });
-
-    queryMock.mockQuery({
-      name: "InsertComment",
-      matchOnVariables: false,
-      data: {
-        comment: {
-          id: 1,
-        },
-      },
-    });
-
-    queryMock.mockQuery({
-      name: "InsertNotification",
-      matchOnVariables: false,
-      data: {
-        notification: {
-          id: 1,
-        },
-      },
-    });
   });
 
   it("correctly updates a templated flow that has been customised", async () => {
@@ -121,11 +101,17 @@ describe("success", () => {
     });
 
     queryMock.mockQuery({
-      name: "UpdateTemplatedFlowData",
+      name: "UpdateTemplatedFlowTransation",
       matchOnVariables: false,
       data: {
         flow: {
           data: mockUpdatedTemplatedFlowData,
+        },
+        comment: {
+          id: 1,
+        },
+        notification: {
+          id: 1,
         },
       },
     });
@@ -159,11 +145,17 @@ describe("success", () => {
 
     // Without edits to merge or "reconcile", then the templated flow is updated to exactly match the source data
     queryMock.mockQuery({
-      name: "UpdateTemplatedFlowData",
+      name: "UpdateTemplatedFlowTransation",
       matchOnVariables: false,
       data: {
         flow: {
           data: mockSourceTemplateFlowData,
+        },
+        comment: {
+          id: 1,
+        },
+        notification: {
+          id: 1,
         },
       },
     });


### PR DESCRIPTION
A small optimisation effort related to https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1781020983863579

Unfortunately the `data` payload is still a large jsonb (from profiling, this is the spot where this function _was_ hanging and _is_ still most likely to hang!). We don't have a better answer for this yet, common suggestions to only update relevant jsonb keys don't really work in our case and we need to overwrite the full flow graph.

Nonetheless, combining these three independent mutations into a single network request may help a smidge!