### PR TITLE
chore: Bump planx-core

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -12,7 +12,7 @@
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@aws-sdk/s3-request-presigner": "^3.1000.0",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#837fdd3",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#2f19e28",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.5.16",
     "ai": "^6.0.116",

--- a/apps/api.planx.uk/pnpm-lock.yaml
+++ b/apps/api.planx.uk/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.1000.0
         version: 3.1053.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#837fdd3
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.15)
+        specifier: github:theopensystemslab/planx-core#2f19e28
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.15)
       '@types/isomorphic-fetch':
         specifier: ^0.0.36
         version: 0.0.36
@@ -1188,8 +1188,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106}
     version: 1.0.0
 
   '@opentelemetry/api@1.9.1':
@@ -5113,7 +5113,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.15)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.15)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.4))(@types/react@19.2.15)(react@19.2.4)

--- a/apps/api.planx.uk/pnpm-workspace.yaml
+++ b/apps/api.planx.uk/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ allowBuilds:
   "@opensystemslab/planx-core": true
 
 minimumReleaseAge: 10080
+
+minimumReleaseAgeExclude:
+  - dompurify@3.4.11

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -18,7 +18,7 @@
     "@mui/x-charts": "^9.0.0",
     "@mui/x-data-grid": "^9.0.0",
     "@opensystemslab/map": "1.0.0-alpha.11",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#837fdd3",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#2f19e28",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-router-devtools": "^1.163.3",

--- a/apps/editor.planx.uk/pnpm-lock.yaml
+++ b/apps/editor.planx.uk/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#837fdd3
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#2f19e28
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.14)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.95.2(react@19.2.5)
@@ -2048,8 +2048,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.11':
     resolution: {integrity: sha512-ETACPCk5Coef1L2kNT3MhIzLxVPDpyopxsTNcgeRyEqL71HBfTklGyC5+t7HgEgxRkX5wlUXqmKPNL9DdpVj8g==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106}
     version: 1.0.0
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
@@ -9160,7 +9160,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.4)

--- a/apps/editor.planx.uk/pnpm-workspace.yaml
+++ b/apps/editor.planx.uk/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 minimumReleaseAge: 10080
+
+minimumReleaseAgeExclude:
+  - dompurify@3.4.11

--- a/e2e/tests/api-driven/package.json
+++ b/e2e/tests/api-driven/package.json
@@ -8,7 +8,7 @@
   "packageManager": "pnpm@10.30.2",
   "dependencies": {
     "@cucumber/cucumber": "^12.8.3",
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#837fdd3",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#2f19e28",
     "axios": "^1.16.0",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^10.0.0",

--- a/e2e/tests/api-driven/pnpm-lock.yaml
+++ b/e2e/tests/api-driven/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^12.8.3
         version: 12.9.0
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#837fdd3
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#2f19e28
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.6)
       axios:
         specifier: ^1.16.0
         version: 1.16.0
@@ -382,8 +382,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106}
     version: 1.0.0
 
   '@popperjs/core@2.11.8':
@@ -2104,7 +2104,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@19.2.4))(@types/react@19.2.6)(react@19.2.4)

--- a/e2e/tests/api-driven/pnpm-workspace.yaml
+++ b/e2e/tests/api-driven/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 minimumReleaseAge: 10080
+
+minimumReleaseAgeExclude:
+  - dompurify@3.4.11

--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#837fdd3",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#2f19e28",
     "axios": "^1.16.0",
     "dotenv": "^16.6.1",
     "eslint": "^8.57.1",

--- a/e2e/tests/ui-driven/pnpm-lock.yaml
+++ b/e2e/tests/ui-driven/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#837fdd3
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.6)
+        specifier: github:theopensystemslab/planx-core#2f19e28
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.6)
       axios:
         specifier: ^1.16.0
         version: 1.16.0
@@ -318,8 +318,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106}
     version: 1.0.0
 
   '@playwright/test@1.58.2':
@@ -1793,7 +1793,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/837fdd399da9cd4e51eb165cb5174bc9e6f05614(@types/react@19.2.6)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.6)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.6)(react@19.2.4))(@types/react@19.2.6)(react@19.2.4)

--- a/e2e/tests/ui-driven/pnpm-workspace.yaml
+++ b/e2e/tests/ui-driven/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 minimumReleaseAge: 10080
+
+minimumReleaseAgeExclude:
+  - dompurify@3.4.11

--- a/scripts/encrypt/package.json
+++ b/scripts/encrypt/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@10.30.2",
   "keywords": [],
   "dependencies": {
-    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#51a1be9",
+    "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#2f19e28",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3"
   },

--- a/scripts/encrypt/pnpm-lock.yaml
+++ b/scripts/encrypt/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@opensystemslab/planx-core':
-        specifier: github:theopensystemslab/planx-core#51a1be9
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/51a1be9523591fda1ca5fbb0f654e7a6492d7c17(@types/react@19.2.14)
+        specifier: github:theopensystemslab/planx-core#2f19e28
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.14)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -297,14 +297,14 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@formatjs/fast-memoize@3.1.3':
-    resolution: {integrity: sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==}
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
 
-  '@formatjs/intl-listformat@8.3.4':
-    resolution: {integrity: sha512-q7WskvO6C/Cyq7ryyM9maDL2FJzt6u39MMBrxmTHZtpTMZukG5Lw0kl9sZaCOR9tYP34xOdWp4JNUrfrkdLGXQ==}
+  '@formatjs/intl-listformat@8.3.10':
+    resolution: {integrity: sha512-w7eNeoD6oReXmut+Pj7+NlkBO8RppN67Mr2SfwDhPi/D+BrZc+g7khGRhs2waNsk09X932J5Eipo8lB/jZS0wQ==}
 
-  '@formatjs/intl-localematcher@0.8.5':
-    resolution: {integrity: sha512-TEW/NR367c3PcQ2AXfkNig9jC740+qbkM0LgKl7UCE7Xtv7C5Uk1mvlu86MjQZBmscUai8HSWjcEETpwaVvJ6A==}
+  '@formatjs/intl-localematcher@0.8.10':
+    resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -420,8 +420,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -435,8 +435,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/51a1be9523591fda1ca5fbb0f654e7a6492d7c17':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/51a1be9523591fda1ca5fbb0f654e7a6492d7c17}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106}
     version: 1.0.0
 
   '@popperjs/core@2.11.8':
@@ -497,6 +497,9 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -689,11 +692,11 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fast-xml-builder@1.1.7:
-    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+  fast-xml-parser@5.9.0:
+    resolution: {integrity: sha512-duBuXbyIhEeNO4GjFuVqr0nF047oNwr18aum+zJyqo0MUG/n7Afgs3Qv3D6VN3ONedUKxiuFlPiMGIa0Z11chA==}
     hasBin: true
 
   fastq@1.20.1:
@@ -764,8 +767,8 @@ packages:
     peerDependencies:
       graphql: 14 - 16
 
-  graphql@16.13.2:
-    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-flag@4.0.0:
@@ -827,6 +830,9 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
   isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
@@ -1119,8 +1125,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.3:
-    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -1216,6 +1222,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -1492,19 +1502,19 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@formatjs/fast-memoize@3.1.3': {}
+  '@formatjs/fast-memoize@3.1.6': {}
 
-  '@formatjs/intl-listformat@8.3.4':
+  '@formatjs/intl-listformat@8.3.10':
     dependencies:
-      '@formatjs/intl-localematcher': 0.8.5
+      '@formatjs/intl-localematcher': 0.8.10
 
-  '@formatjs/intl-localematcher@0.8.5':
+  '@formatjs/intl-localematcher@0.8.10':
     dependencies:
-      '@formatjs/fast-memoize': 3.1.3
+      '@formatjs/fast-memoize': 3.1.6
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
     dependencies:
-      graphql: 16.13.2
+      graphql: 16.14.2
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -1613,7 +1623,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@nodable/entities@2.1.0': {}
+  '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1627,20 +1637,20 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/51a1be9523591fda1ca5fbb0f654e7a6492d7c17(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2f19e28bf128822d03e55fdd05a779294ea06106(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@formatjs/intl-listformat': 8.3.4
+      '@formatjs/intl-listformat': 8.3.10
       '@mui/material': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       cheerio: 1.2.0
       copyfiles: 2.4.1
       eslint: 8.57.1
-      fast-xml-parser: 5.7.2
-      graphql: 16.13.2
-      graphql-request: 6.1.0(graphql@16.13.2)
+      fast-xml-parser: 5.9.0
+      graphql: 16.14.2
+      graphql-request: 6.1.0(graphql@16.14.2)
       json-schema-to-typescript: 15.0.4
       lodash-es: 4.18.1
       marked: 18.0.2
@@ -1705,6 +1715,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  anynum@1.0.0: {}
 
   argparse@2.0.1: {}
 
@@ -1974,16 +1986,19 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
-  fast-xml-builder@1.1.7:
+  fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
 
-  fast-xml-parser@5.7.2:
+  fast-xml-parser@5.9.0:
     dependencies:
-      '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.7
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
       path-expression-matcher: 1.5.0
-      strnum: 2.2.3
+      strnum: 2.4.0
+      xml-naming: 0.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -2044,15 +2059,15 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-request@6.1.0(graphql@16.13.2):
+  graphql-request@6.1.0(graphql@16.14.2):
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
       cross-fetch: 3.2.0
-      graphql: 16.13.2
+      graphql: 16.14.2
     transitivePeerDependencies:
       - encoding
 
-  graphql@16.13.2: {}
+  graphql@16.14.2: {}
 
   has-flag@4.0.0: {}
 
@@ -2106,6 +2121,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-path-inside@3.0.3: {}
+
+  is-unsafe@1.0.1: {}
 
   isarray@0.0.1: {}
 
@@ -2367,7 +2384,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.3: {}
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
 
   stylis@4.2.0: {}
 
@@ -2446,6 +2465,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/scripts/encrypt/pnpm-workspace.yaml
+++ b/scripts/encrypt/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 minimumReleaseAge: 10080
+
+minimumReleaseAgeExclude:
+  - dompurify@3.4.11


### PR DESCRIPTION
Updates to latest `main` in `planx-core`, aiming to close a number of dependabot issues.