### PR TITLE
fix: Dont enforce fixed height on map containers

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/MapContainer.tsx
@@ -9,28 +9,24 @@ interface MapContainerProps {
   size?: "large";
 }
 
-export const MapContainer = styled(Box)<MapContainerProps>(
-  ({ theme, environment, size }) => ({
-    padding: theme.spacing(0.5, 0, 0.5, 0),
+export const MapContainer = styled(Box)<MapContainerProps>(({ theme }) => ({
+  padding: theme.spacing(0.5, 0, 0.5, 0),
+  width: "100%",
+  maxWidth: "none",
+  "& my-map": {
+    "--autocomplete__error__font-weight": FONT_WEIGHT_SEMI_BOLD,
+    "--autocomplete__input__max-width": `${theme.breakpoints.values.formWrap}px`,
+    "--govuk-error-colour": theme.palette.error.main,
+    "--autocomplete__font-family": "Inter",
     width: "100%",
-    maxWidth: "none",
-    "& my-map": {
-      "--autocomplete__error__font-weight": FONT_WEIGHT_SEMI_BOLD,
-      "--autocomplete__input__max-width": `${theme.breakpoints.values.formWrap}px`,
-      "--govuk-error-colour": theme.palette.error.main,
-      "--autocomplete__font-family": "Inter",
-      width: "100%",
-      // Only increase map size in Published, Preview, and Draft routes
-      height:
-        size === "large" && environment === "standalone" ? "70vh" : "50vh",
-      // Ensure map is not reduced to an unusable height
-      minHeight: "400px",
-      [theme.breakpoints.up("md")]: {
-        minHeight: "480px",
-      },
+    maxHeight: "80vh",
+    // Ensure map is not reduced to an unusable height
+    minHeight: "400px",
+    [theme.breakpoints.up("md")]: {
+      minHeight: "480px",
     },
-  }),
-);
+  },
+}));
 
 export const MapFooter = styled(Box)(({ theme }) => ({
   display: "flex",


### PR DESCRIPTION
## What does this PR do?

- Fixes the issue that causes maps to have a margin-bottom on taller screens
- Simplifies code by making maps a standard height regardless of environment

**Before:**
<img width="1728" height="834" alt="image" src="https://github.com/user-attachments/assets/87bfa42a-1fe9-401a-840c-5ce55eed7f3c" />

**After:**
<img width="1728" height="834" alt="image" src="https://github.com/user-attachments/assets/fdd88aaf-84ad-4a44-b23d-3a67c8887be6" />
