### PR TITLE
feat: show message when no edit history for the last 6 months

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
@@ -11,10 +11,7 @@ import { AddCommentDialog } from "./AddCommentDialog";
 import { EditHistoryTimeline } from "./Timeline";
 
 const EditHistory = () => {
-  const [flowId, user] = useStore((state) => [
-    state.id,
-    state.user,
-  ]);
+  const [flowId, user] = useStore((state) => [state.id, state.user]);
 
   const { data, loading, error } = useSubscription<{ history: HistoryItem[] }>(
     gql`
@@ -69,6 +66,14 @@ const EditHistory = () => {
         </Permission.CanEdit>
       )}
       {data?.history && <EditHistoryTimeline events={data.history} />}
+      {data?.history.length === 0 && (
+        <>
+          <Divider />
+          <Typography variant="body2" sx={{ mt: 2 }} color="GrayText">
+            {`No changes have been made in the last six months.`}
+          </Typography>
+        </>
+      )}
       {data?.history.length === 50 && (
         <>
           <Divider />


### PR DESCRIPTION
Adds a new conditionally rendered message because it looks like a bug when there's no history to render
<img width="600" alt="Screenshot 2026-06-30 103238" src="https://github.com/user-attachments/assets/60f63754-0cea-4d21-82ba-1b9ccfb03fbe" />

To test, create a new flow, open Hasura with the flow ID and update `published_flows` and `operations` table entries to last year or similar (outside of the 6 month query window), then refresh History panel. 