### PR TITLE
fix: Hide actions column for non team editors

### DIFF
--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -48,6 +48,7 @@ export const FlowTable: React.FC<FlowTableProps> = ({
   view,
 }) => {
   const { headerText } = useFlowSortDisplay();
+  const canUserEditTeam = useStore((state) => state.canUserEditTeam);
   const showDetails = view === "flows";
   const useSplitLayout =
     pinnedFlows !== undefined && unpinnedFlows !== undefined;
@@ -65,7 +66,9 @@ export const FlowTable: React.FC<FlowTableProps> = ({
               {showDetails && <TableCell>Pinned</TableCell>}
             </>
           )}
-          <FlowActionsCell align="center">Actions</FlowActionsCell>
+          {canUserEditTeam(teamSlug) && (
+            <FlowActionsCell align="center">Actions</FlowActionsCell>
+          )}
         </TableRow>
       </StyledTableHead>
       <TableBody>

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/styles.tsx
@@ -42,7 +42,6 @@ export const StyledTableHead = styled(TableHead)(({ theme }) => ({
       borderLeft: `1px solid ${theme.palette.border.main}`,
     },
     "&:last-of-type": {
-      borderLeft: `1px solid ${theme.palette.border.main}`,
       borderRight: `1px solid ${theme.palette.border.main}`,
     },
   },


### PR DESCRIPTION
## What does this PR do?

Quick one:

- Hides the action column in the flow table for non team editors or platform admins, rather than just the cells

**Before:**
<img width="3000" height="1362" alt="image" src="https://github.com/user-attachments/assets/ded96b7b-e477-4205-92ed-7128e7c2eae0" />

**After:**
<img width="1500" height="681" alt="image" src="https://github.com/user-attachments/assets/257883e4-fd52-4636-bc15-9ee9c99fe75c" />
