### PR TITLE
feat: include `cachedBreadcrumbs` in `admin/:sessionId/summary` API response when applicable

### DIFF
--- a/apps/api.planx.uk/modules/admin/session/summary.ts
+++ b/apps/api.planx.uk/modules/admin/session/summary.ts
@@ -52,6 +52,7 @@ interface SessionSummary {
     email: LowCalSession["email"];
     passport: Passport["data"];
     breadcrumbs: Breadcrumb;
+    cachedBreadcrumbs?: Breadcrumb;
     payments?: Pick<
       GovUKPayment,
       "created_date" | "payment_id" | "amount" | "state"
@@ -87,6 +88,7 @@ const getSessionSummaryById = async (
           email
           passport: data(path: "passport.data")
           breadcrumbs: data(path: "breadcrumbs")
+          cachedBreadcrumbs: data(path: "cachedBreadcrumbs")
           payments: payment_status(order_by: { created_at: desc }) {
             created_at
             payment_id


### PR DESCRIPTION
Quick follow-up to this thread: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1782739828295229

Useful to have, currently only able to retreive via Hasura console > 'data' > `lowcal_sessions.data`