### PR TITLE
infra: bump Hasura memory and cpu on production

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -46,11 +46,11 @@ config:
     secure: AAABADo05EPv/HWj7Rkf19nBeTcPJd4pEcRi2/uhyB3agraFODpLvNMx2bXfISf5pZ4HA41GYCE4f7OLcJN6hIV6ZMWUlEriPzvkoUAixbLlz1LIERiyk73R8E4F2bV65/9aFqi4l7caLS5c8iDJrE+JAvu2i7oS
   application:hasura-admin-secret:
     secure: AAABAFXUOfERqmY2ht+UN/6j7fNncuB3uwqeEGGUhXzHLXLt5Mu7iGbuLfjMpRC0Niw301Zejtc=
-  application:hasura-cpu: "1024"
+  application:hasura-cpu: "2048"
   application:hasura-memory: "4096"
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
-  application:hasura-proxy-cpu: "512"
+  application:hasura-proxy-cpu: "1024"
   application:hasura-proxy-memory: "2048"
   application:hasura-service-scaling-maximum: "4"
   application:hasura-service-scaling-minimum: "1"

--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -47,11 +47,11 @@ config:
   application:hasura-admin-secret:
     secure: AAABAFXUOfERqmY2ht+UN/6j7fNncuB3uwqeEGGUhXzHLXLt5Mu7iGbuLfjMpRC0Niw301Zejtc=
   application:hasura-cpu: "1024"
-  application:hasura-memory: "2048"
+  application:hasura-memory: "4096"
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
   application:hasura-proxy-cpu: "512"
-  application:hasura-proxy-memory: "1024"
+  application:hasura-proxy-memory: "2048"
   application:hasura-service-scaling-maximum: "4"
   application:hasura-service-scaling-minimum: "1"
   application:idox-nexus-client:


### PR DESCRIPTION
Follows on from https://github.com/theopensystemslab/planx-new/pull/6834 ahead of prod deploy

ShareDB not set via yaml, so would _already_ apply to all envs here. 