### PR TITLE
fix(api): Do not re-validate source template data in insert or update

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -120,6 +120,7 @@ const createFlow = async ({
           $description: String
           $limitations: String
           $is_service: Boolean
+          $creator_id: Int
         ) {
           insertFlow: insert_flows_one(
             object: {
@@ -135,6 +136,7 @@ const createFlow = async ({
               description: $description
               limitations: $limitations
               is_service: $is_service
+              creator_id: $creator_id
             }
           ) {
             id
@@ -153,6 +155,7 @@ const createFlow = async ({
         description: description,
         limitations: limitations,
         is_service: isService,
+        creator_id: userId,
       },
     );
 

--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -82,6 +82,7 @@ const createFlow = async ({
   description,
   limitations,
   isService,
+  $apiClient,
 }: {
   teamId: number;
   slug: string;
@@ -94,8 +95,10 @@ const createFlow = async ({
   description?: string;
   limitations?: string;
   isService?: boolean;
+  $apiClient?: ReturnType<typeof getClient>["client"];
 }) => {
-  const { client: $client } = getClient();
+  const { client: $userClient } = getClient();
+  const $client = $apiClient ?? $userClient;
   const userId = userContext.getStore()?.user?.sub;
 
   try {

--- a/apps/api.planx.uk/modules/auth/requireTeamMembership.test.ts
+++ b/apps/api.planx.uk/modules/auth/requireTeamMembership.test.ts
@@ -1,0 +1,116 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { userContext } from "./middleware.js";
+import { requireTeamMembership } from "./requireTeamMembership.js";
+
+const mockGetById = vi.fn();
+vi.mock("../../client/index.js", () => ({
+  $api: { user: { getById: () => mockGetById() } },
+}));
+
+const getTeamId = (parsedReq: { body: { teamId: number } }) =>
+  parsedReq.body.teamId;
+
+const buildArgs = () => {
+  const req = {} as Request;
+  const res = {
+    locals: { parsedReq: { body: { teamId: 1 } } },
+  } as unknown as Response;
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, next };
+};
+
+// Run the middleware within a user context, mimicking the JWT auth middleware
+const runAsUser = (sub: string | undefined, fn: () => Promise<void>) =>
+  userContext.run({ user: { sub } as Express.User }, fn);
+
+const invoke = async (sub: string | undefined) => {
+  const { req, res, next } = buildArgs();
+  await runAsUser(sub, () => requireTeamMembership(getTeamId)(req, res, next));
+  return next;
+};
+
+describe("requireTeamMembership middleware", () => {
+  beforeEach(() => mockGetById.mockReset());
+
+  it("denies access when there is no user in the request context", async () => {
+    const { req, res, next } = buildArgs();
+    await requireTeamMembership(getTeamId)(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining("userId missing"),
+      }),
+    );
+  });
+
+  it("denies access when the user cannot be found", async () => {
+    mockGetById.mockResolvedValue(null);
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining("unable to find user"),
+      }),
+    );
+  });
+
+  it("allows platformAdmins regardless of team membership", async () => {
+    mockGetById.mockResolvedValue({ isPlatformAdmin: true, teams: [] });
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("allows teamEditors of the target team", async () => {
+    mockGetById.mockResolvedValue({
+      isPlatformAdmin: false,
+      teams: [{ team: { id: 1 }, role: "teamEditor" }],
+    });
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("allows teamAdmins of the target team", async () => {
+    mockGetById.mockResolvedValue({
+      isPlatformAdmin: false,
+      teams: [{ team: { id: 1 }, role: "teamAdmin" }],
+    });
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("denies members of the target team with an insufficient role", async () => {
+    mockGetById.mockResolvedValue({
+      isPlatformAdmin: false,
+      teams: [{ team: { id: 1 }, role: "teamViewer" }],
+    });
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining("not a member"),
+      }),
+    );
+  });
+
+  it("denies users who are not members of the target team", async () => {
+    mockGetById.mockResolvedValue({
+      isPlatformAdmin: false,
+      teams: [{ team: { id: 2 }, role: "teamEditor" }],
+    });
+    const next = await invoke("123");
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining("not a member"),
+      }),
+    );
+  });
+});

--- a/apps/api.planx.uk/modules/auth/requireTeamMembership.ts
+++ b/apps/api.planx.uk/modules/auth/requireTeamMembership.ts
@@ -1,0 +1,52 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { $api } from "../../client/index.js";
+import { userContext } from "./middleware.js";
+
+/**
+ * Authorise that the current user can edit the team targeted by a request
+ *
+ * `useRoleAuth` only checks the user's global role claim, leaving per-team
+ * authorisation to Hasura's row-level check (are they a teamEditor within *this* team?).
+ * Routes that mutate via the `api` role (which has no row-level check) lose that
+ * enforcement, so this middleware refills the permission check in the API layer.
+ *
+ * This middleware should be used sparingly - only when it's not possible to rely on
+ * Hasura row-level checks (e.g. to skip redundant and memory intensive input validation
+ * for template INSERT actions)
+ */
+export const requireTeamMembership =
+  <T>(getTeamId: (parsedReq: T) => number) =>
+  async (_req: Request, res: Response, next: NextFunction) => {
+    const userId = userContext.getStore()?.user?.sub;
+    if (!userId)
+      return next({
+        status: 403,
+        message: "Access denied - userId missing from request",
+      });
+
+    const teamId = getTeamId(res.locals.parsedReq as T);
+
+    const user = await $api.user.getById(Number(userId));
+    if (!user)
+      return next({
+        status: 403,
+        message: `Access denied - unable to find user matching ID ${userId}`,
+      });
+
+    const isUserInTeam = user.teams.some(
+      ({ team, role }) =>
+        team.id === teamId && (role === "teamEditor" || role === "teamAdmin"),
+    );
+
+    const isAuthorised = user.isPlatformAdmin || isUserInTeam;
+
+    if (!isAuthorised) {
+      return next({
+        status: 403,
+        message: `Access denied. User ${userId} is not a member of team ${teamId} with permission to edit it`,
+      });
+    }
+
+    return next();
+  };

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/createFlowFromTemplate.test.ts
@@ -59,10 +59,42 @@ describe("validation and error handling", () => {
         expect(res.body).toHaveProperty("name", "ZodError");
       });
   });
+
+  it("returns an error if the user is not a member of the target team", async () => {
+    queryMock.mockQuery({
+      name: "GetUserById",
+      matchOnVariables: false,
+      data: {
+        user: {
+          id: 123,
+          isPlatformAdmin: false,
+          teams: [{ role: "teamEditor", team: { id: 2, slug: "other-team" } }],
+        },
+      },
+    });
+
+    await supertest(app)
+      .post("/flows/create-from-template/1")
+      .send(validBody)
+      .set(auth)
+      .expect(403);
+  });
 });
 
 describe("success", () => {
   beforeEach(() => {
+    queryMock.mockQuery({
+      name: "GetUserById",
+      matchOnVariables: false,
+      data: {
+        user: {
+          id: 123,
+          isPlatformAdmin: false,
+          teams: [{ role: "teamEditor", team: { id: 1, slug: "my-team" } }],
+        },
+      },
+    });
+
     queryMock.mockQuery({
       name: "GetFlowData",
       matchOnVariables: false,

--- a/apps/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
+++ b/apps/api.planx.uk/modules/flows/createFlowFromTemplate/service.ts
@@ -1,5 +1,6 @@
 import isNull from "lodash/isNull.js";
 
+import { $api } from "../../../client/index.js";
 import { createFlow, getFlowData } from "../../../helpers.js";
 import type { NewFlow } from "./controller.js";
 
@@ -29,6 +30,9 @@ const createFlowFromTemplate = async (
       ? undefined
       : sourceTemplate.limitations,
     isService: sourceTemplate.isService,
+    // INSERT using the API client to bypass redundant input validation
+    // The source data is already pre-validated and comes directly from the DB
+    $apiClient: $api.client,
   });
 
   return { id, slug };

--- a/apps/api.planx.uk/modules/flows/routes.ts
+++ b/apps/api.planx.uk/modules/flows/routes.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
+import type { z } from "zod";
 import { validate } from "../../shared/middleware/validate.js";
 import {
   useLoggedInUserAuth,
   usePlatformAdminAuth,
   useTeamEditorAuth,
 } from "../auth/middleware.js";
+import { requireTeamMembership } from "../auth/requireTeamMembership.js";
 import { copyFlowController, copyFlowSchema } from "./copyFlow/controller.js";
 import {
   copyFlowAsPortalSchema,
@@ -57,6 +59,10 @@ router.post(
   "/flows/create-from-template/:templateId",
   useTeamEditorAuth,
   validate(createFlowFromTemplateSchema),
+  requireTeamMembership(
+    (parsedReq: z.infer<typeof createFlowFromTemplateSchema>) =>
+      parsedReq.body.teamId,
+  ),
   createFlowFromTemplateController,
 );
 

--- a/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
+++ b/apps/editor.planx.uk/src/components/Breadcrumbs.tsx
@@ -54,7 +54,7 @@ const Breadcrumbs: React.FC = () => {
 
   const canUserEditTeam = useStore((state) => state.canUserEditTeam);
 
-  if (!teamSlug || !flowSlug || !data?.flows) return null;
+  if (!teamSlug || !flowSlug || !data?.flows.length) return null;
   const { status: flowStatus, isService } = data.flows[0];
 
   return (

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -153,6 +153,7 @@ insert_permissions:
         - name
         - settings
         - slug
+        - status
         - summary
         - team_id
         - templated_from

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -160,8 +160,6 @@ insert_permissions:
   - role: platformAdmin
     permission:
       check: {}
-      set:
-        creator_id: x-hasura-user-id
       columns:
         - copied_from
         - created_at
@@ -200,8 +198,6 @@ insert_permissions:
                   _eq: x-hasura-user-id
               - role:
                   _eq: teamEditor
-      set:
-        creator_id: x-hasura-user-id
       columns:
         - copied_from
         - created_at

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -158,15 +158,6 @@ insert_permissions:
         - templated_from
         - updated_at
         - version
-      validate_input:
-        definition:
-          forward_client_headers: false
-          headers:
-            - name: authorization
-              value: '{{HASURA_PLANX_API_KEY}}'
-          timeout: 10
-          url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
-        type: http
   - role: platformAdmin
     permission:
       check: {}
@@ -450,15 +441,6 @@ update_permissions:
                 team_settings:
                   is_trial:
                     _eq: true
-      validate_input:
-        definition:
-          forward_client_headers: false
-          headers:
-            - name: authorization
-              value: '{{HASURA_PLANX_API_KEY}}'
-          timeout: 10
-          url: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/validate-input/jsonb/clean-html'
-        type: http
   - role: platformAdmin
     permission:
       columns:

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flows.yaml
@@ -137,8 +137,6 @@ insert_permissions:
   - role: api
     permission:
       check: {}
-      set:
-        creator_id: x-hasura-user-id
       columns:
         - copied_from
         - created_at

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -584,88 +584,93 @@ test.describe("Templates", () => {
     });
   });
 
-  // relies on the templated flow being created in the "As a team editor" block
-  test.describe("As a platform admin", () => {
-    test("can publish changes to the source template and sees affected templated flows listed", async ({
-      browser,
-    }) => {
-      const page = await getTeamPage({
+  // The following tests rely on resources created above and must run sequentially after them
+  test.describe("Hybrid actions", () => {
+    test.describe("As a platform admin", () => {
+      test("can publish changes to the source template and sees affected templated flows listed", async ({
         browser,
-        userId: context.user!.id!,
-        teamName: context.team.name,
+      }) => {
+        const page = await getTeamPage({
+          browser,
+          userId: context.user!.id!,
+          teamName: context.team.name,
+        });
+        await navigateToService(page, SOURCE_TEMPLATE_SLUG);
+
+        // Make a change to the source template by editing the optional node
+        await page.getByRole("link", { name: OPTIONAL_NODE_TITLE }).click();
+        await page.getByRole("dialog").waitFor();
+        await page
+          .getByPlaceholder("Text")
+          .fill(`${OPTIONAL_NODE_TITLE} (source updated)`);
+        await page.locator('button[form="modal"][type="submit"]').click();
+        await page.getByRole("dialog").waitFor({ state: "detached" });
+
+        // Open the publish dialog and advance to the Publish step
+        await page.getByTestId("check-for-changes-to-publish-button").click();
+        await expect(
+          page.getByRole("heading", { name: "Review" }),
+        ).toBeVisible();
+        await page.getByTestId("next-step-test-button").click();
+
+        await expect(page.getByRole("heading", { name: "Test" })).toBeVisible();
+        await page.getByTestId("test-confirmation-checkbox").click();
+        await page.getByTestId("next-step-publish-button").click();
+
+        // The Publish step should show template-specific messaging and list affected flows
+        await expect(
+          page.getByRole("heading", { name: "Publish" }),
+        ).toBeVisible();
+        await expect(page.getByText("This flow is a template")).toBeVisible();
+        await expect(
+          page.getByText(new RegExp(TEMPLATED_FLOW_SLUG)),
+        ).toBeVisible();
+
+        // Complete the publish
+        await page.getByTestId("publish-summary-input").fill(REPUBLISH_MESSAGE);
+        await page.getByTestId("publish-button").click();
+        await expect(
+          page.getByText("Successfully published changes").first(),
+        ).toBeVisible();
       });
-      await navigateToService(page, SOURCE_TEMPLATE_SLUG);
-
-      // Make a change to the source template by editing the optional node
-      await page.getByRole("link", { name: OPTIONAL_NODE_TITLE }).click();
-      await page.getByRole("dialog").waitFor();
-      await page
-        .getByPlaceholder("Text")
-        .fill(`${OPTIONAL_NODE_TITLE} (source updated)`);
-      await page.locator('button[form="modal"][type="submit"]').click();
-      await page.getByRole("dialog").waitFor({ state: "detached" });
-
-      // Open the publish dialog and advance to the Publish step
-      await page.getByTestId("check-for-changes-to-publish-button").click();
-      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
-      await page.getByTestId("next-step-test-button").click();
-
-      await expect(page.getByRole("heading", { name: "Test" })).toBeVisible();
-      await page.getByTestId("test-confirmation-checkbox").click();
-      await page.getByTestId("next-step-publish-button").click();
-
-      // The Publish step should show template-specific messaging and list affected flows
-      await expect(
-        page.getByRole("heading", { name: "Publish" }),
-      ).toBeVisible();
-      await expect(page.getByText("This flow is a template")).toBeVisible();
-      await expect(
-        page.getByText(new RegExp(TEMPLATED_FLOW_SLUG)),
-      ).toBeVisible();
-
-      // Complete the publish
-      await page.getByTestId("publish-summary-input").fill(REPUBLISH_MESSAGE);
-      await page.getByTestId("publish-button").click();
-      await expect(
-        page.getByText("Successfully published changes").first(),
-      ).toBeVisible();
     });
-  });
 
-  // relies on the source template being republished in the "As a platform admin" block above
-  test.describe("As a team editor", () => {
-    test("sees a History entry describing the source template update and still has Customise tasks to complete", async ({
-      browser,
-    }) => {
-      const page = await getTeamPage({
+    test.describe("As a team editor", () => {
+      test("sees a History entry describing the source template update and still has Customise tasks to complete", async ({
         browser,
-        userId: context.user!.id!,
-        teamName: context.team.name,
+      }) => {
+        const page = await getTeamPage({
+          browser,
+          userId: context.user!.id!,
+          teamName: context.team.name,
+        });
+        await navigateToService(page, TEMPLATED_FLOW_SLUG);
+
+        // The History tab should contain an auto-generated entry for the source template update
+        await page.getByRole("tab", { name: "History" }).click();
+        await expect(
+          page.getByText(`Source template published: "${REPUBLISH_MESSAGE}"`),
+        ).toBeVisible();
+
+        // The Customise tab should still list the required and optional tasks
+        await page.getByRole("tab", { name: "Customise" }).click();
+        await expect(page.getByText(REQUIRED_NODE_INSTRUCTIONS)).toBeVisible();
+        await expect(page.getByText(OPTIONAL_NODE_INSTRUCTIONS)).toBeVisible();
+
+        // Check that our required node is complete in the customisation task list
+        const requiredCustomisationTask = page
+          .locator("li")
+          .filter({
+            has: page.getByRole("button", {
+              name: UPDATED_REQUIRED_NODE_TITLE,
+            }),
+          })
+          .first();
+
+        await expect(
+          requiredCustomisationTask.getByTestId("customisation-complete"),
+        ).toBeVisible();
       });
-      await navigateToService(page, TEMPLATED_FLOW_SLUG);
-
-      // The History tab should contain an auto-generated entry for the source template update
-      await page.getByRole("tab", { name: "History" }).click();
-      await expect(
-        page.getByText(`Source template published: "${REPUBLISH_MESSAGE}"`),
-      ).toBeVisible();
-
-      // The Customise tab should still list the required and optional tasks
-      await page.getByRole("tab", { name: "Customise" }).click();
-      await expect(page.getByText(REQUIRED_NODE_INSTRUCTIONS)).toBeVisible();
-      await expect(page.getByText(OPTIONAL_NODE_INSTRUCTIONS)).toBeVisible();
-
-      // Check that our required node is complete in the customisation task list
-      const requiredCustomisationTask = page
-        .locator("li")
-        .filter({
-          has: page.getByRole("button", { name: UPDATED_REQUIRED_NODE_TITLE }),
-        })
-        .first();
-
-      await expect(
-        requiredCustomisationTask.getByTestId("customisation-complete"),
-      ).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

This is a follow-up to #6860.

Creating or updating a flow from a source template re-ran the `clean-html` `validate_input` webhook against the entire `flows.data` JSONB. For template operations this validation is entirely redundant - the data comes straight from `getFlowData()` (a DB read of already-sanitised data), so it always passes. Running it repeatedly  on large flows causes memory spikes.

This PR stops that redundant validation, and re-establishes the authorisation pattern currently in place.

## Approach

The Hasura input validation in Hasura is configured per role + table + operation, so it can't be skipped per-query within a given role securely (e.g. `skipValidation` query param). Instead we route the template insert/update through the `api` role, and remove the input validation from that role's `flows` insert and update permissions.

## Trade-offs

The `api` role has no Hasura row-level check, so switching to it dropped two guarantees that the user role enforced at the DB layer (can the user insert into this team?). Both are re-added - 

1. `creator_id` - previously set via the `set: creator_id: x-hasura-user-id` preset. The `api` role's JWT carries no `x-hasura-user-id`, so `creator_id` is now set explicitly in the insert from the authenticated user context.

2. Per-team authorisation - previously enforced by the `teamEditor` row check (`team.members.user_id == x-hasura-user-id`). The route guard `useTeamEditorAuth` only checks the global role claim, not membership of the target team, so this would otherwise allow a `teamEditor` of team A to create a flow into team B. A new `requireTeamMembership` middleware refills this gap in the API layer. It runs after `validate`, reads the typed request, and authorises platformAdmins plus `teamEditor`/`teamAdmin` members of the target team.

Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/27940200368 ✅ 