### PR TITLE
chore: log copied or templated from flow ID in createFlow error

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -160,8 +160,10 @@ const createFlow = async ({
 
     return { id: flowId };
   } catch (error) {
-    const copyInfo = copiedFrom ? ` (copied from ${copiedFrom})` : '';
-    const templateInfo = templatedFrom ? ` (templated from ${templatedFrom})` : '';
+    const copyInfo = copiedFrom ? ` (copied from ${copiedFrom})` : "";
+    const templateInfo = templatedFrom
+      ? ` (templated from ${templatedFrom})`
+      : "";
 
     throw Error(
       `User ${userId} failed to insert flow to teamId ${teamId}${copyInfo}${templateInfo}. Please check permissions. Error: ${error}`,

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -160,8 +160,11 @@ const createFlow = async ({
 
     return { id: flowId };
   } catch (error) {
+    const copyInfo = copiedFrom ? ` (copied from ${copiedFrom})` : '';
+    const templateInfo = templatedFrom ? ` (templated from ${templatedFrom})` : '';
+
     throw Error(
-      `User ${userId} failed to insert flow to teamId ${teamId}. Please check permissions. Error: ${error}`,
+      `User ${userId} failed to insert flow to teamId ${teamId}${copyInfo}${templateInfo}. Please check permissions. Error: ${error}`,
     );
   }
 };


### PR DESCRIPTION
Following GPDO template bug--we might want to keep track of which flows specifically aren't able to be created.