### PR TITLE
a11y: public-facing fixes

### DIFF
--- a/apps/editor.planx.uk/src/ui/editor/ColorPicker/ColorPicker.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ColorPicker/ColorPicker.tsx
@@ -119,6 +119,7 @@ export default function ColorPicker(props: Props): FCReturn {
           onClick={handleClick}
           disableRipple
           disabled={props.disabled}
+          aria-label={props.label}
         >
           <Swatch sx={{ backgroundColor: props.color }} className="swatch" />
           {props.color}

--- a/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
@@ -4,8 +4,7 @@ import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
-import Tooltip from "@mui/material/Tooltip";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import PublicFileUploadButton, {
   AcceptedFileTypes,
@@ -50,7 +49,6 @@ export default function ImgInput({
 }): FCReturn {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
-  // Auto-generate a random ID on mount
   const menuId = useMemo(() => {
     return `menu-${Math.floor(Math.random() * 1000000)}`;
   }, []);
@@ -59,8 +57,6 @@ export default function ImgInput({
     onChange && onChange(undefined);
     setAnchorEl(null);
   };
-
-  const uploadLabel = "Upload image";
 
   return img ? (
     <ImageUploadContainer>
@@ -102,18 +98,17 @@ export default function ImgInput({
       </ImageWrapper>
     </ImageUploadContainer>
   ) : (
-    <Tooltip title="Drop file here" disableHoverListener={disabled}>
-      <ImageUploadContainer>
-        <PublicFileUploadButton
-          aria-label={uploadLabel}
-          onChange={(newUrl) => {
-            setAnchorEl(null);
-            onChange && onChange(newUrl);
-          }}
-          disabled={disabled}
-          acceptedFileTypes={acceptedFileTypes}
-        />
-      </ImageUploadContainer>
-    </Tooltip>
+    <ImageUploadContainer>
+      <PublicFileUploadButton
+        aria-label="Upload image"
+        tooltipTitle="Drop file here"
+        onChange={(newUrl) => {
+          setAnchorEl(null);
+          onChange && onChange(newUrl);
+        }}
+        disabled={disabled}
+        acceptedFileTypes={acceptedFileTypes}
+      />
+    </ImageUploadContainer>
   );
 }

--- a/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
@@ -60,6 +60,8 @@ export default function ImgInput({
     setAnchorEl(null);
   };
 
+  const uploadLabel = "Upload image";
+
   return img ? (
     <ImageUploadContainer>
       <StyledIconButton
@@ -103,6 +105,7 @@ export default function ImgInput({
     <Tooltip title="Drop file here" disableHoverListener={disabled}>
       <ImageUploadContainer>
         <PublicFileUploadButton
+          aria-label={uploadLabel}
           onChange={(newUrl) => {
             setAnchorEl(null);
             onChange && onChange(newUrl);

--- a/apps/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/MoreInformation/MoreInformation.tsx
@@ -51,7 +51,14 @@ export const MoreInformation = <T extends BaseNodeData>({
             />
           </InputLabel>
           {/* ImgInput must be outside InputLabel: role="button" inside <label> = nested-interactive */}
-          <Box sx={{ display: "flex", gap: "5px", alignItems: "flex-end" }}>
+          <Box
+            sx={{
+              display: "flex",
+              gap: "5px",
+              alignItems: "flex-end",
+              width: "100%",
+            }}
+          >
             <Box sx={{ flex: 1 }}>
               <InputLabel
                 label="How it is defined?"

--- a/apps/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/RichTextInput/RichTextInput.tsx
@@ -280,6 +280,7 @@ const RichTextInput: FC<Props> = (props) => {
               <OrderedListButton editor={editor} />
               <PublicFileUploadButton
                 variant="tooltip"
+                aria-label="Insert image"
                 onChange={(src) =>
                   editor?.chain().focus().setImage({ src }).run()
                 }

--- a/apps/editor.planx.uk/src/ui/public/ExpandableList.tsx
+++ b/apps/editor.planx.uk/src/ui/public/ExpandableList.tsx
@@ -35,6 +35,8 @@ export function ExpandableListItem(props: {
     props.onToggle && props.onToggle();
   };
 
+  const groupId = props.groupId.replace(" ", "-").toLowerCase();
+
   return (
     <ListItem
       disablePadding
@@ -44,7 +46,7 @@ export function ExpandableListItem(props: {
       }}
     >
       <TitleButton
-        aria-controls={props.groupId}
+        aria-controls={groupId}
         aria-expanded={props.expanded}
         disableRipple
         onClick={handleToggle}
@@ -57,7 +59,7 @@ export function ExpandableListItem(props: {
           titleAccess={props.expanded ? "Less Information" : "More Information"}
         />
       </TitleButton>
-      {props.expanded && props.children}
+      {props.expanded && <div id={groupId}>{props.children}</div>}
     </ListItem>
   );
 }

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -1,6 +1,5 @@
 import ErrorIcon from "@mui/icons-material/Error";
 import Image from "@mui/icons-material/Image";
-import ButtonBase, { ButtonBaseProps } from "@mui/material/ButtonBase";
 import CircularProgress from "@mui/material/CircularProgress";
 import { styled } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
@@ -21,24 +20,30 @@ export interface Props {
   variant?: "tooltip";
   disabled?: boolean;
   acceptedFileTypes?: AcceptedFileTypes;
+  "aria-label"?: string;
 }
 
-interface RootProps extends ButtonBaseProps {
+interface RootProps {
   isDragActive?: boolean;
   variant?: "tooltip";
+  disabled?: boolean;
 }
 
-const Root = styled(ButtonBase, {
+const Root = styled("div", {
   shouldForwardProp: (prop) =>
-    !["isDragActive", "variant"].includes(prop.toString()),
+    !["isDragActive", "variant", "disabled"].includes(prop.toString()),
 })<RootProps>(({ theme, isDragActive, variant, disabled }) => ({
   borderRadius: 0,
   height: 50,
   width: 50,
   flexGrow: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
   backgroundColor: theme.palette.background.default,
   color: theme.palette.primary.dark,
   border: `1px solid ${theme.palette.border.main}`,
+  cursor: disabled ? "default" : "pointer",
   ...(isDragActive && {
     border: `2px dashed ${theme.palette.primary.dark}`,
   }),
@@ -54,6 +59,7 @@ const Root = styled(ButtonBase, {
 
 export default function PublicFileUploadButton(props: Props): FCReturn {
   const { onChange, variant, disabled, acceptedFileTypes } = props;
+  const ariaLabel = props["aria-label"] ?? "Upload image";
 
   const [status, setStatus] = useState<
     { type: "none" } | { type: "loading" } | { type: "error"; msg: string }
@@ -99,11 +105,12 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: acceptedFileTypes || DEFAULT_FILETYPES,
+    disabled,
   });
 
   if (status.type === "loading") {
     return (
-      <Root key="status-loading">
+      <Root key="status-loading" role="status" aria-label={ariaLabel} aria-busy>
         <CircularProgress size={24} />
       </Root>
     );
@@ -112,7 +119,7 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
   if (status.type === "error") {
     return (
       <Tooltip open title={status.msg}>
-        <Root>
+        <Root role="alert" aria-label={status.msg}>
           <ErrorIcon titleAccess="Error" />
         </Root>
       </Tooltip>
@@ -124,11 +131,14 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
       isDragActive={isDragActive}
       key="status-none"
       variant={variant}
-      {...getRootProps()}
       disabled={disabled}
+      {...getRootProps()}
+      role="button"
+      aria-label={ariaLabel}
+      tabIndex={disabled ? -1 : 0}
     >
       <input data-testid="upload-file-input" {...getInputProps()} />
-      <Image color={disabled ? "disabled" : "inherit"} />
+      <Image color={disabled ? "disabled" : "inherit"} aria-hidden />
     </Root>
   );
 }

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -29,8 +29,7 @@ interface ButtonProps {
   variant?: "tooltip";
 }
 
-// Plain div — handles drag-and-drop events only. No role/tabIndex so it is
-// never an "interactive control" and cannot trigger nested-interactive.
+// div for drag-and-drop events only - not considered an 'interactive' control
 const DropContainer = styled("div", {
   shouldForwardProp: (prop) => prop !== "isDragActive",
 })<{ isDragActive?: boolean }>(({ isDragActive, theme }) => ({
@@ -40,8 +39,7 @@ const DropContainer = styled("div", {
   }),
 }));
 
-// Native <button> — gets all the visual styling. Uses the `disabled` HTML
-// attribute so axe skips it in the nested-interactive check when inactive.
+// button for visual styling. uses the `disabled` attribute so its not considered interactive when inactive
 const UploadButton = styled("button", {
   shouldForwardProp: (prop) =>
     !["isDragActive", "variant"].includes(prop.toString()),
@@ -140,8 +138,8 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
     );
   }
 
-  // Separate drag-and-drop props (go on the container) from click/keyboard
-  // handlers (go on the button). This keeps the container non-interactive.
+  // drag-and-drop props go on the container, click/keyboard handlers go on the button
+  // this keeps the container considered as non-interactive
   const {
     role: _role,
     tabIndex: _tabIndex,

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -21,18 +21,31 @@ export interface Props {
   disabled?: boolean;
   acceptedFileTypes?: AcceptedFileTypes;
   "aria-label"?: string;
+  tooltipTitle?: string;
 }
 
-interface RootProps {
+interface ButtonProps {
   isDragActive?: boolean;
   variant?: "tooltip";
-  disabled?: boolean;
 }
 
-const Root = styled("div", {
+// Plain div — handles drag-and-drop events only. No role/tabIndex so it is
+// never an "interactive control" and cannot trigger nested-interactive.
+const DropContainer = styled("div", {
+  shouldForwardProp: (prop) => prop !== "isDragActive",
+})<{ isDragActive?: boolean }>(({ isDragActive, theme }) => ({
+  display: "inline-flex",
+  ...(isDragActive && {
+    outline: `2px dashed ${theme.palette.primary.dark}`,
+  }),
+}));
+
+// Native <button> — gets all the visual styling. Uses the `disabled` HTML
+// attribute so axe skips it in the nested-interactive check when inactive.
+const UploadButton = styled("button", {
   shouldForwardProp: (prop) =>
-    !["isDragActive", "variant", "disabled"].includes(prop.toString()),
-})<RootProps>(({ theme, isDragActive, variant, disabled }) => ({
+    !["isDragActive", "variant"].includes(prop.toString()),
+})<ButtonProps>(({ theme, isDragActive, variant }) => ({
   borderRadius: 0,
   height: 50,
   width: 50,
@@ -43,7 +56,12 @@ const Root = styled("div", {
   backgroundColor: theme.palette.background.default,
   color: theme.palette.primary.dark,
   border: `1px solid ${theme.palette.border.main}`,
-  cursor: disabled ? "default" : "pointer",
+  cursor: "pointer",
+  padding: 0,
+  "&:disabled": {
+    backgroundColor: theme.palette.background.disabled,
+    cursor: "default",
+  },
   ...(isDragActive && {
     border: `2px dashed ${theme.palette.primary.dark}`,
   }),
@@ -51,14 +69,14 @@ const Root = styled("div", {
     color: "#757575",
     height: "fitContent",
     width: "fitContent",
-  }),
-  ...(disabled && {
-    backgroundColor: theme.palette.background.disabled,
+    background: "transparent",
+    border: "none",
   }),
 }));
 
 export default function PublicFileUploadButton(props: Props): FCReturn {
-  const { onChange, variant, disabled, acceptedFileTypes } = props;
+  const { onChange, variant, disabled, acceptedFileTypes, tooltipTitle } =
+    props;
   const ariaLabel = props["aria-label"] ?? "Upload image";
 
   const [status, setStatus] = useState<
@@ -74,7 +92,7 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
         clearTimeout(timeout);
       };
     }
-  }, [status, setStatus]);
+  }, [status]);
 
   const onDrop = useCallback(
     (files: FileWithPath[]) => {
@@ -82,14 +100,10 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
       if (!file) {
         return;
       }
-      setStatus({
-        type: "loading",
-      });
+      setStatus({ type: "loading" });
       uploadPublicFile(file)
         .then(({ fileUrl }) => {
-          setStatus({
-            type: "none",
-          });
+          setStatus({ type: "none" });
           onChange && onChange(fileUrl);
         })
         .catch(() => {
@@ -99,7 +113,7 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
           });
         });
     },
-    [onChange, setStatus],
+    [onChange],
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -110,35 +124,55 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
 
   if (status.type === "loading") {
     return (
-      <Root key="status-loading" role="status" aria-label={ariaLabel} aria-busy>
+      <UploadButton type="button" disabled aria-label={ariaLabel} aria-busy>
         <CircularProgress size={24} />
-      </Root>
+      </UploadButton>
     );
   }
 
   if (status.type === "error") {
     return (
       <Tooltip open title={status.msg}>
-        <Root role="alert" aria-label={status.msg}>
+        <UploadButton type="button" disabled aria-label={status.msg}>
           <ErrorIcon titleAccess="Error" />
-        </Root>
+        </UploadButton>
       </Tooltip>
     );
   }
 
+  // Separate drag-and-drop props (go on the container) from click/keyboard
+  // handlers (go on the button). This keeps the container non-interactive.
+  const {
+    role: _role,
+    tabIndex: _tabIndex,
+    onClick: openFilePicker,
+    onKeyDown: handleKeyDown,
+    ...dragProps
+  } = getRootProps();
+
   return (
-    <Root
-      isDragActive={isDragActive}
-      key="status-none"
-      variant={variant}
-      disabled={disabled}
-      {...getRootProps()}
-      role="button"
-      aria-label={ariaLabel}
-      tabIndex={disabled ? -1 : 0}
-    >
-      <input data-testid="upload-file-input" {...getInputProps()} />
-      <Image color={disabled ? "disabled" : "inherit"} aria-hidden />
-    </Root>
+    <DropContainer {...dragProps} isDragActive={isDragActive}>
+      <input
+        data-testid="upload-file-input"
+        {...getInputProps()}
+        aria-label={ariaLabel}
+      />
+      <Tooltip
+        title={tooltipTitle ?? ""}
+        disableHoverListener={!tooltipTitle || disabled}
+      >
+        <UploadButton
+          type="button"
+          isDragActive={isDragActive}
+          variant={variant}
+          aria-label={ariaLabel}
+          disabled={disabled}
+          onClick={openFilePicker}
+          onKeyDown={handleKeyDown}
+        >
+          <Image color={disabled ? "disabled" : "inherit"} aria-hidden />
+        </UploadButton>
+      </Tooltip>
+    </DropContainer>
   );
 }


### PR DESCRIPTION
Fixes the key public facing violations that were flagged:
- A few missing `aria-` props
- fix `ImgInput` nested interactive warning by moving the Tooltip inside it
- rework `PublicFileUploadButton` to fix further `no-nested-interactive` warnings
- rework `MoreInformation` so it still works with new `ImgInput` style