### PR TITLE
Production deploy

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/controller.ts
+++ b/apps/api.planx.uk/modules/webhooks/controller.ts
@@ -1,12 +1,15 @@
 import isNull from "lodash/isNull.js";
+
 import { ServerError } from ".././../errors/index.js";
+import { sendSlackMessage } from "../slack/utils.js";
 import { analyzeSessions } from "./service/analyzeSessions/index.js";
+import { getDailyFailedSubmissions } from "./service/dailyFailedSubmissions/index.js";
 import { softDeleteSession } from "./service/deleteSession/index.js";
 import type { DeleteSessionController } from "./service/deleteSession/schema.js";
 import {
+  createSessionDeleteEvent,
   createSessionExpiryEvent,
   createSessionReminderEvent,
-  createSessionDeleteEvent,
 } from "./service/lowcalSessionEvents/index.js";
 import type {
   CreateSessionDeleteEventController,
@@ -23,10 +26,10 @@ import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/
 import { sendSlackNotification } from "./service/sendNotification/index.js";
 import type { SendSlackNotification } from "./service/sendNotification/types.js";
 import type { SendSlackMessageController } from "./service/sendSlackMessage/schema.js";
-import { sendSlackMessage } from "../slack/utils.js";
+import { updateTemplatedFlowEdits } from "./service/updateTemplatedFlowEdits/index.js";
 import type { UpdateTemplatedFlowEditsController } from "./service/updateTemplatedFlowEdits/schema.js";
 import type { IsCleanJSONBController } from "./service/validateInput/schema.js";
-import { updateTemplatedFlowEdits } from "./service/updateTemplatedFlowEdits/index.js";
+import type { FailedSubmissionController } from "./service/dailyFailedSubmissions/types.js";
 
 export const sendSlackNotificationController: SendSlackNotification = async (
   _req,
@@ -296,3 +299,29 @@ export const updateTemplatedFlowEditsController: UpdateTemplatedFlowEditsControl
       );
     }
   };
+
+export const failedSubmissionsController: FailedSubmissionController = async (
+  _req,
+  res,
+  next,
+) => {
+  try {
+    if (process.env.APP_ENVIRONMENT !== "production") {
+      return res.status(200).send({
+        message: `Not production, skipping failed submissions notification`,
+      });
+    }
+
+    const response = await getDailyFailedSubmissions();
+    return res.status(200).send({
+      message: response,
+    });
+  } catch (error) {
+    return next(
+      new ServerError({
+        message: `Failed to log submission failures today`,
+        cause: error,
+      }),
+    );
+  }
+};

--- a/apps/api.planx.uk/modules/webhooks/routes.ts
+++ b/apps/api.planx.uk/modules/webhooks/routes.ts
@@ -11,6 +11,7 @@ import {
   createSessionExpiryEventController,
   createSessionReminderEventController,
   deleteSessionController,
+  failedSubmissionsController,
   isCleanJSONBController,
   sanitiseApplicationDataController,
   sendSlackMessageController,
@@ -86,12 +87,12 @@ router.post(
   validate(isCleanJSONBSchema),
   isCleanJSONBController,
 );
-
 router.post(
   "/webhooks/hasura/update-templated-flow-edits",
   validate(updateTemplatedFlowEditsEventSchema),
   updateTemplatedFlowEditsController,
 );
+router.post("webhooks/hasura/failed-submissions", failedSubmissionsController);
 
 // TODO: Convert to the new API module structure
 router.post(

--- a/apps/api.planx.uk/modules/webhooks/service/dailyFailedSubmissions/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/dailyFailedSubmissions/index.ts
@@ -1,0 +1,54 @@
+import { gql } from "graphql-request";
+
+import { $api } from "../../../../client/index.js";
+import { sendSlackMessage } from "../../../slack/utils.js";
+
+interface FailedSubmissions {
+  data: {
+    failedSubmissions:
+      | {
+          sessionId: string;
+          eventType: string;
+          teamName: string;
+        }[]
+      | [];
+  };
+}
+
+export const getDailyFailedSubmissions = async (): Promise<string> => {
+  const { data } = await $api.client.request<FailedSubmissions>(gql`
+    query GetDailyFailedSubmissions {
+      failedSubmissions: daily_failed_submissions {
+        sessionId: session_id
+        eventType: event_type
+        teamName: name
+      }
+    }
+  `);
+
+  if (data.failedSubmissions?.length === 0)
+    return "No recent submission failures";
+
+  const failures: string[] = [];
+  for (const failure of data.failedSubmissions) {
+    // Skip notifications related to Southwark Power Automate, which we expect to fail as of June 2026
+    if (
+      failure.teamName !== "Southwark" &&
+      failure.eventType !== "Upload to AWS S3"
+    ) {
+      failures.push(`- *${failure.sessionId}* ${failure.eventType}`);
+    }
+  }
+
+  // If we have failures, send a Slack notification
+  if (failures.length > 0) {
+    const message = `Please investigate recently failed submission(s):\n ${failures.join("\n")}`;
+    sendSlackMessage({
+      channel: "#planx-notifications-internal",
+      text: message,
+      username: "Failed Submissions CRON Job",
+    });
+  }
+
+  return `Sent Slack notification for ${failures.length} recent submission failure(s)`;
+};

--- a/apps/api.planx.uk/modules/webhooks/service/dailyFailedSubmissions/types.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/dailyFailedSubmissions/types.ts
@@ -1,0 +1,12 @@
+import type { z } from "zod";
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+export interface FailedSubmissionCronResponse {
+  message: string;
+  cause?: string;
+}
+
+export type FailedSubmissionController = ValidatedRequestHandler<
+  z.ZodUndefined,
+  FailedSubmissionCronResponse
+>;

--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -7,6 +7,15 @@
     - name: authorization
       value_from_env: HASURA_PLANX_API_KEY
   comment: Parses allow-list answers for submitted sessions to retain for analytics post-sanitation
+- name: log_failed_submissions
+  webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/failed-submissions'
+  schedule: 0 17 * * *
+  include_in_metadata: true
+  payload: {}
+  headers:
+    - name: authorization
+      value_from_env: HASURA_PLANX_API_KEY
+  comment: 'Checks for any failed submissions and logs them to #planx-notifications-internal to investigate further'
 - name: sanitise_application_data
   webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/sanitise-application-data'
   schedule: 0 2 * * *


### PR DESCRIPTION
CRON event included below will _only_ send Slack notifications on production, let's test this sooner than later (unfortunately we have two failures currently in db view that are good candidates if not resolved sooner :melting_face:)