### PR TITLE
feat: assign permissions to teamAdmin

### DIFF
--- a/apps/api.planx.uk/modules/auth/service/jwt.ts
+++ b/apps/api.planx.uk/modules/auth/service/jwt.ts
@@ -51,9 +51,6 @@ const getDefaultRoleForUser = (user: User): Role => {
   if (user.isPlatformAdmin) return "platformAdmin";
   if (user.isAnalyst) return "analyst";
 
-  const isTeamAdmin = user.teams.find((team) => team.role === "teamAdmin");
-  if (isTeamAdmin) return "teamAdmin";
-
   const isTeamEditor = user.teams.find((team) => team.role === "teamEditor");
   if (isTeamEditor) return "teamEditor";
 

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/List.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/List.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/tanstack-react";
 
 import Wrapper from "../../fixtures/Wrapper";
-import { SCHEMAS } from "../Editor";
 import Editor from "../Editor";
+import { SCHEMAS } from "../Editor";
 import ListComponent from ".";
 import Public from ".";
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -33,7 +33,10 @@ const Accordion = ({ isOpen, onToggle }: AccordionProps) => {
 };
 
 export const TeamMembers = () => {
-  const teamSlug = useStore((state) => state.teamSlug);
+  const [teamSlug, role] = useStore((state) => [
+    state.teamSlug,
+    state.getUserRoleForCurrentTeam(),
+  ]);
 
   const { platformAdmins, activeMembers, archivedMembers, loading, error } =
     useTeamMembers(teamSlug);
@@ -42,7 +45,12 @@ export const TeamMembers = () => {
     useTeamManagementPermissions();
   const [openAccordion, setOpenAccordion] = useState(false);
 
-  if (error) return <ErrorSummary message={error.message} />;
+  if (error || !role)
+    return (
+      <ErrorSummary
+        message={error?.message || "Unable to load user role to check access"}
+      />
+    );
 
   return (
     <Container maxWidth="contentWrap">
@@ -61,6 +69,7 @@ export const TeamMembers = () => {
             showAddMemberButton={canManageActiveMembers}
             showEditMemberButton={canManageActiveMembers}
             showRemoveMemberButton={canManageActiveMembers}
+            userRole={role}
           />
         )}
       </SettingsSection>
@@ -84,6 +93,7 @@ export const TeamMembers = () => {
               <MembersTable
                 members={platformAdmins}
                 showEditMemberButton={canManagePlatformAdmins}
+                userRole={role}
               />
             )}
           </>
@@ -98,7 +108,7 @@ export const TeamMembers = () => {
             Past team members who no longer have access to the Editor, but may
             still appear in the edit history of your flows.
           </Typography>
-          <MembersTable members={archivedMembers} />
+          <MembersTable members={archivedMembers} userRole={role} />
         </SettingsSection>
       )}
     </Container>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/TeamMembers.tsx
@@ -37,11 +37,9 @@ export const TeamMembers = () => {
 
   const { platformAdmins, activeMembers, archivedMembers, loading, error } =
     useTeamMembers(teamSlug);
-  const {
-    canManageActiveMembers,
-    canManageTeamAdmins,
-    canManagePlatformAdmins,
-  } = useTeamManagementPermissions();
+
+  const { canManageActiveMembers, canManagePlatformAdmins } =
+    useTeamManagementPermissions();
   const [openAccordion, setOpenAccordion] = useState(false);
 
   if (error) return <ErrorSummary message={error.message} />;
@@ -63,7 +61,6 @@ export const TeamMembers = () => {
             showAddMemberButton={canManageActiveMembers}
             showEditMemberButton={canManageActiveMembers}
             showRemoveMemberButton={canManageActiveMembers}
-            showTeamAdminSwitch={canManagePlatformAdmins || canManageTeamAdmins}
           />
         )}
       </SettingsSection>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/AddUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/AddUserModal.tsx
@@ -14,10 +14,7 @@ import { EmailField } from "./Fields/EmailField";
 import { NameFields } from "./Fields/NameFields";
 import { ModalActions } from "./ModalActions";
 
-export const AddUserModal: React.FC<AddUserModalProps> = ({
-  onClose,
-  showTeamAdminSwitch,
-}) => {
+export const AddUserModal: React.FC<AddUserModalProps> = ({ onClose }) => {
   const {
     step,
     title,
@@ -61,21 +58,19 @@ export const AddUserModal: React.FC<AddUserModalProps> = ({
                   <Box sx={{ mt: 2, mb: 2 }}>
                     <NameFields />
                   </Box>
-                  {showTeamAdminSwitch && (
-                    <Switch
-                      name="role"
-                      checked={formik.values.role === "teamAdmin"}
-                      onChange={() =>
-                        formik.setFieldValue(
-                          "role",
-                          formik.values.role === "teamEditor"
-                            ? "teamAdmin"
-                            : "teamEditor",
-                        )
-                      }
-                      label={"Team Admin"}
-                    />
-                  )}
+                  <Switch
+                    name="role"
+                    checked={formik.values.role === "teamAdmin"}
+                    onChange={() =>
+                      formik.setFieldValue(
+                        "role",
+                        formik.values.role === "teamEditor"
+                          ? "teamAdmin"
+                          : "teamEditor",
+                      )
+                    }
+                    label={"Team Admin"}
+                  />
                 </>
               )}
               {step.stage === "confirm-existing" && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/AddUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/AddUserModal.tsx
@@ -14,7 +14,10 @@ import { EmailField } from "./Fields/EmailField";
 import { NameFields } from "./Fields/NameFields";
 import { ModalActions } from "./ModalActions";
 
-export const AddUserModal: React.FC<AddUserModalProps> = ({ onClose }) => {
+export const AddUserModal: React.FC<AddUserModalProps> = ({
+  onClose,
+  userRole,
+}) => {
   const {
     step,
     title,
@@ -23,7 +26,7 @@ export const AddUserModal: React.FC<AddUserModalProps> = ({ onClose }) => {
     submitButtonText,
     isSubmitting,
     validationSchema,
-  } = useAddUserModal({ onClose });
+  } = useAddUserModal({ onClose, userRole });
 
   return (
     <Dialog

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -92,7 +92,6 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
       formatted.email !== (member.email ?? "").toLowerCase();
 
     const roleChanged = values.role !== member.role;
-    console.log({ userInfoChanged, roleChanged });
 
     if (userInfoChanged) {
       await updateUserOnly({

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -74,7 +74,7 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
         },
       ],
       onCompleted: (data) => {
-        if (data.delete_team_members.affected_rows > 0) {
+        if (data.DeleteTeamMembers.affected_rows > 0) {
           handleCompleted("Successfully updated a user");
         } else {
           toast.warning("No admin role found to remove");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -12,11 +12,7 @@ import React from "react";
 import { Switch } from "ui/shared/Switch";
 
 import { upsertMemberSchema } from "../formSchema";
-import {
-  GET_USERS_FOR_TEAM_QUERY,
-  UPDATE_TEAM_MEMBER,
-  UPDATE_USER_DETAILS,
-} from "../queries";
+import { GET_USERS_FOR_TEAM_QUERY, UPDATE_TEAM_MEMBER } from "../queries";
 import { type EditUserModalProps, type UserFormValues } from "../types";
 import { EmailField } from "./Fields/EmailField";
 import { NameFields } from "./Fields/NameFields";
@@ -35,17 +31,6 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
     toast.success(successMessage);
   };
 
-  const [updateUserOnly] = useMutation(UPDATE_USER_DETAILS, {
-    refetchQueries: [
-      {
-        query: GET_USERS_FOR_TEAM_QUERY,
-        variables: { teamSlug: useStore.getState().teamSlug },
-      },
-    ],
-    onCompleted: () => handleCompleted("Successfully updated user details"),
-    onError: () => toast.error("Failed to update the user, please try again"),
-  });
-
   const [updateTeamMember, { loading }] = useMutation(UPDATE_TEAM_MEMBER, {
     refetchQueries: [
       {
@@ -60,31 +45,18 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
   const handleSubmit = (values: UserFormValues) => {
     const formatted = { ...values, email: values.email.toLowerCase() };
 
-    if (showTeamAdminSwitch) {
-      updateTeamMember({
-        variables: {
-          userId: member.id,
-          teamId: teamId,
-          role: values.role,
-          userValues: {
-            first_name: formatted.firstName,
-            last_name: formatted.lastName,
-            email: formatted.email,
-          },
+    updateTeamMember({
+      variables: {
+        userId: member.id,
+        teamId: teamId,
+        role: values.role,
+        userValues: {
+          first_name: formatted.firstName,
+          last_name: formatted.lastName,
+          email: formatted.email,
         },
-      });
-    } else {
-      updateUserOnly({
-        variables: {
-          userId: member.id,
-          userValues: {
-            first_name: formatted.firstName,
-            last_name: formatted.lastName,
-            email: formatted.email,
-          },
-        },
-      });
-    }
+      },
+    });
   };
 
   return (
@@ -117,21 +89,19 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
               <Box sx={{ mt: 2, mb: 2 }}>
                 <NameFields />
               </Box>
-              {showTeamAdminSwitch && (
-                <Switch
-                  name="role"
-                  checked={formik.values.role === "teamAdmin"}
-                  onChange={() =>
-                    formik.setFieldValue(
-                      "role",
-                      formik.values.role === "teamEditor"
-                        ? "teamAdmin"
-                        : "teamEditor",
-                    )
-                  }
-                  label={"Team Admin"}
-                />
-              )}
+              <Switch
+                name="role"
+                checked={formik.values.role === "teamAdmin"}
+                onChange={() =>
+                  formik.setFieldValue(
+                    "role",
+                    formik.values.role === "teamEditor"
+                      ? "teamAdmin"
+                      : "teamEditor",
+                  )
+                }
+                label={"Team Admin"}
+              />
             </DialogContent>
             <DialogActions>
               <ModalActions

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -29,6 +29,7 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
 }) => {
   const toast = useToast();
   const teamId = useStore((state) => state.teamId);
+  const isPlatformAdmin = member.role === "platformAdmin";
 
   const handleCompleted = (successMessage: string) => {
     onClose();
@@ -149,19 +150,21 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
               <Box sx={{ mt: 2, mb: 2 }}>
                 <NameFields />
               </Box>
-              <Switch
-                name="role"
-                checked={formik.values.role === "teamAdmin"}
-                onChange={() =>
-                  formik.setFieldValue(
-                    "role",
-                    formik.values.role === "teamEditor"
-                      ? "teamAdmin"
-                      : "teamEditor",
-                  )
-                }
-                label={"Team Admin"}
-              />
+              {!isPlatformAdmin && (
+                <Switch
+                  name="role"
+                  checked={formik.values.role === "teamAdmin"}
+                  onChange={() =>
+                    formik.setFieldValue(
+                      "role",
+                      formik.values.role === "teamEditor"
+                        ? "teamAdmin"
+                        : "teamEditor",
+                    )
+                  }
+                  label={"Team Admin"}
+                />
+              )}
             </DialogContent>
             <DialogActions>
               <ModalActions

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -28,7 +28,10 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
   member,
 }) => {
   const toast = useToast();
-  const teamId = useStore((state) => state.teamId);
+  const [teamId, role] = useStore((state) => [
+    state.teamId,
+    state.getUserRoleForCurrentTeam(),
+  ]);
   const isPlatformAdmin = member.role === "platformAdmin";
 
   const handleCompleted = (successMessage: string) => {
@@ -45,6 +48,11 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
           variables: { teamSlug: useStore.getState().teamSlug },
         },
       ],
+      context: {
+        headers: {
+          "x-hasura-role": role,
+        },
+      },
       onCompleted: () => handleCompleted("Successfully updated a user"),
       onError: () => toast.error("Failed to update the user, please try again"),
     },
@@ -59,6 +67,11 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
           variables: { teamSlug: useStore.getState().teamSlug },
         },
       ],
+      context: {
+        headers: {
+          "x-hasura-role": role,
+        },
+      },
       onCompleted: () => handleCompleted("Successfully updated a user"),
       onError: () => toast.error("Failed to update the user, please try again"),
     },
@@ -73,6 +86,11 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
           variables: { teamSlug: useStore.getState().teamSlug },
         },
       ],
+      context: {
+        headers: {
+          "x-hasura-role": role,
+        },
+      },
       onCompleted: (data) => {
         if (data.DeleteTeamMembers.affected_rows > 0) {
           handleCompleted("Successfully updated a user");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -12,7 +12,12 @@ import React from "react";
 import { Switch } from "ui/shared/Switch";
 
 import { upsertMemberSchema } from "../formSchema";
-import { GET_USERS_FOR_TEAM_QUERY, UPDATE_TEAM_MEMBER } from "../queries";
+import {
+  CREATE_TEAM_ADMIN_ONLY,
+  GET_USERS_FOR_TEAM_QUERY,
+  REMOVE_TEAM_ADMIN_ONLY,
+  UPDATE_USER_ONLY,
+} from "../queries";
 import { type EditUserModalProps, type UserFormValues } from "../types";
 import { EmailField } from "./Fields/EmailField";
 import { NameFields } from "./Fields/NameFields";
@@ -21,7 +26,6 @@ import { ModalActions } from "./ModalActions";
 export const EditUserModal: React.FC<EditUserModalProps> = ({
   onClose,
   member,
-  showTeamAdminSwitch,
 }) => {
   const toast = useToast();
   const teamId = useStore((state) => state.teamId);
@@ -31,32 +35,89 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
     toast.success(successMessage);
   };
 
-  const [updateTeamMember, { loading }] = useMutation(UPDATE_TEAM_MEMBER, {
-    refetchQueries: [
-      {
-        query: GET_USERS_FOR_TEAM_QUERY,
-        variables: { teamSlug: useStore.getState().teamSlug },
-      },
-    ],
-    onCompleted: () => handleCompleted("Successfully updated a user"),
-    onError: () => toast.error("Failed to update the user, please try again"),
-  });
+  const [updateUserOnly, { loading: loadingUser }] = useMutation(
+    UPDATE_USER_ONLY,
+    {
+      refetchQueries: [
+        {
+          query: GET_USERS_FOR_TEAM_QUERY,
+          variables: { teamSlug: useStore.getState().teamSlug },
+        },
+      ],
+      onCompleted: () => handleCompleted("Successfully updated a user"),
+      onError: () => toast.error("Failed to update the user, please try again"),
+    },
+  );
 
-  const handleSubmit = (values: UserFormValues) => {
+  const [createTeamAdmin, { loading: loadingCreateTeamAdmin }] = useMutation(
+    CREATE_TEAM_ADMIN_ONLY,
+    {
+      refetchQueries: [
+        {
+          query: GET_USERS_FOR_TEAM_QUERY,
+          variables: { teamSlug: useStore.getState().teamSlug },
+        },
+      ],
+      onCompleted: () => handleCompleted("Successfully updated a user"),
+      onError: () => toast.error("Failed to update the user, please try again"),
+    },
+  );
+
+  const [removeTeamAdmin, { loading: loadingRemoveTeamAdmin }] = useMutation(
+    REMOVE_TEAM_ADMIN_ONLY,
+    {
+      refetchQueries: [
+        {
+          query: GET_USERS_FOR_TEAM_QUERY,
+          variables: { teamSlug: useStore.getState().teamSlug },
+        },
+      ],
+      onCompleted: (data) => {
+        if (data.delete_team_members.affected_rows > 0) {
+          handleCompleted("Successfully updated a user");
+        } else {
+          toast.warning("No admin role found to remove");
+        }
+      },
+      onError: () => toast.error("Failed to update the user, please try again"),
+    },
+  );
+
+  const handleSubmit = async (values: UserFormValues) => {
     const formatted = { ...values, email: values.email.toLowerCase() };
 
-    updateTeamMember({
-      variables: {
-        userId: member.id,
-        teamId: teamId,
-        role: values.role,
-        userValues: {
-          first_name: formatted.firstName,
-          last_name: formatted.lastName,
-          email: formatted.email,
+    const userInfoChanged =
+      formatted.firstName !== member.firstName ||
+      formatted.lastName !== member.lastName ||
+      formatted.email !== (member.email ?? "").toLowerCase();
+
+    const roleChanged = values.role !== member.role;
+    console.log({ userInfoChanged, roleChanged });
+
+    if (userInfoChanged) {
+      await updateUserOnly({
+        variables: {
+          userId: member.id,
+          userValues: {
+            first_name: formatted.firstName,
+            last_name: formatted.lastName,
+            email: formatted.email,
+          },
         },
-      },
-    });
+      });
+    }
+
+    if (roleChanged) {
+      if (values.role === "teamAdmin") {
+        await createTeamAdmin({
+          variables: { userId: member.id, teamId },
+        });
+      } else {
+        await removeTeamAdmin({
+          variables: { userId: member.id, teamId },
+        });
+      }
+    }
   };
 
   return (
@@ -107,7 +168,11 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
               <ModalActions
                 submitButtonText="Update user"
                 submitDataTestId="modal-edit-user-button"
-                isSubmitting={loading}
+                isSubmitting={
+                  loadingUser ||
+                  loadingCreateTeamAdmin ||
+                  loadingRemoveTeamAdmin
+                }
                 onCancel={onClose}
               />
             </DialogActions>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/EditUserModal.tsx
@@ -26,12 +26,10 @@ import { ModalActions } from "./ModalActions";
 export const EditUserModal: React.FC<EditUserModalProps> = ({
   onClose,
   member,
+  userRole,
 }) => {
   const toast = useToast();
-  const [teamId, role] = useStore((state) => [
-    state.teamId,
-    state.getUserRoleForCurrentTeam(),
-  ]);
+  const teamId = useStore((state) => state.teamId);
   const isPlatformAdmin = member.role === "platformAdmin";
 
   const handleCompleted = (successMessage: string) => {
@@ -50,7 +48,7 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
       ],
       context: {
         headers: {
-          "x-hasura-role": role,
+          "x-hasura-role": userRole,
         },
       },
       onCompleted: () => handleCompleted("Successfully updated a user"),
@@ -69,7 +67,7 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
       ],
       context: {
         headers: {
-          "x-hasura-role": role,
+          "x-hasura-role": userRole,
         },
       },
       onCompleted: () => handleCompleted("Successfully updated a user"),
@@ -88,11 +86,11 @@ export const EditUserModal: React.FC<EditUserModalProps> = ({
       ],
       context: {
         headers: {
-          "x-hasura-role": role,
+          "x-hasura-role": userRole,
         },
       },
       onCompleted: (data) => {
-        if (data.DeleteTeamMembers.affected_rows > 0) {
+        if (data.deleteTeamMembers.affected_rows > 0) {
           handleCompleted("Successfully updated a user");
         } else {
           toast.warning("No admin role found to remove");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -9,6 +9,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { Role } from "@opensystemslab/planx-core/types";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { AddButton } from "ui/editor/AddButton";
 
@@ -59,6 +60,7 @@ export const MembersTable = ({
   showAddMemberButton,
   showEditMemberButton,
   showRemoveMemberButton,
+  userRole,
 }: MembersTableProps) => {
   const [modal, setModal] = useState<ModalState>({ action: "closed" });
 
@@ -90,7 +92,9 @@ export const MembersTable = ({
             </TableBody>
           )}
         </Table>
-        {modal.action !== "closed" && <AddUserModal onClose={closeModal} />}
+        {modal.action !== "closed" && (
+          <AddUserModal onClose={closeModal} userRole={userRole} />
+        )}
       </>
     );
   }
@@ -186,17 +190,27 @@ export const MembersTable = ({
       </TableContainer>
 
       {modal.action === "remove" && (
-        <RemoveUserModal onClose={closeModal} member={modal.member} />
+        <RemoveUserModal
+          onClose={closeModal}
+          member={modal.member}
+          userRole={userRole}
+        />
       )}
 
-      {modal.action === "add" && <AddUserModal onClose={closeModal} />}
+      {modal.action === "add" && (
+        <AddUserModal onClose={closeModal} userRole={userRole} />
+      )}
 
       {modal.action === "edit" && (
-        <EditUserModal onClose={closeModal} member={modal.member} />
+        <EditUserModal
+          onClose={closeModal}
+          member={modal.member}
+          userRole={userRole}
+        />
       )}
 
       {modal.action === "attemptedAdd" && (
-        <MaximumUserModal onClose={closeModal} />
+        <MaximumUserModal onClose={closeModal} userRole={userRole} />
       )}
     </>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -59,7 +59,6 @@ export const MembersTable = ({
   showAddMemberButton,
   showEditMemberButton,
   showRemoveMemberButton,
-  showTeamAdminSwitch,
 }: MembersTableProps) => {
   const [modal, setModal] = useState<ModalState>({ action: "closed" });
 
@@ -91,12 +90,7 @@ export const MembersTable = ({
             </TableBody>
           )}
         </Table>
-        {modal.action !== "closed" && (
-          <AddUserModal
-            onClose={closeModal}
-            showTeamAdminSwitch={showTeamAdminSwitch}
-          />
-        )}
+        {modal.action !== "closed" && <AddUserModal onClose={closeModal} />}
       </>
     );
   }
@@ -195,19 +189,10 @@ export const MembersTable = ({
         <RemoveUserModal onClose={closeModal} member={modal.member} />
       )}
 
-      {modal.action === "add" && (
-        <AddUserModal
-          onClose={closeModal}
-          showTeamAdminSwitch={showTeamAdminSwitch}
-        />
-      )}
+      {modal.action === "add" && <AddUserModal onClose={closeModal} />}
 
       {modal.action === "edit" && (
-        <EditUserModal
-          onClose={closeModal}
-          member={modal.member}
-          showTeamAdminSwitch={showTeamAdminSwitch}
-        />
+        <EditUserModal onClose={closeModal} member={modal.member} />
       )}
 
       {modal.action === "attemptedAdd" && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
@@ -6,18 +6,24 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Typography from "@mui/material/Typography";
 import { useToast } from "hooks/useToast";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import { REMOVE_TEAM_MEMBER } from "../queries";
 import type { RemoveUserModalProps } from "../types";
-
 export const RemoveUserModal: React.FC<RemoveUserModalProps> = ({
   onClose,
   member,
 }) => {
   const toast = useToast();
+  const role = useStore((state) => state.getUserRoleForCurrentTeam());
 
   const [removeUser, { loading }] = useMutation(REMOVE_TEAM_MEMBER, {
+    context: {
+      headers: {
+        "x-hasura-role": role,
+      },
+    },
     onCompleted: () => {
       onClose();
       toast.success(

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/RemoveUserModal.tsx
@@ -6,7 +6,6 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Typography from "@mui/material/Typography";
 import { useToast } from "hooks/useToast";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import { REMOVE_TEAM_MEMBER } from "../queries";
@@ -14,14 +13,14 @@ import type { RemoveUserModalProps } from "../types";
 export const RemoveUserModal: React.FC<RemoveUserModalProps> = ({
   onClose,
   member,
+  userRole,
 }) => {
   const toast = useToast();
-  const role = useStore((state) => state.getUserRoleForCurrentTeam());
 
   const [removeUser, { loading }] = useMutation(REMOVE_TEAM_MEMBER, {
     context: {
       headers: {
-        "x-hasura-role": role,
+        "x-hasura-role": userRole,
       },
     },
     onCompleted: () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
@@ -28,10 +28,18 @@ const SUBMIT_BUTTON_TEXT: Record<Step["stage"], string> = {
 };
 
 export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
-  const [teamId, teamSlug] = useStore((state) => [
+  const [teamId, teamSlug, role] = useStore((state) => [
     state.teamId,
     state.teamSlug,
+    state.getUserRoleForCurrentTeam(),
   ]);
+
+  const roleContext = {
+    headers: {
+      "x-hasura-role": role,
+    },
+  };
+
   const toast = useToast();
 
   const [step, setStep] = useState<Step>({ stage: "email" });
@@ -84,6 +92,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     refetchQueries: [
       { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
     ],
+    context: roleContext,
   });
 
   const [assignAdmin, { loading: assignLoadingAdmin }] = useMutation<
@@ -100,6 +109,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     refetchQueries: [
       { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
     ],
+    context: roleContext,
   });
 
   const [createTeamEditor, { loading: createEditorLoading }] = useMutation(
@@ -110,6 +120,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
       refetchQueries: [
         { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
       ],
+      context: roleContext,
     },
   );
 
@@ -122,6 +133,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
       refetchQueries: [
         { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
       ],
+      context: roleContext,
     },
   );
 
@@ -135,6 +147,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     if (step.stage === "confirm-existing" && values.role === "teamEditor") {
       assignEditor({
         variables: { userId: step.existingUser.id, teamId },
+        context: roleContext,
       });
       return;
     }
@@ -142,6 +155,7 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     if (step.stage === "confirm-existing" && values.role === "teamAdmin") {
       assignAdmin({
         variables: { userId: step.existingUser.id, teamId },
+        context: roleContext,
       });
       return;
     }
@@ -149,12 +163,14 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     if (step.stage === "create-new" && values.role === "teamEditor") {
       createTeamEditor({
         variables: { ...values, email, teamId },
+        context: roleContext,
       });
     }
 
     if (step.stage === "create-new" && values.role === "teamAdmin") {
       createTeamAdmin({
         variables: { ...values, email, teamId },
+        context: roleContext,
       });
     }
   };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
@@ -27,16 +27,21 @@ const SUBMIT_BUTTON_TEXT: Record<Step["stage"], string> = {
   "create-new": "Create user",
 };
 
-export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
-  const [teamId, teamSlug, role] = useStore((state) => [
+export const useAddUserModal = ({
+  onClose,
+  userRole,
+}: {
+  onClose: () => void;
+  userRole: Role;
+}) => {
+  const [teamId, teamSlug] = useStore((state) => [
     state.teamId,
     state.teamSlug,
-    state.getUserRoleForCurrentTeam(),
   ]);
 
   const roleContext = {
     headers: {
-      "x-hasura-role": role,
+      "x-hasura-role": userRole,
     },
   };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useAddUserModal.tsx
@@ -7,8 +7,10 @@ import { useEffect, useState } from "react";
 import { isUserAlreadyExistsError } from "../errors/addNewEditorErrors";
 import { emailSchema, upsertMemberSchema } from "../formSchema";
 import {
-  ADD_EXISTING_USER_TO_TEAM,
-  CREATE_AND_ADD_USER_TO_TEAM,
+  ADD_EXISTING_USER_TO_TEAM_AS_ADMIN,
+  ADD_EXISTING_USER_TO_TEAM_AS_EDITOR,
+  CREATE_AND_ADD_ADMIN_TO_TEAM,
+  CREATE_AND_ADD_EDITOR_TO_TEAM,
   GET_USER_BY_EMAIL,
   GET_USERS_FOR_TEAM_QUERY,
 } from "../queries";
@@ -68,10 +70,10 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     setStep({ stage: "create-new" });
   }, [emailCheckData, emailCheckError, toast]);
 
-  const [assignUser, { loading: assignLoading }] = useMutation<
+  const [assignEditor, { loading: assignLoadingEditor }] = useMutation<
     User[],
-    { teamId: number; role: Role; userId: number }
-  >(ADD_EXISTING_USER_TO_TEAM, {
+    { teamId: number; userId: number }
+  >(ADD_EXISTING_USER_TO_TEAM_AS_EDITOR, {
     onCompleted: () => handleCompleted("Successfully added user to team"),
     onError: (error) => {
       if (isUserAlreadyExistsError(error.message)) {
@@ -84,8 +86,36 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     ],
   });
 
-  const [createUser, { loading: createLoading }] = useMutation(
-    CREATE_AND_ADD_USER_TO_TEAM,
+  const [assignAdmin, { loading: assignLoadingAdmin }] = useMutation<
+    User[],
+    { teamId: number; userId: number }
+  >(ADD_EXISTING_USER_TO_TEAM_AS_ADMIN, {
+    onCompleted: () => handleCompleted("Successfully added user to team"),
+    onError: (error) => {
+      if (isUserAlreadyExistsError(error.message)) {
+        return toast.error("User is already a member of this team");
+      }
+      toast.error("Failed to add user to team, please try again");
+    },
+    refetchQueries: [
+      { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
+    ],
+  });
+
+  const [createTeamEditor, { loading: createEditorLoading }] = useMutation(
+    CREATE_AND_ADD_EDITOR_TO_TEAM,
+    {
+      onCompleted: () => handleCompleted("Successfully added a user"),
+      onError: () => toast.error("Failed to add new user, please try again"),
+      refetchQueries: [
+        { query: GET_USERS_FOR_TEAM_QUERY, variables: { teamSlug } },
+      ],
+    },
+  );
+
+  // we have two separate mutations here because teamAdmin model requires two entries in the team_members table (one mutation creates one teamEditor row and the other mutation creates both teamEditor and teamAdmin)
+  const [createTeamAdmin, { loading: createAdminLoading }] = useMutation(
+    CREATE_AND_ADD_ADMIN_TO_TEAM,
     {
       onCompleted: () => handleCompleted("Successfully added a user"),
       onError: () => toast.error("Failed to add new user, please try again"),
@@ -102,16 +132,29 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
       return;
     }
 
-    if (step.stage === "confirm-existing") {
-      assignUser({
-        variables: { userId: step.existingUser.id, teamId, role: values.role },
+    if (step.stage === "confirm-existing" && values.role === "teamEditor") {
+      assignEditor({
+        variables: { userId: step.existingUser.id, teamId },
       });
       return;
     }
 
-    if (step.stage === "create-new") {
-      createUser({
-        variables: { ...values, email, teamId, role: values.role },
+    if (step.stage === "confirm-existing" && values.role === "teamAdmin") {
+      assignAdmin({
+        variables: { userId: step.existingUser.id, teamId },
+      });
+      return;
+    }
+
+    if (step.stage === "create-new" && values.role === "teamEditor") {
+      createTeamEditor({
+        variables: { ...values, email, teamId },
+      });
+    }
+
+    if (step.stage === "create-new" && values.role === "teamAdmin") {
+      createTeamAdmin({
+        variables: { ...values, email, teamId },
       });
     }
   };
@@ -127,7 +170,12 @@ export const useAddUserModal = ({ onClose }: { onClose: () => void }) => {
     handleClose,
     handleSubmit,
     submitButtonText: SUBMIT_BUTTON_TEXT[step.stage],
-    isSubmitting: checkingEmail || assignLoading || createLoading,
+    isSubmitting:
+      checkingEmail ||
+      assignLoadingEditor ||
+      assignLoadingAdmin ||
+      createEditorLoading ||
+      createAdminLoading,
     validationSchema:
       step.stage === "create-new" ? upsertMemberSchema : emailSchema,
   };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamManagementPermissions.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamManagementPermissions.tsx
@@ -5,7 +5,7 @@ export const useTeamManagementPermissions = () => {
   const isPlatformAdmin = usePermission(["platformAdmin"]);
 
   return {
-    canManageActiveMembers: isTeamAdmin,
+    canManageActiveMembers: isPlatformAdmin || isTeamAdmin,
     canManagePlatformAdmins: isPlatformAdmin,
   };
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamManagementPermissions.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamManagementPermissions.tsx
@@ -1,16 +1,11 @@
 import { usePermission } from "hooks/usePermission";
 
 export const useTeamManagementPermissions = () => {
-  const isTeamEditor = usePermission([
-    "platformAdmin",
-    "teamAdmin",
-    "teamEditor",
-  ]);
+  const isTeamAdmin = usePermission(["teamAdmin"]);
   const isPlatformAdmin = usePermission(["platformAdmin"]);
 
   return {
-    canManageActiveMembers: isTeamEditor,
+    canManageActiveMembers: isTeamAdmin,
     canManagePlatformAdmins: isPlatformAdmin,
-    canManageTeamAdmins: isPlatformAdmin, // TODO: since managing team admin permissions are in a forthcoming ticket, this ability is limited to platform admin only now
   };
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamMembers.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/hooks/useTeamMembers.tsx
@@ -4,16 +4,14 @@ import { partition } from "lodash";
 
 import { GET_USERS_FOR_TEAM_QUERY } from "../queries";
 import type { TeamMember } from "../types";
-import {
-  hasEmailPresent,
-  isPlatformAdmin,
-  userToTeamMember,
-} from "../utils";
+import { hasEmailPresent, isPlatformAdmin, userToTeamMember } from "../utils";
 
 export const useTeamMembers = (teamSlug: string) => {
   const { data, loading, error } = useQuery<{ users: User[] }>(
     GET_USERS_FOR_TEAM_QUERY,
-    { variables: { teamSlug } },
+    {
+      variables: { teamSlug },
+    },
   );
 
   const teamMembers: TeamMember[] = data?.users.map(userToTeamMember) ?? [];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
@@ -108,7 +108,7 @@ export const REMOVE_TEAM_MEMBER = gql`
 `;
 
 export const ADD_EXISTING_USER_TO_TEAM_AS_EDITOR = gql`
-  mutation AddExistingUserToTeam($teamId: Int!, $userId: Int!) {
+  mutation AddExistingUserToTeamAsEditor($teamId: Int!, $userId: Int!) {
     insert_team_members_one(
       object: { role: teamEditor, team_id: $teamId, user_id: $userId }
     ) {
@@ -118,14 +118,14 @@ export const ADD_EXISTING_USER_TO_TEAM_AS_EDITOR = gql`
 `;
 
 export const ADD_EXISTING_USER_TO_TEAM_AS_ADMIN = gql`
-  mutation AddExistingUserToTeam($teamId: Int!, $userId: Int!) {
+  mutation AddExistingUserToTeamAsAdmin($teamId: Int!, $userId: Int!) {
     insert_team_members(
       objects: [
         { role: teamEditor, team_id: $teamId, user_id: $userId }
         { role: teamAdmin, team_id: $teamId, user_id: $userId }
       ]
     ) {
-      id
+      affected_rows
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
@@ -24,11 +24,10 @@ export const GET_USERS_FOR_TEAM_QUERY = gql`
   }
 `;
 
-export const UPDATE_TEAM_MEMBER = gql`
+export const UPDATE_USER_ONLY = gql`
   mutation UpdateUser(
-    $userId: Int
+    $userId: Int!
     $userValues: users_set_input
-    $role: user_roles_enum
     $teamId: Int
   ) {
     update_users(where: { id: { _eq: $userId } }, _set: $userValues) {
@@ -39,26 +38,15 @@ export const UPDATE_TEAM_MEMBER = gql`
         email
       }
     }
-    update_team_members(
-      where: { user_id: { _eq: $userId }, team_id: { _eq: $teamId } }
-      _set: { role: $role }
-    ) {
-      returning {
-        role
-        userId: user_id
-        teamId: team_id
-      }
-    }
   }
 `;
 
-export const CREATE_AND_ADD_USER_TO_TEAM = gql`
-  mutation CreateAndAddUserToTeam(
+export const CREATE_AND_ADD_EDITOR_TO_TEAM = gql`
+  mutation CreateAndAddEditorToTeam(
     $email: String!
     $firstName: String!
     $lastName: String!
     $teamId: Int!
-    $role: user_roles_enum!
   ) {
     insertUsersOne: insert_users_one(
       object: {
@@ -66,7 +54,40 @@ export const CREATE_AND_ADD_USER_TO_TEAM = gql`
         first_name: $firstName
         last_name: $lastName
         default_team_id: $teamId
-        teams: { data: { role: $role, team_id: $teamId } }
+        teams: { data: { role: teamEditor, team_id: $teamId } }
+      }
+    ) {
+      id
+      first_name
+      last_name
+      email
+    }
+  }
+`;
+
+/** Our teamAdmin permission is a layer _on top of_ teamEditor
+ * meaning there should be multiple records in team_members for the same user
+ * so this mutation creates both a teamEditor _and_ teamAdmin record.
+ */
+export const CREATE_AND_ADD_ADMIN_TO_TEAM = gql`
+  mutation CreateAndAddAdminToTeam(
+    $email: String!
+    $firstName: String!
+    $lastName: String!
+    $teamId: Int!
+  ) {
+    insertUsersOne: insert_users_one(
+      object: {
+        email: $email
+        first_name: $firstName
+        last_name: $lastName
+        default_team_id: $teamId
+        teams: {
+          data: [
+            { role: teamAdmin, team_id: $teamId }
+            { role: teamEditor, team_id: $teamId }
+          ]
+        }
       }
     ) {
       id
@@ -86,16 +107,49 @@ export const REMOVE_TEAM_MEMBER = gql`
   }
 `;
 
-export const ADD_EXISTING_USER_TO_TEAM = gql`
-  mutation AddExistingUserToTeam(
-    $role: user_roles_enum
-    $teamId: Int!
-    $userId: Int!
-  ) {
+export const ADD_EXISTING_USER_TO_TEAM_AS_EDITOR = gql`
+  mutation AddExistingUserToTeam($teamId: Int!, $userId: Int!) {
     insert_team_members_one(
-      object: { role: $role, team_id: $teamId, user_id: $userId }
+      object: { role: teamEditor, team_id: $teamId, user_id: $userId }
     ) {
       id
+    }
+  }
+`;
+
+export const ADD_EXISTING_USER_TO_TEAM_AS_ADMIN = gql`
+  mutation AddExistingUserToTeam($teamId: Int!, $userId: Int!) {
+    insert_team_members(
+      objects: [
+        { role: teamEditor, team_id: $teamId, user_id: $userId }
+        { role: teamAdmin, team_id: $teamId, user_id: $userId }
+      ]
+    ) {
+      id
+    }
+  }
+`;
+
+export const CREATE_TEAM_ADMIN_ONLY = gql`
+  mutation CreateTeamAdminOnly($teamId: Int!, $userId: Int!) {
+    insert_team_members_one(
+      object: { team_id: $teamId, role: teamAdmin, user_id: $userId }
+    ) {
+      id
+    }
+  }
+`;
+
+export const REMOVE_TEAM_ADMIN_ONLY = gql`
+  mutation RemoveTeamAdminOnly($teamId: Int!, $userId: Int!) {
+    delete_team_members(
+      where: {
+        role: { _eq: teamAdmin }
+        user_id: { _eq: $userId }
+        team_id: { _eq: $teamId }
+      }
+    ) {
+      affected_rows
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
@@ -24,19 +24,6 @@ export const GET_USERS_FOR_TEAM_QUERY = gql`
   }
 `;
 
-export const UPDATE_USER_DETAILS = gql`
-  mutation UpdateUserDetails($userId: Int!, $userValues: users_set_input!) {
-    update_users(where: { id: { _eq: $userId } }, _set: $userValues) {
-      returning {
-        id
-        firstName: first_name
-        lastName: last_name
-        email
-      }
-    }
-  }
-`;
-
 export const UPDATE_TEAM_MEMBER = gql`
   mutation UpdateUser(
     $userId: Int

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
@@ -145,7 +145,7 @@ export const CREATE_TEAM_ADMIN_ONLY = gql`
 
 export const REMOVE_TEAM_ADMIN_ONLY = gql`
   mutation RemoveTeamAdminOnly($teamId: Int!, $userId: Int!) {
-    DeleteTeamMembers: delete_team_members(
+    deleteTeamMembers: delete_team_members(
       where: {
         role: { _eq: teamAdmin }
         user_id: { _eq: $userId }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/queries.ts
@@ -65,7 +65,8 @@ export const CREATE_AND_ADD_EDITOR_TO_TEAM = gql`
   }
 `;
 
-/** Our teamAdmin permission is a layer _on top of_ teamEditor
+/**
+ * Our teamAdmin permission is a layer _on top of_ teamEditor
  * meaning there should be multiple records in team_members for the same user
  * so this mutation creates both a teamEditor _and_ teamAdmin record.
  */
@@ -107,6 +108,7 @@ export const REMOVE_TEAM_MEMBER = gql`
   }
 `;
 
+/** Grants the existing user editor permissions _only_ for this team */
 export const ADD_EXISTING_USER_TO_TEAM_AS_EDITOR = gql`
   mutation AddExistingUserToTeamAsEditor($teamId: Int!, $userId: Int!) {
     insert_team_members_one(
@@ -117,6 +119,7 @@ export const ADD_EXISTING_USER_TO_TEAM_AS_EDITOR = gql`
   }
 `;
 
+/** Grants the existing user both team editor _and_ team admin permissions */
 export const ADD_EXISTING_USER_TO_TEAM_AS_ADMIN = gql`
   mutation AddExistingUserToTeamAsAdmin($teamId: Int!, $userId: Int!) {
     insert_team_members(
@@ -142,7 +145,7 @@ export const CREATE_TEAM_ADMIN_ONLY = gql`
 
 export const REMOVE_TEAM_ADMIN_ONLY = gql`
   mutation RemoveTeamAdminOnly($teamId: Int!, $userId: Int!) {
-    delete_team_members(
+    DeleteTeamMembers: delete_team_members(
       where: {
         role: { _eq: teamAdmin }
         user_id: { _eq: $userId }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
@@ -123,7 +123,7 @@ describe("when the addNewMember modal is rendered", () => {
   it("should not have any accessibility issues", async () => {
     const { container } = await setup(
       <DndProvider backend={HTML5Backend}>
-        <AddUserModal onClose={vi.fn()} />
+        <AddUserModal onClose={vi.fn()} userRole="teamAdmin" />
       </DndProvider>,
     );
     await screen.findByTestId("modal-create-user");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.test.tsx
@@ -11,7 +11,10 @@ import { AddUserModal } from "../components/AddUserModal";
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
 import { userTriesToAddNewTeamAdmin } from "./helpers/userTriesToAddNewTeamAdmin";
 import { userTriesToAddNewTeamEditor } from "./helpers/userTriesToAddNewTeamEditor";
-import { createUserHandler } from "./mocks/handlers";
+import {
+  createTeamAdminHandler,
+  createTeamEditorHandler,
+} from "./mocks/handlers";
 import { mockPlainUser, mockPlatformAdminUser } from "./mocks/users";
 
 let initialState: FullStore;
@@ -20,6 +23,7 @@ describe("when a user presses 'add a new member'", () => {
   beforeEach(async () => {
     useStore.setState({
       user: mockPlatformAdminUser,
+      teamSlug: "test",
     });
 
     const { user } = await setupTeamMembersScreen();
@@ -43,9 +47,11 @@ describe("when a user fills in the 'add a new member' form correctly", () => {
   beforeEach(async () => {
     useStore.setState({
       user: mockPlatformAdminUser,
+      teamSlug: "test",
+      teamId: 2,
     });
 
-    server.use(createUserHandler());
+    server.use(createTeamEditorHandler());
 
     const { user } = await setupTeamMembersScreen();
     await userTriesToAddNewTeamEditor(user);
@@ -81,9 +87,10 @@ describe("when a user adds a new teamAdmin", () => {
   beforeEach(async () => {
     useStore.setState({
       user: mockPlatformAdminUser,
+      teamSlug: "test",
     });
 
-    server.use(createUserHandler());
+    server.use(createTeamAdminHandler());
 
     const { user } = await setupTeamMembersScreen();
     await userTriesToAddNewTeamAdmin(user);
@@ -130,6 +137,7 @@ describe("when a user is not a platform admin", () => {
   beforeEach(async () => {
     useStore.setState({
       user: mockPlainUser,
+      teamSlug: "test",
     });
 
     await setupTeamMembersScreen();

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.maximumUsers.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.maximumUsers.test.tsx
@@ -17,6 +17,7 @@ describe("when the maximum number of active users exists for a team", () => {
         <MembersTable
           members={mockTeamMembersAt20}
           showAddMemberButton={true}
+          userRole="platformAdmin"
         />
       </DndProvider>,
     );
@@ -36,6 +37,7 @@ describe(`when there are <${MAX_USER_COUNT} active users`, () => {
         <MembersTable
           members={mockTeamMembersAt19}
           showAddMemberButton={true}
+          userRole="platformAdmin"
         />
       </DndProvider>,
     );
@@ -56,6 +58,7 @@ describe("when the addNewMember modal is rendered", () => {
         <MembersTable
           members={mockTeamMembersAt20}
           showAddMemberButton={true}
+          userRole="platformAdmin"
         />
       </DndProvider>,
     );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.permissions.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.permissions.test.tsx
@@ -2,14 +2,23 @@ import { screen, waitFor, within } from "@testing-library/react";
 import { FullStore, useStore } from "pages/FlowEditor/lib/store";
 import server from "test/mockServer";
 
-import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { userEntersInput } from "./helpers/userEntersInput";
-// import { userTriesToAddNewTeamAdmin } from "./helpers/userTriesToAddNewTeamAdmin";
-import { createUserHandler, updateUserHandler } from "./mocks/handlers";
+import {
+  setupTeamMembersScreen,
+  setupTeamMembersScreenWithData,
+} from "./helpers/setupTeamMembersScreen";
+import { userTriesToAddNewTeamAdmin } from "./helpers/userTriesToAddNewTeamAdmin";
+import { userTriesToDemoteFromTeamAdmin } from "./helpers/userTriesToDemoteFromTeamAdmin";
+import { userTriesToPromoteToTeamAdmin } from "./helpers/userTriesToPromoteToTeamAdmin";
+import {
+  createTeamAdminHandler,
+  updateUserAsTeamAdminHandler,
+  updateUserAsTeamEditorHandler,
+} from "./mocks/handlers";
 import {
   mockPlainUser,
   mockPlatformAdminUser,
   mockTeamAdminUser,
+  mockUsersWithTeamAdmin,
 } from "./mocks/users";
 
 let initialState: FullStore;
@@ -22,44 +31,17 @@ describe("Role-based permissions", () => {
     beforeEach(() => {
       useStore.setState({
         user: mockPlatformAdminUser,
+        teamId: 2,
       });
     });
 
     describe("adding new members", () => {
       it("can add a new teamAdmin", async () => {
-        server.use(createUserHandler());
+        server.use(createTeamAdminHandler());
 
         const { user } = await setupTeamMembersScreen();
 
-        const teamMembersTable = screen.getByTestId("team-members");
-        const addMemberButton =
-          await within(teamMembersTable).findByText("Add a new member");
-        await user.click(addMemberButton);
-
-        const modal = await screen.findByTestId("modal-create-user");
-        await userEntersInput(
-          "Email address",
-          "minniemouse@email.com",
-          modal,
-          user,
-        );
-
-        const continueButton = await screen.findByTestId(
-          "modal-create-user-button",
-        );
-        await user.click(continueButton);
-
-        await userEntersInput("First name", "Minnie", modal, user);
-        await userEntersInput("Last name", "Mouse", modal, user);
-
-        const teamAdminSwitch =
-          await within(modal).findByLabelText("Team Admin");
-        await user.click(teamAdminSwitch);
-
-        const createUserButton = await screen.findByTestId(
-          "modal-create-user-button",
-        );
-        await user.click(createUserButton);
+        await userTriesToAddNewTeamAdmin(user);
 
         const membersTable = screen.getByTestId("members-table-add-member");
         await waitFor(() => {
@@ -74,41 +56,12 @@ describe("Role-based permissions", () => {
     });
 
     describe("editing existing members", () => {
-      it("shows the Team Admin switch in the edit member modal", async () => {
-        const { user } = await setupTeamMembersScreen();
-
-        const teamMembersTable = screen.getByTestId("team-members");
-        const editButton =
-          await within(teamMembersTable).findByTestId("edit-button-3");
-        await user.click(editButton);
-
-        const modal = await screen.findByTestId("modal-edit-user");
-        const teamAdminSwitch =
-          await within(modal).findByLabelText("Team Admin");
-
-        expect(teamAdminSwitch).toBeInTheDocument();
-      });
-
       it("can promote a teamEditor to teamAdmin", async () => {
-        server.use(updateUserHandler());
+        server.use(updateUserAsTeamAdminHandler());
 
         const { user } = await setupTeamMembersScreen();
 
-        const teamMembersTable = screen.getByTestId("team-members");
-        const editButton =
-          await within(teamMembersTable).findByTestId("edit-button-3");
-        await user.click(editButton);
-
-        const teamAdminSwitch = await screen.findByLabelText("Team Admin");
-        expect(teamAdminSwitch).not.toBeChecked();
-
-        await user.click(teamAdminSwitch);
-        expect(teamAdminSwitch).toBeChecked();
-
-        const updateUserButton = await screen.findByRole("button", {
-          name: "Update user",
-        });
-        await user.click(updateUserButton);
+        await userTriesToPromoteToTeamAdmin(user);
 
         const membersTable = await screen.findByTestId(
           "members-table-add-member",
@@ -116,6 +69,24 @@ describe("Role-based permissions", () => {
         await waitFor(() => {
           expect(
             within(membersTable).getByText(/Team admin/),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("can demote a teamAdmin to teamEditor", async () => {
+        server.use(updateUserAsTeamEditorHandler());
+
+        const { user } = await setupTeamMembersScreenWithData(
+          mockUsersWithTeamAdmin,
+        );
+        await userTriesToDemoteFromTeamAdmin(user);
+
+        const membersTable = await screen.findByTestId(
+          "members-table-add-member",
+        );
+        await waitFor(() => {
+          expect(
+            within(membersTable).getByText(/Team editor/),
           ).toBeInTheDocument();
         });
       });
@@ -127,63 +98,64 @@ describe("Role-based permissions", () => {
       useStore.setState({
         user: mockTeamAdminUser,
         teamSlug: "test",
+        teamId: 2,
       });
     });
 
     describe("adding new members", () => {
-      it.todo(
-        "can add a new teamAdmin",
-        //   , async () => {
-        //   server.use(createUserHandler());
+      it("can add a new teamAdmin", async () => {
+        server.use(createTeamAdminHandler());
 
-        //   const { user } = await setupTeamMembersScreen();
-        //   await userTriesToAddNewTeamAdmin(user);
+        const { user } = await setupTeamMembersScreen();
+        await userTriesToAddNewTeamAdmin(user);
 
-        //   const membersTable = screen.getByTestId("members-table-add-member");
-        //   await waitFor(() => {
-        //     expect(
-        //       within(membersTable).getByText(/Minnie Mouse/),
-        //     ).toBeInTheDocument();
-        //     expect(
-        //       within(membersTable).getByText(/Team admin/),
-        //     ).toBeInTheDocument();
-        //   });
-        // });
-      );
+        const membersTable = screen.getByTestId("members-table-add-member");
+        await waitFor(() => {
+          expect(
+            within(membersTable).getByText(/Minnie Mouse/),
+          ).toBeInTheDocument();
+          expect(
+            within(membersTable).getByText(/Team admin/),
+          ).toBeInTheDocument();
+        });
+      });
     });
 
     describe("editing existing members", () => {
-      it.todo(
-        "can make a teamEditor an teamAdmin",
-        //   , async () => {
-        //   server.use(updateUserHandler());
+      it("can promote a teamEditor to teamAdmin", async () => {
+        server.use(updateUserAsTeamAdminHandler());
 
-        //   const { user } = await setupTeamMembersScreen();
+        const { user } = await setupTeamMembersScreen();
 
-        //   const teamMembersTable = screen.getByTestId("team-members");
-        //   const editButton =
-        //     await within(teamMembersTable).findByTestId("edit-button-3");
-        //   await user.click(editButton);
+        await userTriesToPromoteToTeamAdmin(user);
 
-        //   const teamAdminSwitch = await screen.findByLabelText("Team Admin");
-        //   await user.click(teamAdminSwitch);
+        const membersTable = await screen.findByTestId(
+          "members-table-add-member",
+        );
+        await waitFor(() => {
+          expect(
+            within(membersTable).getByText(/Team admin/),
+          ).toBeInTheDocument();
+        });
+      });
 
-        //   const updateUserButton = await screen.findByRole("button", {
-        //     name: "Update user",
-        //   });
-        //   await user.click(updateUserButton);
+      it("can demote a teamAdmin to teamEditor", async () => {
+        server.use(updateUserAsTeamEditorHandler());
 
-        //   const membersTable = await screen.findByTestId(
-        //     "members-table-add-member",
-        //   );
-        //   await waitFor(() => {
-        //     expect(
-        //       within(membersTable).getByText(/Team admin/),
-        //     ).toBeInTheDocument();
-        //   });
-        // });
-        // });
-      );
+        const { user } = await setupTeamMembersScreenWithData(
+          mockUsersWithTeamAdmin,
+        );
+        await userTriesToDemoteFromTeamAdmin(user);
+
+        const membersTable = await screen.findByTestId(
+          "members-table-add-member",
+        );
+        await waitFor(() => {
+          expect(
+            within(membersTable).getByText(/Team editor/),
+          ).toBeInTheDocument();
+        });
+      });
     });
   });
 
@@ -196,40 +168,20 @@ describe("Role-based permissions", () => {
     });
 
     describe("adding new members", () => {
-      it("does not show the Team Admin switch in the add member modal", async () => {
-        const { user } = await setupTeamMembersScreen();
+      it("does not show add, edit or remove user buttons", async () => {
+        await setupTeamMembersScreen();
 
         const teamMembersTable = screen.getByTestId("team-members");
         const addMemberButton =
-          await within(teamMembersTable).findByText("Add a new member");
-        await user.click(addMemberButton);
+          within(teamMembersTable).queryByText("Add a new member");
+        expect(addMemberButton).not.toBeInTheDocument();
 
-        const modal = await screen.findByTestId("modal-create-user");
-        await userEntersInput("Email address", "newuser@test.com", modal, user);
+        const editMemberButton = within(teamMembersTable).queryByText("Edit");
+        expect(editMemberButton).not.toBeInTheDocument();
 
-        const continueButton = await screen.findByTestId(
-          "modal-create-user-button",
-        );
-        await user.click(continueButton);
-
-        const teamAdminSwitch = within(modal).queryByLabelText("Team Admin");
-        expect(teamAdminSwitch).not.toBeInTheDocument();
-      });
-    });
-
-    describe("editing existing members", () => {
-      it("does not show the Team Admin switch in the edit member modal", async () => {
-        const { user } = await setupTeamMembersScreen();
-
-        const teamMembersTable = screen.getByTestId("team-members");
-        const editButton =
-          await within(teamMembersTable).findByTestId("edit-button-3");
-        await user.click(editButton);
-
-        const modal = await screen.findByTestId("modal-edit-user");
-        const teamAdminSwitch = within(modal).queryByLabelText("Team Admin");
-
-        expect(teamAdminSwitch).not.toBeInTheDocument();
+        const removeMemberButton =
+          within(teamMembersTable).queryByText("Remove");
+        expect(removeMemberButton).not.toBeInTheDocument();
       });
     });
   });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.updateEditor.test.tsx
@@ -3,7 +3,10 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import server from "test/mockServer";
 
 import { setupTeamMembersScreen } from "./helpers/setupTeamMembersScreen";
-import { updateUserHandler } from "./mocks/handlers";
+import {
+  updateUserAsTeamAdminHandler,
+  updateUserOnlyHandler,
+} from "./mocks/handlers";
 import {
   mockPlainUser,
   mockPlatformAdminUser,
@@ -87,11 +90,11 @@ describe("when a user updates a field correctly", () => {
   });
 });
 
-describe("when a user correctly updates an Editor", () => {
+describe("when a user correctly updates an Editors user details only", () => {
   beforeEach(async () => {
     useStore.setState({ teamSlug: "test" });
 
-    server.use(updateUserHandler());
+    server.use(updateUserOnlyHandler());
 
     const { user } = await setupTeamMembersScreen();
 
@@ -139,9 +142,10 @@ describe("when a user correctly makes a teamEditor a teamAdmin", () => {
     useStore.setState({
       user: mockPlatformAdminUser,
       teamSlug: "test",
+      teamId: 2,
     });
 
-    server.use(updateUserHandler());
+    server.use(updateUserAsTeamAdminHandler());
 
     const { user } = await setupTeamMembersScreen();
 
@@ -197,24 +201,6 @@ describe("'edit' button is hidden from Templates team", () => {
     const teamMembersTable = screen.getByTestId("team-members");
     const editButton = within(teamMembersTable).queryByTestId("edit-button-0");
     expect(editButton).not.toBeInTheDocument();
-  });
-});
-
-describe("when a user is not a platform admin", () => {
-  beforeEach(async () => {
-    useStore.setState({
-      user: mockPlainUser,
-    });
-
-    await setupTeamMembersScreen();
-  });
-
-  it("does not show an edit button", async () => {
-    const teamMembersTable = screen.getByTestId("team-members");
-    const addMemberButton =
-      within(teamMembersTable).queryByTestId("edit-button-3");
-
-    expect(addMemberButton).not.toBeInTheDocument();
   });
 });
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/setupTeamMembersScreen.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import { graphql, HttpResponse } from "msw";
 import React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -7,6 +8,28 @@ import server from "test/mockServer";
 import { setup } from "../../../../../../test/utils";
 import { TeamMembers } from "../../TeamMembers";
 import { getNoExistingUserHandler, getUsersHandler } from "../mocks/handlers";
+import { mockUsersData } from "../mocks/users";
+
+export const setupTeamMembersScreenWithData = async (
+  usersData = mockUsersData,
+) => {
+  server.use(
+    graphql.query("GetUsersForTeam", () =>
+      HttpResponse.json({
+        data: { users: usersData },
+      }),
+    ),
+    getNoExistingUserHandler(),
+  );
+
+  const setupResult = await setup(
+    <DndProvider backend={HTML5Backend}>
+      <TeamMembers />
+    </DndProvider>,
+  );
+  await screen.findByTestId("team-members");
+  return setupResult;
+};
 
 export const setupTeamMembersScreen = async () => {
   server.use(getUsersHandler(), getNoExistingUserHandler());

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToDemoteFromTeamAdmin.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToDemoteFromTeamAdmin.tsx
@@ -1,0 +1,22 @@
+import { screen, within } from "@testing-library/react";
+// eslint-disable-next-line no-restricted-imports
+import type { UserEvent } from "@testing-library/user-event";
+
+export const userTriesToDemoteFromTeamAdmin = async (user: UserEvent) => {
+  const teamMembersTable = screen.getByTestId("team-members");
+
+  const editButton =
+    await within(teamMembersTable).findByTestId("edit-button-3");
+  await user.click(editButton);
+
+  const teamAdminSwitch = await screen.findByLabelText("Team Admin");
+  expect(teamAdminSwitch).toBeChecked();
+
+  await user.click(teamAdminSwitch);
+  expect(teamAdminSwitch).not.toBeChecked();
+
+  const updateUserButton = await screen.findByRole("button", {
+    name: "Update user",
+  });
+  await user.click(updateUserButton);
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToPromoteToTeamAdmin.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/helpers/userTriesToPromoteToTeamAdmin.tsx
@@ -1,0 +1,21 @@
+import { screen, within } from "@testing-library/react";
+// eslint-disable-next-line no-restricted-imports
+import type { UserEvent } from "@testing-library/user-event";
+
+export const userTriesToPromoteToTeamAdmin = async (user: UserEvent) => {
+  const teamMembersTable = screen.getByTestId("team-members");
+  const editButton =
+    await within(teamMembersTable).findByTestId("edit-button-3");
+  await user.click(editButton);
+
+  const teamAdminSwitch = await screen.findByLabelText("Team Admin");
+  expect(teamAdminSwitch).not.toBeChecked();
+
+  await user.click(teamAdminSwitch);
+  expect(teamAdminSwitch).toBeChecked();
+
+  const updateUserButton = await screen.findByRole("button", {
+    name: "Update user",
+  });
+  await user.click(updateUserButton);
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/handlers.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/handlers.ts
@@ -1,19 +1,8 @@
+import { TeamRole } from "@opensystemslab/planx-core/types";
 import { graphql, HttpResponse } from "msw";
 import server from "test/mockServer";
 
 import { mockTeamMembersDataWithNoTeamEditors, mockUsersData } from "./users";
-
-export const createUserAlreadyExistsHandler = () =>
-  graphql.mutation("CreateAndAddUserToTeam", () =>
-    HttpResponse.json({
-      errors: [
-        {
-          message:
-            'Uniqueness violation. duplicate key value violates unique constraint "users_email_key"',
-        },
-      ],
-    }),
-  );
 
 export const getUsersHandler = () =>
   graphql.query("GetUsersForTeam", () =>
@@ -23,7 +12,7 @@ export const getUsersHandler = () =>
   );
 
 export const failToAddUserHandler = () =>
-  graphql.mutation("CreateAndAddUserToTeam", () =>
+  graphql.mutation("CreateAndAddEditorToTeam", () =>
     HttpResponse.json({
       errors: [{ message: "Unable to create user" }],
     }),
@@ -36,18 +25,59 @@ export const getUsersWithNoTeamEditorHandler = () =>
     }),
   );
 
-export const createUserHandler = () =>
-  graphql.mutation("CreateAndAddUserToTeam", ({ variables }) => {
-    const { role, firstName, lastName, email } = variables;
+export const createTeamEditorHandler = () =>
+  graphql.mutation("CreateAndAddEditorToTeam", ({ variables }) => {
+    const { firstName, lastName, email } = variables;
 
     const createdMember = {
-      id: role === "teamAdmin" ? 100 : 99,
+      id: 99,
       firstName: firstName,
       lastName: lastName,
       email: email,
       isPlatformAdmin: false,
       defaultTeamId: 2,
-      teams: [{ role }],
+      teams: [
+        {
+          role: "teamEditor",
+          team: { name: "Test Team", slug: "test", id: 2 },
+        },
+      ],
+    };
+
+    server.use(
+      graphql.query("GetUsersForTeam", () =>
+        HttpResponse.json({
+          data: { users: [...mockUsersData, createdMember] },
+        }),
+      ),
+    );
+
+    return HttpResponse.json({
+      data: { insertUsersOne: { id: createdMember.id, __typename: "users" } },
+    });
+  });
+
+export const createTeamAdminHandler = () =>
+  graphql.mutation("CreateAndAddAdminToTeam", ({ variables }) => {
+    const { firstName, lastName, email, teamId } = variables;
+
+    const createdMember = {
+      id: 100,
+      firstName: firstName,
+      lastName: lastName,
+      email: email,
+      isPlatformAdmin: false,
+      defaultTeamId: teamId,
+      teams: [
+        {
+          role: "teamEditor",
+          team: { name: "Test Team", slug: "test", id: teamId },
+        },
+        {
+          role: "teamAdmin",
+          team: { name: "Test Team", slug: "test", id: teamId },
+        },
+      ],
     };
 
     server.use(
@@ -72,9 +102,9 @@ export const deleteUserHandler = () =>
     }),
   );
 
-export const updateUserHandler = () =>
+export const updateUserOnlyHandler = () =>
   graphql.mutation("UpdateUser", ({ variables }) => {
-    const { userId, userValues, role } = variables;
+    const { userId, userValues } = variables;
 
     const updatedUsers = mockUsersData.map((user) =>
       user.id === userId
@@ -83,7 +113,7 @@ export const updateUserHandler = () =>
             firstName: userValues.first_name,
             lastName: userValues.last_name,
             email: userValues.email,
-            teams: user.teams.map((team) => ({ ...team, role })),
+            teams: user.teams.map((team) => ({ ...team })),
           }
         : user,
     );
@@ -109,14 +139,155 @@ export const updateUserHandler = () =>
             },
           ],
         },
-        update_team_members: {
-          returning: [
-            {
-              role: role,
-              userId: userId,
-              teamId: variables.teamId,
-            },
-          ],
+      },
+    });
+  });
+
+export const updateUserAsTeamAdminHandler = () =>
+  graphql.mutation("CreateTeamAdminOnly", ({ variables }) => {
+    const { userId, teamId } = variables;
+    console.log({ userId, teamId });
+
+    const updatedUsers = mockUsersData.map((user) =>
+      user.id === userId
+        ? {
+            ...user,
+            teams: user.teams.map((team) =>
+              team.team.id === teamId ? { ...team, role: "teamAdmin" } : team,
+            ),
+          }
+        : user,
+    );
+
+    server.use(
+      graphql.query("GetUsersForTeam", () =>
+        HttpResponse.json({
+          data: { users: updatedUsers },
+        }),
+      ),
+    );
+
+    return HttpResponse.json({
+      data: {
+        insert_team_members_one: {
+          id: "12345678-1234-1234-1234-123456789abc",
+        },
+      },
+    });
+  });
+
+export const updateUserAsTeamEditorHandler = () =>
+  graphql.mutation("RemoveTeamAdminOnly", ({ variables }) => {
+    const { userId, teamId } = variables;
+
+    const updatedUsers = mockUsersData.map((user) =>
+      user.id === userId
+        ? {
+            ...user,
+            teams: user.teams.map((team) =>
+              team.team.id === teamId ? { ...team, role: "teamEditor" } : team,
+            ),
+          }
+        : user,
+    );
+
+    server.use(
+      graphql.query("GetUsersForTeam", () =>
+        HttpResponse.json({
+          data: { users: updatedUsers },
+        }),
+      ),
+    );
+
+    return HttpResponse.json({
+      data: {
+        delete_team_members: {
+          affected_rows: 1,
+        },
+      },
+    });
+  });
+
+// TODO: tests for this and update user as teamEditor
+export const addUserAsTeamEditorHandler = () =>
+  graphql.mutation("AddExistingUserToTeamAsEditor", ({ variables }) => {
+    const { userId, teamId } = variables;
+
+    const newTeamEditor = {
+      __typename: "users" as const,
+      firstName: "abc",
+      lastName: "123",
+      email: "123abc@email.com",
+      id: userId,
+      isPlatformAdmin: false,
+      isAnalyst: false,
+      defaultTeamId: null,
+      teams: [
+        {
+          role: "teamEditor" as TeamRole,
+          team: { name: "Test Team", slug: "test", id: teamId },
+        },
+      ],
+    };
+
+    const updatedUsers = [...mockUsersData, newTeamEditor];
+
+    server.use(
+      graphql.query("GetUsersForTeam", () =>
+        HttpResponse.json({
+          data: { users: updatedUsers },
+        }),
+      ),
+    );
+
+    return HttpResponse.json({
+      data: {
+        insert_team_members_one: {
+          id: "12345678-1234-1234-1234-123456789abc",
+        },
+      },
+    });
+  });
+
+export const addUserAsTeamAdminHandler = () =>
+  graphql.mutation("AddExistingUserToTeamAsAdmin", ({ variables }) => {
+    const { userId, teamId } = variables;
+
+    const newTeamAdmin = {
+      __typename: "users" as const,
+      firstName: "abc",
+      lastName: "123",
+      email: "123abc@email.com",
+      id: userId,
+      isPlatformAdmin: false,
+      isAnalyst: false,
+      defaultTeamId: null,
+      teams: [
+        {
+          role: "teamEditor" as TeamRole,
+          team: { name: "Test Team", slug: "test", id: teamId },
+        },
+        {
+          role: "teamAdmin" as TeamRole,
+          team: { name: "Test Team", slug: "test", id: teamId },
+        },
+      ],
+    };
+
+    const updatedUsers = [...mockUsersData, newTeamAdmin];
+
+    server.use(
+      graphql.query("GetUsersForTeam", () =>
+        HttpResponse.json({
+          data: { users: updatedUsers },
+        }),
+      ),
+    );
+
+    return HttpResponse.json({
+      data: {
+        insert_team_members: {
+          affected_rows: 2,
         },
       },
     });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/users.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/mocks/users.tsx
@@ -83,6 +83,10 @@ export const mockTeamAdminUser: User = {
   ...mockPlainUser,
   teams: [
     {
+      role: "teamEditor",
+      team: { name: "Test Team", slug: "test", id: 2 },
+    },
+    {
       role: "teamAdmin",
       team: { name: "Test Team", slug: "test", id: 2 },
     },
@@ -127,3 +131,21 @@ export const mockTeamMembersDataWithNoTeamEditors: User[] = [
     teams: [],
   },
 ];
+
+export const mockUsersWithTeamAdmin = mockUsersData.map((user) =>
+  user.id === 3
+    ? {
+        ...user,
+        teams: [
+          {
+            role: "teamEditor" as const,
+            team: { name: "Test Team", slug: "test", id: 2 },
+          },
+          {
+            role: "teamAdmin" as const,
+            team: { name: "Test Team", slug: "test", id: 2 },
+          },
+        ],
+      }
+    : user,
+);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/types.ts
@@ -29,6 +29,7 @@ export interface MembersTableProps {
   showEditMemberButton?: boolean;
   showRemoveMemberButton?: boolean;
   showTeamAdminSwitch?: boolean;
+  userRole: Role;
 }
 
 export interface UserFormValues {
@@ -47,7 +48,7 @@ export type ModalState =
 
 type SharedModalProps = {
   onClose: () => void;
-  showTeamAdminSwitch?: boolean;
+  userRole: Role;
 };
 
 export type AddUserModalProps = SharedModalProps;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/utils.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/utils.tsx
@@ -8,8 +8,11 @@ const getRole = (user: User): Role => {
   if (user.isPlatformAdmin) return "platformAdmin";
   if (user.isAnalyst) return "analyst";
 
+  const isUserTeamAdmin = user.teams.some((user) => user.role === "teamAdmin"); // teamAdmins have two team_member records per-team: teamEditor _and_ teamAdmin. when we check for 'some' here, this is _within_ the team (ie checking if member x is a teamAdmin of this _specific_ team, not teamAdmin of _any_ team)
+  if (isUserTeamAdmin) return "teamAdmin";
+
   return user.teams[0].role;
-}
+};
 
 export const userToTeamMember = (user: User): TeamMember => ({
   firstName: user.firstName,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/utils.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/utils.tsx
@@ -8,7 +8,10 @@ const getRole = (user: User): Role => {
   if (user.isPlatformAdmin) return "platformAdmin";
   if (user.isAnalyst) return "analyst";
 
-  const isUserTeamAdmin = user.teams.some((user) => user.role === "teamAdmin"); // teamAdmins have two team_member records per-team: teamEditor _and_ teamAdmin. when we check for 'some' here, this is _within_ the team (ie checking if member x is a teamAdmin of this _specific_ team, not teamAdmin of _any_ team)
+  /**
+   * teamAdmins have two team_member records per-team: teamEditor _and_ teamAdmin.
+   * when we check for 'some' here, this is _within_ the team (ie checking if member x is a teamAdmin of this _specific_ team, not teamAdmin of _any_ team) */
+  const isUserTeamAdmin = user.teams.some((user) => user.role === "teamAdmin");
   if (isUserTeamAdmin) return "teamAdmin";
 
   return user.teams[0].role;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -7,12 +7,14 @@ import { TeamStore } from "./team";
 
 export const getDisplayRole = (
   user: User,
-  currentUserTeam: UserTeams | undefined,
+  currentUserTeam: UserTeams[] | undefined,
 ): string => {
   if (user.isPlatformAdmin) return ROLE_LABELS.platformAdmin;
   if (user.isAnalyst) return ROLE_LABELS.analyst;
-  if (currentUserTeam?.role === "teamAdmin") return ROLE_LABELS.teamAdmin;
-  if (currentUserTeam?.role === "teamEditor") return ROLE_LABELS.teamEditor;
+  if (currentUserTeam?.some((team) => team.role === "teamAdmin"))
+    return ROLE_LABELS.teamAdmin;
+  if (currentUserTeam?.some((team) => team.role === "teamEditor"))
+    return ROLE_LABELS.teamEditor;
 
   return ROLE_LABELS.teamViewer;
 };
@@ -54,7 +56,6 @@ export const userStore: StateCreator<
     const isUserTeamAdmin = currentUserTeam.some(
       (user) => user.role === "teamAdmin",
     );
-
     if (isUserTeamAdmin) return "teamAdmin";
 
     return currentUserTeam[0].role;
@@ -64,7 +65,7 @@ export const userStore: StateCreator<
     const { user, teamSlug } = get();
     if (!user) return;
 
-    const currentUserTeam = user.teams.find(
+    const currentUserTeam = user.teams.filter(
       ({ team: { slug } }) => slug === teamSlug,
     );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -46,12 +46,19 @@ export const userStore: StateCreator<
     if (user.isPlatformAdmin) return "platformAdmin";
     if (user.isAnalyst) return "analyst";
 
-    const currentUserTeam = user.teams.find(
+    const currentUserTeam = user.teams.filter(
       ({ team: { slug } }) => slug === teamSlug,
     );
+
     if (!currentUserTeam) return;
 
-    return currentUserTeam.role;
+    const isUserTeamAdmin = currentUserTeam.some(
+      (user) => user.role === "teamAdmin",
+    );
+
+    if (isUserTeamAdmin) return "teamAdmin";
+
+    return currentUserTeam[0].role;
   },
 
   getUserRole: () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -58,7 +58,9 @@ export const userStore: StateCreator<
     );
     if (isUserTeamAdmin) return "teamAdmin";
 
-    return currentUserTeam[0].role;
+    if (currentUserTeam[0]?.role) return currentUserTeam[0].role;
+
+    return "teamViewer";
   },
 
   getUserRole: () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/user.ts
@@ -45,12 +45,11 @@ export const userStore: StateCreator<
 
     if (user.isPlatformAdmin) return "platformAdmin";
     if (user.isAnalyst) return "analyst";
+    if (!teamSlug) return "teamViewer"; // for EditorNavMenu, before teamSlug is set
 
     const currentUserTeam = user.teams.filter(
       ({ team: { slug } }) => slug === teamSlug,
     );
-
-    if (!currentUserTeam) return;
 
     const isUserTeamAdmin = currentUserTeam.some(
       (user) => user.role === "teamAdmin",

--- a/apps/editor.planx.uk/src/pages/Users/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Users/index.tsx
@@ -3,6 +3,7 @@ import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { MembersTable } from "pages/FlowEditor/components/Team/components/MembersTable";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { useToggle } from "react-use";
 import { AddButton } from "ui/editor/AddButton";
@@ -15,8 +16,14 @@ import { useGetAnalysts } from "./hooks/useGetAnalysts";
 export const UserManagement = () => {
   const { analysts, loading, error } = useGetAnalysts();
   const [showAddAnalystModal, toggleAddAnalystModal] = useToggle(false);
+  const role = useStore((state) => state.getUserRoleForCurrentTeam());
 
-  if (error) return <ErrorSummary message={error.message} />;
+  if (error || !role)
+    return (
+      <ErrorSummary
+        message={error?.message || "Unable to load user role to check access"}
+      />
+    );
 
   // Filtering out active analysts allows the MembersTable to responsively update when an analyst is removed
   const activeAnalysts = analysts.filter(({ email }) => email);
@@ -38,6 +45,7 @@ export const UserManagement = () => {
               members={activeAnalysts}
               showEditMemberButton
               showRemoveMemberButton
+              userRole={role}
             />
             <Box sx={{ m: 1 }}>
               <AddButton onClick={toggleAddAnalystModal}>

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
+import ErrorPage from "pages/ErrorPage/ErrorPage";
 import { Subscription } from "pages/FlowEditor/components/Subscription/Subscription";
 import { ServiceCharge } from "pages/FlowEditor/components/Subscription/types";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -16,9 +17,7 @@ export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
       );
 
     if (!isAuthorised) {
-      throw new Error(
-        "You do not have the necessary permissions to view this page. Please contact a platform administrator if you think this is an error.",
-      );
+      throw new Error("The user does not have permission to access this page.");
     }
 
     const {
@@ -53,6 +52,20 @@ export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
     return {
       serviceCharges,
     };
+  },
+  errorComponent: ({ error }) => {
+    if (
+      error?.message?.includes("permission") ||
+      error?.message?.includes("access")
+    ) {
+      return (
+        <ErrorPage title="Access denied">
+          You don't have permission to access this page. Please contact your
+          administrator if you believe this is an error.
+        </ErrorPage>
+      );
+    }
+    throw error;
   },
   component: SubscriptionRoute,
 });

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
@@ -9,12 +9,13 @@ import React from "react";
 
 export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
   loader: async ({ params, context }) => {
+    const role = useStore.getState().getUserRoleForCurrentTeam();
+
     const isAuthorised =
       context.user?.isPlatformAdmin ||
       // TODO limit *after* we assign teamAdmin roles to existing users
-      ["teamEditor", "teamAdmin"].includes(
-        useStore.getState().getUserRoleForCurrentTeam() || "",
-      );
+      role === "teamEditor" ||
+      role === "teamAdmin";
 
     if (!isAuthorised) {
       throw new Error("The user does not have permission to access this page.");
@@ -47,6 +48,11 @@ export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
       `,
       variables: { teamSlug: params.team },
       fetchPolicy: "no-cache",
+      context: {
+        headers: {
+          "x-hasura-role": role,
+        },
+      },
     });
 
     return {

--- a/apps/editor.planx.uk/src/ui/public/ApplicationSummary.tsx
+++ b/apps/editor.planx.uk/src/ui/public/ApplicationSummary.tsx
@@ -3,8 +3,8 @@ import { getValidSchemaDictionary } from "@opensystemslab/planx-core";
 import { SummaryListTable } from "@planx/components/shared/Preview/SummaryList";
 import { objectWithoutNullishValues } from "lib/objectHelpers";
 import { type Store, useStore } from "pages/FlowEditor/lib/store";
-import { Fragment } from "react";
 import React from "react";
+import { Fragment } from "react";
 
 const getApplicationTypeDescriptionFromPassportValue = (
   passport: Store.Passport,

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
@@ -115,17 +115,3 @@ delete_permissions:
               - role:
                   _eq: teamAdmin
     comment: ""
-  - role: teamEditor
-    permission:
-      filter:
-        _and:
-          - team:
-              members:
-                _and:
-                  - user_id:
-                      _eq: X-Hasura-User-Id
-                  - role:
-                      _eq: teamEditor
-          - role:
-              _eq: teamEditor
-    comment: teamEditors can revoke membership of other teamEditors in their team

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
@@ -17,25 +17,22 @@ insert_permissions:
         - user_id
         - role
         - id
-  - role: teamEditor
+  - role: teamAdmin
     permission:
       check:
-        _and:
-          - team:
-              members:
-                _and:
-                  - user_id:
-                      _eq: X-Hasura-User-Id
-                  - role:
-                      _eq: teamEditor
-          - role:
-              _eq: teamEditor
+        team:
+          members:
+            _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _eq: teamAdmin
       columns:
         - team_id
         - user_id
         - role
         - id
-    comment: teamEditors can assign other teamEditors to their team
+    comment: "teamAdmins can assign other teamAdmins to their team"
 select_permissions:
   - role: analyst
     permission:
@@ -62,6 +59,15 @@ select_permissions:
         - role
         - id
       filter: {}
+  - role: teamAdmin
+    permission:
+      columns:
+        - team_id
+        - user_id
+        - role
+        - id
+      filter: {}
+    comment: ""
   - role: teamEditor
     permission:
       columns:
@@ -80,6 +86,20 @@ update_permissions:
         - id
       filter: {}
       check: {}
+  - role: teamAdmin
+    permission:
+      columns:
+        - role
+      filter:
+        team:
+          members:
+            _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _eq: teamAdmin
+      check: null
+    comment: ""
 delete_permissions:
   - role: platformAdmin
     permission:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_members.yaml
@@ -32,7 +32,7 @@ insert_permissions:
         - user_id
         - role
         - id
-    comment: "teamAdmins can assign other teamAdmins to their team"
+    comment: teamAdmins can assign other teamAdmins to their team
 select_permissions:
   - role: analyst
     permission:
@@ -104,6 +104,17 @@ delete_permissions:
   - role: platformAdmin
     permission:
       filter: {}
+  - role: teamAdmin
+    permission:
+      filter:
+        team:
+          members:
+            _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _eq: teamAdmin
+    comment: ""
   - role: teamEditor
     permission:
       filter:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
@@ -66,7 +66,7 @@ insert_permissions:
         - id
         - last_name
         - updated_at
-    comment: "teamAdmin can insert other users. The permission boundary is enforced on the team_members table."
+    comment: teamAdmin can insert other users. The permission boundary is enforced on the team_members table.
 select_permissions:
   - role: analyst
     permission:
@@ -151,7 +151,7 @@ update_permissions:
                 - role:
                     _eq: teamAdmin
       check: null
-    comment: "teamAdmins can update the details of other teamEditors and teamAdmins, within their team"
+    comment: teamAdmins can update the details of other teamEditors and teamAdmins, within their team
 event_triggers:
   - name: send_user_welcome_emails
     definition:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_users.yaml
@@ -55,7 +55,7 @@ insert_permissions:
         - is_staging_only
         - last_name
         - updated_at
-  - role: teamEditor
+  - role: teamAdmin
     permission:
       check: {}
       columns:
@@ -66,10 +66,7 @@ insert_permissions:
         - id
         - last_name
         - updated_at
-    comment: |-
-      teamEditor can insert other users.
-
-      The permission boundary is enforced on the team_members table.
+    comment: "teamAdmin can insert other users. The permission boundary is enforced on the team_members table."
 select_permissions:
   - role: analyst
     permission:
@@ -136,7 +133,7 @@ update_permissions:
         - last_name
       filter: {}
       check: {}
-  - role: teamEditor
+  - role: teamAdmin
     permission:
       columns:
         - created_at
@@ -152,9 +149,9 @@ update_permissions:
                 - user_id:
                     _eq: X-Hasura-User-Id
                 - role:
-                    _eq: teamEditor
+                    _eq: teamAdmin
       check: null
-    comment: teamEditors can update the details of other teamEditors, within their team
+    comment: "teamAdmins can update the details of other teamEditors and teamAdmins, within their team"
 event_triggers:
   - name: send_user_welcome_emails
     definition:

--- a/apps/hasura.planx.uk/migrations/default/1781085919051_drop_team_members_user_id_team_id_key/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781085919051_drop_team_members_user_id_team_id_key/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."team_members" add constraint "team_members_user_id_team_id_key" unique ("user_id", "team_id");

--- a/apps/hasura.planx.uk/migrations/default/1781085919051_drop_team_members_user_id_team_id_key/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781085919051_drop_team_members_user_id_team_id_key/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."team_members" drop constraint "team_members_user_id_team_id_key";

--- a/apps/hasura.planx.uk/migrations/default/1781086338506_alter_table_public_team_members_add_unique_user_id_team_id_role/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781086338506_alter_table_public_team_members_add_unique_user_id_team_id_role/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."team_members" drop constraint "team_members_user_id_team_id_role_key";

--- a/apps/hasura.planx.uk/migrations/default/1781086338506_alter_table_public_team_members_add_unique_user_id_team_id_role/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781086338506_alter_table_public_team_members_add_unique_user_id_team_id_role/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."team_members" add constraint "team_members_user_id_team_id_role_key" unique ("user_id", "team_id", "role");

--- a/apps/hasura.planx.uk/tests/team_members.test.js
+++ b/apps/hasura.planx.uk/tests/team_members.test.js
@@ -56,15 +56,10 @@ describe("team_members", () => {
       expect(i.queries).toContain("team_members");
     });
 
-    test("cannot update team_members", () => {
+    test("cannot update, add or remove team_members", () => {
       expect(i).not.toContain("update_team_members_by_pk");
-    });
-
-    // Row-level permissions in place
-    // teamEditor can only assign teamEditor roles to their team
-    test("can add and remove team_members", () => {
-      expect(i.mutations).toContain("insert_team_members");
-      expect(i.mutations).toContain("delete_team_members");
+      expect(i.mutations).not.toContain("insert_team_members");
+      expect(i.mutations).not.toContain("delete_team_members");
     });
   });
 

--- a/apps/hasura.planx.uk/tests/users.test.js
+++ b/apps/hasura.planx.uk/tests/users.test.js
@@ -57,16 +57,14 @@ describe("users", () => {
     });
 
     // Row-level permissions tested in e2e/tests/api-driven
-    // teamEditors can only query their own record
+    // teamEditors can only query their own team's records
     test("can query users", async () => {
       expect(i.queries).toContain("users");
     });
 
-    // Row-level permissions in place
-    // teamEditor can only mutate other users from their team
-    test("has full access to create and update users", async () => {
-      expect(i.mutations).toContain("insert_users");
-      expect(i.mutations).toContain("update_users_by_pk");
+    test("cannot create and update users", async () => {
+      expect(i.mutations).not.toContain("insert_users");
+      expect(i.mutations).not.toContain("update_users_by_pk");
     });
   });
 


### PR DESCRIPTION
v2--new version of #6807 but, per [Daf's suggestions](https://github.com/theopensystemslab/planx-new/pull/6807#pullrequestreview-4429107372), reworked to not use inherited roles anymore

Much of this (~400 lines?) is updated tests and helper functions--if it's helpful for reviewing, I can separate into Hasura + editor PRs now that the model is clearer! 

# What does this PR do?
- Removes `teamAdmin` as inherited role 
    - Changes `team_members` so that the constraint is on `team_id`, `user_id` _and_ `role` (not just `team_id` and `user_id`)
    - `teamAdmin` is an _additional_ role granted to `teamEditors`
- Adds relevant mutations for all of these scenarios
    - eg updating a user's name or email only will just mutate `users` table
    - promoting a `teamEditor` to `teamAdmin` will add a row to `team_members`, and demoting will remove a row
- Introspection tests + editor tests

# Why?
- The benefits of inherited roles weren't actually relevant when we got into role-based custom checks on row-level permissions, this is a simpler way of ensuring that team admins have all the permissions of team editors but with an additional layer of permissions where relevant (subscription page, team membership management)

# Next steps
- [ ] Make the Team Admin toggle into a dropdown
- [ ] Migrate select users to new Team Admin role