### PR TITLE
[infra] re-align ECS compute allocation for staging and prod

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -5,6 +5,8 @@ config:
     secure: AAABAE+ZtQZO26XlmfAS7tG1DkwQ+G5OP82Roe4EOuk/tG1bMsI=
   application:airbrake-project-key:
     secure: AAABAMykToEvR6LGE6kUIjNeKfV/MsLtGq1Uv8dk6wAHp5og8/UIFF7yoo8rAZX5brx08nUnqwqrDrS8/I16+g==
+  application:api-cpu: "4096"
+  application:api-memory: "8192"
   application:cloudflare-zone-id:
     secure: AAABAMvLmULFOFiKvka1nnX/mMlFocCVlBtBXrXuJbkdJeS1xKRxloKX10LYMoScqaMHSNlFSAMA6SeWFkm4Pw==
   application:db-host:
@@ -50,8 +52,8 @@ config:
   application:hasura-memory: "4096"
   application:hasura-planx-api-key:
     secure: AAABAExsXFL7HabeK0Z1oSUJzI2NqVqEmKJ1ojYXyX4Hi8Sbt1Ht9QJc/Yn3cPBAB2r32HKa4HtqqLmfGjS+04lFB/I=
-  application:hasura-proxy-cpu: "1024"
-  application:hasura-proxy-memory: "2048"
+  application:hasura-proxy-cpu: "512"
+  application:hasura-proxy-memory: "1024"
   application:hasura-service-scaling-maximum: "4"
   application:hasura-service-scaling-minimum: "1"
   application:idox-nexus-client:
@@ -60,6 +62,7 @@ config:
   application:idox-nexus-token-url: todo
   application:jwt-secret:
     secure: AAABAEGWTi+vTHnjkJfyJQneZIz1aDoplF4y3/sLFnAKuvDcP/80/7ReX3W4wiKWuHMygSxKY5y2PImYJjZ9YbSZMP9d7NtD
+  application:lambda-nodejs-runtime: nodejs24.x
   application:lps-cloudflare-zone-id:
     secure: AAABAH+7QupNP8cRQRnFKSufAxT0Fd3BpC2rMnamjDNfPCJfJZ68AJ4CtE6Rc2ZNF9olgrF6zzsH2nzj2wNdzg==
   application:lps-domain: localplanning.services
@@ -81,8 +84,14 @@ config:
     secure: AAABADAL9YkrUfJaDga7MaVRD/dZaElsnFnnC+7IvqqlgBFywXFwVKnSMbVZ1SMFoitG8C6bKHhl2BPwOHcuvkzMKblwYzvu
   application:ordnance-survey-api-key:
     secure: AAABANmVR/iyxoja6JGBOBjhlijbMiqdqpNRwqS2p+ZusuwiYdKBACIi5y/vi2HMg7+ydXWR0SPVqtQuK5O/tA==
+  application:resend-from-address:
+    secure: AAABACSDFBG/Z8fAVReyp/KD41l9YAsuqldyHSYDCBmZaY7EqAgsod8TjdXYLvOR4CQ8c07XTJ8UsirXOwQ=
+  application:resend-api-key:
+    secure: AAABAGl5L3MjVaGcm6xCnQeGpoBflVREcAielFkw1CSGs7dfeQJoU41d30Br/QVTkrn8dk/dr6IVavqT3Cbtq07jGuI=
   application:session-secret:
     secure: AAABACeZpncVIdwarlb/J9qtaPqUob0YwbaOVDNEgfhSJ71aq0pkZml1EP+JqMKvyhkG483LcIiGzEh/ZDJehMu2
+  application:sharedb-cpu: "512"
+  application:sharedb-memory: "1024"
   application:skip-rate-limit-secret:
     secure: AAABADPv0Fp55IK8xL0Kxx/Kq2sFeRIgbKn0sgHBFhTsWh09kV3/OyG0d/wkE3zm+15zbud0GR4TSl4z//MV5XgxLWDhJgGJ
   application:slack-internal-errors-webhook:
@@ -125,8 +134,3 @@ config:
   application:uniform-token-url: https://identity.idoxgroup.com/uaa/oauth/token
   cloudflare:apiToken:
     secure: AAABAMbIBX9N21ModHyDYCQCGZXkRUP62NIUMhsxkK+/YUPRQr6PEqgZX9LRP2UuVwvVHd2RxvKGT8lpq8oAgyeDYP1eZSUl
-  application:resend-from-address:
-    secure: AAABACSDFBG/Z8fAVReyp/KD41l9YAsuqldyHSYDCBmZaY7EqAgsod8TjdXYLvOR4CQ8c07XTJ8UsirXOwQ=
-  application:resend-api-key:
-    secure: AAABAGl5L3MjVaGcm6xCnQeGpoBflVREcAielFkw1CSGs7dfeQJoU41d30Br/QVTkrn8dk/dr6IVavqT3Cbtq07jGuI=
-  application:lambda-nodejs-runtime: nodejs24.x

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -5,6 +5,8 @@ config:
     secure: AAABABxcp8r3CZAw1kXuXkwPZ8cKRDQyOg4+gVvqzKuCFWb8BEU=
   application:airbrake-project-key:
     secure: AAABAJ0llO2jfZjF0MsWRzA2gpcp/FyZg8tBe8ZwPCOvZy4EepGkUH74GoBzAiroVh1Om5uAoGmVWirlLhJ7cA==
+  application:api-cpu: "2048"
+  application:api-memory: "4096"
   application:cloudflare-zone-id:
     secure: AAABAPZz/bzFCZEZd+jzPpYP4HXAOLYQmLGf2YLQE2YPfMBUtDC83KCo2l2DJ4AL4OKL+jFFx8wrrJc6DDwXJQ==
   application:db-host:
@@ -45,12 +47,12 @@ config:
     secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
   application:hasura-admin-secret:
     secure: AAABACnU/Z5aGH2DaNQ29YkJqx8bKKRYFEdXvJm0yswo0pK2Iqnz09j7H2kOaZOzY2fSfEDu8rU=
-  application:hasura-cpu: "2048"
-  application:hasura-memory: "4096"
+  application:hasura-cpu: "1024"
+  application:hasura-memory: "2048"
   application:hasura-planx-api-key:
     secure: AAABANHLs3ItPxkteh0chwMP2bKuHO3ovuRLi4FsIrCqerzXVIaTLFDqNR+4KBTeMPz4cnF5tCTwsrJv9GruZdXU+lg=
-  application:hasura-proxy-cpu: "1024"
-  application:hasura-proxy-memory: "2048"
+  application:hasura-proxy-cpu: "256"
+  application:hasura-proxy-memory: "512"
   application:hasura-service-scaling-maximum: "2"
   application:hasura-service-scaling-minimum: "1"
   application:idox-nexus-client:
@@ -59,6 +61,7 @@ config:
   application:idox-nexus-token-url: https://dev.identity.idoxgroup.com/uaa/oauth/token
   application:jwt-secret:
     secure: AAABAOo4AlDxNYjUfyS2yp8VjbhmziWGQvA54PfnGYOyi5i6o3Lt9GLwAeUCrQYnr663MFjWw49+0wXVdeumyvtRF49cdFEb
+  application:lambda-nodejs-runtime: nodejs24.x
   application:lps-domain: localplanning.editor.planx.dev
   application:mapbox-access-token:
     secure: AAABAMWf2zVq5/mKCLynpgzAidNsnbUEBpb47n7MRWp2xzRgwaf3kzOvnZax9N04ZScQqU6I5/tEKTBAbSb8MIBJ8mU2iTZbPg8FD6wYsetRyftm1K39KBsIl9aS7fXvZFOG7BsC4qMDEhlDkH8gbV2HTev3VvvRUe3lzVhjNGNHqQ==
@@ -76,8 +79,14 @@ config:
     secure: AAABAGYZX5lmaa/axrVQODrnHmVIaoWpHP+yN/KsBt0RHnTNcPx63LJhHD0MB5d3WAjVF/Q3RLD+81tuq2ZC1sAYF18YwiZp
   application:ordnance-survey-api-key:
     secure: AAABAMqkRWGvu4THnzddRYpNddFfIFFKCqEE3gm9DkYuVJRCjZBCWpKogsT+X4j3R2f9V8OyeZxHK53yIpl8rQ==
+  application:resend-api-key:
+    secure: AAABAFmzQejlInptwqtYYDEGS+U+aizq8a/+vGvFei2iMyHKwiwCgKmuGoN3o+7D/tbH0wgZIWtEW5p6nZ5p7DZTyyw=
+  application:resend-from-address:
+    secure: AAABAIyo5sjwMg+bJ1iRAU44fOPdQNsdpJqTdcazQibTLktJdxQHi+hDi/0rIyrbviDizNaMNtrWcf9EZE0=
   application:session-secret:
     secure: AAABALL3iIm9+wB88/0ig7H+Y8Rmhb9OqaIz6sSTHmb5jf8+vBvXzY79z4pG6mJq9YPCxg==
+  application:sharedb-cpu: "256"
+  application:sharedb-memory: "512"
   application:skip-rate-limit-secret:
     secure: AAABANwjBmGN73bwF6nqQP5i8tKMe3mi0NMBdae4uaLasG2VfPvC1D4mk7QWIFqVnzsD5jCN20Eqos/r2B+EAo2rAws3JeD/
   application:slack-internal-errors-webhook:
@@ -94,8 +103,3 @@ config:
   application:uniform-token-url: https://staging.identity.idoxgroup.com/uaa/oauth/token
   cloudflare:apiToken:
     secure: AAABABWhDm+7RstbxLXd1D8CcxkylHS6UKMqk4kOaY7Y0E7FJS4bZfvyGs0nks80hl3vjENH4eDuFbUgA82/sA4SmDlfpNXr
-  application:resend-api-key:
-    secure: AAABAFmzQejlInptwqtYYDEGS+U+aizq8a/+vGvFei2iMyHKwiwCgKmuGoN3o+7D/tbH0wgZIWtEW5p6nZ5p7DZTyyw=
-  application:resend-from-address:
-    secure: AAABAIyo5sjwMg+bJ1iRAU44fOPdQNsdpJqTdcazQibTLktJdxQHi+hDi/0rIyrbviDizNaMNtrWcf9EZE0=
-  application:lambda-nodejs-runtime: nodejs24.x

--- a/infrastructure/application/services/api.ts
+++ b/infrastructure/application/services/api.ts
@@ -104,8 +104,8 @@ export const createApiService = async ({
       name: "api",
       image: apiImage.imageUri,
       essential: true,
-      cpu: 2048,
-      memory: 4096 /*MB*/,
+      cpu: config.requireNumber("api-cpu"),
+      memory: config.requireNumber("api-memory"),
       portMappings: [{ targetGroup: apiTargetGroup }],
       environment: [
           { name: "NODE_ENV", value: env },

--- a/infrastructure/application/services/sharedb.ts
+++ b/infrastructure/application/services/sharedb.ts
@@ -66,7 +66,8 @@ export const createSharedbService = async ({
       name: "sharedb",
       image: sharedbImage.imageUri,
       essential: true,
-      memory: 1024 /*MB*/,
+      cpu: config.requireNumber("sharedb-cpu"),
+      memory: config.requireNumber("sharedb-memory"),
       portMappings: [{ targetGroup: sharedbTargetGroup }],
       environment: [
         { name: "PORT", value: String(SHAREDB_PORT) },


### PR DESCRIPTION
In responding to a bug in June, we bumped memory/cpu for `sharedb`, `hasura` and `hasura-proxy` containers on staging and prod, across #6834 and #6848 (with no changes to `api` or `metabase`).

We set a reminder to revisit later ([Slack](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1782478824167919)) and took the opportunity to evaluate CPU and memory utilisation across all ECS services before and after these changes.

There's a full Notion doc with analysis [here](https://app.notion.com/p/opensystemslab/ECS-allocations-39235d469ad1805eb7c6d9189928b6b6?source=copy_link), which explains the changes here, but I'll also comment it up.

There's some open questions re Metabase which I'll raise on Slack.