### PR TITLE
chore(editor): Don't persist `showSidebar` in local storage

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -227,7 +227,6 @@ export const editorUIStore: StateCreator<
   {
     name: "editorUIStore",
     partialize: (state) => ({
-      showSidebar: state.showSidebar,
       flowCardView: state.flowCardView,
       dashboardFlowsTab: state.dashboardFlowsTab,
       showTags: state.showTags,


### PR DESCRIPTION
We're concerned that some Editors may be missing this sidebar after previously closing it.

Lets try just persisting this in memory for a session instead of persisting in local storage. This will mean that the sidebar will be open on each refresh.