### PR TITLE
[infra] push Epsom custom domain to cutover stage

### DIFF
--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -71,7 +71,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "epsom-and-ewell",
           domain: "planningservices.epsom-ewell.gov.uk",
-          cloudFrontState: "legacy-with-validation",
+          cloudFrontState: "cutover-ongoing",
           certificateLocation: "pulumiConfig",
         },
         {


### PR DESCRIPTION
as per title - part of migration Epsom & Ewell to new SSL regime ([ticket](https://trello.com/c/lpmaLrr0))

next up (after this is on prod) will be returning to the [how to at step 8](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md#b-migrating-a-council-from-legacy-setup) :)