### PR TITLE
fix(api): Single DOMPurify instance per-request

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/service/validateInput/schema.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/validateInput/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
-import { isCleanHTML, isObjectValid } from "./utils.js";
+import { HTMLSanitiser, isObjectValid, makeIsCleanHTML } from "./utils.js";
 
 // Definition: https://hasura.io/docs/latest/schema/postgres/input-validations/#response
 type HasuraValidateInputResponse = undefined | { message: string };
@@ -38,10 +38,18 @@ type isCleanJSONBSchema = z.ZodType<
  */
 export const isCleanJSONBSchema: isCleanJSONBSchema =
   hasuraValidateInputRequestSchema.transform((original) => {
-    const isClean = original.body.data.input.every((input) =>
-      isObjectValid(input, isCleanHTML),
-    );
-    return { body: { isClean } };
+    // Instantiate a single instance per-request to avoid memory leaks
+    const sanitiser = new HTMLSanitiser();
+
+    try {
+      const isCleanHTML = makeIsCleanHTML(sanitiser);
+      const isClean = original.body.data.input.every((input) =>
+        isObjectValid(input, isCleanHTML),
+      );
+      return { body: { isClean } };
+    } finally {
+      sanitiser.close();
+    }
   });
 
 export type IsCleanJSONBController = ValidatedRequestHandler<

--- a/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.test.ts
@@ -1,4 +1,4 @@
-import { isCleanHTML, isObjectValid } from "./utils.js";
+import { HTMLSanitiser, isObjectValid, makeIsCleanHTML } from "./utils.js";
 
 describe("isObjectValid", () => {
   it("calls the callback for each child if validator returns true", () => {
@@ -81,6 +81,15 @@ describe("isObjectValid", () => {
 });
 
 describe("isCleanHTML() helper function", () => {
+  const checkIsClean = (input: string): boolean => {
+    const purifier = new HTMLSanitiser();
+    try {
+      return makeIsCleanHTML(purifier)(input);
+    } finally {
+      purifier.close();
+    }
+  };
+
   const dirtyHTML = [
     "<img src=x onerror=alert(1)//>",
     "<svg><g/onload=alert(2)//<p>",
@@ -92,7 +101,7 @@ describe("isCleanHTML() helper function", () => {
 
   for (const example of dirtyHTML) {
     it(`returns false for example ${example}`, () => {
-      expect(isCleanHTML(example)).toBe(false);
+      expect(checkIsClean(example)).toBe(false);
     });
   }
 
@@ -109,7 +118,7 @@ describe("isCleanHTML() helper function", () => {
 
   for (const example of cleanHTML) {
     it(`returns true for example ${example}`, () => {
-      expect(isCleanHTML(example)).toBe(true);
+      expect(checkIsClean(example)).toBe(true);
     });
   }
 });

--- a/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -39,6 +39,10 @@ export const isObjectValid = (
 export const isCleanHTML = (input: unknown): boolean => {
   // Skip validation for non-string values
   if (typeof input !== "string") return true;
+  
+  // Optimisation: Only run sanitation on potential HTML (rich text), skip for plain strings
+  const isHTMLCandidate = input.includes("<") || input.includes("&");
+  if (!isHTMLCandidate) return true;
 
   // Only run sanitation on potential HTML (rich text), skip for plain strings
   const isHTMLCandidate = input.includes("<") || input.includes("&");

--- a/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/validateInput/utils.ts
@@ -1,12 +1,26 @@
 import isObject from "lodash/isObject.js";
-import { JSDOM } from "jsdom";
 import createDOMPurify, { type WindowLike } from "dompurify";
 import he from "he";
+import { JSDOM } from "jsdom";
 import { reportError } from "../../../pay/helpers.js";
 
-// Setup JSDOM and DOMPurify
-const window = new JSDOM("").window;
-const DOMPurify = createDOMPurify(window as unknown as WindowLike);
+export class HTMLSanitiser {
+  private readonly dom: JSDOM;
+  private readonly purifier: ReturnType<typeof createDOMPurify>;
+
+  constructor() {
+    this.dom = new JSDOM("");
+    this.purifier = createDOMPurify(this.dom.window as unknown as WindowLike);
+  }
+
+  sanitise(input: string): string {
+    return this.purifier.sanitize(input, { ADD_ATTR: ["target"] });
+  }
+
+  close(): void {
+    this.dom.window.close();
+  }
+}
 
 /**
  * Function which returns -
@@ -16,7 +30,7 @@ const DOMPurify = createDOMPurify(window as unknown as WindowLike);
 type Validator = (input: unknown) => boolean;
 
 /**
- * Recursively iterate over an object, checking is validator callback condition is met
+ * Recursively iterate over an object, checking the validator callback condition is met
  * Fails fast - will return false once first invalid value is encountered
  */
 export const isObjectValid = (
@@ -36,29 +50,30 @@ export const isObjectValid = (
   return validator(input);
 };
 
-export const isCleanHTML = (input: unknown): boolean => {
-  // Skip validation for non-string values
-  if (typeof input !== "string") return true;
-  
-  // Optimisation: Only run sanitation on potential HTML (rich text), skip for plain strings
-  const isHTMLCandidate = input.includes("<") || input.includes("&");
-  if (!isHTMLCandidate) return true;
+/**
+ * Build a clean-HTML validator bound to a per-request sanitiser
+ */
+export const makeIsCleanHTML =
+  (purifier: HTMLSanitiser): Validator =>
+  (input: unknown): boolean => {
+    // Skip validation for non-string values
+    if (typeof input !== "string") return true;
 
-  // Only run sanitation on potential HTML (rich text), skip for plain strings
-  const isHTMLCandidate = input.includes("<") || input.includes("&");
-  if (!isHTMLCandidate) return true;
+    // Only run sanitation on potential HTML (rich text), skip for plain strings
+    const isHTMLCandidate = input.includes("<") || input.includes("&");
+    if (!isHTMLCandidate) return true;
 
-  const cleanHTML = DOMPurify.sanitize(input, { ADD_ATTR: ["target"] });
+    const cleanHTML = purifier.sanitise(input);
 
-  // DOMPurify has not removed any attributes or values
-  const isClean =
-    cleanHTML.length === input.length ||
-    he.decode(cleanHTML).length === he.decode(input).length;
+    // Sanitiser has not removed any attributes or values
+    const isClean =
+      cleanHTML.length === input.length ||
+      he.decode(cleanHTML).length === he.decode(input).length;
 
-  if (!isClean) logUncleanHTMLError(input, cleanHTML);
+    if (!isClean) logUncleanHTMLError(input, cleanHTML);
 
-  return isClean;
-};
+    return isClean;
+  };
 
 /**
  * Explicity log error when unsafe HTML is encountered


### PR DESCRIPTION
This is a follow up to #6860 which is attempting to improve performance here.

This PR converts the DOMPurify instance from a module level singleton to a factory pattern - this instantiates and closes one instance per-request to the API.

When profiling this on the GPDO flow, I noticed that the current implementation just bloats memory usage and slows down per-iteration. This could be the underlying cause of the issues here - even if not, it's worth resolving and ruling out.

```
Shared instance (current pattern):
  round 0:   2049 ms | heapUsed 176 MB
  round 1:   9464 ms | heapUsed 268 MB
  round 2:   9269 ms | heapUsed 396 MB
  round 3:  15261 ms | heapUsed 474 MB
  round 4:  21077 ms | heapUsed 557 MB
  round 5:  25421 ms | heapUsed 685 MB     ← ~12× slower than round 0

Fresh instance per round (this PR):
  round 0:   1246 ms
  round 1:   1089 ms
  round 2:   1688 ms
  round 3:   2260 ms
  round 4:   1371 ms
  round 5:   1021 ms                       ← flat, no upward trend
  ```