### PR TITLE
fix(editor): Standardise box shadow and border radius from theme

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
@@ -72,7 +72,7 @@ const FeatureFlagsPanel = ({ anchorEl, onClose }: Props) => {
             width: 360,
             display: "flex",
             flexDirection: "column",
-            borderRadius: 1,
+            borderRadius: (theme) => `${theme.shape.borderRadius}px`,
           },
         },
         backdrop: {

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
@@ -72,7 +72,7 @@ const FeatureFlagsPanel = ({ anchorEl, onClose }: Props) => {
             width: 360,
             display: "flex",
             flexDirection: "column",
-            borderRadius: (theme) => theme.shape.borderRadius,
+            borderRadius: 1,
           },
         },
         backdrop: {

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -84,7 +84,7 @@ const NotificationsPanel = ({
             height: 640,
             display: "flex",
             flexDirection: "column",
-            borderRadius: (theme) => theme.shape.borderRadius,
+            borderRadius: 1,
           },
         },
         backdrop: {

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -84,7 +84,7 @@ const NotificationsPanel = ({
             height: 640,
             display: "flex",
             flexDirection: "column",
-            borderRadius: 1,
+            borderRadius: (theme) => `${theme.shape.borderRadius}px`,
           },
         },
         backdrop: {

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -14,7 +14,7 @@ import { useLoaderData } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { TeamSummary } from "pages/FlowEditor/lib/store/team";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { cardBoxShadow, focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
 const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
@@ -22,11 +22,10 @@ const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
     backgroundColor: theme.palette.background.default,
     width: "100%",
     borderLeft: `8px solid ${teamcolor || theme.palette.primary.main}`,
-    borderRadius: 3,
+    borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(1, 0.5, 1, 1),
     justifyContent: "space-between",
-    // TODO: standardise box shadow across nav menu items
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    boxShadow: cardBoxShadow,
     "&:hover": {
       backgroundColor: theme.palette.background.paper,
       color: "inherit",
@@ -52,7 +51,7 @@ const StyledCard = styled(Card)<{ selected?: boolean; teamcolor?: string }>(
     borderRadius: theme.shape.borderRadius,
     borderLeft: `6px solid ${teamcolor || "OliveDrab"}`,
     padding: theme.spacing(0.75),
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    boxShadow: cardBoxShadow,
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
@@ -189,7 +188,7 @@ export const TeamSelect: React.FC<Props> = ({
               maxWidth: "260px",
               minWidth: "unset",
               borderTop: "none",
-              borderRadius: (theme) => theme.shape.borderRadius,
+              borderRadius: 1,
             },
           },
         }}

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -48,7 +48,7 @@ const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
 const StyledCard = styled(Card)<{ selected?: boolean; teamcolor?: string }>(
   ({ theme, teamcolor }) => ({
     backgroundColor: theme.palette.background.default,
-    borderRadius: theme.shape.borderRadius,
+    borderRadius: theme.shape.borderRadiusSm,
     borderLeft: `6px solid ${teamcolor || "OliveDrab"}`,
     padding: theme.spacing(0.75),
     boxShadow: cardBoxShadow,

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -188,7 +188,7 @@ export const TeamSelect: React.FC<Props> = ({
               maxWidth: "260px",
               minWidth: "unset",
               borderTop: "none",
-              borderRadius: 1,
+              borderRadius: (theme) => `${theme.shape.borderRadius}px`,
             },
           },
         }}

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/styles.tsx
@@ -3,7 +3,7 @@ import Chip, { chipClasses } from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 export const MENU_WIDTH_COMPACT = 51;
 export const MENU_WIDTH_FULL = 200;
@@ -57,16 +57,16 @@ export const MenuButton = styled(IconButton, {
   justifyContent: "flex-start",
   gap: theme.spacing(0.65),
   alignItems: "center",
-  borderRadius: theme.shape.borderRadius,
+  borderRadius: theme.shape.borderRadiusSm,
   padding: theme.spacing(0.8, 0.5),
   "&:hover": {
     background: theme.palette.common.white,
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    boxShadow: cardBoxShadow,
   },
   ...(isActive && {
     background: theme.palette.common.white,
     color: theme.palette.text.primary,
-    boxShadow: "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)",
+    boxShadow: cardBoxShadow,
   }),
   ...(disabled && {
     color: theme.palette.text.disabled,
@@ -99,7 +99,7 @@ export const StyledChip = styled(Chip)(({ theme }) => ({
   height: "16px",
   fontSize: "0.625rem",
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  borderRadius: "3px",
+  borderRadius: theme.shape.borderRadius,
   margin: theme.spacing(0.15, 0.2, 0, 0),
   marginLeft: "auto",
   [`& .${chipClasses.label}`]: {
@@ -111,7 +111,7 @@ export const BadgeChip = styled(Chip)(({ theme }) => ({
   height: "22px",
   fontSize: "0.75rem",
   fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  borderRadius: "3px",
+  borderRadius: theme.shape.borderRadius,
   margin: theme.spacing(0.15, 0, 0, 0),
   marginLeft: "auto",
   minWidth: "22px",

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -4,7 +4,7 @@ import { keyframes, styled, type Theme } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import {
@@ -19,6 +19,7 @@ const Root = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1.5),
   zIndex: 1,
   borderRadius: theme.shape.borderRadius,
+  boxShadow: cardBoxShadow,
 }));
 
 const Header = styled(Box)(({ theme }) => ({

--- a/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
+++ b/apps/editor.planx.uk/src/pages/Team/components/FlowCard/styles.tsx
@@ -1,6 +1,6 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
-import { inputFocusStyle } from "theme";
+import { cardBoxShadow, inputFocusStyle } from "theme";
 
 import { CustomLink } from "../../../../ui/shared/CustomLink/CustomLink";
 
@@ -10,10 +10,10 @@ export const Card = styled("li")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   justifyContent: "stretch",
-  borderRadius: "3px",
+  borderRadius: theme.shape.borderRadius,
   backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
-  boxShadow: "0 2px 6px 1px rgba(0, 0, 0, 0.1)",
+  boxShadow: cardBoxShadow,
   "&:hover": {
     backgroundColor: theme.palette.background.paper,
   },

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -134,6 +134,9 @@ export const borderedFocusStyle = {
   background: "transparent",
 };
 
+// Subtle elevation shadow used for cards and menu items throughout the editor
+export const cardBoxShadow = "0 1px 1.5px 0 rgba(0, 0, 0, 0.2)";
+
 export const linkStyle = (linkColour: string) => ({
   color: linkColour || "inherit",
   textDecoration: "underline",
@@ -259,7 +262,8 @@ const getThemeOptions = ({
       },
     },
     shape: {
-      borderRadius: 2,
+      borderRadius: 3,
+      borderRadiusSm: 2,
     },
     components: {
       MuiAccordion: {

--- a/apps/editor.planx.uk/src/themeOverrides.d.ts
+++ b/apps/editor.planx.uk/src/themeOverrides.d.ts
@@ -162,3 +162,13 @@ declare module "@mui/material/Drawer" {
     "aria-label": string;
   }
 }
+
+// Add a smaller border radius variant, used for compact elements like menu items
+declare module "@mui/material/styles" {
+  interface Shape {
+    borderRadiusSm: number;
+  }
+  interface ShapeOptions {
+    borderRadiusSm?: number;
+  }
+}

--- a/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/DashboardWidget/index.tsx
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography";
 import { LinkOptions, RegisteredRouter } from "@tanstack/react-router";
 import { BadgeChip } from "components/EditorNavMenu/styles";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { CustomLink } from "ui/shared/CustomLink/CustomLink";
 
 interface DashboardWidgetProps {
@@ -19,6 +19,8 @@ interface DashboardWidgetProps {
 const Root = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   border: `1px solid ${theme.palette.border.light}`,
+  borderRadius: theme.shape.borderRadius,
+  boxShadow: cardBoxShadow,
   display: "flex",
   flexDirection: "column",
   height: "400px",


### PR DESCRIPTION
## What does this PR do?

- Standardised `box-shadow` from theme, to be used for card and menu items
- Standardised `border-radius` with small variant for smaller UI elements

Very subtle visual change across the editor to unify styles