### PR TITLE
chore(templates): if publishing only source template updates in a templated flow, set a default summary

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -103,7 +103,10 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
     templatedFlows,
   } = props;
 
-  const [isTemplate] = useStore((state) => [state.isTemplate]);
+  const [isTemplate, isTemplatedFrom] = useStore((state) => [
+    state.isTemplate,
+    state.isTemplatedFrom,
+  ]);
 
   const steps = ["Review", "Test", "Publish"];
   const [activeStep, setActiveStep] = useState<number>(0);
@@ -242,7 +245,17 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
   };
 
   const PublishStep = () => {
-    const [summary, setSummary] = useState<string>("");
+    // If this is a templated flow and the only changes are the source template updates (eg no 'operations' in history), set a default summary message
+    const onlySourceTemplateUpdates = history?.every(
+      (item) =>
+        item.type === "comment" &&
+        item.comment.startsWith("Source template published:"),
+    );
+    const [summary, setSummary] = useState<string>(
+      isTemplatedFrom && onlySourceTemplateUpdates
+        ? "Latest source template updates"
+        : "",
+    );
     const [showError, setShowError] = useState<boolean>(false);
 
     const changeInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -253,7 +253,7 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
     );
     const [summary, setSummary] = useState<string>(
       isTemplatedFrom && onlySourceTemplateUpdates
-        ? "Latest source template updates"
+        ? "Publish latest source template updates"
         : "",
     );
     const [showError, setShowError] = useState<boolean>(false);


### PR DESCRIPTION
Quick action following on from templates chat yesterday: https://app.notion.com/p/opensystemslab/Templates-101-34535d469ad1804a9db1ca73bf45c45d

Context: https://opensystemslab.slack.com/archives/C07F7215W7P/p1783084493924809