### PR TITLE
fix: don't restrict `Subsription` page access from `teamEditors` yet

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -187,7 +187,7 @@ function EditorNavMenu() {
             title: "Subscription",
             Icon: CurrencyPoundIcon,
             route: `/app/${teamSlug}/subscription`,
-            accessibleBy: ["platformAdmin", "teamAdmin"],
+            accessibleBy: ["platformAdmin", "teamAdmin", "teamEditor"], // TODO update *after* we assign teamAdmin roles to existing users
             isNew: true,
           },
         ],

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/subscription.tsx
@@ -10,7 +10,10 @@ export const Route = createFileRoute("/_authenticated/app/$team/subscription")({
   loader: async ({ params, context }) => {
     const isAuthorised =
       context.user?.isPlatformAdmin ||
-      useStore.getState().getUserRoleForCurrentTeam() === "teamAdmin";
+      // TODO limit *after* we assign teamAdmin roles to existing users
+      ["teamEditor", "teamAdmin"].includes(
+        useStore.getState().getUserRoleForCurrentTeam() || "",
+      );
 
     if (!isAuthorised) {
       throw new Error(

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_service_charges.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_service_charges.yaml
@@ -51,3 +51,26 @@ select_permissions:
               - role:
                   _eq: teamAdmin
     comment: ""
+  - role: teamEditor
+    permission:
+      columns:
+        - fiscal_year
+        - fiscal_year_quarter
+        - month
+        - service_charge_amount
+        - flow_name
+        - flow_slug
+        - month_text
+        - payment_id
+        - team_slug
+        - paid_at
+        - session_id
+      filter:
+        team:
+          members:
+            _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - role:
+                  _eq: teamEditor
+    comment: ""


### PR DESCRIPTION
Per report from South Glos here: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1781519277542449

We don't want to restrict permissions here yet because we have _not_ actually assigned `team_members` "teamAdmin" roles per #6840! Everyone on the team is still a "teamEditor" and needs to maintain access in interim.

Just a minor sequencing glitch, we can revert this later ! 