### PR TITLE
feat: New component select for change component function

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -9,6 +9,7 @@ import InputGroup from "ui/editor/InputGroup";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
@@ -125,7 +126,7 @@ export default function Component(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Calculate" Icon={ICONS[TYPES.Calculate]}>
+        <ModalComponentHeader title="Calculate" Icon={ICONS[TYPES.Calculate]}>
           <Typography variant="body2" sx={{ mb: 2 }}>
             This component does math! Write formulas using{" "}
             <a href="https://mathjs.org/index.html" target="_blank">
@@ -143,7 +144,7 @@ export default function Component(props: Props) {
               disabled={props.disabled}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent title="Output">
           <DataFieldAutocomplete
             required

--- a/apps/editor.planx.uk/src/@planx/components/Content/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Content/Editor.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import ColorPicker from "ui/editor/ColorPicker/ColorPicker";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import InputRow from "ui/shared/InputRow";
@@ -43,7 +43,7 @@ const ContentComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Content" Icon={ICONS[TYPES.Content]}>
+        <ModalComponentHeader title="Content" Icon={ICONS[TYPES.Content]}>
           <InputRow>
             <RichTextInput
               placeholder="Content"
@@ -74,7 +74,7 @@ const ContentComponent: React.FC<Props> = (props) => {
               disabled={props.disabled}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -11,7 +11,7 @@ import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import DateInputUi from "ui/shared/DateInput/DateInput";
@@ -50,7 +50,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Date input" Icon={ICONS[TYPES.DateInput]}>
+        <ModalComponentHeader title="Date input" Icon={ICONS[TYPES.DateInput]}>
           <InputRow>
             <Input
               format="large"
@@ -106,7 +106,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
               />
             </InputRow>
           </Box>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import { InternalNotes } from "ui/editor/InternalNotes";
 import ModalSection from "ui/editor/ModalSection";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import { MoreInformation } from "ui/editor/MoreInformation/MoreInformation";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
@@ -59,7 +60,7 @@ const EnhancedTextInputComponent = (props: Props) => {
             }
           />
           <ModalSection>
-            <ModalSectionContent
+            <ModalComponentHeader
               title="Enhanced text input"
               Icon={ICONS[ComponentType.EnhancedTextInput]}
             >
@@ -89,7 +90,7 @@ const EnhancedTextInputComponent = (props: Props) => {
                   </RadioGroup>
                 </FormControl>
               </InputRow>
-            </ModalSectionContent>
+            </ModalComponentHeader>
           </ModalSection>
           <ModalSection>
             <ModalSectionContent>

--- a/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -9,6 +9,7 @@ import React, { MutableRefObject } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import AutocompleteInput from "ui/shared/Autocomplete/AutocompleteInput";
 import { RenderGroupHeaderBlock } from "ui/shared/Autocomplete/components/RenderGroupHeaderBlock";
@@ -111,12 +112,12 @@ const ExternalPortalForm: React.FC<{
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Flow" Icon={ICONS[TYPES.ExternalPortal]}>
+        <ModalComponentHeader title="Flow" Icon={ICONS[TYPES.ExternalPortal]}>
           <span>
             Nest all content from another flow inline within this flow. Deleting
             this node does NOT delete the flow that it references.
           </span>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent key={"flow-section"} title="Pick a flow">
           <ErrorWrapper error={formik.errors.flowId}>
             <AutocompleteInput<Flow>

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -7,7 +7,7 @@ import InputGroup from "ui/editor/InputGroup";
 import InputLabel from "ui/editor/InputLabel";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -46,7 +46,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Feedback" Icon={ICONS[TYPES.Feedback]}>
+        <ModalComponentHeader title="Feedback" Icon={ICONS[TYPES.Feedback]}>
           <InputGroup flowSpacing>
             <InputRow>
               <InputLabel label="Title">
@@ -118,7 +118,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
               />
             </InputRow>
           </InputGroup>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -4,7 +4,7 @@ import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -49,7 +49,7 @@ function Component(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="File upload" Icon={ICONS[TYPES.FileUpload]}>
+        <ModalComponentHeader title="File upload" Icon={ICONS[TYPES.FileUpload]}>
           <InputRow>
             <Input
               required
@@ -105,7 +105,7 @@ function Component(props: Props) {
               disabled={props.disabled}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -10,6 +10,7 @@ import { FormikProps } from "formik";
 import React, { MutableRefObject } from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 
 import { ICONS } from "../shared/icons";
 
@@ -69,13 +70,13 @@ const Filter: React.FC<Props> = (props) => {
       data-testid="filter-component-form"
     >
       <ModalSection>
-        <ModalSectionContent title="Filter" Icon={ICONS[TYPES.Filter]}>
+        <ModalComponentHeader title="Filter" Icon={ICONS[TYPES.Filter]}>
           <Typography variant="body2">
             Filters automatically sort based on collected flags. Flags within a
             category are ordered heirarchically and the filter will route
             through the left-most matching flag option only.
           </Typography>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent title="Pick a flagset category">
           <select
             data-testid="flagset-category-select"

--- a/apps/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/InternalPortal/Editor.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import InputLabel from "ui/public/InputLabel";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -79,7 +80,7 @@ const InternalPortalForm: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Folder" Icon={ICONS[TYPES.InternalPortal]}>
+        <ModalComponentHeader title="Folder" Icon={ICONS[TYPES.InternalPortal]}>
           <ErrorWrapper error={formik.errors.text}>
             <Input
               name="text"
@@ -91,7 +92,7 @@ const InternalPortalForm: React.FC<Props> = (props) => {
               id="portalFlowId"
             />
           </ErrorWrapper>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         {props.flows && props.flows?.length > 0 && (
           <ModalSectionContent subtitle="Select an existing folder">
             <InputLabel

--- a/apps/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -4,7 +4,7 @@ import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -123,7 +123,7 @@ function ListComponent(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="List" Icon={ICONS[TYPES.List]}>
+        <ModalComponentHeader title="List" Icon={ICONS[TYPES.List]}>
           <InputRow>
             <Input
               format="large"
@@ -179,7 +179,7 @@ function ListComponent(props: Props) {
               </InputRowItem>
             </InputRow>
           </ErrorWrapper>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -15,7 +15,7 @@ import ListManager, {
 } from "ui/editor/ListManager/ListManager";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -110,7 +110,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Next steps" Icon={ICONS[TYPES.NextSteps]}>
+        <ModalComponentHeader title="Next steps" Icon={ICONS[TYPES.NextSteps]}>
           <Typography variant="body2" sx={{ mb: 2 }}>
             If you want users to continue to the next step in the service from a
             given step, leave that URL section empty.
@@ -149,7 +149,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
             disabled={props.disabled}
             collapsible={true}
           />
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import ColorPicker from "ui/editor/ColorPicker/ColorPicker";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeConfiguration } from "ui/editor/TemplatedNodeConfiguration";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
@@ -43,7 +43,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = ({ formik, disabled }) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Notice" Icon={ICONS[TYPES.Notice]}>
+        <ModalComponentHeader title="Notice" Icon={ICONS[TYPES.Notice]}>
           <InputRow>
             <Input
               name="title"
@@ -82,7 +82,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = ({ formik, disabled }) => {
               disabled={disabled}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <MoreInformation formik={formik} disabled={disabled} />
       <InternalNotes

--- a/apps/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -4,7 +4,7 @@ import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -58,7 +58,7 @@ function PageComponent(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Page" Icon={ICONS[TYPES.Page]}>
+        <ModalComponentHeader title="Page" Icon={ICONS[TYPES.Page]}>
           <InputRow>
             <Input
               format="large"
@@ -112,7 +112,7 @@ function PageComponent(props: Props) {
               </SelectInput>
             </InputRowItem>
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalFooter formik={formik} disabled={props.disabled} />
     </form>

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -12,6 +12,7 @@ import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
 import { InternalNotes } from "ui/editor/InternalNotes";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { MoreInformation } from "ui/editor/MoreInformation/MoreInformation";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeConfiguration } from "ui/editor/TemplatedNodeConfiguration";
@@ -55,7 +56,7 @@ const Component: React.FC<Props> = (props: Props) => {
             }
           />
           <ModalSection>
-            <ModalSectionContent title="Payment" Icon={ICONS[TYPES.Pay]}>
+            <ModalComponentHeader title="Payment" Icon={ICONS[TYPES.Pay]}>
               <InputRow>
                 <Input
                   format="large"
@@ -90,7 +91,7 @@ const Component: React.FC<Props> = (props: Props) => {
               <InputRow>
                 <Input format="data" name="fn" value={PAY_FN} disabled />
               </InputRow>
-            </ModalSectionContent>
+            </ModalComponentHeader>
             <ModalSectionContent>
               <InputRow>
                 <Input

--- a/apps/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -12,7 +12,7 @@ import groupBy from "lodash/groupBy";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import InputLabel from "ui/public/InputLabel";
@@ -116,7 +116,7 @@ const ResultComponent: React.FC<Props> = (props) => {
             }
           />
           <ModalSection>
-            <ModalSectionContent title="Result" Icon={ICONS[TYPES.Result]}>
+            <ModalComponentHeader title="Result" Icon={ICONS[TYPES.Result]}>
               <InputRow>
                 <Typography variant="h5" component="h6">
                   <label htmlFor="result-flagSet">Flag set</label>
@@ -181,7 +181,7 @@ const ResultComponent: React.FC<Props> = (props) => {
                   })}
                 </Box>
               </Box>
-            </ModalSectionContent>
+            </ModalComponentHeader>
           </ModalSection>
           <ModalFooter
             formik={formik}

--- a/apps/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -40,7 +41,7 @@ function Component(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Review" Icon={ICONS[TYPES.Review]}>
+        <ModalComponentHeader title="Review" Icon={ICONS[TYPES.Review]}>
           <InputRow>
             <Input
               format="large"
@@ -62,7 +63,7 @@ function Component(props: Props) {
               errorMessage={formik.errors.description}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent subtitle="Disclaimer">
           <InputRow>
             <RichTextInput

--- a/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -11,6 +11,7 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -81,7 +82,7 @@ function SectionComponent(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Section marker" Icon={ICONS[TYPES.Section]}>
+        <ModalComponentHeader title="Section marker" Icon={ICONS[TYPES.Section]}>
           <InputRow>
             <Input
               required
@@ -104,7 +105,7 @@ function SectionComponent(props: Props) {
               errorMessage={formik.errors.description}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent title="Section length" Icon={MoreTimeIcon}>
           <Typography variant="subtitle2" sx={{ mb: 2 }}>
             Please estimate the relative length of this section. This will be

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -13,6 +13,7 @@ import React, { useCallback } from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
@@ -71,7 +72,7 @@ const SendForm: React.FC<SendFormProps> = ({ disabled }) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Send" Icon={ICONS[TYPES.Send]}>
+        <ModalComponentHeader title="Send" Icon={ICONS[TYPES.Send]}>
           <InputRow>
             <Input
               format="large"
@@ -83,7 +84,7 @@ const SendForm: React.FC<SendFormProps> = ({ disabled }) => {
               errorMessage={formik.errors.title}
             />
           </InputRow>
-        </ModalSectionContent>
+        </ModalComponentHeader>
       </ModalSection>
       <ModalSection>
         <ErrorWrapper error={getIn(formik.errors, "destinations")}>

--- a/apps/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
@@ -63,7 +64,7 @@ function SetFeeComponent(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Set fees" Icon={ICONS[TYPES.SetFee]} />
+        <ModalComponentHeader title="Set fees" Icon={ICONS[TYPES.SetFee]} />
       </ModalSection>
       <ModalSection>
         <ModalSectionContent title="Application fee VAT">

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -14,7 +14,7 @@ import ListManager, {
 } from "ui/editor/ListManager/ListManager";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -94,7 +94,7 @@ const TaskListComponent: React.FC<Props> = (props) => (
           }
         />
         <ModalSection>
-          <ModalSectionContent title="Task list" Icon={ICONS[TYPES.TaskList]}>
+          <ModalComponentHeader title="Task list" Icon={ICONS[TYPES.TaskList]}>
             <Box sx={{ mb: "1rem" }}>
               <InputRow>
                 <Input
@@ -128,7 +128,7 @@ const TaskListComponent: React.FC<Props> = (props) => (
               collapsible={true}
               itemName="task"
             />
-          </ModalSectionContent>
+          </ModalComponentHeader>
         </ModalSection>
         <ModalFooter formik={formik} disabled={props.disabled} />
       </Form>

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import Input from "ui/shared/Input/Input";
@@ -77,7 +78,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title="Text input" Icon={ICONS[TYPES.TextInput]}>
+        <ModalComponentHeader title="Text input" Icon={ICONS[TYPES.TextInput]}>
           <InputRow>
             <Input
               format="large"
@@ -104,7 +105,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
             onChange={(value) => formik.setFieldValue("fn", value)}
             disabled={props.disabled}
           />
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent title="Input style">
           <FormControl component="fieldset">
             <RadioGroup defaultValue="short" value={formik.values.type}>

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
@@ -5,7 +5,7 @@ import React, { useRef } from "react";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
 import InputGroup from "ui/editor/InputGroup";
 import ModalSection from "ui/editor/ModalSection";
-import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -49,7 +49,7 @@ export const BaseChecklistComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title={title} Icon={ICONS[type]}>
+        <ModalComponentHeader title={title} Icon={ICONS[type]}>
           <InputGroup>
             <InputRow>
               <Input
@@ -156,7 +156,7 @@ export const BaseChecklistComponent: React.FC<Props> = (props) => {
               </>
             )}
           </InputGroup>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ErrorWrapper error={getIn(formik.errors, "options")}>
           <Options {...props} />
         </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -13,6 +13,7 @@ import InputGroup from "ui/editor/InputGroup";
 import ListManager from "ui/editor/ListManager/ListManager";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
+import ModalComponentHeader from "ui/editor/ModalComponentHeader";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -81,7 +82,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
         }
       />
       <ModalSection>
-        <ModalSectionContent title={title} Icon={ICONS[type]}>
+        <ModalComponentHeader title={title} Icon={ICONS[type]}>
           <InputGroup>
             <InputRow>
               <Input
@@ -161,7 +162,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
               </>
             )}
           </InputGroup>
-        </ModalSectionContent>
+        </ModalComponentHeader>
         <ModalSectionContent subtitle="Options">
           <ErrorWrapper error={getIn(formik.errors, "options")}>
             <ListManager

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
@@ -33,7 +33,7 @@ const ChangeComponentHeader: React.FC<Props> = ({ type, onChange, canChange }) =
   return (
     <>
       <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-        {Icon && <Icon sx={{ color: "text.primary" }} />}
+        {Icon && <Icon sx={{ color: "text.primary", fontSize: "1.6rem" }} />}
         <Typography variant="h3" component="h1">
           {componentTitle}
         </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
@@ -19,7 +19,8 @@ interface Props {
 const ChangeComponentHeader: React.FC<Props> = ({ type, onChange, canChange }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const item = ALL_ITEMS.find((i) => i.slug === type);
+  const displaySlug = type === "enhanced-text-input" ? "text-input" : type;
+  const item = ALL_ITEMS.find((i) => i.slug === displaySlug);
   const Icon = item ? ICONS[item.type] : undefined;
   const componentTitle = item?.title ?? type;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/ChangeComponentHeader.tsx
@@ -1,0 +1,77 @@
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import Popover from "@mui/material/Popover";
+import Typography from "@mui/material/Typography";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
+import { ICONS } from "@planx/components/shared/icons";
+import React, { useState } from "react";
+
+import { fromSlug } from "../../data/types";
+import { AddComponentModalContent } from "./AddComponentModal";
+import { ALL_ITEMS } from "./componentData";
+
+interface Props {
+  type: string;
+  onChange: (newType: TYPES) => void;
+  canChange: boolean;
+}
+
+const ChangeComponentHeader: React.FC<Props> = ({ type, onChange, canChange }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const item = ALL_ITEMS.find((i) => i.slug === type);
+  const Icon = item ? ICONS[item.type] : undefined;
+  const componentTitle = item?.title ?? type;
+
+  const handleSelect = (slug: string) => {
+    setAnchorEl(null);
+    const newType = fromSlug(slug);
+    if (newType !== undefined) onChange(newType);
+  };
+
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        {Icon && <Icon sx={{ color: "text.primary" }} />}
+        <Typography variant="h3" component="h1">
+          {componentTitle}
+        </Typography>
+        {canChange && (
+          <Link
+            component="button"
+            variant="body2"
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            sx={{ flexShrink: 0 }}
+          >
+            change
+          </Link>
+        )}
+      </Box>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        disableScrollLock
+        slotProps={{
+          paper: {
+            sx: {
+              width: 300,
+              maxHeight: "min(480px, 85vh)",
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              border: 1,
+              borderColor: "divider",
+            },
+          },
+        }}
+      >
+        <AddComponentModalContent onSelect={handleSelect} />
+      </Popover>
+    </>
+  );
+};
+
+export default ChangeComponentHeader;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -159,7 +159,7 @@ const TextInputToggle: React.FC<{
   };
 
   return (
-    <Box sx={{ position: "absolute", right: 82, top: 30, zIndex: 1 }}>
+    <Box sx={{ px: 6, height: 0, py: 1.5 }}>
       <Switch
         label={
           <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -23,7 +23,7 @@ import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
-import React, { createContext, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { Switch } from "ui/shared/Switch";
@@ -33,7 +33,6 @@ import { fromSlug, SLUGS } from "../../data/types";
 import { useStore } from "../../lib/store";
 import ChangeComponentHeader from "./ChangeComponentHeader";
 
-export const ModalFormContext = createContext({ hideComponentTypeHeader: false });
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
   // Target all modal sections (the direct child is the backdrop, hence the double child selector)
@@ -382,11 +381,6 @@ const FormModal: React.FC<FormModalProps> = ({
           {!handleDelete && (
             <TextInputToggle type={type} parent={parent} before={before} />
           )}
-          <ModalFormContext.Provider
-            value={{
-              hideComponentTypeHeader: hasFeatureFlag("COMPONENT_SELECT"),
-            }}
-          >
             <ErrorBoundary FallbackComponent={ErrorFallback}>
               <Component
                 formikRef={formikRef}
@@ -434,7 +428,6 @@ const FormModal: React.FC<FormModalProps> = ({
                 }}
               />
             </ErrorBoundary>
-          </ModalFormContext.Provider>
         </DialogContent>
         <DialogActions
           disableSpacing

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -130,15 +130,14 @@ const TextInputToggle: React.FC<{
   before?: string;
 }> = ({ type, parent, before }) => {
   const navigate = useNavigate();
-  const [checked, setChecked] = useState(type === "enhanced-text-input");
   const { flow, team } = useParams({ from: "/_authenticated/app/$team/$flow" });
 
   if (!["text-input", "enhanced-text-input"].includes(type)) return null;
 
-  const toggleTextInput = () => {
-    // Toggle visual state immediately without waiting for route change
-    setChecked(!checked);
+  // Ensure toggle stays in sync with component state
+  const checked = type === "enhanced-text-input";
 
+  const toggleTextInput = () => {
     const destinationType =
       type === "text-input" ? TYPES.EnhancedTextInput : TYPES.TextInput;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -17,12 +17,13 @@ import { type BaseNodeData, parseFormValues } from "@planx/components/shared";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import ErrorFallback from "components/Error/ErrorFallback";
 import { FormikProps } from "formik";
+import { hasFeatureFlag } from "lib/featureFlags";
 import isEqual from "lodash/isEqual";
 import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
-import React, { useMemo, useRef, useState } from "react";
+import React, { createContext, useMemo, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { Switch } from "ui/shared/Switch";
@@ -30,6 +31,9 @@ import { getNodeRoute } from "utils/routeUtils/utils";
 
 import { fromSlug, SLUGS } from "../../data/types";
 import { useStore } from "../../lib/store";
+import ChangeComponentHeader from "./ChangeComponentHeader";
+
+export const ModalFormContext = createContext({ hideComponentTypeHeader: false });
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
   // Target all modal sections (the direct child is the backdrop, hence the double child selector)
@@ -353,13 +357,22 @@ const FormModal: React.FC<FormModalProps> = ({
         <DialogTitle
           sx={{
             py: 1,
+            px: 2.5,
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
           }}
         >
-          {!handleDelete && (
-            <NodeTypeSelect value={type} onChange={changeNodeType} />
+          {hasFeatureFlag("COMPONENT_SELECT") ? (
+            <ChangeComponentHeader
+              type={type}
+              onChange={changeNodeType}
+              canChange={!handleDelete}
+            />
+          ) : (
+            !handleDelete && (
+              <NodeTypeSelect value={type} onChange={changeNodeType} />
+            )
           )}
 
           <CloseButton aria-label="close" onClick={handleClose} size="large">
@@ -370,53 +383,59 @@ const FormModal: React.FC<FormModalProps> = ({
           {!handleDelete && (
             <TextInputToggle type={type} parent={parent} before={before} />
           )}
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
-            <Component
-              formikRef={formikRef}
-              node={node}
-              {...node?.data}
-              {...extraProps}
-              id={id}
-              disabled={disabled}
-              handleSubmit={(
-                data: { data?: Record<string, unknown> },
-                children:
-                  | Array<Record<string, unknown>>
-                  | undefined = undefined,
-              ) => {
-                // Handle internal portals
-                if (typeof data === "string" && parent) {
-                  connect(parent, data, { before });
-                } else {
-                  const parsedData = parseFormValues(Object.entries(data));
-                  const parsedChildren =
-                    children?.map((o) => parseFormValues(Object.entries(o))) ||
-                    undefined;
-
-                  if (handleDelete) {
-                    updateNode(
-                      { id, ...parsedData },
-                      { children: parsedChildren },
-                    );
+          <ModalFormContext.Provider
+            value={{
+              hideComponentTypeHeader: hasFeatureFlag("COMPONENT_SELECT"),
+            }}
+          >
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
+              <Component
+                formikRef={formikRef}
+                node={node}
+                {...node?.data}
+                {...extraProps}
+                id={id}
+                disabled={disabled}
+                handleSubmit={(
+                  data: { data?: Record<string, unknown> },
+                  children:
+                    | Array<Record<string, unknown>>
+                    | undefined = undefined,
+                ) => {
+                  // Handle internal portals
+                  if (typeof data === "string" && parent) {
+                    connect(parent, data, { before });
                   } else {
-                    addNode(parsedData, {
-                      children: parsedChildren,
-                      parent,
-                      before,
-                    });
-                  }
-                }
+                    const parsedData = parseFormValues(Object.entries(data));
+                    const parsedChildren =
+                      children?.map((o) => parseFormValues(Object.entries(o))) ||
+                      undefined;
 
-                navigate({
-                  to: "/app/$team/$flow",
-                  params: {
-                    team: teamSlug,
-                    flow: flowSlug,
-                  },
-                });
-              }}
-            />
-          </ErrorBoundary>
+                    if (handleDelete) {
+                      updateNode(
+                        { id, ...parsedData },
+                        { children: parsedChildren },
+                      );
+                    } else {
+                      addNode(parsedData, {
+                        children: parsedChildren,
+                        parent,
+                        before,
+                      });
+                    }
+                  }
+
+                  navigate({
+                    to: "/app/$team/$flow",
+                    params: {
+                      team: teamSlug,
+                      flow: flowSlug,
+                    },
+                  });
+                }}
+              />
+            </ErrorBoundary>
+          </ModalFormContext.Provider>
         </DialogContent>
         <DialogActions
           disableSpacing
@@ -523,4 +542,5 @@ const FormModal: React.FC<FormModalProps> = ({
     </>
   );
 };
+
 export default FormModal;

--- a/apps/editor.planx.uk/src/ui/editor/ModalComponentHeader.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalComponentHeader.tsx
@@ -1,0 +1,19 @@
+import { OverridableComponent } from "@mui/material/OverridableComponent";
+import { SvgIconProps, SvgIconTypeMap } from "@mui/material/SvgIcon";
+import React from "react";
+
+import ModalSectionContent from "./ModalSectionContent";
+
+interface Props {
+  title?: string;
+  subtitle?: string;
+  children?: React.JSX.Element[] | React.JSX.Element;
+  author?: string;
+  Icon?:
+    | React.ComponentType<SvgIconProps>
+    | (OverridableComponent<SvgIconTypeMap<{}, "svg">> & { muiName: string });
+}
+
+export default function ModalComponentHeader(props: Props): FCReturn {
+  return <ModalSectionContent {...props} isComponentHeader />;
+}

--- a/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
@@ -12,6 +12,7 @@ interface Props {
   subtitle?: string;
   children?: React.JSX.Element[] | React.JSX.Element;
   author?: string;
+  isComponentHeader?: boolean;
   Icon?:
     | React.ComponentType<SvgIconProps>
     | (OverridableComponent<SvgIconTypeMap<{}, "svg">> & { muiName: string });
@@ -68,9 +69,10 @@ export default function ModalSectionContent({
   subtitle,
   children,
   author,
+  isComponentHeader,
   Icon,
 }: Props): FCReturn {
- const suppressHeader = hasFeatureFlag("COMPONENT_SELECT") && Boolean(Icon) && Boolean(title);
+  const suppressHeader = hasFeatureFlag("COMPONENT_SELECT") && Boolean(isComponentHeader);
 
   return (
     <SectionContentGrid container>

--- a/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
@@ -75,10 +75,8 @@ export default function ModalSectionContent({
 
   return (
     <SectionContentGrid container>
-      <LeftGutter sx={suppressHeader ? { flex: "0 0 0" } : undefined}>
-        {!suppressHeader && Icon && <Icon />}
-      </LeftGutter>
-      <SectionContent sx={suppressHeader ? { paddingRight: 3 } : undefined}>
+      <LeftGutter>{!suppressHeader && Icon && <Icon />}</LeftGutter>
+      <SectionContent>
         {!suppressHeader && title && (
           <Title variant="h3">
             {title}

--- a/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
@@ -3,8 +3,8 @@ import { OverridableComponent } from "@mui/material/OverridableComponent";
 import { styled } from "@mui/material/styles";
 import { SvgIconProps, SvgIconTypeMap } from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
-import { ModalFormContext } from "pages/FlowEditor/components/forms/FormModal";
-import React, { useContext } from "react";
+import { hasFeatureFlag } from "lib/featureFlags";
+import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface Props {
@@ -70,8 +70,7 @@ export default function ModalSectionContent({
   author,
   Icon,
 }: Props): FCReturn {
-  const { hideComponentTypeHeader } = useContext(ModalFormContext);
-  const suppressHeader = hideComponentTypeHeader && Boolean(Icon) && Boolean(title);
+ const suppressHeader = hasFeatureFlag("COMPONENT_SELECT") && Boolean(Icon) && Boolean(title);
 
   return (
     <SectionContentGrid container>

--- a/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalSectionContent.tsx
@@ -3,7 +3,8 @@ import { OverridableComponent } from "@mui/material/OverridableComponent";
 import { styled } from "@mui/material/styles";
 import { SvgIconProps, SvgIconTypeMap } from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import { ModalFormContext } from "pages/FlowEditor/components/forms/FormModal";
+import React, { useContext } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface Props {
@@ -31,7 +32,7 @@ const LeftGutter = styled(Grid)(({ theme }) => ({
   flex: `0 0 ${theme.spacing(3)}`,
   textAlign: "center",
   [theme.breakpoints.up("md")]: {
-    flex: `0 0 ${theme.spacing(6)}`,
+    flex: `0 0 ${theme.spacing(4)}`,
   },
   [theme.breakpoints.up("lg")]: {
     paddingTop: theme.spacing(0.2),
@@ -42,7 +43,7 @@ const SectionContent = styled(Grid)(({ theme }) => ({
   flexGrow: 1,
   width: "100%",
   [theme.breakpoints.up("md")]: {
-    paddingRight: theme.spacing(6),
+    paddingRight: theme.spacing(4),
   },
 }));
 
@@ -69,11 +70,16 @@ export default function ModalSectionContent({
   author,
   Icon,
 }: Props): FCReturn {
+  const { hideComponentTypeHeader } = useContext(ModalFormContext);
+  const suppressHeader = hideComponentTypeHeader && Boolean(Icon) && Boolean(title);
+
   return (
     <SectionContentGrid container>
-      <LeftGutter>{Icon && <Icon />}</LeftGutter>
-      <SectionContent>
-        {title && (
+      <LeftGutter sx={suppressHeader ? { flex: "0 0 0" } : undefined}>
+        {!suppressHeader && Icon && <Icon />}
+      </LeftGutter>
+      <SectionContent sx={suppressHeader ? { paddingRight: 3 } : undefined}>
+        {!suppressHeader && title && (
           <Title variant="h3">
             {title}
             {author && <Author>by {author}</Author>}


### PR DESCRIPTION
## What does this PR do?

- Refactors the editor modal so that the header bar is used for the component title and conditional "change" link
  - Component icon and title is moved to the header, making better use of available space and enabling a sticky component type header
  - On component creation (still "draft"), a change link appears

The above is in anticipation of our forthcoming work to allow saved components to be changed to a different component type.

**Testing:**
- Enable feature flag `COMPONENT_SELECT`
- Add a new component to a flow, the "change" link will be visible when the component is still draft, and the component title will persist in all states