### PR TITLE
chore(iac): Inital setup for East Riding certs

### DIFF
--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -120,6 +120,11 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
           domain: "planningservices.stockport.gov.uk",
           cloudFrontState: "validation-only",
         },
+        {
+          name: "east-riding-of-yorkshire",
+          domain: "planningservices.eastriding.gov.uk",
+          cloudFrontState: "validation-only",
+        },
       ]
     : [
         // we keep one custom domain on staging to function as a canary (monitored by UptimeRobot)


### PR DESCRIPTION
Step 1 here - https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md#a-onboarding-a-new-council

`certificates` layer not manually deployed, we should pair on this as an upskilling / onboarding session for @DafyddLlyr and @zz-hh-aa with @freemvmt 👌 🏫 