### PR TITLE
feat(editor): Improve and unify empty states

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -1,4 +1,6 @@
 import CloseIcon from "@mui/icons-material/Close";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
@@ -126,11 +128,11 @@ const NotificationsPanel = ({
           <EmptyState
             size="small"
             title={
-              tab === 0
-                ? "No notifications, you're all up to date"
-                : "No resolved notifications"
+              tab === 0 ? "No notifications found" : "No resolved notifications"
             }
+            description={tab === 0 ? "You're all up to date" : ""}
             sx={{ mx: 2 }}
+            icon={tab === 0 ? <NotificationsNoneIcon /> : <NotificationsIcon />}
           />
         )}
         <Stack>

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.tsx
@@ -1,3 +1,4 @@
+import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
@@ -10,6 +11,7 @@ import { Link } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 import StyledTab from "ui/editor/StyledTab";
@@ -57,7 +59,12 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
         <Tabs
           value={tab}
           onChange={(_e, v) => setTab(v)}
-          sx={{ minHeight: 0, borderBottom: 1, borderColor: "border.main", paddingX: 1.25, }}
+          sx={{
+            minHeight: 0,
+            borderBottom: 1,
+            borderColor: "border.main",
+            paddingX: 1.25,
+          }}
         >
           <StyledTab label="Recent flows" value="recent" />
           <StyledTab label="Pinned flows" value="pinned" />
@@ -142,18 +149,19 @@ export const FlowsPanel: React.FC<FlowsPanelProps> = ({
           {displayed.length === 0 && (
             <ListItem
               sx={{
-                display: "flex",
-                flex: 1,
-                alignItems: "center",
-                justifyContent: "center",
+                display: "block",
+                alignItems: "flex-start",
               }}
             >
               {tab === "pinned" ? (
-                <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                  No pinned flows
-                </Typography>
+                <EmptyState
+                  size="small"
+                  icon={<PushPinOutlinedIcon />}
+                  title="No pinned flows"
+                  description="Use the pin icon on a flow to add it here"
+                />
               ) : (
-                <NoFlowsGetStarted />
+                <NoFlowsGetStarted size="small" />
               )}
             </ListItem>
           )}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/NotificationsWidget.tsx
@@ -1,3 +1,4 @@
+import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import Stack from "@mui/material/Stack";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useRecentNotifications } from "hooks/data/useRecentNotifications";
@@ -50,8 +51,10 @@ export function NotificationsWidget({
       >
         <EmptyState
           size="small"
-          title="No notifications, you're all up to date"
-          sx={{ mx: 2 }}
+          icon={<NotificationsNoneIcon />}
+          title="No notifications found"
+          description="You're all up to date"
+          sx={{ mx: 1.5 }}
         />
       </DashboardWidget>
     );

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/ServiceListWithCount.tsx
@@ -1,8 +1,10 @@
+import BarChartIcon from "@mui/icons-material/BarChart";
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { ActivityItem } from "hooks/data/useActivityData";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { EmptyState } from "ui/editor/EmptyState";
 
 const ServiceList = styled(Box)(({ theme }) => ({
   overflowY: "auto",
@@ -47,16 +49,12 @@ export default function ServiceListWithCount({
 
   if (activeItems.length === 0) {
     return (
-      <ServiceList
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          No activity to show
-        </Typography>
+      <ServiceList>
+        <EmptyState
+          size="small"
+          title="No activity to show"
+          icon={<BarChartIcon />}
+        />
       </ServiceList>
     );
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/FeedbackLog/FeedbackLog.tsx
@@ -1,3 +1,4 @@
+import BarChartIcon from "@mui/icons-material/BarChart";
 import Typography from "@mui/material/Typography";
 import { BREADCRUMBS_HEIGHT } from "components/Breadcrumbs";
 import { format } from "date-fns";
@@ -157,6 +158,7 @@ export const FeedbackLog: React.FC<FeedbackLogProps> = ({
         <EmptyState
           title={`No feedback found for this ${isFlowLevel ? "service" : "team"}`}
           description="If you're looking for feedback from more than six months ago, please contact a PlanX developer"
+          icon={<BarChartIcon />}
         />
       ) : (
         <DataTable

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/Notifications.tsx
@@ -1,3 +1,5 @@
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
@@ -67,11 +69,11 @@ export const Notifications = ({ notifications }: NotificationProps) => {
           <EmptyState
             size="small"
             title={
-              tab === 0
-                ? "No notifications, you're all up to date"
-                : "No resolved notifications"
+              tab === 0 ? "No notifications found" : "No resolved notifications"
             }
-            sx={{ mt: 0 }}
+            description={tab === 0 ? "You're all up to date" : ""}
+            icon={tab === 0 ? <NotificationsNoneIcon /> : <NotificationsIcon />}
+            sx={{ mt: -1 }}
           />
         )}
         {visibleNotifications.length > 0 && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/index.tsx
@@ -1,10 +1,12 @@
 import { gql, useSubscription } from "@apollo/client";
+import HistoryIcon from "@mui/icons-material/History";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { HistoryItem } from "lib/api/publishFlow/types";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { EmptyState } from "ui/editor/EmptyState";
 import Permission from "ui/editor/Permission";
 
 import { AddCommentDialog } from "./AddCommentDialog";
@@ -68,10 +70,11 @@ const EditHistory = () => {
       {data?.history && <EditHistoryTimeline events={data.history} />}
       {data?.history.length === 0 && (
         <>
-          <Divider />
-          <Typography variant="body2" sx={{ mt: 2 }} color="GrayText">
-            {`No changes have been made in the last six months.`}
-          </Typography>
+          <EmptyState
+            size="small"
+            title="No changes have been made in the last six months"
+            icon={<HistoryIcon />}
+          />
         </>
       )}
       {data?.history.length === 50 && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
@@ -1,3 +1,4 @@
+import BarChartIcon from "@mui/icons-material/BarChart";
 import { GridFilterItem } from "@mui/x-data-grid";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
@@ -50,6 +51,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       <EmptyState
         title={`No payment or send events found for this ${filterByFlow ? "service" : "team"}`}
         description="If you're looking for events before 1st January 2024, please contact a PlanX developer"
+        icon={<BarChartIcon />}
       />
     );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Contract.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography";
-import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import SettingsSection from "ui/editor/SettingsSection";
 
 export const Contract = () => (
@@ -16,6 +16,6 @@ export const Contract = () => (
       Terms and key dates of your software contract. OSL invoices annually for
       the fixed subscription cost of Plan✕.
     </Typography>
-    <Typography variant="body1">[Coming soon]</Typography>
+    <EmptyState size="small" title="Contract details coming soon" />
   </SettingsSection>
 );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/Discount.tsx
@@ -5,7 +5,7 @@ import { formattedPriceWithCurrencySymbol } from "@planx/components/Pay/model";
 import { DEFAULT_SERVICE_CHARGE_AMOUNT } from "@planx/components/SetFee/model";
 import { getQuarter } from "date-fns";
 import sumBy from "lodash/sumBy";
-import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
 import SettingsSection from "ui/editor/SettingsSection";
 
 import { SubscriptionProps } from "../types";
@@ -44,7 +44,7 @@ export const Discount = ({ serviceCharges }: SubscriptionProps) => {
       {serviceChargesThisFiscalYear.length > 0 ? (
         <DiscountProgress serviceCharges={serviceChargesThisFiscalYear} />
       ) : (
-        <Typography variant="body1">{`No service charges found.`}</Typography>
+        <EmptyState size="small" title="No service charges found" />
       )}
     </SettingsSection>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
@@ -16,6 +16,7 @@ import Typography from "@mui/material/Typography";
 import { getQuarter } from "date-fns";
 import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { EmptyState } from "ui/editor/EmptyState";
 import SettingsSection from "ui/editor/SettingsSection";
 import Caret from "ui/icons/Caret";
 
@@ -47,7 +48,7 @@ export const ServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
       {serviceCharges.length > 0 ? (
         <ActiveServiceCharges serviceCharges={serviceCharges} />
       ) : (
-        <Typography variant="body1">No service charges found.</Typography>
+        <EmptyState size="small" title="No service charges found" />
       )}
     </SettingsSection>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -1,3 +1,4 @@
+import GroupIcon from "@mui/icons-material/Group";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
@@ -9,9 +10,9 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { Role } from "@opensystemslab/planx-core/types";
-import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
+import { useState } from "react";
 import { AddButton } from "ui/editor/AddButton";
+import { EmptyState } from "ui/editor/EmptyState";
 
 import { StyledAvatar, StyledTableRow } from "../styles";
 import {
@@ -78,7 +79,11 @@ export const MembersTable = ({
           <TableHead>
             <TableRow>
               <TableCell>
-                <strong>No members found</strong>
+                <EmptyState
+                  size="small"
+                  title="No team members found"
+                  icon={<GroupIcon />}
+                />
               </TableCell>
             </TableRow>
           </TableHead>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/components/MembersTable.tsx
@@ -75,28 +75,16 @@ export const MembersTable = ({
   if (members.length === 0) {
     return (
       <>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                <EmptyState
-                  size="small"
-                  title="No team members found"
-                  icon={<GroupIcon />}
-                />
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          {showAddMemberButton && (
-            <TableBody>
-              <TableRow>
-                <TableCell colSpan={3}>
-                  <AddButton onClick={addUser}>Add a new member</AddButton>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          )}
-        </Table>
+        <EmptyState
+          size="small"
+          title="No team members found"
+          icon={<GroupIcon />}
+        />
+        {showAddMemberButton && (
+          <Box sx={{ mt: 2 }}>
+            <AddButton onClick={addUser}>Add a new member</AddButton>
+          </Box>
+        )}
         {modal.action !== "closed" && (
           <AddUserModal onClose={closeModal} userRole={userRole} />
         )}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Team/tests/TeamMembers.addNewMember.noExistingMembers.test.tsx
@@ -24,7 +24,7 @@ describe("when a user views the 'Team members' screen but there are no existing 
       </DndProvider>,
     );
 
-    screen.getByText("No members found");
+    screen.getByText("No team members found");
   });
 
   it("shows the 'add a new member' button", async () => {

--- a/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/AddFlow/index.tsx
@@ -88,7 +88,7 @@ export const AddFlow: React.FC = () => {
 
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   return (
-    <Box>
+    <Box sx={{ display: "flex", justifyContent: "center", mt: 0.5 }}>
       <AddButton onClick={() => setDialogOpen(true)}>Add a new flow</AddButton>
       <Formik<CreateFlow>
         initialValues={initialValues}

--- a/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/Archive.tsx
@@ -1,4 +1,5 @@
 import { ApolloError } from "@apollo/client";
+import DeleteIcon from "@mui/icons-material/Delete";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import Box from "@mui/material/Box";
@@ -74,7 +75,7 @@ const Archive: React.FC<Props> = ({
   }
 
   if (!isFiltered && archivedFlows !== null && archivedFlows.length === 0) {
-    return <EmptyState title="No archived flows found" />;
+    return <EmptyState title="No archived flows found" icon={<DeleteIcon />} />;
   }
 
   return (

--- a/apps/editor.planx.uk/src/pages/Team/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/index.tsx
@@ -6,6 +6,7 @@ import { isEmpty } from "lodash";
 import React, { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import { InfoChip } from "ui/editor/InfoChip";
+import EditorIcon from "ui/icons/Editor";
 import { DebouncedSearchInput } from "ui/shared/SearchBox/DebouncedSearchInput";
 
 import { useStore } from "../FlowEditor/lib/store";
@@ -21,8 +22,16 @@ import TeamLayout from "./TeamLayout";
 
 export type FlowView = "flows" | "archive";
 
-export const NoFlowsGetStarted: React.FC = () => (
+interface NoFlowsGetStartedProps {
+  size?: "medium" | "small";
+}
+
+export const NoFlowsGetStarted: React.FC<NoFlowsGetStartedProps> = ({
+  size,
+}) => (
   <EmptyState
+    size={size}
+    icon={<EditorIcon />}
     title="No flows found"
     description="Get started by creating your first flow"
     action={<AddFlow />}

--- a/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/EmptyState.tsx
@@ -9,6 +9,7 @@ interface EmptyStateProps {
   title?: string;
   description?: string;
   action?: React.ReactNode;
+  icon?: React.ReactNode;
   size?: EmptyStateSize;
   sx?: BoxProps["sx"];
 }
@@ -16,23 +17,40 @@ interface EmptyStateProps {
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "size",
 })<{ size?: EmptyStateSize }>(({ theme, size }) => ({
+  position: "relative",
   marginTop: theme.spacing(2),
-  padding: size === "small" ? theme.spacing(1.5) : theme.spacing(2.5),
-  border: `4px solid ${theme.palette.border.light}`,
+  padding:
+    size === "small"
+      ? theme.spacing(1.5, 1.5, 1.75)
+      : theme.spacing(2.5, 2.5, 2.75),
+  border: `2px solid ${theme.palette.border.light}`,
   backgroundColor: theme.palette.background.default,
   display: "flex",
   flexDirection: "column",
-  gap: size === "small" ? theme.spacing(0.5) : theme.spacing(1.5),
+  gap: size === "small" ? theme.spacing(0.75) : theme.spacing(1.5),
+  textAlign: "center",
 }));
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   action,
+  icon,
   size = "medium",
   sx,
 }) => (
   <Root size={size} sx={sx}>
+    {icon && (
+      <Box
+        sx={(theme) => ({
+          display: "flex",
+          justifyContent: "center",
+          "& svg": { fontSize: "3rem", color: theme.palette.text.secondary },
+        })}
+      >
+        {icon}
+      </Box>
+    )}
     {title && (
       <Typography variant={size === "small" ? "h4" : "h3"}>{title}</Typography>
     )}


### PR DESCRIPTION
## What does this PR do?

- Improves `EmptyState` component to be more obvious
  - Less "system error" like in appearance
  - Optional icon
- Updates component and views to use unified `EmptyState`

<img width="985" height="252" alt="image" src="https://github.com/user-attachments/assets/931d4b43-fe8c-4235-b7fa-e2014b88bd23" />

<img width="985" height="416" alt="image" src="https://github.com/user-attachments/assets/02c1425f-eb31-49fa-8723-0623cecadc9c" />

<img width="985" height="330" alt="image" src="https://github.com/user-attachments/assets/bce6adb3-40f0-4517-9db1-79c0458c84f2" />

<img width="985" height="436" alt="image" src="https://github.com/user-attachments/assets/7f5a12d6-aeb9-46a9-b228-4db5fce90cdd" />

<img width="985" height="436" alt="image" src="https://github.com/user-attachments/assets/0d5c7c03-7264-4022-acb1-f27078d3ac90" />

<img width="985" height="436" alt="image" src="https://github.com/user-attachments/assets/aa7d9366-c221-4211-9bd4-01db105df7ce" />

<img width="985" height="436" alt="image" src="https://github.com/user-attachments/assets/884575f1-1fac-450e-b201-f4f7024dd100" />

<img width="985" height="369" alt="image" src="https://github.com/user-attachments/assets/29045060-1456-40d0-ad9d-807f626964f1" />

<img width="985" height="369" alt="image" src="https://github.com/user-attachments/assets/23cee724-e680-436d-8e37-ffcadd9cd62a" />

<img width="985" height="322" alt="image" src="https://github.com/user-attachments/assets/b7416e00-8b83-4208-b1f3-7527a75edcb1" />

<img width="985" height="322" alt="image" src="https://github.com/user-attachments/assets/48f27b8a-9c49-4318-9a7c-14146de65ae2" />
