### PR TITLE
onboard Stockport for custom domain

### DIFF
--- a/apps/editor.planx.uk/src/airbrake.ts
+++ b/apps/editor.planx.uk/src/airbrake.ts
@@ -28,6 +28,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.southglos.gov.uk":
     case "planningservices.southwark.gov.uk":
     case "planningservices.stalbans.gov.uk":
+    case "planningservices.stockport.gov.uk":
     case "planningservices.tewkesbury.gov.uk":
     case "planningservices.westberks.gov.uk":
     case "editor.planx.uk":

--- a/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
@@ -54,6 +54,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.southglos.gov.uk",
   "planningservices.southwark.gov.uk",
   "planningservices.stalbans.gov.uk",
+  "planningservices.stockport.gov.uk",
   "planningservices.tewkesbury.gov.uk",
   "planningservices.westberks.gov.uk",
   // XXX: un-comment the next line to test custom domains locally

--- a/doc/how-to/how-to-setup-custom-domains.md
+++ b/doc/how-to/how-to-setup-custom-domains.md
@@ -58,7 +58,7 @@ Path: `validation-only` → `shared-final`
     },
     ```
 
-    Then commit this change. Note that `certificateLocation` is not necessary here.
+    Here `name` should match the `teams.slug` value in the [db](https://hasura.editor.planx.uk/console/data/default/schema/public/tables/teams/browse). Note also that `certificateLocation` is not necessary here. Then commit this change.
 
 2. Deploy the `certificates` stack. Make sure you have the appropriate AWS credentials/profile exported in your terminal, then run:
 

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -114,7 +114,12 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           name: "coventry",
           domain: "planningservices.coventry.gov.uk",
           cloudFrontState: "validation-only",
-        }
+        },
+        {
+          name: "stockport-metropolitan",
+          domain: "planningservices.stockport.gov.uk",
+          cloudFrontState: "validation-only",
+        },
       ]
     : [
         // we keep one custom domain on staging to function as a canary (monitored by UptimeRobot)

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -111,7 +111,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           cloudFrontState: "shared-final",
         },
         {
-          name: "coventry",
+          name: "coventry-city",
           domain: "planningservices.coventry.gov.uk",
           cloudFrontState: "validation-only",
         },


### PR DESCRIPTION
As per title ([ticket](https://trello.com/c/573YBL7y)). Also fixes slug for Coventry and adds reminder in howto about that.