### PR TITLE
feat: auto-suggest data values for minor editor enums like EPC form

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -96,6 +96,10 @@ export const getOptionsSchemaByFn = (
     case "application.leadDeveloper":
       schema = getValidSchemaValuesByEnumPath("LeadDeveloper", "type");
       break;
+    case "application.preAppAdvice.form":
+      // this one is not defined/accessible _within_ ODP Schema JSON, but mappings do rely on "Yes" so we still want to auto-suggest !
+      schema = ["Yes"];
+      break;
     case "application.type":
       schema = getValidSchemaValues("ApplicationType");
       break;

--- a/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/utils.ts
@@ -1,4 +1,7 @@
-import { getValidSchemaValues } from "@opensystemslab/planx-core";
+import {
+  getValidSchemaValues,
+  getValidSchemaValuesByEnumPath,
+} from "@opensystemslab/planx-core";
 import isNil from "lodash/isNil";
 
 export const validateEmail = (email: string) => {
@@ -79,11 +82,60 @@ export const getOptionsSchemaByFn = (
 
   // For certain data fields, suggest based on full ODP Schema enums rather than current flow schema
   //   Note that many `property.{}` fields which auto-suggest based on Planning Data entities set their schema one level up
-  if (fn === "application.type")
-    schema = getValidSchemaValues("ApplicationType");
-  if (fn === "proposal.projectType")
-    schema = getValidSchemaValues("ProjectType");
-  if (fn === "property.type") schema = getValidSchemaValues("PropertyType");
+  switch (fn) {
+    case "applicant.type":
+      schema = getValidSchemaValuesByEnumPath("BaseApplicant", "type");
+      break;
+    case "applicant.siteContact.role":
+      // .concat() on user role is lazy manual handling of discriminated union enum type for BaseApplicant/SiteContact/Role !
+      schema = getValidSchemaValuesByEnumPath("User", "role")?.concat("other");
+      break;
+    case "application.declaration.connection.form":
+      schema = getValidSchemaValuesByEnumPath("Declaration", "connection");
+      break;
+    case "application.leadDeveloper":
+      schema = getValidSchemaValuesByEnumPath("LeadDeveloper", "type");
+      break;
+    case "application.type":
+      schema = getValidSchemaValues("ApplicationType");
+      break;
+    case "property.EPCKnown.form":
+      schema = getValidSchemaValuesByEnumPath("LondonProperty", "EPC");
+      break;
+    case "property.occupation":
+      schema = getValidSchemaValuesByEnumPath(
+        "LondonProperty",
+        "occupation",
+        "status",
+      );
+      break;
+    case "property.ownership.status":
+      schema = getValidSchemaValuesByEnumPath(
+        "LondonProperty",
+        "ownership",
+        "status",
+      );
+      break;
+    case "property.titleNumberKnown.form":
+      schema = getValidSchemaValuesByEnumPath("LondonProperty", "titleNumber");
+      break;
+    case "property.type":
+      schema = getValidSchemaValues("PropertyType");
+      break;
+    case "proposal.cost.projected":
+      schema = getValidSchemaValuesByEnumPath(
+        "LondonProposal",
+        "cost",
+        "projected",
+      );
+      break;
+    case "proposal.projectType":
+      schema = getValidSchemaValues("ProjectType");
+      break;
+    case "user.role":
+      schema = getValidSchemaValuesByEnumPath("User", "role");
+      break;
+  }
 
   // Ensure that any initial values outside of ODP Schema enums will still be recognised/pre-populated when modal loads
   currentOptions?.forEach((option) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   default:
     '@opensystemslab/planx-core':
-      specifier: github:theopensystemslab/planx-core#91e4296
+      specifier: github:theopensystemslab/planx-core#bcae17e
       version: 1.0.0
     '@types/jsdom':
       specifier: ^28.0.1
@@ -147,7 +147,7 @@ importers:
         version: 3.1032.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
       '@types/geojson':
         specifier: ^7946.0.16
         version: 7946.0.16
@@ -454,7 +454,7 @@ importers:
         version: 1.0.0-alpha.14
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
       '@tanstack/react-query':
         specifier: ^5.101.1
         version: 5.101.1(react@19.2.5)
@@ -1030,7 +1030,7 @@ importers:
         version: 12.9.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1073,7 +1073,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1251,7 +1251,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3704,8 +3704,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.14':
     resolution: {integrity: sha512-kIVrXtq2rcOzayTtUkVUQWSJMGrhER7FuuMR9cJw5a8AOH69XnXrkDPGBMVQmNJOIoMkO4dOzTt6ofUchZxLQA==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1}
     version: 1.0.0
 
   '@opentelemetry/api-logs@0.57.2':
@@ -15728,7 +15728,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -15738,7 +15738,7 @@ snapshots:
       lru-cache: 11.3.5
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -15759,7 +15759,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.1
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15774,7 +15774,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -15844,7 +15844,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/91e4296a313276971ea5759d52b487048c4d8199(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
@@ -18247,7 +18247,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -19254,7 +19254,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.25.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -21993,7 +21993,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -22709,7 +22709,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.13
       tinyglobby: 0.2.17
       undici: 6.27.0
@@ -22776,7 +22776,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -22795,7 +22795,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -22803,7 +22803,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -22816,7 +22816,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.7.4
+      semver: 7.8.5
 
   npm-registry-fetch@19.1.1:
     dependencies:
@@ -25350,8 +25350,7 @@ snapshots:
 
   undici@7.25.0: {}
 
-  undici@7.28.0:
-    optional: true
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   default:
     '@opensystemslab/planx-core':
-      specifier: github:theopensystemslab/planx-core#bcae17e
+      specifier: github:theopensystemslab/planx-core#4c82701
       version: 1.0.0
     '@types/jsdom':
       specifier: ^28.0.1
@@ -147,7 +147,7 @@ importers:
         version: 3.1032.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)
       '@types/geojson':
         specifier: ^7946.0.16
         version: 7946.0.16
@@ -454,7 +454,7 @@ importers:
         version: 1.0.0-alpha.14
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)
       '@tanstack/react-query':
         specifier: ^5.101.1
         version: 5.101.1(react@19.2.5)
@@ -1030,7 +1030,7 @@ importers:
         version: 12.9.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1073,7 +1073,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1251,7 +1251,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3704,8 +3704,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.14':
     resolution: {integrity: sha512-kIVrXtq2rcOzayTtUkVUQWSJMGrhER7FuuMR9cJw5a8AOH69XnXrkDPGBMVQmNJOIoMkO4dOzTt6ofUchZxLQA==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a}
     version: 1.0.0
 
   '@opentelemetry/api-logs@0.57.2':
@@ -12063,6 +12063,10 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -15844,7 +15848,7 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/bcae17eaa0c3806412454c3a738922984fbfa4d1(@types/react@19.2.14)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/4c827019cb486ab2e61adf13d5da570ba676048a(@types/react@19.2.14)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
@@ -15865,7 +15869,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       type-fest: 4.41.0
-      uuid: 14.0.0
+      uuid: 14.0.1
       zod: 3.25.76
     transitivePeerDependencies:
       - '@mui/material-pigment-css'
@@ -25522,6 +25526,8 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@14.0.0: {}
+
+  uuid@14.0.1: {}
 
   uuid@8.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
   - 'scripts/*'
 
 catalog:
-  "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#bcae17e"
+  "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#4c82701"
   "@types/jsdom": ^28.0.1
   "@types/node": ~24.10.15
   axios: ^1.18.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
   - 'scripts/*'
 
 catalog:
-  "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#91e4296"
+  "@opensystemslab/planx-core": "github:theopensystemslab/planx-core#bcae17e"
   "@types/jsdom": ^28.0.1
   "@types/node": ~24.10.15
   axios: ^1.18.1


### PR DESCRIPTION
A quick solution off the back of some recent service testing bugs! See this thread https://opensystemslab.slack.com/archives/C5Q59R3HB/p1782910757324799

Relies on https://github.com/theopensystemslab/planx-core/pull/1019

We've been quite good at auto-suggesting "big" schema enums like `proposal.projectType`, `property.type` etc. But there are also many minor enums (eg less than 5 possible values) which we have _not_ handled, mostly because we publish these in a different format in the JSON Schema (_not_ `anyOf` value/description pairs, but rather actual `enum` properties). 

The planx-core helper method sets up basic handling for some (most?) of these and allows us to auto-suggest values for a range of new values here - notably `property.EPCKnown.form` which has been a recent culprit!

Further context about which data fields (`fn`s) included here in #planx-content thread, it can be a bit separate chat than code review! https://opensystemslab.slack.com/archives/C07F7215W7P/p1782942853790559