### PR TITLE
feat(api): Generic Slack endpoint for Hasura events

### DIFF
--- a/apps/api.planx.uk/modules/pay/service/utils.ts
+++ b/apps/api.planx.uk/modules/pay/service/utils.ts
@@ -2,8 +2,8 @@ import type { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { $api } from "../../../client/index.js";
 import { gql } from "graphql-request";
 
-import SlackNotify from "slack-notify";
 import type { Request } from "express";
+import { sendSlackMessage } from "../../slack/utils.js";
 
 export const addGovPayPaymentIdToPaymentRequest = async (
   paymentRequestId: string,
@@ -60,7 +60,6 @@ export async function postPaymentNotificationToSlack(
 ) {
   if (isTestPayment(govUkResponse)) return;
 
-  const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
   const getStatus = (state: GovUKPayment["state"]) =>
     state.status + (state.message ? ` (${state.message})` : "");
   const payMessage = `:coin: New GOV Pay payment ${label} *${
@@ -68,6 +67,6 @@ export async function postPaymentNotificationToSlack(
   }* with status *${getStatus(govUkResponse.state)}* [${
     req.params.localAuthority
   }]`;
-  await slack.send(payMessage);
+  await sendSlackMessage(payMessage);
   console.log("Payment notification posted to Slack");
 }

--- a/apps/api.planx.uk/modules/slack/controller.ts
+++ b/apps/api.planx.uk/modules/slack/controller.ts
@@ -1,7 +1,7 @@
-import SlackNotify from "slack-notify";
 import { z } from "zod";
 import { ServerError } from "../../errors/index.js";
 import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
+import { sendSlackMessage } from "./utils.js";
 
 interface SendSlackNotificationResponse {
   message: string;
@@ -30,8 +30,7 @@ export const sendSlackNotificationController: SendSlackNotificationController =
     }
 
     try {
-      const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
-      await slack.send(message);
+      await sendSlackMessage(message);
 
       return res.status(200).send({
         message: `Sent Slack notification. Message "${message}"`,

--- a/apps/api.planx.uk/modules/slack/utils.ts
+++ b/apps/api.planx.uk/modules/slack/utils.ts
@@ -1,0 +1,5 @@
+import SlackNotify from "slack-notify";
+import type { SendArgs } from "slack-notify";
+
+export const sendSlackMessage = (message: string | SendArgs) =>
+  SlackNotify(process.env.SLACK_WEBHOOK_URL!).send(message);

--- a/apps/api.planx.uk/modules/webhooks/controller.ts
+++ b/apps/api.planx.uk/modules/webhooks/controller.ts
@@ -22,6 +22,8 @@ import { sanitiseApplicationData } from "./service/sanitiseApplicationData/index
 import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
 import { sendSlackNotification } from "./service/sendNotification/index.js";
 import type { SendSlackNotification } from "./service/sendNotification/types.js";
+import type { SendSlackMessageController } from "./service/sendSlackMessage/schema.js";
+import { sendSlackMessage } from "../slack/utils.js";
 import type { UpdateTemplatedFlowEditsController } from "./service/updateTemplatedFlowEdits/schema.js";
 import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
 import { updateTemplatedFlowEdits } from "./service/updateTemplatedFlowEdits/index.js";
@@ -49,6 +51,35 @@ export const sendSlackNotificationController: SendSlackNotification = async (
     return next(
       new ServerError({
         message: `Failed to send ${eventType} Slack notification`,
+        cause: error,
+      }),
+    );
+  }
+};
+
+export const sendSlackMessageController: SendSlackMessageController = async (
+  _req,
+  res,
+  next,
+) => {
+  const { channel, message, username } = res.locals.parsedReq.body;
+
+  const isProduction = process.env.APP_ENVIRONMENT === "production";
+  if (!isProduction) {
+    return res.status(200).send({
+      message: `Staging environment, skipping Slack notification to ${channel}. Message "${message}"`,
+    });
+  }
+
+  try {
+    await sendSlackMessage({ channel, text: message, username });
+    return res.status(200).send({
+      message: `Sent Slack notification to ${channel}. Message "${message}"`,
+    });
+  } catch (error) {
+    return next(
+      new ServerError({
+        message: `Failed to send Slack notification to ${channel}. Error ${error}`,
         cause: error,
       }),
     );

--- a/apps/api.planx.uk/modules/webhooks/routes.ts
+++ b/apps/api.planx.uk/modules/webhooks/routes.ts
@@ -13,6 +13,7 @@ import {
   deleteSessionController,
   isCleanJSONBController,
   sanitiseApplicationDataController,
+  sendSlackMessageController,
   sendSlackNotificationController,
   updateTemplatedFlowEditsController,
 } from "./controller.js";
@@ -23,6 +24,7 @@ import {
 } from "./service/lowcalSessionEvents/schema.js";
 import { createPaymentEventSchema } from "./service/paymentRequestEvents/schema.js";
 import { sendSlackNotificationSchema } from "./service/sendNotification/schema.js";
+import { sendSlackMessageSchema } from "./service/sendSlackMessage/schema.js";
 import { updateTemplatedFlowEditsEventSchema } from "./service/updateTemplatedFlowEdits/schema.js";
 import { isCleanJSONBSchema } from "./service/validateInput/schema.js";
 
@@ -48,6 +50,11 @@ router.post(
   "/webhooks/hasura/send-slack-notification",
   validate(sendSlackNotificationSchema),
   sendSlackNotificationController,
+);
+router.post(
+  "/webhooks/hasura/send-slack-message",
+  validate(sendSlackMessageSchema),
+  sendSlackMessageController,
 );
 router.post(
   "/webhooks/hasura/create-reminder-event",

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
@@ -1,8 +1,7 @@
-import SlackNotify from "slack-notify";
-
 import { getOperations, operationHandler } from "./operations.js";
 import type { OperationResult } from "./types.js";
 import { getFormattedEnvironment } from "../../../../helpers.js";
+import { sendSlackMessage } from "../../../slack/utils.js";
 
 /**
  * Called by Hasura cron job `sanitise_application_data` on a nightly basis
@@ -27,7 +26,6 @@ export const postToSlack = async (
   results: OperationResult[],
   jobName: string,
 ) => {
-  const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
   const text = results.map((result) =>
     result.status === "failure"
       ? `:x: ${result.operationName} failed. Error: ${result.errorMessage}`
@@ -35,7 +33,7 @@ export const postToSlack = async (
   );
   const env = getFormattedEnvironment();
 
-  await slack.send({
+  await sendSlackMessage({
     channel: "#planx-notifications-internal",
     text: text.join("\n"),
     username: `${jobName} Cron Job (${env})`,

--- a/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -1,5 +1,4 @@
 import { Passport } from "@opensystemslab/planx-core";
-import SlackNotify from "slack-notify";
 import type {
   BOPSEventData,
   EmailEventData,
@@ -9,12 +8,12 @@ import type {
   UniformEventData,
 } from "./types.js";
 import { $api } from "../../../../client/index.js";
+import { sendSlackMessage } from "../../../slack/utils.js";
 
 export const sendSlackNotification = async (
   data: EventData,
   type: EventType,
 ) => {
-  const slack = SlackNotify(process.env.SLACK_WEBHOOK_URL!);
   let message = getMessageForEventType(data, type);
 
   const sessionId = getSessionIdFromEvent(data, type);
@@ -64,7 +63,7 @@ export const sendSlackNotification = async (
   const baseMessage = ":incoming_envelope: " + message;
   message = isPilotEvent ? ":large_orange_square: " + baseMessage : baseMessage;
 
-  await slack.send(message);
+  await sendSlackMessage(message);
   return message;
 };
 

--- a/apps/api.planx.uk/modules/webhooks/service/sendSlackMessage/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendSlackMessage/index.test.ts
@@ -1,0 +1,128 @@
+import supertest from "supertest";
+import app from "../../../../server.js";
+import SlackNotify from "slack-notify";
+
+const mockSend = vi.fn();
+vi.mock("slack-notify", () => ({
+  default: vi.fn().mockImplementation(() => {
+    return { send: mockSend };
+  }),
+}));
+
+const { post } = supertest(app);
+
+describe("Generic send Slack message endpoint", () => {
+  const ENDPOINT = "/webhooks/hasura/send-slack-message";
+  const ORIGINAL_ENV = process.env;
+
+  const validBody = {
+    channel: "#planx-notifications-internal",
+    message: ":tada: New team created: example-council",
+  };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    mockSend.mockResolvedValue("Success!");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("authentication and validation", () => {
+    it("fails without correct authentication", async () => {
+      await post(ENDPOINT)
+        .send(validBody)
+        .expect(401)
+        .then((response) => {
+          expect(response.body).toEqual({ error: "Unauthorised" });
+        });
+    });
+
+    it("returns a 400 if 'message' is missing", async () => {
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send({ channel: "#planx-notifications-internal" })
+        .expect(400)
+        .then((response) => {
+          expect(response.body).toHaveProperty("issues");
+          expect(response.body).toHaveProperty("name", "ZodError");
+        });
+    });
+
+    it("returns a 400 if 'channel' is missing", async () => {
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send({ message: "Hello" })
+        .expect(400)
+        .then((response) => {
+          expect(response.body).toHaveProperty("issues");
+          expect(response.body).toHaveProperty("name", "ZodError");
+        });
+    });
+  });
+
+  describe("sending", () => {
+    it("skips the staging environment", async () => {
+      process.env.APP_ENVIRONMENT = "staging";
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(validBody)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.message).toMatch(/skipping Slack notification/);
+        });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("posts to the requested channel on success", async () => {
+      process.env.APP_ENVIRONMENT = "production";
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(validBody)
+        .expect(200)
+        .then((response) => {
+          expect(SlackNotify).toHaveBeenCalledWith(
+            process.env.SLACK_WEBHOOK_URL,
+          );
+          expect(mockSend).toHaveBeenCalledWith({
+            channel: validBody.channel,
+            text: validBody.message,
+            username: undefined,
+          });
+          expect(response.body.message).toMatch(/Sent Slack notification/);
+        });
+    });
+
+    it("forwards an optional username override", async () => {
+      process.env.APP_ENVIRONMENT = "production";
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send({ ...validBody, username: "Teams Bot" })
+        .expect(200);
+
+      expect(mockSend).toHaveBeenCalledWith({
+        channel: validBody.channel,
+        text: validBody.message,
+        username: "Teams Bot",
+      });
+    });
+
+    it("returns a 500 when Slack fails", async () => {
+      process.env.APP_ENVIRONMENT = "production";
+      mockSend.mockRejectedValue("Fail!");
+
+      await post(ENDPOINT)
+        .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+        .send(validBody)
+        .expect(500)
+        .then((response) => {
+          expect(response.body.error).toMatch(/Failed to send Slack/);
+        });
+    });
+  });
+});

--- a/apps/api.planx.uk/modules/webhooks/service/sendSlackMessage/schema.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendSlackMessage/schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+/**
+ * Generic payload allowing Hasura events to post Slack messages to a channel
+ */
+export const sendSlackMessageSchema = z.object({
+  body: z.object({
+    channel: z.string(),
+    message: z.string(),
+    username: z.string().optional(),
+  }),
+});
+
+interface SendSlackMessageResponse {
+  message: string;
+}
+
+export type SendSlackMessageController = ValidatedRequestHandler<
+  typeof sendSlackMessageSchema,
+  SendSlackMessageResponse
+>;


### PR DESCRIPTION
## What does this PR do?
Adds a generic, reusable way to post Slack messages from Hasura events, and tidies up the existing Slack code along the way.

- New generic endpoint -  `POST /webhooks/hasura/send-slack-message` accepting `{ channel, message, username? }`. The message text and target channel are built in the Hasura event trigger's JSON template, so that adding a new notification is can be done purely via metadata (a new event-trigger YAML block, no new `controller/schema/route`.)
- Shared `sendSlackMessage` util. All existing callers (submission notifications, pay flow, sanitise + analytics crons) now route through it.
- Existing notifications (e.g. submission pings that need session/exemption lookups from DB) untouched and keep their custom logic.

## Motivation

* Tidying up - one Slack helper instead of the same client/`.send()` re-implemented in four places.
* Expandability - pinging a channel from a new event no longer means writing (and deploying) a bespoke endpoint each time
* Possible implementation details of https://github.com/theopensystemslab/planx-new/pull/6883