### PR TITLE
fix(api): Ensure `InsertApplicationAccessToken` can handle failures and retries without issue

### DIFF
--- a/apps/api.planx.uk/modules/send/email/service.ts
+++ b/apps/api.planx.uk/modules/send/email/service.ts
@@ -306,6 +306,10 @@ const insertApplicationAccessTokenRecord = async (
       ) {
         applicationAccessTokens: insert_application_access_tokens_one(
           object: { expires_at: $expiresAt, session_id: $sessionId }
+          on_conflict: {
+            constraint: application_access_tokens_session_id_key
+            update_columns: [expires_at]
+          }
         ) {
           token
         }


### PR DESCRIPTION
## What's the problem?
When a "send to email" event fails (e.g. due to Resend downtime) we have an automatic retry in place. This fails on second run due to the unique constraint on the `application_access_tokens` table - we cannot insert a second record.

## What's the solution?
Account for this by adding na `on_conflict` clause to the mutation. On a retry, we'll just bump the `expires_at` value allowing us to proceed as expected. We care about updating this value as a retry may not be an automatic Hasura retry, but a manual dev retry at a slightly later time.

## Testing
There's no meaningful way of testing this via mocks in the API tests - we can't mock the actual DB conflict. I'd suggest that if we hit issues here in the future we maybe aim to get some meaningful E2E tests in place.