### PR TITLE
chore(api): Remove legacy `@swagger` JSDocs

### DIFF
--- a/apps/api.planx.uk/README.md
+++ b/apps/api.planx.uk/README.md
@@ -79,8 +79,6 @@ api.planx.uk/
 
 API docs are written as `docs.yaml` files per module and served via Swagger UI at `/docs`.
 
-Inline JSDoc `@swagger` annotations are a legacy pattern — do not add new ones, and migrate them to `docs.yaml` if you come across them.
-
 ## Hasura clients
 
 When querying Hasura, use the right client for the context. All clients are exported from `client/index.ts`:

--- a/apps/api.planx.uk/docs/index.ts
+++ b/apps/api.planx.uk/docs/index.ts
@@ -33,14 +33,14 @@ const parameters = {
   sessionId: {
     in: "path",
     name: "sessionId",
-    type: "string",
+    schema: { type: "string" },
     required: true,
     description: "Session ID",
   },
   localAuthority: {
     in: "path",
     name: "localAuthority",
-    type: "string",
+    schema: { type: "string" },
     required: true,
     description:
       "Name of the Local Authority, usually the same as PlanX `team`",
@@ -50,7 +50,7 @@ const parameters = {
     in: "header",
     description: "An authorisation header provided by Hasura",
     required: true,
-    type: "string",
+    schema: { type: "string" },
   },
 };
 
@@ -150,7 +150,7 @@ const options = {
       responses,
     },
   },
-  apis: ["./**/*.ts", "./**/*.js", "./**/docs.yaml"],
+  apis: ["./**/docs.yaml"],
 };
 
 export const useSwaggerDocs = (app: Express) => {

--- a/apps/api.planx.uk/modules/admin/docs.yaml
+++ b/apps/api.planx.uk/modules/admin/docs.yaml
@@ -1,0 +1,93 @@
+openapi: 3.1.0
+info:
+  title: Plan✕ API
+  version: 0.1.0
+paths:
+  /admin/feedback/{feedbackId}:
+    get:
+      summary: Returns a feedback entry with user data
+      description: Returns a feedback entry plus its associated session user data, including the passport and breadcrumbs
+      tags:
+        - admin
+      parameters:
+        - in: path
+          name: feedbackId
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+  /admin/session/{sessionId}/xml:
+    get:
+      summary: Generates a OneApp XML
+      description: Generates a OneApp XML
+      tags:
+        - admin
+      parameters:
+        - $ref: "#/components/parameters/sessionId"
+      security:
+        - bearerAuth: []
+  /admin/session/{sessionId}/html:
+    get:
+      summary: Generates an application overview HTML
+      description: Generates an application overview HTML
+      tags:
+        - admin
+      parameters:
+        - $ref: "#/components/parameters/sessionId"
+      security:
+        - bearerAuth: []
+  /admin/session/{sessionId}/zip:
+    get:
+      summary: Generates and downloads a zip file for integrations
+      description: Generates and downloads a zip file for integrations
+      tags:
+        - admin
+      parameters:
+        - $ref: "#/components/parameters/sessionId"
+        - in: query
+          name: includeOneAppXML
+          required: false
+          schema:
+            type: boolean
+          description: If the OneApp XML file should be included in the zip
+        - in: query
+          name: includeDigitalPlanningJSON
+          required: false
+          schema:
+            type: boolean
+          description: If the Digital Planning JSON file should be included in the zip (only generated for supported application types)
+        - in: query
+          name: onlyDigitalPlanningJSON
+          required: false
+          schema:
+            type: boolean
+          description: If the Digital Planning JSON file should be the ONLY file included in the zip (only generated for supported application types)
+      security:
+        - bearerAuth: []
+  /admin/session/{sessionId}/summary:
+    get:
+      summary: Returns a passport, breadcrumbs, and other key details about a session
+      description: Returns a passport, breadcrumbs, and other key details about a session
+      tags:
+        - admin
+      parameters:
+        - $ref: "#/components/parameters/sessionId"
+      security:
+        - bearerAuth: []
+  /admin/session/{sessionId}/digital-planning-application:
+    get:
+      summary: Generates a Digital Planning Application payload
+      description: Generates a Digital Planning Application payload and validates it against the Digital Planning Data JSON Schema
+      tags:
+        - admin
+      parameters:
+        - $ref: "#/components/parameters/sessionId"
+        - in: query
+          name: skipValidation
+          required: false
+          schema:
+            type: boolean
+          description: If invalid JSON data should still be returned, instead of logging validation errors
+      security:
+        - bearerAuth: []

--- a/apps/api.planx.uk/modules/admin/feedback/feedback.ts
+++ b/apps/api.planx.uk/modules/admin/feedback/feedback.ts
@@ -5,22 +5,6 @@ import { gql } from "graphql-request";
 import { $api } from "../../../client/index.js";
 import type { Flow, Passport } from "../../../types.js";
 
-/**
- * @swagger
- * /admin/feedback/{feedbackId}:
- *  get:
- *    summary: Returns a feedback entry with user data
- *    description: Returns a feedback entry plus its' associated session user data, including the passport and breadcrumbs
- *    tags:
- *      - admin
- *    parameters:
- *      - in: path
- *        name: feedbackId
- *        type: string
- *        required: true
- *    security:
- *      - bearerAuth: []
- */
 export const getFeedbackWithUserData = async (
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/admin/session/digitalPlanningData.ts
+++ b/apps/api.planx.uk/modules/admin/session/digitalPlanningData.ts
@@ -1,24 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { $api } from "../../../client/index.js";
 
-/**
- * @swagger
- * /admin/session/{sessionId}/digital-planning-application:
- *  get:
- *    summary: Generates a Digital Planning Application payload
- *    description: Generates a Digital Planning Application payload and validates it against the Digital Planning Data JSON Schema
- *    tags:
- *      - admin
- *    parameters:
- *      - $ref: '#/components/parameters/sessionId'
- *      - in: query
- *        name: skipValidation
- *        type: boolean
- *        required: false
- *        description: If invalid JSON data should still be returned, instead of logging validation errors
- *    security:
- *      - bearerAuth: []
- */
 export const getDigitalPlanningApplicationPayload = async (
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/admin/session/html.ts
+++ b/apps/api.planx.uk/modules/admin/session/html.ts
@@ -4,19 +4,6 @@ import { generateHTMLForSession } from "../../lps/service/generateHTML.js";
 
 type HTMLExportHandler = RequestHandler<{ sessionId: string }, string>;
 
-/**
- * @swagger
- * /admin/session/{sessionId}/html:
- *  get:
- *    summary: Generates an application overview HTML
- *    description: Generates an application overview HTML
- *    tags:
- *      - admin
- *    parameters:
- *      - $ref: '#/components/parameters/sessionId'
- *    security:
- *      - bearerAuth: []
- */
 export const getHTMLExport: HTMLExportHandler = async (req, res, next) => {
   try {
     const session = await $api.session.find(req.params.sessionId);

--- a/apps/api.planx.uk/modules/admin/session/oneAppXML.ts
+++ b/apps/api.planx.uk/modules/admin/session/oneAppXML.ts
@@ -1,19 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { $api } from "../../../client/index.js";
 
-/**
- * @swagger
- * /admin/session/{sessionId}/xml:
- *  get:
- *    summary: Generates a OneApp XML
- *    description: Generates a OneApp XML
- *    tags:
- *      - admin
- *    parameters:
- *      - $ref: '#/components/parameters/sessionId'
- *    security:
- *      - bearerAuth: []
- */
 export const getOneAppXML = async (
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/admin/session/summary.ts
+++ b/apps/api.planx.uk/modules/admin/session/summary.ts
@@ -15,19 +15,6 @@ import type {
 } from "../../../types.js";
 import { $api } from "../../../client/index.js";
 
-/**
- * @swagger
- * /admin/session/{sessionId}/summary:
- *  get:
- *    summary: Returns a passport, breadcrumbs, and other key details about a session
- *    description: Returns a passport, breadcrumbs, and other key details about a session
- *    tags:
- *      - admin
- *    parameters:
- *      - $ref: '#/components/parameters/sessionId'
- *    security:
- *      - bearerAuth: []
- */
 export async function getSessionSummary(
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/admin/session/zip.ts
+++ b/apps/api.planx.uk/modules/admin/session/zip.ts
@@ -1,34 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { buildSubmissionExportZip } from "../../send/utils/exportZip.js";
 
-/**
- * @swagger
- * /admin/session/{sessionId}/zip:
- *  get:
- *    summary: Generates and downloads a zip file for integrations
- *    description: Generates and downloads a zip file for integrations
- *    tags:
- *      - admin
- *    parameters:
- *      - $ref: '#/components/parameters/sessionId'
- *      - in: query
- *        name: includeOneAppXML
- *        type: boolean
- *        required: false
- *        description: If the OneApp XML file should be included in the zip
- *      - in: query
- *        name: includeDigitalPlanningJSON
- *        type: boolean
- *        required: false
- *        description: If the Digital Planning JSON file should be included in the zip (only generated for supported application types)
- *      - in: query
- *        name: onlyDigitalPlanningJSON
- *        type: boolean
- *        required: false
- *        description: If the Digital Planning JSON file should be the ONLY file included in the zip (only generated for supported application types)
- *    security:
- *      - bearerAuth: []
- */
 export async function generateZip(
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/gis/docs.yaml
+++ b/apps/api.planx.uk/modules/gis/docs.yaml
@@ -26,6 +26,51 @@ paths:
                 type: array
                 items:
                   type: object
+  /gis/{localAuthority}:
+    get:
+      tags: ["gis"]
+      summary: Fetches planning constraints
+      description: Fetches and formats planning constraints from planning.data.gov.uk that overlap with a geometry
+      parameters:
+        - $ref: "#/components/parameters/localAuthority"
+        - in: query
+          name: geom
+          required: true
+          schema:
+            type: string
+          description: Well-Known Text (WKT) formatted polygon or point
+        - in: query
+          name: vals
+          required: false
+          schema:
+            type: string
+          description: Comma-separated list of planning constraint values (formatted using `fn` property names) that should be returned
+      responses:
+        "200":
+          description: A JSON object of planning constraints
+          content:
+            application/json:
+              schema:
+                type: object
+  /roads:
+    get:
+      tags: ["gis"]
+      summary: Fetches road classifications
+      description: Fetches and formats road classifications from Ordnance Survey MasterMap Highways via OS Features API for a USRN
+      parameters:
+        - in: query
+          name: usrn
+          required: true
+          schema:
+            type: string
+          description: Unique Street Reference Number (USRN)
+      responses:
+        "200":
+          description: A JSON object of road classifications
+          content:
+            application/json:
+              schema:
+                type: object
   /planning-constraints-schema:
     get:
       tags: ["gis"]

--- a/apps/api.planx.uk/modules/gis/service/classifiedRoads.ts
+++ b/apps/api.planx.uk/modules/gis/service/classifiedRoads.ts
@@ -40,21 +40,6 @@ interface RoadConstraint extends Constraint {
 // Passport key comes from Digital Planning Schemas googlesheet
 export const PASSPORT_FN = "road.classified";
 
-/**
- * @swagger
- * /roads:
- *  get:
- *    summary: Fetches road classifications
- *    description: Fetches and formats road classifications from Ordnance Survey MasterMap Highways via OS Features API for a USRN
- *    tags:
- *      - gis
- *    parameters:
- *      - in: query
- *        name: usrn
- *        type: string
- *        required: true
- *        description: Unique Street Reference Number (USRN)
- */
 export const classifiedRoadsSearch = async (
   req: Request,
   res: Response,

--- a/apps/api.planx.uk/modules/gis/service/index.js
+++ b/apps/api.planx.uk/modules/gis/service/index.js
@@ -2,28 +2,6 @@ import * as digitalLand from "./digitalLand.js";
 
 const localAuthorities = { digitalLand };
 
-/**
- * @swagger
- * /gis/{localAuthority}:
- *  get:
- *    summary: Fetches planning constraints
- *    description: Fetches and formats planning constraints from planning.data.gov.uk that overlap with a geometry
- *    tags:
- *      - gis
- *    parameters:
- *      - $ref: '#/components/parameters/localAuthority'
- *        description: Name of the Local Authority, usually the same as Planx `team`. Required until Planning Data is available for any council
- *      - in: query
- *        name: geom
- *        type: string
- *        required: true
- *        description: Well-Known Text (WKT) formatted polygon or point
- *      - in: query
- *        name: vals
- *        type: string
- *        required: false
- *        description: Comma-separated list of planning constraint values (formatted using `fn` property names) that should be returned
- */
 export async function locationSearch(req, res, next) {
   // 'geom' param signals this localAuthority has data available via Planning Data
   if (req.query.geom) {

--- a/apps/api.planx.uk/modules/pay/docs.yaml
+++ b/apps/api.planx.uk/modules/pay/docs.yaml
@@ -22,13 +22,13 @@ components:
       type: string
       format: uuid
       required: true
-    sessionId:
+    sessionIdQuery:
       in: query
       name: sessionId
-      schema:
-      type: string
-      format: uuid
       required: true
+      schema:
+        type: string
+        format: uuid
     paymentRequest:
       in: path
       name: paymentId
@@ -315,7 +315,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/localAuthority"
         - $ref: "#/components/parameters/flowId"
-        - $ref: "#/components/parameters/sessionId"
+        - $ref: "#/components/parameters/sessionIdQuery"
       requestBody:
         $ref: "#/components/schemas/CreatePaymentRequest"
       responses:
@@ -334,7 +334,7 @@ paths:
         - $ref: "#/components/parameters/localAuthority"
         - $ref: "#/components/parameters/paymentId"
         - $ref: "#/components/parameters/flowId"
-        - $ref: "#/components/parameters/sessionId"
+        - $ref: "#/components/parameters/sessionIdQuery"
       responses:
         "200":
           $ref: "#/components/responses/FetchPaymentResponse"


### PR DESCRIPTION
## What does this PR do?
 - Remove all legacy API docs generated via JSDocs (`@swagger` keyword), in favour of standard `docs.yaml`
 - Update docs to remove old reference
 - Fixed clash of two `sessionId` parameters - see comment on code

## Motivation
 - I hit the `sessionId` issue on prod API docs whilst debugging and I wanted to fix this 
 - Long overdue - nice to have a single method here...!