### PR TITLE
chore: add Liverpool A4 metadata

### DIFF
--- a/apps/api.planx.uk/modules/gis/service/helpers.ts
+++ b/apps/api.planx.uk/modules/gis/service/helpers.ts
@@ -16,6 +16,7 @@ import * as gloucester from "./local_authorities/metadata/gloucester.js";
 import * as greaterCambridge from "./local_authorities/metadata/greaterCambridge.js";
 import * as horsham from "./local_authorities/metadata/horsham.js";
 import * as lambeth from "./local_authorities/metadata/lambeth.js";
+import * as liverpoolCity from "./local_authorities/metadata/liverpoolCity.js";
 import * as medway from "./local_authorities/metadata/medway.js";
 import * as newcastle from "./local_authorities/metadata/newcastle.js";
 import * as northumberland from "./local_authorities/metadata/northumberland.js";
@@ -60,6 +61,7 @@ export const localAuthorityMetadata: Record<string, LocalAuthorityMetadata> = {
   "greater-cambridge-shared-planning": greaterCambridge,
   horsham,
   lambeth,
+  "liverpool-city": liverpoolCity,
   medway,
   newcastle,
   northumberland,

--- a/apps/api.planx.uk/modules/gis/service/local_authorities/metadata/liverpoolCity.ts
+++ b/apps/api.planx.uk/modules/gis/service/local_authorities/metadata/liverpoolCity.ts
@@ -1,0 +1,21 @@
+/*
+LAD20CD: E08000012
+LAD20NM: Liverpool City
+LAD20NMW:
+
+https://www.planning.data.gov.uk/entity/?dataset=article-4-direction-area&geometry_curie=statistical-geography%3AE08000012&q=&entry_date_day=&entry_date_month=&entry_date_year=
+*/
+
+import type { LocalAuthorityMetadata } from "../../helpers.js";
+
+const planningConstraints: LocalAuthorityMetadata["planningConstraints"] = {
+  articleFour: {
+    // Only two actual A4 directions in Liverpool, others are planning conditions
+    records: {
+      "articleFour.liverpoolCity.liverpoolDirection": "A4Da407",
+      "articleFour.liverpoolCity.dales": "A4Da408",
+    },
+  },
+};
+
+export { planningConstraints };


### PR DESCRIPTION
Liverpool requested to only cover their actual A4 directions (of which they only have two) as A4 constraints.

All other article-4-direction-area entries should be dealt with as a 'Planning conditions' constraint, [see card here](https://trello.com/c/64Hvru9h/3627-add-planning-conditions-removing-pd-rights-as-a-planning-constraint).