### PR TITLE
feat: Update Permission component for can/cannot edit and new TeamAdmin role

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
@@ -5,16 +5,14 @@ import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { HistoryItem } from "lib/api/publishFlow/types";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import Permission from "ui/editor/Permission";
 
 import { AddCommentDialog } from "./AddCommentDialog";
 import { EditHistoryTimeline } from "./Timeline";
 
 const EditHistory = () => {
-  const [flowId, canUserEditTeam, teamSlug, user] = useStore((state) => [
+  const [flowId, user] = useStore((state) => [
     state.id,
-    state.canUserEditTeam,
-    state.teamSlug,
     state.user,
   ]);
 
@@ -65,8 +63,10 @@ const EditHistory = () => {
 
   return (
     <Box sx={{ p: 2 }}>
-      {user?.id && canUserEditTeam(teamSlug) && (
-        <AddCommentDialog flowId={flowId} actorId={user.id} />
+      {user?.id && (
+        <Permission.CanEdit>
+          <AddCommentDialog flowId={flowId} actorId={user.id} />
+        </Permission.CanEdit>
       )}
       {data?.history && <EditHistoryTimeline events={data.history} />}
       {data?.history.length === 50 && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredNodes.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/AlteredNodes.tsx
@@ -7,11 +7,11 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { AlteredNode, HistoryItem } from "lib/api/publishFlow/types";
-import { useStore } from "pages/FlowEditor/lib/store";
 import { formatLastEditDate } from "pages/FlowEditor/utils";
 import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import BlockQuote from "ui/editor/BlockQuote";
+import Permission from "ui/editor/Permission";
 import Caret from "ui/icons/Caret";
 
 import { isAutoComment } from "../utils";
@@ -92,8 +92,6 @@ export const AlteredNodesSummaryContent = (props: {
   const [expanded, setExpanded] = useState(false);
   const comments = history?.filter((item) => item.type === "comment") || [];
   const operations = history?.filter((item) => item.type === "operation") || [];
-
-  const isPlatformAdmin = useStore.getState().user?.isPlatformAdmin;
 
   const changeSummary: AlteredNodesSummary = {
     title,
@@ -192,7 +190,7 @@ export const AlteredNodesSummaryContent = (props: {
       {changeSummary["portals"].length > 0 && (
         <AlteredExternalPortalsSummary portals={changeSummary["portals"]} />
       )}
-      {isPlatformAdmin && (
+      <Permission.IsPlatformAdmin>
         <PublishModalAccordion
           sx={(theme) => ({
             borderTop: `1px solid ${theme.palette.border.main}`,
@@ -239,7 +237,7 @@ export const AlteredNodesSummaryContent = (props: {
             </List>
           </AccordionDetails>
         </PublishModalAccordion>
-      )}
+      </Permission.IsPlatformAdmin>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/index.tsx
@@ -9,6 +9,7 @@ import TruncatedText from "ui/editor/TruncatedText";
 
 import { useStore } from "../../../FlowEditor/lib/store";
 import { FlowSummary } from "../../../FlowEditor/lib/store/editor";
+import Permission from "ui/editor/Permission";
 import ActiveFlowMenu from "../ActiveFlowMenu";
 import ArchivedFlowMenu from "../ArchivedFlowMenu";
 import { FlowPinButton } from "../FlowPinButton";
@@ -29,8 +30,7 @@ interface Props {
 }
 
 const FlowCard: React.FC<Props> = ({ flow, view }) => {
-  const [canUserEditTeam, teamSlug, teamId] = useStore((state) => [
-    state.canUserEditTeam,
+  const [teamSlug, teamId] = useStore((state) => [
     state.teamSlug,
     state.teamId,
   ]);
@@ -137,21 +137,25 @@ const FlowCard: React.FC<Props> = ({ flow, view }) => {
           )}
         </CardContent>
       </Box>
-      {canUserEditTeam(teamSlug) && view === "flows" && (
-        <ActiveFlowMenu
-          flow={flow}
-          isAnyTemplate={isAnyTemplate}
-          variant="card"
-          teamId={teamId}
-        />
+      {view === "flows" && (
+        <Permission.CanEdit>
+          <ActiveFlowMenu
+            flow={flow}
+            isAnyTemplate={isAnyTemplate}
+            variant="card"
+            teamId={teamId}
+          />
+        </Permission.CanEdit>
       )}
-      {canUserEditTeam(teamSlug) && view === "archive" && (
-        <ArchivedFlowMenu
-          flow={flow}
-          isAnyTemplate={isAnyTemplate}
-          variant="card"
-          teamId={teamId}
-        />
+      {view === "archive" && (
+        <Permission.CanEdit>
+          <ArchivedFlowMenu
+            flow={flow}
+            isAnyTemplate={isAnyTemplate}
+            variant="card"
+            teamId={teamId}
+          />
+        </Permission.CanEdit>
       )}
     </Card>
   );

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowTable/index.tsx
@@ -11,6 +11,7 @@ import { FlowTagType } from "ui/editor/FlowTag/types";
 import TruncatedText from "ui/editor/TruncatedText";
 
 import { useStore } from "../../../FlowEditor/lib/store";
+import Permission from "ui/editor/Permission";
 import ActiveFlowMenu from "../ActiveFlowMenu";
 import ArchivedFlowMenu from "../ArchivedFlowMenu";
 import { FlowPinButton } from "../FlowPinButton";
@@ -48,7 +49,6 @@ export const FlowTable: React.FC<FlowTableProps> = ({
   view,
 }) => {
   const { headerText } = useFlowSortDisplay();
-  const canUserEditTeam = useStore((state) => state.canUserEditTeam);
   const showDetails = view === "flows";
   const useSplitLayout =
     pinnedFlows !== undefined && unpinnedFlows !== undefined;
@@ -66,9 +66,9 @@ export const FlowTable: React.FC<FlowTableProps> = ({
               {showDetails && <TableCell>Pinned</TableCell>}
             </>
           )}
-          {canUserEditTeam(teamSlug) && (
+          <Permission.CanEdit>
             <FlowActionsCell align="center">Actions</FlowActionsCell>
-          )}
+          </Permission.CanEdit>
         </TableRow>
       </StyledTableHead>
       <TableBody>
@@ -127,10 +127,7 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
   view,
   showDetails,
 }) => {
-  const [canUserEditTeam, teamId] = useStore((state) => [
-    state.canUserEditTeam,
-    state.teamId,
-  ]);
+  const teamId = useStore((state) => state.teamId);
 
   const {
     hasSendComponent,
@@ -223,28 +220,25 @@ const FlowTableRow: React.FC<FlowTableRowProps> = ({
           )}
         </>
       )}
-      {canUserEditTeam(teamSlug) && (
-        <>
-          <FlowActionsCell
-            className="actions-cell"
-            align="center"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {view === "flows" && (
-              <ActiveFlowMenu
-                flow={flow}
-                isAnyTemplate={isAnyTemplate}
-                variant="table"
-                teamId={teamId}
-              />
-            )}
-
-            {view === "archive" && (
-              <ArchivedFlowMenu flow={flow} variant="table" teamId={teamId} />
-            )}
-          </FlowActionsCell>
-        </>
-      )}
+      <Permission.CanEdit>
+        <FlowActionsCell
+          className="actions-cell"
+          align="center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {view === "flows" && (
+            <ActiveFlowMenu
+              flow={flow}
+              isAnyTemplate={isAnyTemplate}
+              variant="table"
+              teamId={teamId}
+            />
+          )}
+          {view === "archive" && (
+            <ArchivedFlowMenu flow={flow} variant="table" teamId={teamId} />
+          )}
+        </FlowActionsCell>
+      </Permission.CanEdit>
     </StyledTableRow>
   );
 };

--- a/apps/editor.planx.uk/src/ui/editor/Permission.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/Permission.tsx
@@ -1,11 +1,20 @@
+import type { Role } from "@opensystemslab/planx-core/types";
 import { usePermission } from "hooks/usePermission";
 import React, { PropsWithChildren } from "react";
 
 type FC = React.FC<PropsWithChildren>;
 
+const EDITOR_ROLES: Role[] = ["platformAdmin", "teamAdmin", "teamEditor"];
+
 interface PermissionComponent extends FC {
+  /** Platform admins only */
   IsPlatformAdmin: FC;
+  /** Everyone except platform admins */
   IsNotPlatformAdmin: FC;
+  /** Platform admins, team admins, and team editors for the current team */
+  CanEdit: FC;
+  /** Everyone without edit access (team viewers, analysts, etc.) */
+  CannotEdit: FC;
 }
 
 const Permission: PermissionComponent = ({ children }) => {
@@ -18,9 +27,16 @@ const IsPlatformAdmin: FC = ({ children }) =>
 const IsNotPlatformAdmin: FC = ({ children }) =>
   !usePermission(["platformAdmin"]) ? children : null;
 
+const CanEdit: FC = ({ children }) =>
+  usePermission(EDITOR_ROLES) ? children : null;
+
+const CannotEdit: FC = ({ children }) =>
+  !usePermission(EDITOR_ROLES) ? children : null;
 
 // Attach permission specific components as static properties
 Permission.IsPlatformAdmin = IsPlatformAdmin;
 Permission.IsNotPlatformAdmin = IsNotPlatformAdmin;
+Permission.CanEdit = CanEdit;
+Permission.CannotEdit = CannotEdit;
 
 export default Permission;

--- a/apps/editor.planx.uk/src/ui/editor/Permission.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/Permission.tsx
@@ -11,6 +11,8 @@ interface PermissionComponent extends FC {
   IsPlatformAdmin: FC;
   /** Everyone except platform admins */
   IsNotPlatformAdmin: FC;
+  /** Platform admins and team admins for the current team */
+  IsTeamAdmin: FC;
   /** Platform admins, team admins, and team editors for the current team */
   CanEdit: FC;
   /** Everyone without edit access (team viewers, analysts, etc.) */
@@ -27,6 +29,9 @@ const IsPlatformAdmin: FC = ({ children }) =>
 const IsNotPlatformAdmin: FC = ({ children }) =>
   !usePermission(["platformAdmin"]) ? children : null;
 
+const IsTeamAdmin: FC = ({ children }) =>
+  usePermission(["platformAdmin", "teamAdmin"]) ? children : null;
+
 const CanEdit: FC = ({ children }) =>
   usePermission(EDITOR_ROLES) ? children : null;
 
@@ -36,6 +41,7 @@ const CannotEdit: FC = ({ children }) =>
 // Attach permission specific components as static properties
 Permission.IsPlatformAdmin = IsPlatformAdmin;
 Permission.IsNotPlatformAdmin = IsNotPlatformAdmin;
+Permission.IsTeamAdmin = IsTeamAdmin;
 Permission.CanEdit = CanEdit;
 Permission.CannotEdit = CannotEdit;
 


### PR DESCRIPTION
## What does this PR do?

Updates the `<Permission>` component:
- Adds `CanEdit` and `CannotEdit` to be used in view logic, replacing calls to the store for `canUserEditTeam`
- Applies the above to:
  - Flow table actions menu
  - Flow card actions menu
  - Edit history comment function
  - "Show individual node changes" accordion in public modal
 - Also adds `TeamAdmin` for future use (includes `PlatformAdmin` as per hierarchy)
 
 No expected change in functionality.
   