### PR TITLE
chore: add flow ID to "Failed to publish flow" error messages

### DIFF
--- a/apps/api.planx.uk/modules/flows/publish/controller.ts
+++ b/apps/api.planx.uk/modules/flows/publish/controller.ts
@@ -32,9 +32,10 @@ export const publishFlowController: PublishFlowController = async (
   res,
   next,
 ) => {
+  const { flowId } = res.locals.parsedReq.params;
+  const { summary, templatedFlowIds } = res.locals.parsedReq.body;
+
   try {
-    const { flowId } = res.locals.parsedReq.params;
-    const { summary, templatedFlowIds } = res.locals.parsedReq.body;
     const response = await publishFlow(flowId, summary, templatedFlowIds);
 
     return res.json({
@@ -47,7 +48,9 @@ export const publishFlowController: PublishFlowController = async (
     });
   } catch (error) {
     return next(
-      new ServerError({ message: `Failed to publish flow: ${error}` }),
+      new ServerError({
+        message: `Failed to publish flow (${flowId}): ${error}`,
+      }),
     );
   }
 };


### PR DESCRIPTION
Would be helpful to have more context on these in light of latest GDPO bugs - see example https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1781693402979589