### PR TITLE
chore: update template copiable permissions

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Layout.tsx
@@ -24,12 +24,17 @@ const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
   const [flowId, flowSlug] = useStore((state) => [state.id, state.flowSlug]);
   const { team } = useParams({ from: "/_authenticated/app/$team" });
 
-  const { data: templateData } = useQuery<GetFlowTemplateStatus>(GET_FLOW_TEMPLATE_STATUS, {
-    variables: { flowId },
-  });
-  
-  const { data: isServiceData } = useGetIsService(flowId)
-  const isService = isServiceData?.flow.isService
+  const { data: templateData } = useQuery<GetFlowTemplateStatus>(
+    GET_FLOW_TEMPLATE_STATUS,
+    {
+      variables: { flowId },
+    },
+  );
+
+  const isTemplated = templateData?.flow.templatedFrom !== null;
+
+  const { data: isServiceData } = useGetIsService(flowId);
+  const isService = isServiceData?.flow.isService;
 
   // TODO: Make type-safe!
   const serviceSettingsLinks = [
@@ -47,10 +52,23 @@ const FlowSettingsLayout: React.FC<Props> = ({ children }) => {
     { label: "Emails", path: "/emails", icon: EmailIcon },
   ];
 
+  const flowSettingsLinks =
+    isTemplated === false
+      ? []
+      : [
+          { label: "Visibility", path: "/visibility", icon: VisibilityIcon },
+          {
+            label: "Templates",
+            path: "/templates",
+            icon: StarIcon,
+            condition: Boolean(templateData?.flow.templatedFrom),
+          },
+        ];
+
   return (
     <SettingsLayout
       title="Flow settings"
-      settingsLinks={isService ? serviceSettingsLinks : []}
+      settingsLinks={isService ? serviceSettingsLinks : flowSettingsLinks}
       getNavigationPath={(path) => `/app/${team}/${flowSlug}/settings${path}`}
       topOffset={BREADCRUMBS_HEIGHT}
     >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/shared/SettingsForm.tsx
@@ -184,6 +184,7 @@ const SettingsFormContainer = <
                       disabled={
                         userPermissionError || !formik.dirty || updating
                       }
+                      data-testid="settings-submit-button"
                     >
                       Save
                     </Button>

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
@@ -22,7 +22,10 @@ export const CreateFromTemplateFormSection: React.FC = () => {
   const { data } = useQuery<{ templates: TemplateOption[] }>(gql`
     query GetOnlineSourceTemplates {
       templates: flows(
-        where: { is_template: { _eq: true }, status: { _eq: online } }
+        where: {
+          is_template: { _eq: true }
+          can_create_from_copy: { _eq: true }
+        }
       ) {
         id
         slug

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/CreateFromTemplateFormSection.tsx
@@ -25,6 +25,7 @@ export const CreateFromTemplateFormSection: React.FC = () => {
         where: {
           is_template: { _eq: true }
           can_create_from_copy: { _eq: true }
+          archived_at: { _is_null: true }
         }
       ) {
         id

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useGetCopiableFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/hooks/useGetCopiableFlows.ts
@@ -5,6 +5,7 @@ const GET_COPIABLE_FLOWS = gql`
     copiableFlows: flows(
       where: {
         can_create_from_copy: { _eq: true }
+        is_template: { _eq: false }
         archived_at: { _is_null: true }
       }
       order_by: { team: { name: asc }, name: asc }

--- a/apps/hasura.planx.uk/migrations/default/1781704337693_make_online_templates_copiable/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781704337693_make_online_templates_copiable/down.sql
@@ -1,0 +1,5 @@
+UPDATE flows
+SET can_create_from_copy = false
+WHERE is_template = true
+AND is_service = true
+AND status = 'online';

--- a/apps/hasura.planx.uk/migrations/default/1781704337693_make_online_templates_copiable/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781704337693_make_online_templates_copiable/up.sql
@@ -1,0 +1,5 @@
+UPDATE flows
+SET can_create_from_copy = true
+WHERE is_template = true
+AND is_service = true
+AND status = 'online';

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -244,7 +244,7 @@ test.describe("Templates", () => {
       await publishService(page);
     });
 
-    test("source template is not yet selectable in 'New flow' modal before going online", async ({
+    test("source template is not yet selectable in 'New flow' modal before being set as 'copiable'", async ({
       browser,
     }) => {
       const page = await getTeamPage({
@@ -267,6 +267,23 @@ test.describe("Templates", () => {
       await page.keyboard.press("Escape");
     });
 
+    test("can set the source template copiable", async ({ browser }) => {
+      const page = await getTeamPage({
+        browser,
+        userId: context.user!.id!,
+        teamName: context.team.name,
+      });
+      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+      await navigateToFlowSettings(page);
+
+      await page.getByLabel("Cannot be copied to create new services").click();
+      await page.getByTestId("settings-submit-button").click();
+
+      await expect(
+        page.getByText("Settings updated successfully"),
+      ).toBeVisible();
+    });
+
     test("can set the source template to be a Service", async ({ browser }) => {
       const page = await getTeamPage({
         browser,
@@ -278,18 +295,7 @@ test.describe("Templates", () => {
       await makeFlowAService(page);
     });
 
-    test("can set the source template online", async ({ browser }) => {
-      const page = await getTeamPage({
-        browser,
-        userId: context.user!.id!,
-        teamName: context.team.name,
-      });
-      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
-      await navigateToFlowSettings(page);
-      await turnServiceOnline(page);
-    });
-
-    test("source template is selectable in 'New flow' modal after going online", async ({
+    test("source template is selectable in 'New flow' modal after being set to copiable", async ({
       browser,
     }) => {
       const page = await getTeamPage({


### PR DESCRIPTION
As [discussed in Slack](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1781009706080469), we want templatable flows to be controlled via copy permissions, and not the previous `status = online` model (since that now requires `is_service = true` and not all templates will be services). 

This PR:
- Sets all online, `is_service` templates to `can_create_from_copy = true`
- Updates the templatable flows to search on this column instead
- Updates the copiable flows query to filter out templates

Questions for @augustlindemer:
-  I think after this merges to prod, what we want is for the service team to go through and manually remove `is_service = true` for relevant templates (eg Article 4s), does that sound right to you? 
- Is using the flow copy component (as is) to control template functionality confusing / do you want any updates to the UI here? 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6df2f89d-2566-4ecd-844f-b9d1eed9325a" />
