### PR TITLE
perf(api): Only run HTML sanitisation on potential HTML strings

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -40,6 +40,10 @@ export const isCleanHTML = (input: unknown): boolean => {
   // Skip validation for non-string values
   if (typeof input !== "string") return true;
 
+  // Only run sanitation on potential HTML (rich text), skip for plain strings
+  const isHTMLCandidate = input.includes("<") || input.includes("&");
+  if (!isHTMLCandidate) return true;
+
   const cleanHTML = DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
 
   // DOMPurify has not removed any attributes or values


### PR DESCRIPTION
## What does this PR do?
Adds additional guard clauses to improve the performance of the `/clean-html` endpoint.

Please see https://github.com/theopensystemslab/planx-new/pull/6860 for more details

## Perfomance
Local testing yields the following for the GDPO flow - 

```sh
[perf] gpdo.json { strings: 17232, htmlCandidates: 1842, precheckSkips: 15390 }
[perf] gpdo.json baseline  x1: 3579.0 ms   (DOMPurify on all 17,232 strings)
[perf] gpdo.json optimised x1: 1456.8 ms   (DOMPurify on only the 1,842 markup strings)
```

This is a ~2.5x improvement - we only run DOMPurify against potential HTML candidates. On a simpler flow (A4) with fewer rich text strings, this was a ~120x improvement.

## Next steps...
I don't think this solves the underlying issue wholesale, but it's a decent improvement and can be merged without problem. I'll keep working on the underlying issue here.