### PR TITLE
feat: disable update button when no change in component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
@@ -2,8 +2,9 @@ import FormControl from "@mui/material/FormControl";
 import RadioGroup from "@mui/material/RadioGroup";
 import Typography from "@mui/material/Typography";
 import { ComponentType } from "@opensystemslab/planx-core/types";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
-import { Form, Formik } from "formik";
+import { FormikProvider } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
@@ -19,6 +20,7 @@ import InputRow from "ui/shared/InputRow";
 
 import { DataFieldAutocomplete } from "../shared/DataFieldAutocomplete";
 import type { EditorProps } from "../shared/types";
+import { useFormikWithRef } from "../shared/useFormikWithRef";
 import {
   parseEnhancedTextInput,
   taskDefaults,
@@ -30,174 +32,163 @@ import { type EnhancedTextInput, type Task } from "./types";
 type Props = EditorProps<ComponentType.EnhancedTextInput, EnhancedTextInput>;
 
 const EnhancedTextInputComponent = (props: Props) => {
-  const isTemplate = useStore((state) => state.isTemplate);
-  const initialValues = parseEnhancedTextInput(props.node?.data);
+  const formik = useFormikWithRef<EnhancedTextInput>(
+    {
+      initialValues: parseEnhancedTextInput(props.node?.data),
+      onSubmit: (data: EnhancedTextInput) => {
+        if (props.handleSubmit) {
+          props.handleSubmit({ type: ComponentType.EnhancedTextInput, data });
+        }
+      },
+      validationSchema: validationSchema,
+    },
+    props.formikRef,
+  );
 
-  const onSubmit = (data: EnhancedTextInput) => {
-    if (props.handleSubmit) {
-      props.handleSubmit({ type: ComponentType.EnhancedTextInput, data });
-    }
-  };
+  const isTemplate = useStore((state) => state.isTemplate);
 
   return (
-    <Formik<EnhancedTextInput>
-      initialValues={initialValues}
-      onSubmit={onSubmit}
-      validationSchema={validationSchema}
-      validateOnChange={false}
-      validateOnBlur={false}
-      innerRef={props.formikRef}
-    >
-      {(formik) => (
-        <Form id="modal" name="modal">
-          <TemplatedNodeInstructions
-            isTemplatedNode={formik.values.isTemplatedNode}
-            templatedNodeInstructions={formik.values.templatedNodeInstructions}
-            areTemplatedNodeInstructionsRequired={
-              formik.values.areTemplatedNodeInstructionsRequired
-            }
-          />
-          <ModalSection>
-            <ModalSectionContent>
-              <InputRow>
-                <FormControl component="fieldset">
-                  <Typography component="legend" variant="body2" sx={{ py: 1 }}>
-                    Select a function
-                  </Typography>
-                  <RadioGroup defaultValue="short" value={formik.values.task}>
-                    {Object.entries(TASKS).map(([task, { label }]) => (
-                      <BasicRadio
-                        key={task}
-                        id={task}
-                        label={label}
-                        variant="compact"
-                        value={task}
-                        onChange={(e) => {
-                          formik.setFieldValue("task", e.target);
-                          formik.setFieldValue(
-                            "fn",
-                            taskDefaults[task as Task].fn,
-                          );
-                        }}
-                        disabled={props.disabled}
-                      />
-                    ))}
-                  </RadioGroup>
-                </FormControl>
-              </InputRow>
-            </ModalSectionContent>
-          </ModalSection>
-          <ModalSection>
-            <ModalSectionContent>
-              <p>
-                Project descriptions are often invalid or in need of revision at
-                point of receipt. This component uses Google Gemini to review
-                the users input and suggest revisions upfront that better match
-                the expected tone and format of typical statutory planning
-                proposals.
-              </p>
-              <p>You can see our exact Gemini prompt (coming soon).</p>
-              <p>
-                Your Plan× submission payload will include metadata about
-                whether the user accepted, revised, or discarded the Gemini
-                suggested description both for your internal review and to help
-                us improve the prompt over time.
-              </p>
-            </ModalSectionContent>
-          </ModalSection>
-          <ModalSection>
-            <ModalSectionContent title="Initial screen">
-              <InputRow>
-                <Input
-                  format="large"
-                  name="title"
-                  value={formik.values.title}
-                  placeholder="Title"
-                  aria-label="Title"
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.title}
-                />
-              </InputRow>
-              <InputRow>
-                <RichTextInput
-                  placeholder="Description"
-                  name="description"
-                  value={formik.values.description}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  errorMessage={formik.errors.description}
-                  inputProps={{ "aria-label": "Description" }}
-                />
-              </InputRow>
-              <InputRow>
-                <DataFieldAutocomplete
-                  required
-                  value={formik.values.fn}
-                  onChange={(value) => formik.setFieldValue("fn", value)}
-                  disabled
-                  errorMessage={formik.errors.fn}
-                />
-              </InputRow>
-            </ModalSectionContent>
-          </ModalSection>
-          {formik.values.task === "projectDescription" && (
-            <ModalSection>
-              <ModalSectionContent title="Results screen">
-                <InputRow>
-                  <Input
-                    format="large"
-                    name="revisionTitle"
-                    value={formik.values.revisionTitle}
-                    placeholder="Revision title"
-                    aria-label="Revision title"
-                    onChange={formik.handleChange}
+    <form id="modal" name="modal" onSubmit={formik.handleSubmit}>
+      <TemplatedNodeInstructions
+        isTemplatedNode={formik.values.isTemplatedNode}
+        templatedNodeInstructions={formik.values.templatedNodeInstructions}
+        areTemplatedNodeInstructionsRequired={
+          formik.values.areTemplatedNodeInstructionsRequired
+        }
+      />
+      <ModalSection>
+        <ModalSectionContent>
+          <InputRow>
+            <FormControl component="fieldset">
+              <Typography component="legend" variant="body2" sx={{ py: 1 }}>
+                Select a function
+              </Typography>
+              <RadioGroup defaultValue="short" value={formik.values.task}>
+                {Object.entries(TASKS).map(([task, { label }]) => (
+                  <BasicRadio
+                    key={task}
+                    id={task}
+                    label={label}
+                    variant="compact"
+                    value={task}
+                    onChange={(e) => {
+                      formik.setFieldValue("task", e.target);
+                      formik.setFieldValue("fn", taskDefaults[task as Task].fn);
+                    }}
                     disabled={props.disabled}
-                    errorMessage={formik.errors.revisionTitle}
                   />
-                </InputRow>
-                <InputRow>
-                  <RichTextInput
-                    placeholder="Revision description"
-                    name="revisionDescription"
-                    value={formik.values.revisionDescription}
-                    onChange={formik.handleChange}
-                    disabled={props.disabled}
-                    errorMessage={formik.errors.revisionDescription}
-                    inputProps={{ "aria-label": "Revision description" }}
-                  />
-                </InputRow>
-              </ModalSectionContent>
-            </ModalSection>
-          )}
-          <MoreInformation formik={formik} disabled={props.disabled} />
-          <InternalNotes
-            name="notes"
-            onChange={formik.handleChange}
-            value={formik.values.notes}
-            disabled={props.disabled}
-          />
-          <ComponentTagSelect
-            onChange={(value) => formik.setFieldValue("tags", value)}
-            value={formik.values.tags}
-            disabled={props.disabled}
-          />
-          {isTemplate && (
-            <TemplatedNodeConfiguration
-              formik={formik}
-              isTemplatedNode={formik.values.isTemplatedNode}
-              templatedNodeInstructions={
-                formik.values.templatedNodeInstructions
-              }
-              areTemplatedNodeInstructionsRequired={
-                formik.values.areTemplatedNodeInstructionsRequired
-              }
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </InputRow>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalSection>
+        <ModalSectionContent>
+          <p>
+            Project descriptions are often invalid or in need of revision at
+            point of receipt. This component uses Google Gemini to review the
+            users input and suggest revisions upfront that better match the
+            expected tone and format of typical statutory planning proposals.
+          </p>
+          <p>You can see our exact Gemini prompt (coming soon).</p>
+          <p>
+            Your Plan× submission payload will include metadata about whether
+            the user accepted, revised, or discarded the Gemini suggested
+            description both for your internal review and to help us improve the
+            prompt over time.
+          </p>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalSection>
+        <ModalSectionContent title="Initial screen">
+          <InputRow>
+            <Input
+              format="large"
+              name="title"
+              value={formik.values.title}
+              placeholder="Title"
+              aria-label="Title"
+              onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.title}
             />
-          )}
-        </Form>
+          </InputRow>
+          <InputRow>
+            <RichTextInput
+              placeholder="Description"
+              name="description"
+              value={formik.values.description}
+              onChange={formik.handleChange}
+              disabled={props.disabled}
+              errorMessage={formik.errors.description}
+              inputProps={{ "aria-label": "Description" }}
+            />
+          </InputRow>
+          <InputRow>
+            <DataFieldAutocomplete
+              required
+              value={formik.values.fn}
+              onChange={(value) => formik.setFieldValue("fn", value)}
+              disabled
+              errorMessage={formik.errors.fn}
+            />
+          </InputRow>
+        </ModalSectionContent>
+      </ModalSection>
+      {formik.values.task === "projectDescription" && (
+        <ModalSection>
+          <ModalSectionContent title="Results screen">
+            <InputRow>
+              <Input
+                format="large"
+                name="revisionTitle"
+                value={formik.values.revisionTitle}
+                placeholder="Revision title"
+                aria-label="Revision title"
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+                errorMessage={formik.errors.revisionTitle}
+              />
+            </InputRow>
+            <InputRow>
+              <RichTextInput
+                placeholder="Revision description"
+                name="revisionDescription"
+                value={formik.values.revisionDescription}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+                errorMessage={formik.errors.revisionDescription}
+                inputProps={{ "aria-label": "Revision description" }}
+              />
+            </InputRow>
+          </ModalSectionContent>
+        </ModalSection>
       )}
-    </Formik>
+      <MoreInformation formik={formik} disabled={props.disabled} />
+      <InternalNotes
+        name="notes"
+        onChange={formik.handleChange}
+        value={formik.values.notes}
+        disabled={props.disabled}
+      />
+      <ComponentTagSelect
+        onChange={(value) => formik.setFieldValue("tags", value)}
+        value={formik.values.tags}
+        disabled={props.disabled}
+      />
+      {isTemplate && (
+        <TemplatedNodeConfiguration
+          formik={formik}
+          isTemplatedNode={formik.values.isTemplatedNode}
+          templatedNodeInstructions={formik.values.templatedNodeInstructions}
+          areTemplatedNodeInstructionsRequired={
+            formik.values.areTemplatedNodeInstructionsRequired
+          }
+          disabled={props.disabled}
+        />
+      )}
+    </form>
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -78,26 +78,23 @@ const ExternalPortalForm: React.FC<{
   areTemplatedNodeInstructionsRequired = false,
   formikRef,
 }) => {
-  const formik = useFormikWithRef<ExternalPortalFormData>(
-    {
-      initialValues: {
-        flow: flows.find((flow) => flow.id === flowId) || null,
-        flowId: flowId || null,
-        tags,
-        notes,
-        isTemplatedNode,
-        templatedNodeInstructions,
-        areTemplatedNodeInstructionsRequired,
-      },
-      onSubmit: (data) => {
-        if (handleSubmit) {
-          handleSubmit({ type: TYPES.ExternalPortal, data });
-        }
-      },
-      validationSchema,
+  const formik = useFormikWithRef<ExternalPortalFormData>({
+    initialValues: {
+      flow: flows.find((flow) => flow.id === flowId) || null,
+      flowId: flowId || null,
+      tags,
+      notes,
+      isTemplatedNode,
+      templatedNodeInstructions,
+      areTemplatedNodeInstructionsRequired,
     },
-    formikRef,
-  );
+    onSubmit: (data) => {
+      if (handleSubmit) {
+        handleSubmit({ type: TYPES.ExternalPortal, data });
+      }
+    },
+    validationSchema,
+  });
 
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">

--- a/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ExternalPortal/Editor.tsx
@@ -65,7 +65,10 @@ const ExternalPortalForm: React.FC<{
   isTemplatedNode?: boolean;
   templatedNodeInstructions?: string;
   areTemplatedNodeInstructionsRequired?: boolean;
-  formikRef?: MutableRefObject<FormikProps<ExternalPortalFormData> | null>;
+  formikRef?: {
+    current: FormikProps<ExternalPortalFormData> | null;
+    onDirtyChange: (dirty: boolean) => void;
+  };
 }> = ({
   handleSubmit,
   flowId,
@@ -78,23 +81,26 @@ const ExternalPortalForm: React.FC<{
   areTemplatedNodeInstructionsRequired = false,
   formikRef,
 }) => {
-  const formik = useFormikWithRef<ExternalPortalFormData>({
-    initialValues: {
-      flow: flows.find((flow) => flow.id === flowId) || null,
-      flowId: flowId || null,
-      tags,
-      notes,
-      isTemplatedNode,
-      templatedNodeInstructions,
-      areTemplatedNodeInstructionsRequired,
+  const formik = useFormikWithRef<ExternalPortalFormData>(
+    {
+      initialValues: {
+        flow: flows.find((flow) => flow.id === flowId) || null,
+        flowId: flowId || null,
+        tags,
+        notes,
+        isTemplatedNode,
+        templatedNodeInstructions,
+        areTemplatedNodeInstructionsRequired,
+      },
+      onSubmit: (data) => {
+        if (handleSubmit) {
+          handleSubmit({ type: TYPES.ExternalPortal, data });
+        }
+      },
+      validationSchema,
     },
-    onSubmit: (data) => {
-      if (handleSubmit) {
-        handleSubmit({ type: TYPES.ExternalPortal, data });
-      }
-    },
-    validationSchema,
-  });
+    formikRef,
+  );
 
   return (
     <form id="modal" onSubmit={formik.handleSubmit} data-testid="form">

--- a/apps/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Filter/Editor.tsx
@@ -5,26 +5,22 @@ import {
   DEFAULT_FLAG_CATEGORY,
   flatFlags,
 } from "@opensystemslab/planx-core/types";
+import type { Child, EditorProps } from "@planx/components/shared/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import type { FormikProps } from "formik";
-import type { MutableRefObject } from "react";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 
-interface FilterData {
+export interface FilterData {
   fn: string;
   category: string;
 }
 
-export interface Props {
-  id?: string;
-  handleSubmit?: (data: any, children?: any) => void;
-  node?: any;
-  autoAnswer?: Node["id"];
-  disabled?: boolean;
-  formikRef?: MutableRefObject<FormikProps<FilterData> | null>;
-}
+export type Props = EditorProps<
+  TYPES.Filter,
+  FilterData,
+  { autoAnswer?: Node["id"] }
+>;
 
 const Filter: React.FC<Props> = (props) => {
   const formik = useFormikWithRef<FilterData>(
@@ -35,7 +31,7 @@ const Filter: React.FC<Props> = (props) => {
       },
       onSubmit: (newValues) => {
         if (props?.handleSubmit) {
-          const children = [
+          const children: Child[] = [
             ...flatFlags,
             {
               category: formik.values.category,

--- a/apps/editor.planx.uk/src/@planx/components/Filter/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Filter/Public.tsx
@@ -1,18 +1,18 @@
 import { useEffect } from "react";
 
 import type { PublicProps } from "../shared/types";
-import type { Props as Filter } from "./Editor";
+import type { FilterData } from "./Editor";
 
-export type Props = PublicProps<Filter>;
+export type Props = PublicProps<FilterData>;
 
 // Filters are always auto-answered and never seen by a user, but should still leave a breadcrumb
 export default function Component(props: Props) {
   useEffect(() => {
     props.handleSubmit?.({
-      answers: [props.autoAnswer],
+      answers: props.autoAnswers,
       auto: true,
     });
-  }, [props.autoAnswer]);
+  }, [props.autoAnswers]);
 
   return null;
 }

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -5,7 +5,8 @@ import {
   PAY_FN,
   validationSchema,
 } from "@planx/components/Pay/model";
-import { Form, Formik } from "formik";
+import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
+import { FormikProvider } from "formik";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { ComponentTagSelect } from "ui/editor/ComponentTagSelect";
@@ -29,6 +30,19 @@ export type Props = EditorProps<TYPES.Pay, Pay>;
 const Component: React.FC<Props> = (props: Props) => {
   const isTemplate = useStore.getState().isTemplate;
 
+  const formik = useFormikWithRef<Pay>(
+    {
+      initialValues: parsePay(props.node?.data),
+      onSubmit: (newValues) => {
+        if (props.handleSubmit) {
+          props.handleSubmit({ type: TYPES.Pay, data: newValues });
+        }
+      },
+      validationSchema: validationSchema,
+    },
+    props.formikRef,
+  );
+
   const onSubmit = (newValues: Pay) => {
     if (props.handleSubmit) {
       props.handleSubmit({ type: TYPES.Pay, data: newValues });
@@ -36,124 +50,113 @@ const Component: React.FC<Props> = (props: Props) => {
   };
 
   return (
-    <Formik<Pay>
-      innerRef={props.formikRef}
-      initialValues={parsePay(props.node?.data)}
-      onSubmit={onSubmit}
-      validationSchema={validationSchema}
-      validateOnBlur={false}
-      validateOnChange={false}
-    >
-      {(formik) => (
-        <Form id="modal" name="modal">
-          <TemplatedNodeInstructions
+    <FormikProvider value={formik}>
+      <form id="modal" name="modal" onSubmit={formik.handleSubmit}>
+        <TemplatedNodeInstructions
+          isTemplatedNode={formik.values.isTemplatedNode}
+          templatedNodeInstructions={formik.values.templatedNodeInstructions}
+          areTemplatedNodeInstructionsRequired={
+            formik.values.areTemplatedNodeInstructionsRequired
+          }
+        />
+        <ModalSection>
+          <ModalSectionContent>
+            <InputRow>
+              <Input
+                format="large"
+                placeholder="Page title"
+                name="title"
+                value={formik.values.title}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            </InputRow>
+            <InputRow>
+              <Input
+                format="bold"
+                placeholder="Banner title"
+                name="bannerTitle"
+                value={formik.values.bannerTitle}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            </InputRow>
+            <InputRow>
+              <RichTextInput
+                placeholder="Banner description"
+                name="description"
+                value={formik.values.description}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+                variant="nestedContent"
+                errorMessage={formik.errors.description}
+              />
+            </InputRow>
+            <InputRow>
+              <Input format="data" name="fn" value={PAY_FN} disabled />
+            </InputRow>
+          </ModalSectionContent>
+          <ModalSectionContent>
+            <InputRow>
+              <Input
+                format="large"
+                placeholder="Instructions title"
+                name="instructionsTitle"
+                value={formik.values.instructionsTitle}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+              />
+            </InputRow>
+            <InputRow>
+              <RichTextInput
+                placeholder="Instructions description"
+                name="instructionsDescription"
+                value={formik.values.instructionsDescription}
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+                variant="nestedContent"
+                errorMessage={formik.errors.instructionsDescription}
+              />
+            </InputRow>
+            <InputRow>
+              <Switch
+                checked={formik.values.hidePay}
+                onChange={() =>
+                  formik.setFieldValue("hidePay", !formik.values.hidePay)
+                }
+                label="Hide the pay buttons and show fee for information only"
+                disabled={props.disabled}
+              />
+            </InputRow>
+          </ModalSectionContent>
+        </ModalSection>
+        <InviteToPaySection disabled={props.disabled} />
+        <GovPayMetadataSection disabled={props.disabled} />
+        <MoreInformation formik={formik} disabled={props.disabled} />
+        <InternalNotes
+          name="notes"
+          onChange={formik.handleChange}
+          value={formik.values.notes}
+          disabled={props.disabled}
+        />
+        <ComponentTagSelect
+          onChange={(value) => formik.setFieldValue("tags", value)}
+          value={formik.values.tags}
+          disabled={props.disabled}
+        />
+        {isTemplate && (
+          <TemplatedNodeConfiguration
+            formik={formik}
             isTemplatedNode={formik.values.isTemplatedNode}
             templatedNodeInstructions={formik.values.templatedNodeInstructions}
             areTemplatedNodeInstructionsRequired={
               formik.values.areTemplatedNodeInstructionsRequired
             }
-          />
-          <ModalSection>
-            <ModalSectionContent>
-              <InputRow>
-                <Input
-                  format="large"
-                  placeholder="Page title"
-                  name="title"
-                  value={formik.values.title}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-              <InputRow>
-                <Input
-                  format="bold"
-                  placeholder="Banner title"
-                  name="bannerTitle"
-                  value={formik.values.bannerTitle}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-              <InputRow>
-                <RichTextInput
-                  placeholder="Banner description"
-                  name="description"
-                  value={formik.values.description}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  variant="nestedContent"
-                  errorMessage={formik.errors.description}
-                />
-              </InputRow>
-              <InputRow>
-                <Input format="data" name="fn" value={PAY_FN} disabled />
-              </InputRow>
-            </ModalSectionContent>
-            <ModalSectionContent>
-              <InputRow>
-                <Input
-                  format="large"
-                  placeholder="Instructions title"
-                  name="instructionsTitle"
-                  value={formik.values.instructionsTitle}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-              <InputRow>
-                <RichTextInput
-                  placeholder="Instructions description"
-                  name="instructionsDescription"
-                  value={formik.values.instructionsDescription}
-                  onChange={formik.handleChange}
-                  disabled={props.disabled}
-                  variant="nestedContent"
-                  errorMessage={formik.errors.instructionsDescription}
-                />
-              </InputRow>
-              <InputRow>
-                <Switch
-                  checked={formik.values.hidePay}
-                  onChange={() =>
-                    formik.setFieldValue("hidePay", !formik.values.hidePay)
-                  }
-                  label="Hide the pay buttons and show fee for information only"
-                  disabled={props.disabled}
-                />
-              </InputRow>
-            </ModalSectionContent>
-          </ModalSection>
-          <InviteToPaySection disabled={props.disabled} />
-          <GovPayMetadataSection disabled={props.disabled} />
-          <MoreInformation formik={formik} disabled={props.disabled} />
-          <InternalNotes
-            name="notes"
-            onChange={formik.handleChange}
-            value={formik.values.notes}
             disabled={props.disabled}
           />
-          <ComponentTagSelect
-            onChange={(value) => formik.setFieldValue("tags", value)}
-            value={formik.values.tags}
-            disabled={props.disabled}
-          />
-          {isTemplate && (
-            <TemplatedNodeConfiguration
-              formik={formik}
-              isTemplatedNode={formik.values.isTemplatedNode}
-              templatedNodeInstructions={
-                formik.values.templatedNodeInstructions
-              }
-              areTemplatedNodeInstructionsRequired={
-                formik.values.areTemplatedNodeInstructionsRequired
-              }
-              disabled={props.disabled}
-            />
-          )}
-        </Form>
-      )}
-    </Formik>
+        )}
+      </form>
+    </FormikProvider>
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/Result/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Result/Editor.tsx
@@ -6,7 +6,7 @@ import {
   flatFlags,
   getNoResultFlag,
 } from "@opensystemslab/planx-core/types";
-import { Form, Formik, useFormikContext } from "formik";
+import { FormikProvider, useFormikContext } from "formik";
 import groupBy from "lodash/groupBy";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -20,8 +20,9 @@ import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
 import type { EditorProps } from "../shared/types";
-import type { FlagDisplayText, Result } from "./model";
-import { validationSchema } from "./model";
+import { useFormikWithRef } from "../shared/useFormikWithRef";
+import type { FlagDisplayText, Result } from "./model"
+import {  parseResult, validationSchema } from "./model";
 
 type FlagWithValue = Flag & { value: NonNullable<Flag["value"]> };
 
@@ -84,112 +85,108 @@ const FlagEditor: React.FC<{
 type Props = EditorProps<TYPES.Result, Result>;
 
 const ResultComponent: React.FC<Props> = (props) => {
+  const formik = useFormikWithRef<Result>(
+    {
+      initialValues: parseResult(props.node?.data),
+      onSubmit: (newValues) => {
+        if (props.handleSubmit) {
+          props.handleSubmit({ type: TYPES.Result, data: newValues });
+        }
+      },
+      validationSchema: validationSchema,
+    },
+    props.formikRef,
+  );
+
   const allFlagsForSet = (flagSet: FlagSet): FlagWithValue[] => [
     ...(flags[flagSet] ?? []),
     getNoResultFlag(flagSet) as FlagWithValue,
   ];
 
   return (
-    <Formik<Result>
-      innerRef={props.formikRef}
-      initialValues={{
-        flagSet: props.node?.data?.flagSet || Object.keys(flags)[0],
-        overrides: props.node?.data?.overrides || {},
-      }}
-      onSubmit={(newValues) => {
-        if (props.handleSubmit) {
-          props.handleSubmit({ type: TYPES.Result, data: newValues });
-        }
-      }}
-      validationSchema={validationSchema}
-      validateOnBlur={false}
-      validateOnChange={false}
-    >
-      {(formik) => (
-        <Form name="modal" id="modal">
-          <TemplatedNodeInstructions
-            isTemplatedNode={formik.values.isTemplatedNode}
-            templatedNodeInstructions={formik.values.templatedNodeInstructions}
-            areTemplatedNodeInstructionsRequired={
-              formik.values.areTemplatedNodeInstructionsRequired
-            }
-          />
-          <ModalSection>
-            <ModalSectionContent>
-              <InputRow>
-                <Typography variant="h5" component="h6">
-                  <label htmlFor="result-flagSet">Flag set</label>
-                </Typography>
-                <select
-                  id="result-flagSet"
-                  name="flagSet"
-                  value={formik.values.flagSet}
-                  onChange={formik.handleChange}
-                  required
-                  disabled={props.disabled}
-                >
-                  {Object.keys(flags).map((flagSet) => (
-                    <option key={flagSet} value={flagSet}>
-                      {flagSet}
-                    </option>
-                  ))}
-                </select>
-              </InputRow>
+    <FormikProvider value={formik}>
+      <form name="modal" id="modal" onSubmit={formik.handleSubmit}>
+        <TemplatedNodeInstructions
+          isTemplatedNode={formik.values.isTemplatedNode}
+          templatedNodeInstructions={formik.values.templatedNodeInstructions}
+          areTemplatedNodeInstructionsRequired={
+            formik.values.areTemplatedNodeInstructionsRequired
+          }
+        />
+        <ModalSection>
+          <ModalSectionContent>
+            <InputRow>
+              <Typography variant="h5" component="h6">
+                <label htmlFor="result-flagSet">Flag set</label>
+              </Typography>
+              <select
+                id="result-flagSet"
+                name="flagSet"
+                value={formik.values.flagSet}
+                onChange={formik.handleChange}
+                required
+                disabled={props.disabled}
+              >
+                {Object.keys(flags).map((flagSet) => (
+                  <option key={flagSet} value={flagSet}>
+                    {flagSet}
+                  </option>
+                ))}
+              </select>
+            </InputRow>
 
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="h5" component="h6">
+                Flag text overrides (optional)
+              </Typography>
+              <Typography variant="body2">
+                The overrides you set here will change what is displayed to the
+                user upon arriving at this result. If you provide no overrides,
+                the flag title will be used.
+              </Typography>
               <Box sx={{ mt: 2 }}>
-                <Typography variant="h5" component="h6">
-                  Flag text overrides (optional)
-                </Typography>
-                <Typography variant="body2">
-                  The overrides you set here will change what is displayed to
-                  the user upon arriving at this result. If you provide no
-                  overrides, the flag title will be used.
-                </Typography>
-                <Box sx={{ mt: 2 }}>
-                  {allFlagsForSet(formik.values.flagSet).map((flag) => {
-                    const override =
-                      formik.values.overrides?.[flag.value] || {};
-                    return (
-                      <FlagEditor
-                        key={flag.value}
-                        flag={flag}
-                        existingOverrides={override}
-                        onChange={(newValues) => {
+                {allFlagsForSet(formik.values.flagSet).map((flag) => {
+                  const override = formik.values.overrides?.[flag.value] || {};
+                  return (
+                    <FlagEditor
+                      key={flag.value}
+                      flag={flag}
+                      existingOverrides={override}
+                      onChange={(newValues) => {
+                        formik.setFieldValue("overrides", {
+                          ...formik.values.overrides,
+                          [flag.value]: newValues,
+                        });
+                      }}
+                      disabled={props.disabled}
+                    >
+                      <Switch
+                        checked={Boolean(override.resetButton)}
+                        onChange={() =>
                           formik.setFieldValue("overrides", {
                             ...formik.values.overrides,
-                            [flag.value]: newValues,
-                          });
-                        }}
-                        disabled={props.disabled}
-                      >
-                        <Switch
-                          checked={Boolean(override.resetButton)}
-                          onChange={() =>
-                            formik.setFieldValue("overrides", {
-                              ...formik.values.overrides,
-                              [flag.value]: {
-                                ...override,
-                                resetButton: !override.resetButton,
-                              },
-                            })
-                          }
-                          label="Reset to start of service"
-                        />
-                      </FlagEditor>
-                    );
-                  })}
-                </Box>
+                            [flag.value]: {
+                              ...override,
+                              resetButton: !override.resetButton,
+                            },
+                          })
+                        }
+                        label="Reset to start of service"
+                      />
+                    </FlagEditor>
+                  );
+                })}
               </Box>
-            </ModalSectionContent>
-          </ModalSection>
-          <ModalFooter
-            formik={formik}
-            showMoreInformation={false}
-            disabled={props.disabled}
-          />
-        </Form>
-      )}
-    </Formik>
+            </Box>
+          </ModalSectionContent>
+        </ModalSection>
+        <ModalFooter
+          formik={formik}
+          showMoreInformation={false}
+          disabled={props.disabled}
+        />
+      </form>
+    </FormikProvider>
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/Result/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Result/model.ts
@@ -9,7 +9,7 @@ import type { TextContent } from "types";
 import { boolean, lazy, mixed, object, string } from "yup";
 
 import type { BaseNodeData } from "../shared";
-import { baseNodeDataValidationSchema } from "../shared";
+import { baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface FlagDisplayText {
   heading?: string;
@@ -51,6 +51,13 @@ const overridesSchema = lazy((obj) =>
     ),
   ),
 );
+
+export const parseResult = (data: Store.Node["data"] | undefined): Result => ({
+  ...parseBaseNodeData(data),
+  flagSet: data?.flagSet || FLAG_SETS[0],
+  overrides: data?.overrides,
+  resetButton: data?.resetButton,
+});
 
 export const validationSchema = baseNodeDataValidationSchema.concat(
   object({

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -7,7 +7,7 @@ import {
   parseTaskList,
   validationSchema,
 } from "@planx/components/TaskList/model";
-import { Form, Formik, getIn, useFormikContext } from "formik";
+import { FormikProvider, getIn, useFormikContext } from "formik";
 import type { ChangeEvent } from "react";
 import React from "react";
 import type { EditorProps as ListManagerEditorProps } from "ui/editor/ListManager/ListManager";
@@ -17,8 +17,11 @@ import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";
 import RichTextInput from "ui/editor/RichTextInput/RichTextInput";
 import { TemplatedNodeInstructions } from "ui/editor/TemplatedNodeInstructions";
+import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
+
+import { useFormikWithRef } from "../shared/useFormikWithRef";
 
 export type Props = EditorProps<TYPES.TaskList, TaskList>;
 
@@ -28,7 +31,7 @@ const newTask = (): Task => ({
 });
 
 const TaskEditor: React.FC<ListManagerEditorProps<Task>> = (props) => {
-  const { errors } = useFormikContext<Task>();
+  const { errors } = useFormikContext<TaskList>();
 
   return (
     <Box sx={{ flex: 1 }}>
@@ -69,21 +72,23 @@ const TaskEditor: React.FC<ListManagerEditorProps<Task>> = (props) => {
   );
 };
 
-const TaskListComponent: React.FC<Props> = (props) => (
-  <Formik<TaskList>
-    innerRef={props.formikRef}
-    initialValues={parseTaskList(props.node?.data)}
-    onSubmit={(newValues) => {
-      if (props.handleSubmit) {
-        props.handleSubmit({ type: TYPES.TaskList, data: newValues });
-      }
-    }}
-    validationSchema={validationSchema}
-    validateOnChange={false}
-    validateOnBlur={false}
-  >
-    {(formik) => (
-      <Form id="modal">
+const TaskListComponent: React.FC<Props> = (props) => {
+  const formik = useFormikWithRef<TaskList>(
+    {
+      initialValues: parseTaskList(props.node?.data),
+      onSubmit: (newValues) => {
+        if (props.handleSubmit) {
+          props.handleSubmit({ type: TYPES.TaskList, data: newValues });
+        }
+      },
+      validationSchema: validationSchema,
+    },
+    props.formikRef,
+  );
+
+  return (
+    <FormikProvider value={formik}>
+      <form id="modal" onSubmit={formik.handleSubmit}>
         <TemplatedNodeInstructions
           isTemplatedNode={formik.values.isTemplatedNode}
           templatedNodeInstructions={formik.values.templatedNodeInstructions}
@@ -95,14 +100,16 @@ const TaskListComponent: React.FC<Props> = (props) => (
           <ModalSectionContent>
             <Box sx={{ mb: "1rem" }}>
               <InputRow>
-                <Input
-                  name="title"
-                  value={formik.values.title}
-                  onChange={formik.handleChange}
-                  placeholder="Main title"
-                  format="large"
-                  disabled={props.disabled}
-                />
+                <ErrorWrapper error={formik.errors.title}>
+                  <Input
+                    name="title"
+                    value={formik.values.title}
+                    onChange={formik.handleChange}
+                    placeholder="Main title"
+                    format="large"
+                    disabled={props.disabled}
+                  />
+                </ErrorWrapper>
               </InputRow>
               <InputRow>
                 <RichTextInput
@@ -115,23 +122,31 @@ const TaskListComponent: React.FC<Props> = (props) => (
                 />
               </InputRow>
             </Box>
-            <ListManager
-              values={formik.values.tasks}
-              onChange={(tasks: Array<Task>) => {
-                formik.setFieldValue("tasks", tasks);
-              }}
-              Editor={TaskEditor}
-              newValue={newTask}
-              disabled={props.disabled}
-              collapsible={true}
-              itemName="task"
-            />
+            <ErrorWrapper
+              error={
+                typeof formik.errors.tasks === "string"
+                  ? formik.errors.tasks
+                  : undefined
+              }
+            >
+              <ListManager
+                values={formik.values.tasks}
+                onChange={(tasks: Array<Task>) => {
+                  formik.setFieldValue("tasks", tasks);
+                }}
+                Editor={TaskEditor}
+                newValue={newTask}
+                disabled={props.disabled}
+                collapsible={true}
+                itemName="task"
+              />
+            </ErrorWrapper>
           </ModalSectionContent>
         </ModalSection>
         <ModalFooter formik={formik} disabled={props.disabled} />
-      </Form>
-    )}
-  </Formik>
-);
+      </form>
+    </FormikProvider>
+  );
+};
 
 export default TaskListComponent;

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/model.ts
@@ -37,9 +37,11 @@ const taskSchema = object({
 
 export const validationSchema = baseNodeDataValidationSchema.concat(
   object({
-    title: string().required(),
+    title: string().required("Please enter a title"),
     description: richText(),
-    tasks: array(taskSchema).required().min(1),
+    tasks: array(taskSchema)
+      .required()
+      .min(1, "Please enter at least one task"),
     taskList: object({
       tasks: array(taskSchema).min(1),
     }).optional(),

--- a/apps/editor.planx.uk/src/@planx/components/shared/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/types.tsx
@@ -18,7 +18,10 @@ export type EditorProps<
   Data,
   ExtraProps extends object = Record<string, unknown>,
 > = {
-  formikRef?: MutableRefObject<FormikProps<any> | null>;
+  formikRef?: {
+    current: FormikProps<any> | null;
+    onDirtyChange: (dirty: boolean) => void;
+  };
   id?: string;
   handleSubmit?: (data: { type: Type; data: Data }, children?: Child[]) => void;
   node?: any;

--- a/apps/editor.planx.uk/src/@planx/components/shared/useFormikWithRef.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/useFormikWithRef.ts
@@ -9,7 +9,10 @@ import { useEffect } from "react";
  */
 export function useFormikWithRef<T extends FormikValues>(
   formikConfig: FormikConfig<T>,
-  formikRef?: MutableRefObject<FormikProps<T> | null>,
+  formikRef?: {
+    current: FormikProps<T> | null;
+    onDirtyChange: (dirty: boolean) => void;
+  },
 ) {
   const formik = useFormik<T>({
     validateOnChange: false,
@@ -22,6 +25,12 @@ export function useFormikWithRef<T extends FormikValues>(
       formikRef.current = formik;
     }
   });
+
+  useEffect(() => {
+    if (formikRef) {
+      formikRef.onDirtyChange(formik.dirty);
+    }
+  }, [formik.dirty, formikRef]);
 
   return formik;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -191,8 +191,7 @@ const FormModal: React.FC<FormModalProps> = ({
   //  2. The user has edit access to this team, but it is:
   //    - a templated flow
   //    - and the node itself is not marked "isTemplatedNode" or a child of an internal portal marked "isTemplatedNode"
-  //  3. The form is not dirty
-  //    - except for when a user is creating an allow-listed component (this is because they can be created and used as-is)
+  //  3. The form is being updated and not dirty
   const canUserEditNode = (teamSlug: string) => {
     return useStore.getState().canUserEditTeam(teamSlug);
   };
@@ -221,9 +220,6 @@ const FormModal: React.FC<FormModalProps> = ({
     ? !canUserEditTemplatedNode
     : !canUserEditNode(teamSlug);
 
-  // submit (create / update) button is disabled when:
-  // 1. user cannot edit, OR
-  // 2. form needs to be dirty but isn't (unless it's allow list component)
   const isSubmitDisabled =
     userCannotEdit || (isEditingExistingNode && !isFormDirty);
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -9,20 +9,16 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
-import {
-  ComponentType,
-  ComponentType as TYPES,
-} from "@opensystemslab/planx-core/types";
+import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { type BaseNodeData, parseFormValues } from "@planx/components/shared";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import ErrorFallback from "components/Error/ErrorFallback";
 import type { FormikProps } from "formik";
-import isEqual from "lodash/isEqual";
 import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { Switch } from "ui/shared/Switch";
@@ -110,20 +106,6 @@ interface FormModalProps {
   parent?: string;
   extraProps?: any;
 }
-
-const CAN_CREATE_WITHOUT_CONFIG_ALLOW_LIST = [
-  "feedback",
-  "review",
-  "result",
-  "confirmation",
-  "find-property",
-  "property-information",
-  "draw-boundary",
-  "planning-constraints",
-  "filter",
-  "pay",
-  "send",
-];
 
 const FormModal: React.FC<FormModalProps> = ({
   type,
@@ -239,16 +221,11 @@ const FormModal: React.FC<FormModalProps> = ({
     ? !canUserEditTemplatedNode
     : !canUserEditNode(teamSlug);
 
-  // result, review and feedback components can be created without any changes
-  const canCreateWithoutChanges =
-    !isEditingExistingNode &&
-    CAN_CREATE_WITHOUT_CONFIG_ALLOW_LIST.includes(type);
-
   // submit (create / update) button is disabled when:
   // 1. user cannot edit, OR
   // 2. form needs to be dirty but isn't (unless it's allow list component)
   const isSubmitDisabled =
-    userCannotEdit || (!canCreateWithoutChanges && !isFormDirty);
+    userCannotEdit || (isEditingExistingNode && !isFormDirty);
 
   const showDeleteButton = id && !isDisabledTemplatedNode;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -111,6 +111,20 @@ interface FormModalProps {
   extraProps?: any;
 }
 
+const CAN_CREATE_WITHOUT_CONFIG_ALLOW_LIST = [
+  "feedback",
+  "review",
+  "result",
+  "confirmation",
+  "find-property",
+  "property-information",
+  "draw-boundary",
+  "planning-constraints",
+  "filter",
+  "pay",
+  "send",
+];
+
 const FormModal: React.FC<FormModalProps> = ({
   type,
   Component,
@@ -196,7 +210,7 @@ const FormModal: React.FC<FormModalProps> = ({
   //    - a templated flow
   //    - and the node itself is not marked "isTemplatedNode" or a child of an internal portal marked "isTemplatedNode"
   //  3. The form is not dirty
-  //    - except for when a user is creating a 'review' or 'result' component (this is because they can be created and used as-is)
+  //    - except for when a user is creating an allow-listed component (this is because they can be created and used as-is)
   const canUserEditNode = (teamSlug: string) => {
     return useStore.getState().canUserEditTeam(teamSlug);
   };
@@ -228,11 +242,11 @@ const FormModal: React.FC<FormModalProps> = ({
   // result, review and feedback components can be created without any changes
   const canCreateWithoutChanges =
     !isEditingExistingNode &&
-    (type === "result" || type === "review" || type === "feedback");
+    CAN_CREATE_WITHOUT_CONFIG_ALLOW_LIST.includes(type);
 
   // submit (create / update) button is disabled when:
   // 1. user cannot edit, OR
-  // 2. form needs to be dirty but isn't (unless it's result/review/feedback)
+  // 2. form needs to be dirty but isn't (unless it's allow list component)
   const isSubmitDisabled =
     userCannotEdit || (!canCreateWithoutChanges && !isFormDirty);
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -241,13 +241,14 @@ const FormModal: React.FC<FormModalProps> = ({
     ? !canUserEditTemplatedNode
     : !canUserEditNode(teamSlug);
 
-  // result and review components can be created without any changes
+  // result, review and feedback components can be created without any changes
   const canCreateWithoutChanges =
-    !isEditingExistingNode && (type === "result" || type === "review");
+    !isEditingExistingNode &&
+    (type === "result" || type === "review" || type === "feedback");
 
   // submit (create / update) button is disabled when:
   // 1. user cannot edit, OR
-  // 2. form needs to be dirty but isn't (unless it's result/review)
+  // 2. form needs to be dirty but isn't (unless it's result/review/feedback)
   const isSubmitDisabled =
     userCannotEdit || (!canCreateWithoutChanges && !isFormDirty);
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -22,7 +22,7 @@ import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { Switch } from "ui/shared/Switch";
@@ -174,6 +174,20 @@ const FormModal: React.FC<FormModalProps> = ({
       normalizeFormValues(formik.initialValues),
     );
   };
+
+  const [isFormDirty, setIsFormDirty] = useState(false);
+
+  useEffect(() => {
+    const formik = formikRef.current;
+    if (!formik) return;
+
+    const checkDirty = () => {
+      const dirty = isDirty(formik);
+      setIsFormDirty(dirty);
+    };
+
+    checkDirty();
+  }, [formikRef.current?.values, formikRef.current?.initialValues, isDirty]);
 
   const hasUnsavedChanges = () => {
     const formik = formikRef.current;
@@ -408,7 +422,7 @@ const FormModal: React.FC<FormModalProps> = ({
               variant="contained"
               color="primary"
               form="modal"
-              disabled={disabled}
+              disabled={disabled || !isFormDirty}
             >
               {handleDelete ? `Update` : `Create`}
             </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -123,6 +123,8 @@ const FormModal: React.FC<FormModalProps> = ({
   const navigate = useNavigate();
   const formikRef = useRef<FormikProps<BaseNodeData & unknown> | null>(null);
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
+  const [isFormDirty, setIsFormDirty] = useState(false);
+
   const { team: teamSlug, flow: flowSlug } = useParams({
     from: "/_authenticated/app/$team/$flow",
   });
@@ -146,54 +148,33 @@ const FormModal: React.FC<FormModalProps> = ({
     store.orderedFlow,
     store.isClone,
   ]);
+
   const node = id ? flow[id] : undefined;
+  const isEditingExistingNode = Boolean(handleDelete);
 
-  const normalizeFormValues = (obj: any): any => {
-    if (obj === null || obj === undefined || obj === "") {
-      return "";
-    }
-
-    if (Array.isArray(obj)) {
-      return obj.map(normalizeFormValues);
-    }
-
-    if (typeof obj === "object") {
-      const normalized: any = {};
-      for (const key in obj) {
-        normalized[key] = normalizeFormValues(obj[key]);
-      }
-      return normalized;
-    }
-
-    return obj;
-  };
-
-  const isDirty = (formik: FormikProps<BaseNodeData & unknown>): boolean => {
-    return !isEqual(
-      normalizeFormValues(formik.values),
-      normalizeFormValues(formik.initialValues),
-    );
-  };
-
-  const [isFormDirty, setIsFormDirty] = useState(false);
-
+  // checking formik periodically because useEffect would create infinite re-render
   useEffect(() => {
-    const formik = formikRef.current;
-    if (!formik) return;
-
     const checkDirty = () => {
-      const dirty = isDirty(formik);
-      setIsFormDirty(dirty);
+      const formik = formikRef.current;
+      if (!formik) {
+        if (isFormDirty) setIsFormDirty(false);
+        return;
+      }
+
+      if (formik.dirty !== isFormDirty) {
+        setIsFormDirty(formik.dirty);
+      }
     };
 
     checkDirty();
-  }, [formikRef.current?.values, formikRef.current?.initialValues, isDirty]);
 
-  const hasUnsavedChanges = () => {
-    const formik = formikRef.current;
-    if (!formik) return false;
+    const interval = setInterval(checkDirty, 100);
 
-    return isDirty(formik);
+    return () => clearInterval(interval);
+  }, [isFormDirty]); // so this depends on our state, not formik--avoiding infinite rerender
+
+  const hasUnsavedChanges = (): boolean => {
+    return isFormDirty;
   };
 
   const handleClose = () => {
@@ -230,6 +211,8 @@ const FormModal: React.FC<FormModalProps> = ({
   //  2. The user has edit access to this team, but it is:
   //    - a templated flow
   //    - and the node itself is not marked "isTemplatedNode" or a child of an internal portal marked "isTemplatedNode"
+  //  3. The form is not dirty
+  //    - except for when a user is creating a 'review' or 'result' component (this is because they can be created and used as-is)
   const canUserEditNode = (teamSlug: string) => {
     return useStore.getState().canUserEditTeam(teamSlug);
   };
@@ -253,6 +236,20 @@ const FormModal: React.FC<FormModalProps> = ({
     Boolean(node?.data?.isTemplatedNode) &&
     (!parentIsTemplatedInternalPortal ||
       !parentIsChildOfTemplatedInternalPortal);
+
+  const userCannotEdit = isTemplatedFrom
+    ? !canUserEditTemplatedNode
+    : !canUserEditNode(teamSlug);
+
+  // result and review components can be created without any changes
+  const canCreateWithoutChanges =
+    !isEditingExistingNode && (type === "result" || type === "review");
+
+  // submit (create / update) button is disabled when:
+  // 1. user cannot edit, OR
+  // 2. form needs to be dirty but isn't (unless it's result/review)
+  const isSubmitDisabled =
+    userCannotEdit || (!canCreateWithoutChanges && !isFormDirty);
 
   const showDeleteButton = id && !isDisabledTemplatedNode;
 
@@ -422,7 +419,7 @@ const FormModal: React.FC<FormModalProps> = ({
               variant="contained"
               color="primary"
               form="modal"
-              disabled={disabled || !isFormDirty}
+              disabled={isSubmitDisabled}
             >
               {handleDelete ? `Update` : `Create`}
             </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -121,9 +121,14 @@ const FormModal: React.FC<FormModalProps> = ({
   extraProps,
 }) => {
   const navigate = useNavigate();
-  const formikRef = useRef<FormikProps<BaseNodeData & unknown> | null>(null);
+
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
   const [isFormDirty, setIsFormDirty] = useState(false);
+
+  const formikRef = useMemo<{
+    current: FormikProps<BaseNodeData & unknown> | null;
+    onDirtyChange: (dirty: boolean) => void;
+  }>(() => ({ current: null, onDirtyChange: setIsFormDirty }), []);
 
   const { team: teamSlug, flow: flowSlug } = useParams({
     from: "/_authenticated/app/$team/$flow",
@@ -151,27 +156,6 @@ const FormModal: React.FC<FormModalProps> = ({
 
   const node = id ? flow[id] : undefined;
   const isEditingExistingNode = Boolean(handleDelete);
-
-  // checking formik periodically because useEffect would create infinite re-render
-  useEffect(() => {
-    const checkDirty = () => {
-      const formik = formikRef.current;
-      if (!formik) {
-        if (isFormDirty) setIsFormDirty(false);
-        return;
-      }
-
-      if (formik.dirty !== isFormDirty) {
-        setIsFormDirty(formik.dirty);
-      }
-    };
-
-    checkDirty();
-
-    const interval = setInterval(checkDirty, 100);
-
-    return () => clearInterval(interval);
-  }, [isFormDirty]); // so this depends on our state, not formik--avoiding infinite rerender
 
   const hasUnsavedChanges = (): boolean => {
     return isFormDirty;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/filters.test.ts
@@ -34,7 +34,7 @@ describe("A filter on the root of the graph", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("RootFilter");
-    expect(autoAnswerableFlag("RootFilter")).toEqual("RootFilterYes");
+    expect(autoAnswerableFlag("RootFilter")).toEqual(["RootFilterYes"]);
   });
 
   test("Filter options are auto-answered correctly when a lower order flag is collected first", () => {
@@ -55,7 +55,7 @@ describe("A filter on the root of the graph", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("RootFilter");
-    expect(autoAnswerableFlag("RootFilter")).toEqual("RootFilterYes");
+    expect(autoAnswerableFlag("RootFilter")).toEqual(["RootFilterYes"]);
   });
 
   test("Filter 'No flag result' option is auto-answered correctly when no flags in this category have been collected", () => {
@@ -76,7 +76,9 @@ describe("A filter on the root of the graph", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("RootFilter");
-    expect(autoAnswerableFlag("RootFilter")).toEqual("RootFilterNoFlagResult");
+    expect(autoAnswerableFlag("RootFilter")).toEqual([
+      "RootFilterNoFlagResult",
+    ]);
   });
 });
 
@@ -112,7 +114,7 @@ describe("A filter on a branch", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("BranchFilter");
-    expect(autoAnswerableFlag("BranchFilter")).toEqual("BranchFilterYes");
+    expect(autoAnswerableFlag("BranchFilter")).toEqual(["BranchFilterYes"]);
   });
 
   test("Filter options are auto-answered correctly when a lower order flag is collected first", () => {
@@ -141,7 +143,7 @@ describe("A filter on a branch", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("BranchFilter");
-    expect(autoAnswerableFlag("BranchFilter")).toEqual("BranchFilterYes");
+    expect(autoAnswerableFlag("BranchFilter")).toEqual(["BranchFilterYes"]);
   });
 
   test("Filter 'No flag result' option is auto-answered correctly when no flags in this category have been collected", () => {
@@ -163,9 +165,9 @@ describe("A filter on a branch", () => {
     });
 
     expect(upcomingCardIds()?.[0]).toEqual("BranchFilter");
-    expect(autoAnswerableFlag("BranchFilter")).toEqual(
+    expect(autoAnswerableFlag("BranchFilter")).toEqual([
       "BranchFilterNoFlagResult",
-    );
+    ]);
   });
 });
 
@@ -187,7 +189,7 @@ describe("Auto-answerable Questions or Checklists on filter paths", () => {
     expect(visitedNodes()).not.toContain("AutoAnswerableChecklist");
 
     expect(upcomingCardIds()?.[0]).toEqual("RootFilter");
-    expect(autoAnswerableFlag("RootFilter")).toEqual("RootFilterYes");
+    expect(autoAnswerableFlag("RootFilter")).toEqual(["RootFilterYes"]);
     clickContinue("RootFilter", { answers: ["RootFilterYes"], auto: true });
 
     expect(upcomingCardIds()?.[0]).toEqual("AutoAnswerableChecklist");
@@ -209,7 +211,7 @@ describe("Auto-answerable Questions or Checklists on filter paths", () => {
     expect(visitedNodes()).not.toContain("AutoAnswerableChecklist");
 
     expect(upcomingCardIds()?.[0]).toEqual("RootFilter");
-    expect(autoAnswerableFlag("RootFilter")).toEqual("RootFilterNo");
+    expect(autoAnswerableFlag("RootFilter")).toEqual(["RootFilterNo"]);
     clickContinue("RootFilter", { answers: ["RootFilterNo"], auto: true });
 
     expect(upcomingCardIds()).not.toContain("AutoAnswerableChecklist");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -112,7 +112,7 @@ export interface PreviewStore extends Store.Store {
     id: NodeId,
   ) => AutoAnswerableInputMap[T];
   autoAnswerableOptions: (id: NodeId) => Array<NodeId> | undefined;
-  autoAnswerableFlag: (filterId: NodeId) => NodeId | undefined;
+  autoAnswerableFlag: (filterId: NodeId) => NodeId[] | undefined;
   hasAcknowledgedWarning: boolean;
   setHasAcknowledgedWarning: () => void;
   currentCardURL: () => string | null;
@@ -789,7 +789,7 @@ export const previewStore: StateCreator<
     }
 
     // Filters 'select one' and therefore can only auto-answer the single left-most matching flag option
-    return optionsThatCanBeAutoAnswered.slice(0, 1).toString();
+    return optionsThatCanBeAutoAnswered.slice(0, 1);
   },
 
   isFinalCard: () => {

--- a/apps/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -26,7 +26,7 @@ import type { FileUpload } from "@planx/components/FileUpload/model";
 import FileUploadComponent from "@planx/components/FileUpload/Public";
 import type { FileUploadAndLabel } from "@planx/components/FileUploadAndLabel/model";
 import FileUploadAndLabelComponent from "@planx/components/FileUploadAndLabel/Public";
-import type { Props as Filter } from "@planx/components/Filter/Editor";
+import type { FilterData } from "@planx/components/Filter/Editor";
 import FilterComponent from "@planx/components/Filter/Public";
 import type { FindProperty } from "@planx/components/FindProperty/model";
 import FindPropertyComponent from "@planx/components/FindProperty/Public";
@@ -220,10 +220,15 @@ const Node: React.FC<Props> = (props) => {
       );
 
     case TYPES.Filter: {
-      const filterProps = getComponentProps<Filter>();
-      const autoAnswer = nodeId ? autoAnswerableFlag(nodeId) : undefined;
+      const filterProps = getComponentProps<FilterData>();
+      const autoAnswers = nodeId ? autoAnswerableFlag(nodeId) : undefined;
 
-      return <FilterComponent {...filterProps} autoAnswer={autoAnswer} />;
+      return (
+        <FilterComponent
+          {...filterProps}
+          autoAnswers={autoAnswers ? [autoAnswers] : undefined}
+        />
+      );
     }
 
     case TYPES.FindProperty:

--- a/apps/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -223,12 +223,7 @@ const Node: React.FC<Props> = (props) => {
       const filterProps = getComponentProps<FilterData>();
       const autoAnswers = nodeId ? autoAnswerableFlag(nodeId) : undefined;
 
-      return (
-        <FilterComponent
-          {...filterProps}
-          autoAnswers={autoAnswers ? [autoAnswers] : undefined}
-        />
-      );
+      return <FilterComponent {...filterProps} autoAnswers={autoAnswers} />;
     }
 
     case TYPES.FindProperty:

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -466,10 +466,15 @@ test.describe("Templates", () => {
       // Nodes inside the folder are fully editable (submit button enabled)
       await page.getByRole("link", { name: FIRST_NODE_IN_FOLDER }).click();
       await page.getByRole("dialog").waitFor();
+
+      const editor = page.getByRole("textbox", { name: "Description" });
+      await editor.click();
+      await editor.pressSequentially("some text");
+
       await expect(
         page.locator('button[form="modal"][type="submit"]'),
       ).toBeEnabled();
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[form="modal"][type="submit"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 
       // Drag SECOND_NODE_IN_FOLDER to before FIRST_NODE_IN_FOLDER


### PR DESCRIPTION
In `FormModal`, this PR adds a new `isSubmitDisabled` var (instead of just `disabled`--we use this elsewhere but the logic for disabling submit is different from that of disabling the rest of the component!)

`isSubmitDisabled` now checks for:
- if the user has editing privileges
- if it's an existing node & formik is not dirty

Changes are predominantly in `FormModal` following Daf's [previous suggestions on a relevant PR](https://github.com/theopensystemslab/planx-new/pull/5851#pullrequestreview-3551984380). 

Most components were using `useFormikWithRef` but a handful were using `innerRef` (eg Enhanced Text Input, Pay), so they have been refactored here to use the hook too.

e2e tests also updated as needed. 

Before:
https://github.com/user-attachments/assets/02db3697-16e0-4f96-b0ad-3aa7a8c6da3a

After:
https://github.com/user-attachments/assets/9c56cd6d-a77e-4a61-bba6-93dd2a79134d
