### PR TITLE
fix: reload settings after ejecting from template

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/index.tsx
@@ -21,7 +21,7 @@ import {
 } from "./types";
 
 const Template: React.FC = () => {
-  const flowId = useStore((state) => state.id);
+  const [flowId, flowSlug] = useStore((state) => [state.id, state.flowSlug]);
   const navigate = useNavigate();
   const { mutate: sendSlackMessage } = useSlackMessage();
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -29,10 +29,6 @@ const Template: React.FC = () => {
   const handleClose = () => setIsOpen(false);
 
   const handleSuccess = (data: GetFlowTemplateStatus | undefined) => {
-    // Navigate away from tab, as we're about to remove it
-    navigate({ to: "." });
-    setIsOpen(false);
-
     // Type-narrowing only, should not happen!
     if (!data)
       throw Error("Failed to get query data for template ejection form");
@@ -40,6 +36,14 @@ const Template: React.FC = () => {
     const {
       flow: { name, team, template },
     } = data;
+
+    // Navigate away from tab, as we're about to remove it
+    navigate({
+      to: "/app/$team/$flow/settings/visibility",
+      params: { team: team.slug, flow: flowSlug },
+    });
+    setIsOpen(false);
+
     const message = `:eject: *${team.name}* have ejected their "${name}" service from the "${template.name} "template`;
     sendSlackMessage(message);
   };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/queries.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/queries.tsx
@@ -9,6 +9,7 @@ export const GET_FLOW_TEMPLATE_STATUS = gql`
       team {
         id
         name
+        slug
       }
       template {
         id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/types.ts
@@ -5,6 +5,7 @@ export interface GetFlowTemplateStatus {
     team: {
       id: number;
       name: string;
+      slug: string;
     };
     template: {
       id: string;


### PR DESCRIPTION
Noticed this little bug while doing some other templates settings work. Should now correctly redirect route / reload settings after ejecting from templates. 

Before:

https://github.com/user-attachments/assets/0ffd98a7-1c85-41a6-9851-aff607409a2a

After:

https://github.com/user-attachments/assets/10a30b04-256e-4df8-88e9-c2d524622460