### PR TITLE
fix(ci): Resolve failing cache-keys for build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,9 @@ infrastructure
 
 apps/editor.planx.uk/*
 !apps/editor.planx.uk/package.json
+apps/hasura.planx.uk/*
+!apps/hasura.planx.uk/package.json
 apps/localplanning.services/*
 !apps/localplanning.services/package.json
+apps/postgres/*
+!apps/postgres/package.json

--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install -g pnpm@10.30.2
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
-COPY . .
+COPY apps/api.planx.uk ./apps/api.planx.uk
 RUN pnpm install --frozen-lockfile --prefer-offline
 RUN pnpm --filter api.planx.uk build
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE

--- a/apps/sharedb.planx.uk/Dockerfile
+++ b/apps/sharedb.planx.uk/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g pnpm@10.30.2
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
-COPY . .
+COPY apps/sharedb.planx.uk ./apps/sharedb.planx.uk
 RUN pnpm install --frozen-lockfile --prefer-offline
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE
 # It's not exposed as a CLI flag, so we set it via npm's `npm_config_<key>` env-var convention

--- a/infrastructure/application/services/api.ts
+++ b/infrastructure/application/services/api.ts
@@ -90,7 +90,8 @@ export const createApiService = async ({
 
   const apiImage = new awsx.ecr.Image("api-image", {
     repositoryUrl: repo.url,
-    context: "../../apps/api.planx.uk",
+    context: "../..",
+    dockerfile: "apps/api.planx.uk/Dockerfile",
     args: {
       target: "production",
     },

--- a/infrastructure/application/services/api.ts
+++ b/infrastructure/application/services/api.ts
@@ -91,7 +91,7 @@ export const createApiService = async ({
   const apiImage = new awsx.ecr.Image("api-image", {
     repositoryUrl: repo.url,
     context: "../..",
-    dockerfile: "apps/api.planx.uk/Dockerfile",
+    dockerfile: "../../apps/api.planx.uk/Dockerfile",
     args: {
       target: "production",
     },

--- a/infrastructure/application/services/sharedb.ts
+++ b/infrastructure/application/services/sharedb.ts
@@ -52,7 +52,8 @@ export const createSharedbService = async ({
 
   const sharedbImage = new awsx.ecr.Image("sharedb-image", {
     repositoryUrl: repo.repository.repositoryUrl,
-    context: "../../apps/sharedb.planx.uk",
+    context: "../..",
+    dockerfile: "apps/sharedb.planx.uk/Dockerfile",
   });
   const sharedbLogGroup = new aws.cloudwatch.LogGroup("sharedb", {
     name: "/ecs/sharedb",

--- a/infrastructure/application/services/sharedb.ts
+++ b/infrastructure/application/services/sharedb.ts
@@ -53,7 +53,7 @@ export const createSharedbService = async ({
   const sharedbImage = new awsx.ecr.Image("sharedb-image", {
     repositoryUrl: repo.repository.repositoryUrl,
     context: "../..",
-    dockerfile: "apps/sharedb.planx.uk/Dockerfile",
+    dockerfile: "../../apps/sharedb.planx.uk/Dockerfile",
   });
   const sharedbLogGroup = new aws.cloudwatch.LogGroup("sharedb", {
     name: "/ecs/sharedb",


### PR DESCRIPTION
## What's the problem?
Following the merge of https://github.com/theopensystemslab/planx-new/pull/6540 the Pulumi build is failing with the following error - 

```
docker-build:index:Image (07a03b10-container):
      error: failed to solve: failed to compute cache key: failed to calculate checksum of ref wn2yotpyeufgkdaklj8k8k865::yiyateh0eoji9imozhkftqo8i: "/pnpm-workspace.yaml": not found

    docker-build:index:Image (508f1352-container):
      error: failed to solve: failed to compute cache key: failed to calculate checksum of ref wn2yotpyeufgkdaklj8k8k865::2qlct8ekp0f029rb9l413y0uh: "/pnpm-workspace.yaml": not found
```

## What's the solution?
- Correctly set local build context so the single new `pnpm-lock.yaml` file can be located correctly