### PR TITLE
feat(editor): Support validation of reference codes for LPGs

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/ReferenceCode/schema.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/ReferenceCode/schema.test.ts
@@ -1,0 +1,33 @@
+import { validationSchema } from "./schema";
+
+describe("Reference code validation", () => {
+  describe("LPA reference codes", () => {
+    it("rejects invalid codes", async () => {
+      await expect(() =>
+        validationSchema.validate({
+          referenceCode: "123XYZ",
+        }),
+      ).rejects.toThrow(/Invalid format for Local Planning Authority reference code/);
+    });
+
+    it("accepts a valid code", async () => {
+      const result = await validationSchema.isValid({ referenceCode: "ABC" });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("LPG reference codes", () => {
+    it("rejects invalid codes", async () => {
+      await expect(() =>
+        validationSchema.validate({
+          referenceCode: "123-UVWXYZ",
+        }),
+      ).rejects.toThrow(/Invalid format for Local Planning Group reference code/);
+    });
+
+    it("accepts a valid code", async () => {
+      const result = await validationSchema.isValid({ referenceCode: "CAB-SCA" });
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/ReferenceCode/schema.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/GIS/ReferenceCode/schema.ts
@@ -5,9 +5,23 @@ import type { ReferenceCodeFormValues } from "./types";
 export const validationSchema: SchemaOf<ReferenceCodeFormValues> =
   object().shape({
     referenceCode: string()
-      .min(3, "Code must be at least 3 characters long")
-      .max(5, "Code cannot exceed 5 characters long")
-      .required("Enter a reference code"),
+      .required("Enter a reference code")
+      .test("is-valid-ref-code", "Invalid code format", function (value) {
+        if (!value) return false;
+
+        // If the code includes a hyphen, treat it as a reference code for a Local Planning Group
+        // e.g. Greater Cambridgeshire Shared Planning Local Planning Group (https://www.planning.data.gov.uk/entity/62009)
+        if (value.includes("-")) {
+          const lpgRegex = /^[A-Z]{3,5}-[A-Z]{3,5}$/;
+          return lpgRegex.test(value)
+            || this.createError({ message: "Invalid format for Local Planning Group reference code. These must match the format ABC-DEF" });
+        }
+
+        // Otherwise, treat it as a standard Local Planning Authority reference code
+        const lpaRegex = /^[A-Z]{3,5}$/;
+        return lpaRegex.test(value)
+          || this.createError({ message: "Invalid format for Local Planning Authority reference code. Code must be between 3 and 5 characters long" });
+      }),
   });
 
 export const defaultValues: ReferenceCodeFormValues = {


### PR DESCRIPTION
## What's the problem?
The `team.reference_code` value `CAB-SCA` is valid, but cannot be entered via the UI. To update this I've had to set the values directly via the DB.

<img width="755" height="246" alt="image" src="https://github.com/user-attachments/assets/0fe4c358-6ddd-4d4c-a021-0e7374661cbc" />

Please see the folloiwng thread for further context - https://opensystemslab.slack.com/archives/C0ARCE260LF/p1782396116018359 (OSL Slack)

## What's the solution?
 - Update validation schema
 - Add basic test coverage