### PR TITLE
feat[editor]: auto-suggest editor data values for `property.constraints.planning`

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/ExclusiveOrOptionManager.tsx
@@ -7,9 +7,13 @@ import {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
-import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
+import {
+  usePlanningConstraintsSchema,
+  usePlanningDataEntityNames,
+} from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { getIn } from "formik";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { FormikHookReturn } from "types";
 import ListManager from "ui/editor/ListManager/ListManager";
@@ -39,9 +43,15 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
   disabled,
   isTemplatedNode,
 }: Props<T>) => {
+  const teamSlug = useStore((state) => state.teamSlug);
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+
   const { data: planningDataSchema } = usePlanningDataEntityNames(
     formik.values.fn || "",
+  );
+  const { data: planningConstraintsSchema } = usePlanningConstraintsSchema(
+    formik.values.fn || "",
+    teamSlug,
   );
 
   return (
@@ -105,7 +115,7 @@ export const ExclusiveOrOptionManager = <T extends AnyChecklist>({
               optionPlaceholder: "Exclusive 'or' option",
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
-                planningDataSchema ?? schema,
+                planningDataSchema ?? planningConstraintsSchema ?? schema,
                 currentOptionVals,
               ),
             }}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/GroupedOptions.tsx
@@ -8,7 +8,10 @@ import type {
   AnyChecklist,
   OptionGroup,
 } from "@planx/components/shared/BaseChecklist/model";
-import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
+import {
+  usePlanningConstraintsSchema,
+  usePlanningDataEntityNames,
+} from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { FormikValues, getIn } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -39,9 +42,15 @@ export const GroupedOptions = <T extends AnyChecklist>({
   disabled,
   isTemplatedNode,
 }: Props<T>) => {
+  const teamSlug = useStore((state) => state.teamSlug);
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+
   const { data: planningDataSchema } = usePlanningDataEntityNames(
     formik.values.fn || "",
+  );
+  const { data: planningConstraintsSchema } = usePlanningConstraintsSchema(
+    formik.values.fn || "",
+    teamSlug,
   );
 
   // Type-narrowing only - groupedOptions will be defined here
@@ -155,7 +164,7 @@ export const GroupedOptions = <T extends AnyChecklist>({
                 groups: nonExclusiveOptionGroups.map((opt) => opt.title),
                 schema: getOptionsSchemaByFn(
                   formik.values.fn,
-                  planningDataSchema ?? schema,
+                  planningDataSchema ?? planningConstraintsSchema ?? schema,
                   currentOptionVals,
                 ),
               }}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/components/Options/index.tsx
@@ -1,9 +1,13 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { AnyOption } from "@planx/components/Option/model";
 import { DEFAULT_RULE } from "@planx/components/ResponsiveChecklist/model";
-import { usePlanningDataEntityNames } from "@planx/components/shared/hooks";
+import {
+  usePlanningConstraintsSchema,
+  usePlanningDataEntityNames,
+} from "@planx/components/shared/hooks";
 import { getOptionsSchemaByFn } from "@planx/components/shared/utils";
 import { partition } from "lodash";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { FormikHookReturn } from "types";
 import ListManager from "ui/editor/ListManager/ListManager";
@@ -26,6 +30,7 @@ export const Options = <T extends AnyChecklist>({
   disabled?: boolean;
   isTemplatedNode?: boolean;
 }) => {
+  const teamSlug = useStore((state) => state.teamSlug);
   const [exclusiveOptions, nonExclusiveOptions] = partition<AnyOption>(
     formik.values.options,
     (option) => option.data.exclusive,
@@ -34,8 +39,13 @@ export const Options = <T extends AnyChecklist>({
   const exclusiveOrOptionManagerShouldRender = nonExclusiveOptions.length > 0;
 
   const { schema, currentOptionVals } = useCurrentOptions(formik);
+
   const { data: planningDataSchema } = usePlanningDataEntityNames(
     formik.values.fn || "",
+  );
+  const { data: planningConstraintsSchema } = usePlanningConstraintsSchema(
+    formik.values.fn || "",
+    teamSlug,
   );
 
   return (
@@ -79,7 +89,7 @@ export const Options = <T extends AnyChecklist>({
               showValueField: !!formik.values.fn,
               schema: getOptionsSchemaByFn(
                 formik.values.fn,
-                planningDataSchema ?? schema,
+                planningDataSchema ?? planningConstraintsSchema ?? schema,
                 currentOptionVals,
               ),
             }}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -22,7 +22,10 @@ import { Switch } from "ui/shared/Switch";
 
 import { InternalNotes } from "../../../../../ui/editor/InternalNotes";
 import { DataFieldAutocomplete } from "../../DataFieldAutocomplete";
-import { usePlanningDataEntityNames } from "../../hooks";
+import {
+  usePlanningConstraintsSchema,
+  usePlanningDataEntityNames,
+} from "../../hooks";
 import { ICONS } from "../../icons";
 import { clearOptionsDataFields, getOptionsSchemaByFn } from "../../utils";
 import MoreInformation from "./MoreInformation";
@@ -40,12 +43,21 @@ import { Props } from "./types";
 const BaseQuestionComponent: React.FC<Props> = (props) => {
   const { type, formik } = props;
 
-  const schema = useStore().getFlowSchema();
+  const [schema, teamSlug] = useStore((state) => [
+    state.getFlowSchema(),
+    state.teamSlug,
+  ]);
+
   const currentOptionVals = formik.values.options?.map(
     (option) => option.data?.val,
   );
+
   const { data: planningDataSchema } = usePlanningDataEntityNames(
     formik.values.fn || "",
+  );
+  const { data: planningConstraintsSchema } = usePlanningConstraintsSchema(
+    formik.values.fn || "",
+    teamSlug,
   );
 
   const focusRef = useRef<HTMLInputElement | null>(null);
@@ -176,7 +188,9 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
                 showValueField: !!formik.values.fn,
                 schema: getOptionsSchemaByFn(
                   formik.values.fn,
-                  planningDataSchema ?? schema?.options,
+                  planningDataSchema ??
+                    planningConstraintsSchema ??
+                    schema?.options,
                   currentOptionVals,
                 ),
               }}

--- a/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getEntityNames } from "lib/planningData/requests";
+import {
+  getEntityNames,
+  getPlanningConstraintsSchema,
+} from "lib/planningData/requests";
 import { useEffect, useState } from "react";
 
 export type UseFileUrlProps =
@@ -52,4 +55,14 @@ export const usePlanningDataEntityNames = (fn: string) => {
   });
 
   return query;
+};
+
+export const usePlanningConstraintsSchema = (fn: string, teamSlug?: string) => {
+  return useQuery({
+    queryKey: [`planning-constraints-${teamSlug ?? "default"}`],
+    queryFn: () => getPlanningConstraintsSchema(teamSlug),
+    enabled: fn === "property.constraints.planning",
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+  });
 };

--- a/apps/editor.planx.uk/src/lib/planningData/requests.ts
+++ b/apps/editor.planx.uk/src/lib/planningData/requests.ts
@@ -85,3 +85,20 @@ export const getEntityNames = async (dataset: string) => {
 
   return data.entities.map((entity) => entity.name).sort();
 };
+
+/**
+ * Get all possible data values for `property.constraints.planning`
+ *   Includes granular `articleFour` values for applicable teams
+ */
+export const getPlanningConstraintsSchema = async (teamSlug?: string) => {
+  const { data } = await axios.get<string[]>(`/planning-constraints-schema`, {
+    baseURL: import.meta.env.VITE_APP_API_URL,
+    ...(teamSlug && {
+      params: {
+        localAuthority: teamSlug,
+      },
+    }),
+  });
+
+  return data;
+};


### PR DESCRIPTION
Editor side counterpart to https://github.com/theopensystemslab/planx-new/pull/6824

See https://trello.com/c/5ESXGcMr/3643-auto-suggest-data-values-based-on-external-data-schemas-like-planning-data?filter=member%3Ajessicamcinchak

<img width="917" height="1051" alt="image" src="https://github.com/user-attachments/assets/a1b47e93-c49b-42fe-9b85-1dbbff052504" />

**Testing:** 
- Options within a team with A4s setup auto-suggest "default" planning constraints values _plus_ granular A4s for this team only (eg Barnet)
- Options within a team without A4s setup auto-suggest "default" planning constraint values only (eg Westminster or Testing)