### PR TITLE
feat[dashboard]: link feedback items directly to the service it concerns

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.stories.tsx
@@ -5,10 +5,26 @@ import { DashboardWidget } from "ui/editor/DashboardWidget";
 import { FeedbackWidget } from "./FeedbackWidget";
 
 const mockFlows = [
-  { flowName: "Apply for planning permission", count: 14 },
-  { flowName: "Apply for a lawful development certificate", count: 7 },
-  { flowName: "Report a planning breach", count: 3 },
-  { flowName: "Prior approval: larger home extension", count: 1 },
+  {
+    flowName: "Apply for planning permission",
+    flowSlug: "apply-for-planning-permission",
+    count: 14,
+  },
+  {
+    flowName: "Apply for a lawful development certificate",
+    flowSlug: "apply-for-a-lawful-development-certificate",
+    count: 7,
+  },
+  {
+    flowName: "Report a planning breach",
+    flowSlug: "report-a-planning-breach",
+    count: 3,
+  },
+  {
+    flowName: "Prior approval: larger home extension",
+    flowSlug: "prior-approval-larger-home-extension",
+    count: 1,
+  },
 ];
 
 const meta = {
@@ -31,6 +47,7 @@ const meta = {
   args: {
     flows: mockFlows,
     total: mockFlows.reduce((sum, { count }) => sum + count, 0),
+    teamSlug: "test-council",
     loading: false,
   },
 } satisfies Meta<typeof FeedbackWidget>;

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FeedbackWidget.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import { Link } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import React from "react";
 
@@ -10,12 +11,14 @@ import { FlowSummary, useUnreadFeedback } from "./useUnreadFeedback";
 interface FeedbackWidgetProps {
   flows: FlowSummary[];
   total: number;
+  teamSlug: string;
   loading?: boolean;
 }
 
 export function FeedbackWidget({
   flows,
   total,
+  teamSlug,
   loading = false,
 }: FeedbackWidgetProps) {
   if (loading) {
@@ -53,9 +56,15 @@ export function FeedbackWidget({
       </Box>
       <Divider />
       <Box sx={{ overflowY: "auto" }}>
-        {flows.map(({ flowName, count }) => (
+        {flows.map(({ flowName, flowSlug, count }) => (
           <React.Fragment key={flowName}>
-            <Box sx={{ px: 1.5, py: 1 }}>
+            <Box sx={{ position: "relative", px: 1.5, py: 1 }}>
+              <Link
+                to="/app/$team/$flow/feedback"
+                params={{ team: teamSlug, flow: flowSlug }}
+                style={{ position: "absolute", inset: 0, zIndex: 1 }}
+                aria-label={`View feedback for ${flowName}`}
+              />
               <Typography variant="body2">
                 <strong>{flowName}</strong>
               </Typography>
@@ -75,5 +84,12 @@ export default function ConnectedFeedbackWidget() {
   const teamSlug = useStore((state) => state.getTeam().slug);
   const { flows, total, loading } = useUnreadFeedback(teamSlug);
 
-  return <FeedbackWidget flows={flows} total={total} loading={loading} />;
+  return (
+    <FeedbackWidget
+      flows={flows}
+      total={total}
+      teamSlug={teamSlug}
+      loading={loading}
+    />
+  );
 }

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 
 export const GET_UNREAD_FEEDBACK_SUMMARY = gql`
   query GetUnreadFeedbackByTeam($teamSlug: String!) {
-    feedback_summary(
+    feedbackSummary: feedback_summary(
       where: { team_slug: { _eq: $teamSlug }, status: { _eq: "unread" } }
     ) {
       flowName: service_name

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/queries.ts
@@ -6,6 +6,7 @@ export const GET_UNREAD_FEEDBACK_SUMMARY = gql`
       where: { team_slug: { _eq: $teamSlug }, status: { _eq: "unread" } }
     ) {
       flowName: service_name
+      flowSlug: service_slug
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
@@ -10,12 +10,12 @@ export interface FlowSummary {
 
 export const useUnreadFeedback = (teamSlug: string) => {
   const { data, loading, error } = useQuery<{
-    feedback_summary: { flowName: string; flowSlug: string }[];
+    feedbackSummary: { flowName: string; flowSlug: string }[];
   }>(GET_UNREAD_FEEDBACK_SUMMARY, {
     variables: { teamSlug },
   });
 
-  const aggregated = (data?.feedback_summary ?? []).reduce<
+  const aggregated = (data?.feedbackSummary ?? []).reduce<
     Record<string, { count: number; flowSlug: string }>
   >((acc, { flowName, flowSlug }) => {
     acc[flowName] = {

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/useUnreadFeedback.tsx
@@ -4,26 +4,29 @@ import { GET_UNREAD_FEEDBACK_SUMMARY } from "./queries";
 
 export interface FlowSummary {
   flowName: string;
+  flowSlug: string;
   count: number;
 }
 
 export const useUnreadFeedback = (teamSlug: string) => {
   const { data, loading, error } = useQuery<{
-    feedback_summary: { flowName: string }[];
+    feedback_summary: { flowName: string; flowSlug: string }[];
   }>(GET_UNREAD_FEEDBACK_SUMMARY, {
     variables: { teamSlug },
   });
 
-  const counts = (data?.feedback_summary ?? []).reduce<Record<string, number>>(
-    (acc, { flowName }) => {
-      acc[flowName] = (acc[flowName] ?? 0) + 1;
-      return acc;
-    },
-    {},
-  );
+  const aggregated = (data?.feedback_summary ?? []).reduce<
+    Record<string, { count: number; flowSlug: string }>
+  >((acc, { flowName, flowSlug }) => {
+    acc[flowName] = {
+      count: (acc[flowName]?.count ?? 0) + 1,
+      flowSlug,
+    };
+    return acc;
+  }, {});
 
-  const flows: FlowSummary[] = Object.entries(counts)
-    .map(([flowName, count]) => ({ flowName, count }))
+  const flows: FlowSummary[] = Object.entries(aggregated)
+    .map(([flowName, { count, flowSlug }]) => ({ flowName, flowSlug, count }))
     .sort((a, b) => b.count - a.count);
 
   const total = flows.reduce((sum, { count }) => sum + count, 0);


### PR DESCRIPTION
As per Silvia's suggestion, links each feedback item to the service feedback page. Required fetching the service slug with the feedback items.