### PR TITLE
fix(ci): Fargate build of new API dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .claude
 .github
 node_modules
+**/node_modules
 e2e
 infrastructure
 

--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install -g pnpm@10.30.2
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
-COPY apps/api.planx.uk ./apps/api.planx.uk
+COPY . .
 RUN pnpm install --frozen-lockfile --prefer-offline
 RUN pnpm --filter api.planx.uk build
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE

--- a/apps/sharedb.planx.uk/Dockerfile
+++ b/apps/sharedb.planx.uk/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g pnpm@10.30.2
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
-COPY apps/sharedb.planx.uk ./apps/sharedb.planx.uk
+COPY . .
 RUN pnpm install --frozen-lockfile --prefer-offline
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE
 # It's not exposed as a CLI flag, so we set it via npm's `npm_config_<key>` env-var convention

--- a/infrastructure/application/services/api.ts
+++ b/infrastructure/application/services/api.ts
@@ -92,9 +92,7 @@ export const createApiService = async ({
     repositoryUrl: repo.url,
     context: "../..",
     dockerfile: "../../apps/api.planx.uk/Dockerfile",
-    args: {
-      target: "production",
-    },
+    target: "production",
   });
   const apiLogGroup = new aws.cloudwatch.LogGroup("api", {
     name: "/ecs/api",

--- a/infrastructure/application/services/sharedb.ts
+++ b/infrastructure/application/services/sharedb.ts
@@ -54,6 +54,7 @@ export const createSharedbService = async ({
     repositoryUrl: repo.repository.repositoryUrl,
     context: "../..",
     dockerfile: "../../apps/sharedb.planx.uk/Dockerfile",
+    target: "production",
   });
   const sharedbLogGroup = new aws.cloudwatch.LogGroup("sharedb", {
     name: "/ecs/sharedb",


### PR DESCRIPTION
Follow up to #6912 - Pulumi is now timing out.

Locally this builds expected, but it might just be a case of correctly configuring these paths.