### PR TITLE
feat: Show dashboard activity widget scoped to previous 30 days

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
@@ -1,5 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { useMemo } from "react";
 
 const GET_ACTIVITY_BY_SERVICE = gql`
   query GetActivityByService($teamId: Int!, $thirtyDaysAgo: timestamptz!) {
@@ -52,9 +53,10 @@ export const useActivityData = (): {
 } => {
   const teamId = useStore((state) => state.teamId);
 
-  const thirtyDaysAgo = new Date(
-    Date.now() - 30 * 24 * 60 * 60 * 1000,
-  ).toISOString();
+  const thirtyDaysAgo = useMemo(
+    () => new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+    [],
+  );
 
   const { data, loading } = useQuery<GetActivityByServiceQuery>(
     GET_ACTIVITY_BY_SERVICE,

--- a/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
@@ -1,4 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
+import { subDays } from "date-fns";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { useMemo } from "react";
 
@@ -54,7 +55,7 @@ export const useActivityData = (): {
   const teamId = useStore((state) => state.teamId);
 
   const thirtyDaysAgo = useMemo(
-    () => new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+    () => subDays(new Date(), 30).toISOString(),
     [],
   );
 

--- a/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
@@ -2,13 +2,13 @@ import { gql, useQuery } from "@apollo/client";
 import { useStore } from "pages/FlowEditor/lib/store";
 
 const GET_ACTIVITY_BY_SERVICE = gql`
-  query GetActivityByService($teamId: Int!) {
+  query GetActivityByService($teamId: Int!, $thirtyDaysAgo: timestamptz!) {
     flows(
       where: { team_id: { _eq: $teamId }, deleted_at: { _is_null: true } }
     ) {
       name
-      sessions: lowcal_sessions_aggregate(
-        where: { deleted_at: { _is_null: true } }
+      sessions: analytics_aggregate(
+        where: { created_at: { _gte: $thirtyDaysAgo } }
       ) {
         aggregate {
           count
@@ -17,7 +17,7 @@ const GET_ACTIVITY_BY_SERVICE = gql`
       submissions: lowcal_sessions_aggregate(
         where: {
           deleted_at: { _is_null: true }
-          submitted_at: { _is_null: false }
+          submitted_at: { _gte: $thirtyDaysAgo }
         }
       ) {
         aggregate {
@@ -52,10 +52,14 @@ export const useActivityData = (): {
 } => {
   const teamId = useStore((state) => state.teamId);
 
+  const thirtyDaysAgo = new Date(
+    Date.now() - 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
   const { data, loading } = useQuery<GetActivityByServiceQuery>(
     GET_ACTIVITY_BY_SERVICE,
     {
-      variables: { teamId },
+      variables: { teamId, thirtyDaysAgo },
       skip: !teamId,
     },
   );

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { ActivityItem } from "hooks/data/useActivityData";
-import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 const ServiceList = styled(Box)(({ theme }) => ({
   overflowY: "auto",
@@ -11,9 +11,7 @@ const ServiceList = styled(Box)(({ theme }) => ({
 }));
 
 const ServiceRow = styled(Box)(({ theme }) => ({
-  paddingTop: theme.spacing(1.5),
-  paddingBottom: theme.spacing(1.5),
-  borderBottom: `1px solid ${theme.palette.border.light}`,
+  padding: theme.spacing(1.5, 0),
   "&:last-child": {
     borderBottom: "none",
   },
@@ -68,10 +66,16 @@ export default function ServiceListWithCount({
       {activeItems.map((item) => (
         <ServiceRow key={item.name}>
           <ServiceMeta>
-            <Typography variant="body3" sx={{ fontWeight: "bold" }}>
+            <Typography
+              variant="body3"
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
               {item.name}
             </Typography>
-            <Typography variant="body3" sx={{ fontWeight: "bold" }}>
+            <Typography
+              variant="body3"
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
               {item.count}
             </Typography>
           </ServiceMeta>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -85,7 +85,7 @@ export default function Dashboard() {
           >
             <FeedbackWidget />
           </DashboardWidget>
-          <DashboardWidget title="Activity" subtitle="Last 30 days">
+          <DashboardWidget title="User Activity" subtitle="Last 30 days">
             <ActivityWidget />
           </DashboardWidget>
         </Box>

--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -52,8 +52,8 @@ export default function Dashboard() {
           <StatsBanner />
         </Container>
       </Box>
-      <Container 
-        maxWidth="contentWide" 
+      <Container
+        maxWidth="contentWide"
         // Override default container padding to align with widgets
         sx={{ py: "30px !important" }}
       >
@@ -85,7 +85,7 @@ export default function Dashboard() {
           >
             <FeedbackWidget />
           </DashboardWidget>
-          <DashboardWidget title="Activity">
+          <DashboardWidget title="Activity" subtitle="Last 30 days">
             <ActivityWidget />
           </DashboardWidget>
         </Box>

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -9,6 +9,7 @@ import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
   title: string;
+  subtitle?: string;
   count?: number;
   link?: LinkOptions<RegisteredRouter> & { label: string };
   children: React.ReactNode;
@@ -34,7 +35,7 @@ const Header = styled(Box)(({ theme }) => ({
 const StyledWidgetLink = styled(CustomLink)(({ theme }) => ({
   fontSize: theme.typography.body2.fontSize,
   color: theme.palette.text.primary,
-  fontWeight: FONT_WEIGHT_SEMI_BOLD,  
+  fontWeight: FONT_WEIGHT_SEMI_BOLD,
   "&:hover": {
     textDecorationThickness: "2px",
   },
@@ -52,6 +53,7 @@ export const WidgetLink = ({ label, ...linkProps }: WidgetLinkProps) => (
 
 export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   title,
+  subtitle,
   count,
   link,
   children,
@@ -59,10 +61,15 @@ export const DashboardWidget: React.FC<DashboardWidgetProps> = ({
 }) => (
   <Root sx={sx}>
     <Header>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
         <Typography variant="h3" component="h2">
           {title}
         </Typography>
+        {subtitle && (
+          <Typography variant="body2" color="textSecondary">
+            {subtitle}
+          </Typography>
+        )}
         {count !== undefined && count > 0 && (
           <BadgeChip label={count} color="info" />
         )}

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_analytics.yaml
@@ -26,11 +26,27 @@ insert_permissions:
         - type
         - user_agent
 select_permissions:
+  - role: platformAdmin
+    permission:
+      columns:
+        - created_at
+        - flow_id
+        - id
+      filter: {}
+      allow_aggregations: true
   - role: public
     permission:
       columns:
         - id
       filter: {}
+  - role: teamEditor
+    permission:
+      columns:
+        - created_at
+        - flow_id
+        - id
+      filter: {}
+      allow_aggregations: true
 update_permissions:
   - role: public
     permission:


### PR DESCRIPTION
## What does this PR do?

Addresses issues with the dashboard activity widget:
- Currently shows an undefined date range - updates to show previous 30 days
- `Sessions by service` currently shows only submission services, updated to read `analytics_aggregate` to include guidance sessions
- Small styling refinements