### PR TITLE
feat[db]: create internal audit view `daily_failed_submissions`

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_daily_failed_submissions.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_daily_failed_submissions.yaml
@@ -1,0 +1,3 @@
+table:
+  name: daily_failed_submissions
+  schema: public

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -19,6 +19,7 @@
 - "!include public_application_access_tokens.yaml"
 - "!include public_blpu_codes.yaml"
 - "!include public_bops_applications.yaml"
+- "!include public_daily_failed_submissions.yaml"
 - "!include public_downtime_banner.yaml"
 - "!include public_email_applications.yaml"
 - "!include public_email_events_log.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1781823231755_create_view_daily_failed_submissions/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781823231755_create_view_daily_failed_submissions/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW daily_failed_submissions;

--- a/apps/hasura.planx.uk/migrations/default/1781823231755_create_view_daily_failed_submissions/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1781823231755_create_view_daily_failed_submissions/up.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE VIEW daily_failed_submissions AS (
+	with send_event_statuses_per_session as (
+			select
+					session_id,
+			event_type,
+			flow_name,
+			team_id,
+					array_agg(status) as statuses,
+			max(created_at) as last_event
+			from submission_services_log
+			where event_type != 'Pay'
+			and created_at >= NOW() - INTERVAL '24 hours'
+			group by session_id, event_type, flow_name, team_id
+	)
+	select 
+		t.name,
+		s.flow_name,
+		s.session_id, 
+		s.event_type,
+		s.statuses,
+		s.last_event
+	from send_event_statuses_per_session s
+		join teams t on s.team_id = t.id
+	where 'Success' != ALL(statuses)
+);


### PR DESCRIPTION
See https://trello.com/c/JdLmMcxP/3645-implement-a-nightly-cron-job-to-check-for-failed-submission-events-without-a-successful-retry-resubmit

Airbrake errors remain the first line of defense for spotting submission errors. But during a recent blip of API downtime, we failed to correctly log failed events for a submission to Lambeth. 

A few days passed before a Lambeth editor noticed and asked for it to be resubmitted (it _was_ successfully sent to email the original day, but failed to send to 3x other destinations which Lambeth uses to dual-process). We want to introduce a second-line of defense for more proactively spotting these errors.

On production, this view returns this (as expected; redundant with Airbrake when all systems in working order!):
<img width="1308" height="755" alt="Screenshot from 2026-06-18 18-54-40" src="https://github.com/user-attachments/assets/94b4ea9b-5537-4912-a103-31a5ac934d93" />

**Next steps:**
- Let's decide how we want to access this view
  - Hasura cron event/webhook which queries the view and if >= 1 row is returned, logs it to #planx-notifications-internal via `postToSlack`?
  - Metabase bot maybe? The view itself isn't PPI, can we configure non-ODP channel for that bot?
  - Just manually check if we experience API downtime to not create redundant noise on most days?