### PR TITLE
fix: archive & delete handling

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -35,7 +35,7 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
       toast.success("Archived flow");
     } catch (error) {
       toast.error(
-        "We are unable to archive this flow, refesh and try again or contact an admin",
+        "We are unable to archive this flow, refresh and try again or contact an admin",
       );
     } finally {
       setOpenDialog(null);

--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -21,7 +21,7 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
   type OpenDialog = "archive" | "copy" | "rename" | "move";
   const [openDialog, setOpenDialog] = useState<OpenDialog | null>(null);
   const dateTime = Date.now();
-  const archivedSlug = flow.slug.concat(`-archived${dateTime}`);
+  const archivedSlug = flow.slug.concat(`-archived-${dateTime}`); // this is just to make the slug unique, not as an actual timestamp
   const [archiveFlow] = useArchiveFlow(flow.id, archivedSlug, teamId);
 
   const toast = useToast();

--- a/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ActiveFlowMenu.tsx
@@ -20,7 +20,8 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
 }) => {
   type OpenDialog = "archive" | "copy" | "rename" | "move";
   const [openDialog, setOpenDialog] = useState<OpenDialog | null>(null);
-  const archivedSlug = flow.slug.concat("-archived");
+  const dateTime = Date.now();
+  const archivedSlug = flow.slug.concat(`-archived${dateTime}`);
   const [archiveFlow] = useArchiveFlow(flow.id, archivedSlug, teamId);
 
   const toast = useToast();

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -27,7 +27,10 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
   const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
 
   const dateTime = Date.now();
-  const deletedSlug = flow.slug.replace(/-archived\d+$/, `-deleted${dateTime}`);
+  const deletedSlug = flow.slug.replace(
+    /-archived\d+$/,
+    `-deleted-${dateTime}`,
+  );
   const [deleteFlow] = useDeleteFlow(flow.id, deletedSlug, teamId);
 
   const toast = useToast();

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -22,13 +22,12 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
   const [openFlowDialog, setOpenFlowDialog] = useState<OpenFlowDialog | null>(
     null,
   );
-
-  const unarchivedSlug = flow.slug.replace(/-archived\d+$/, "");
+  const unarchivedSlug = flow.slug.replace(/-archived-\d+$/, "");
   const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
 
   const dateTime = Date.now();
   const deletedSlug = flow.slug.replace(
-    /-archived\d+$/,
+    /-archived-\d+$/,
     `-deleted-${dateTime}`,
   );
   const [deleteFlow] = useDeleteFlow(flow.id, deletedSlug, teamId);

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -51,7 +51,7 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
       }
 
       toast.error(
-        "We are unable to unarchive this flow, refesh and try again or contact an admin",
+        "We are unable to unarchive this flow, refresh and try again or contact an admin",
       );
       setOpenFlowDialog(null);
     }
@@ -63,7 +63,7 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
       toast.success("Deleted flow");
     } catch (error) {
       toast.error(
-        "We are unable to delete this flow, refesh and try again or contact an admin",
+        "We are unable to delete this flow, refresh and try again or contact an admin",
       );
     } finally {
       setOpenFlowDialog(null);

--- a/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/ArchivedFlowMenu.tsx
@@ -23,10 +23,11 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
     null,
   );
 
-  const unarchivedSlug = flow.slug.replace("-archived", "");
+  const unarchivedSlug = flow.slug.replace(/-archived\d+$/, "");
   const [unarchiveFlow] = useUnarchiveFlow(flow.id, unarchivedSlug, teamId);
 
-  const deletedSlug = flow.slug.replace("-archived", "-deleted");
+  const dateTime = Date.now();
+  const deletedSlug = flow.slug.replace(/-archived\d+$/, `-deleted${dateTime}`);
   const [deleteFlow] = useDeleteFlow(flow.id, deletedSlug, teamId);
 
   const toast = useToast();

--- a/apps/editor.planx.uk/src/pages/Team/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/RenameDialog.tsx
@@ -96,7 +96,7 @@ export const RenameDialog: React.FC<Props> = ({
   const initialFlowSlug =
     mode === "rename"
       ? flow.slug
-      : flow.slug.replace("-archived", "-unarchived");
+      : flow.slug.replace(/-archived-\d+$/, "-unarchived");
 
   return (
     <Formik<RenameFlow>


### PR DESCRIPTION
- Fixes a typo (`refesh` -> `refresh`)
- Jonny also hit the edge case of duplicate archived slugs--this made me realise that I hadn't fully implemented Daf's suggestion from before (append `-archived` or `-deleted` [_until_ unique](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1776854434544869?thread_ts=1776852554.614039&cid=C01E3AC0C03)). But given the possibility of slugs that look like `test-deleted-deleted-deleted-deleted-deleted`, maybe it's just neater to append a date? Thoughts welcome! 