### PR TITLE
feat(api): Improve Resend error handling

### DIFF
--- a/apps/api.planx.uk/lib/resend/index.test.ts
+++ b/apps/api.planx.uk/lib/resend/index.test.ts
@@ -1,0 +1,108 @@
+import type { TemplateRegistry } from "./templates/index.js";
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: mockSend };
+  },
+}));
+
+const { sendEmail } = await import("./index.js");
+
+const submitVariables: TemplateRegistry["submit"]["variables"] = {
+  serviceName: "Report a planning breach",
+  sessionId: "33d373d4-fff2-4ef7-a5f2-2a36e39ccc49",
+  applicantName: "Jane Doe",
+  applicantEmail: "jane@example.com",
+  address: "1 High Street",
+  projectType: "New build",
+  fee: "£123",
+  downloadLink: "https://example.com/download?token=abc",
+};
+
+describe("sendEmail (Resend wrapper)", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+  });
+
+  it("returns a success message and forwards the idempotency key", async () => {
+    mockSend.mockResolvedValue({ data: { id: "resend-id" }, error: null });
+
+    const result = await sendEmail(
+      "submit",
+      "planning.office@council.gov.uk",
+      submitVariables,
+      { idempotencyKey: "submit-33d373d4" },
+    );
+
+    expect(result).toEqual({ message: "submit email sent successfully" });
+    expect(mockSend).toHaveBeenCalledWith(expect.any(Object), {
+      idempotencyKey: "submit-33d373d4",
+    });
+  });
+
+  it("sends an undefined idempotency key when none is supplied", async () => {
+    mockSend.mockResolvedValue({ data: { id: "resend-id" }, error: null });
+
+    await sendEmail(
+      "submit",
+      "planning.office@council.gov.uk",
+      submitVariables,
+    );
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(Object), {
+      idempotencyKey: undefined,
+    });
+  });
+
+  it("throws a classified error and logs a transient failure", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        name: "application_error",
+        statusCode: 500,
+        message: "Something went wrong",
+      },
+    });
+
+    await expect(
+      sendEmail("submit", "planning.office@council.gov.uk", submitVariables),
+    ).rejects.toThrow(/\[application_error\]/);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Resend send failed",
+      expect.objectContaining({ code: "application_error", isTransient: true }),
+    );
+
+    consoleError.mockRestore();
+  });
+
+  it("classifies a validation error as critical (non-transient)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        name: "validation_error",
+        statusCode: 400,
+        message: "Invalid `from` field",
+      },
+    });
+
+    await expect(
+      sendEmail("submit", "planning.office@council.gov.uk", submitVariables),
+    ).rejects.toThrow(/\[validation_error\]/);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Resend send failed",
+      expect.objectContaining({ code: "validation_error", isTransient: false }),
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/api.planx.uk/lib/resend/index.ts
+++ b/apps/api.planx.uk/lib/resend/index.ts
@@ -1,4 +1,5 @@
 import { Resend } from "resend";
+import type { ErrorResponse } from "resend";
 import type { ResendTemplate, TemplateRegistry } from "./templates/index.js";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -6,23 +7,43 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 const FROM_ADDRESS =
   process.env.RESEND_FROM_ADDRESS || "PlanX <no-reply@opensystemslab.io>";
 
+// Retrying on these errors can still succeed
+// Any other errors will need a dev intervention somewhere before a retry
+// Docs: https://resend.com/docs/api-reference/errors
+const TRANSIENT_RESEND_CODES = new Set<ErrorResponse["name"]>([
+  "application_error",
+  "internal_server_error",
+  "rate_limit_exceeded",
+]);
+
 export const sendEmail = async <T extends ResendTemplate>(
   templateName: T,
   to: string,
   variables: TemplateRegistry[T]["variables"],
+  { idempotencyKey }: { idempotencyKey?: string } = {},
 ): Promise<{ message: string }> => {
-  const { error } = await resend.emails.send({
-    from: FROM_ADDRESS,
-    to,
-    template: {
-      id: templateName,
-      variables,
+  const { error } = await resend.emails.send(
+    {
+      from: FROM_ADDRESS,
+      to,
+      template: {
+        id: templateName,
+        variables,
+      },
     },
-  });
+    { idempotencyKey },
+  );
 
   if (error) {
+    const isTransient = TRANSIENT_RESEND_CODES.has(error.name);
+    console.error("Resend send failed", {
+      template: templateName,
+      code: error.name,
+      statusCode: error.statusCode,
+      isTransient,
+    });
     throw new Error(
-      `Failed to send ${templateName} email using Resend: ${JSON.stringify(error)}`,
+      `Failed to send "${templateName}" email using Resend [${error.name}]: ${error.message}`,
     );
   }
 

--- a/apps/api.planx.uk/modules/send/email/index.test.ts
+++ b/apps/api.planx.uk/modules/send/email/index.test.ts
@@ -2,6 +2,7 @@ import supertest from "supertest";
 import type * as planxCore from "@opensystemslab/planx-core";
 import { queryMock } from "../../../tests/graphqlQueryMock.js";
 import app from "../../../server.js";
+import { sendEmail } from "../../../lib/resend/index.js";
 
 vi.mock("@opensystemslab/planx-core", async () => {
   const actualCore = await vi.importActual<typeof planxCore>(
@@ -166,6 +167,38 @@ describe(`sending an application by email to a planning office`, () => {
           inbox: "delivered@resend.dev",
           resendTemplate: "submit",
         });
+      });
+  });
+
+  it("passes an idempotency key scoped to the session so retries don't double-send", async () => {
+    await supertest(app)
+      .post("/email-submission/southwark")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+      .send({ payload: { sessionId: "33d373d4-fff2-4ef7-a5f2-2a36e39ccc49" } })
+      .expect(200);
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      "submit",
+      "delivered@resend.dev",
+      expect.any(Object),
+      { idempotencyKey: "submit-33d373d4-fff2-4ef7-a5f2-2a36e39ccc49" },
+    );
+  });
+
+  it("returns a 500 with the classified message when the Resend send fails", async () => {
+    vi.mocked(sendEmail).mockRejectedValueOnce(
+      new Error(
+        `Failed to send "submit" email using Resend [application_error]: Something went wrong`,
+      ),
+    );
+
+    await supertest(app)
+      .post("/email-submission/southwark")
+      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
+      .send({ payload: { sessionId: "33d373d4-fff2-4ef7-a5f2-2a36e39ccc49" } })
+      .expect(500)
+      .then((res) => {
+        expect(res.body.error).toMatch(/application_error/);
       });
   });
 

--- a/apps/api.planx.uk/modules/send/email/index.ts
+++ b/apps/api.planx.uk/modules/send/email/index.ts
@@ -67,7 +67,10 @@ export const sendToEmail: SendIntegrationController = async (
     });
 
     // Send the email
-    const response = await sendEmail("submit", submissionEmailAddress, config);
+    const response = await sendEmail("submit", submissionEmailAddress, config, {
+      // Ensure a Hasura retry never sends a duplicate email
+      idempotencyKey: `submit-${sessionId}`,
+    });
 
     // Mark session as submitted so that reminder and expiry emails are not triggered
     markSessionAsSubmitted(sessionId);


### PR DESCRIPTION
## What does this PR do?
- Improved error handling and logging for Resend, allowing us to better understand failures
- Protects against retries by setting [an idempotency key](https://resend.com/docs/dashboard/emails/idempotency-keys)
- Follow up to #6942 