### PR TITLE
chore(e2e): Apply `@typescript-eslint/consistent-type-imports`

### DIFF
--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -15,10 +15,4 @@ export default [
     ...config,
     files: ["tests/ui-driven/**/*.{js,ts}"],
   })),
-  {
-    rules: {
-      // TODO: Turn on and auto-fix 35 imports
-      "@typescript-eslint/consistent-type-imports": "off",
-    },
-  },
 ];

--- a/e2e/tests/api-driven/src/client.ts
+++ b/e2e/tests/api-driven/src/client.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert";
+
 import { CoreDomainClient } from "@opensystemslab/planx-core";
+
 import { buildJWT } from "./jwt.js";
 
 // check env variables are defined

--- a/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/helpers.ts
@@ -1,7 +1,8 @@
-import { FlowStatus } from "@opensystemslab/planx-core/types";
+import type { FlowStatus } from "@opensystemslab/planx-core/types";
+import { gql } from "graphql-tag";
+
 import { $admin } from "../client.js";
 import { createTeam, createUser } from "../globalHelpers.js";
-import { gql } from "graphql-tag";
 
 export const setup = async () => {
   const teamId = await createTeam();

--- a/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
+++ b/e2e/tests/api-driven/src/flowStatusHistory/steps.ts
@@ -1,13 +1,14 @@
-import { When, Then, World, After, Before, Given } from "@cucumber/cucumber";
+import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
 import assert from "assert";
+
+import { $admin } from "../client.js";
+import { createFlow } from "../globalHelpers.js";
 import {
   cleanup,
   getFlowStatus,
   getFlowStatusHistory,
   setup,
 } from "./helpers.js";
-import { createFlow } from "../globalHelpers.js";
-import { $admin } from "../client.js";
 
 export class CustomWorld extends World {
   teamId!: number;

--- a/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/helpers.ts
@@ -1,12 +1,14 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type {
   FlowGraph,
   PaymentRequest,
 } from "@opensystemslab/planx-core/types";
 import axios from "axios";
 import { gql } from "graphql-tag";
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+
 import { $admin } from "../client.js";
 import { createTeam, createUser, TEST_EMAIL } from "../globalHelpers.js";
 import {
@@ -15,7 +17,7 @@ import {
   mockPassport,
   sendNodeWithDestination,
 } from "./mocks/index.js";
-import { CustomWorld } from "./steps.js";
+import type { CustomWorld } from "./steps.js";
 
 export async function setUpMocks() {
   // we can't directly access `__dirname` in ESM, so get equivalent using fileURLToPath

--- a/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/mocks/index.ts
@@ -1,10 +1,11 @@
 import type {
-  FlowGraph,
   Breadcrumbs,
-  Passport,
+  FlowGraph,
   Node,
+  Passport,
 } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
+
 import flow from "./flow.json" with { type: "json" };
 import session from "./session.json" with { type: "json" };
 

--- a/e2e/tests/api-driven/src/invite-to-pay/steps.ts
+++ b/e2e/tests/api-driven/src/invite-to-pay/steps.ts
@@ -1,15 +1,17 @@
 import { strict as assert } from "node:assert";
-import { Given, When, Then, Before, After, World } from "@cucumber/cucumber";
+
+import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
+
 import {
   buildITPFlow,
-  buildSessionForFlow,
   buildPaymentRequestForSession,
-  markPaymentRequestAsPaid,
+  buildSessionForFlow,
+  cleanup,
   getSendResponse,
   getSessionSubmittedAt,
-  waitForResponse,
-  cleanup,
+  markPaymentRequestAsPaid,
   setup,
+  waitForResponse,
 } from "./helpers.js";
 
 export class CustomWorld extends World {

--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -1,5 +1,6 @@
+import type { Role, User } from "@opensystemslab/planx-core/types";
 import JWT from "jsonwebtoken";
-import { User, Role } from "@opensystemslab/planx-core/types";
+
 import { $admin } from "./client.js";
 
 // This code is copied from apps/api.planx.uk/modules/auth/service.ts

--- a/e2e/tests/api-driven/src/lps/helpers.ts
+++ b/e2e/tests/api-driven/src/lps/helpers.ts
@@ -1,4 +1,7 @@
 import { strict as assert } from "node:assert";
+
+import { gql } from "graphql-tag";
+
 import { $admin } from "../client.js";
 import {
   createFlow,
@@ -6,8 +9,7 @@ import {
   createUser,
   safely,
 } from "../globalHelpers.js";
-import { CustomWorld } from "./steps.js";
-import { gql } from "graphql-tag";
+import type { CustomWorld } from "./steps.js";
 
 export const setup = async ({
   email,

--- a/e2e/tests/api-driven/src/lps/steps.ts
+++ b/e2e/tests/api-driven/src/lps/steps.ts
@@ -1,5 +1,8 @@
 import { strict as assert } from "node:assert";
-import { Given, When, Then, Before, After, World } from "@cucumber/cucumber";
+
+import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
+
+import { TEST_EMAIL } from "../globalHelpers.js";
 import {
   cleanup,
   getApplications,
@@ -7,7 +10,6 @@ import {
   login,
   setup,
 } from "./helpers.js";
-import { TEST_EMAIL } from "../globalHelpers.js";
 
 interface Success {
   status: 200;

--- a/e2e/tests/api-driven/src/permissions/helpers.ts
+++ b/e2e/tests/api-driven/src/permissions/helpers.ts
@@ -1,8 +1,10 @@
-import { DocumentNode, Kind } from "graphql/language/index.js";
+import type { DocumentNode } from "graphql/language/index.js";
+import { Kind } from "graphql/language/index.js";
+
 import { $admin, getClient } from "../client.js";
-import { CustomWorld } from "./steps.js";
-import { queries } from "./queries/index.js";
 import { createFlow, createTeam, createUser } from "../globalHelpers.js";
+import { queries } from "./queries/index.js";
+import type { CustomWorld } from "./steps.js";
 
 export type Action = "insert" | "update" | "delete" | "select";
 export type Table = keyof typeof queries;

--- a/e2e/tests/api-driven/src/permissions/steps.ts
+++ b/e2e/tests/api-driven/src/permissions/steps.ts
@@ -1,15 +1,10 @@
-import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
+
+import { After, Before, Given, Then, When, World } from "@cucumber/cucumber";
+
 import { getUser } from "../globalHelpers.js";
-import {
-  Action,
-  GQLQueryResult,
-  Table,
-  addUserToTeam,
-  cleanup,
-  performGQLQuery,
-  setup,
-} from "./helpers.js";
+import type { Action, GQLQueryResult, Table } from "./helpers.js";
+import { addUserToTeam, cleanup, performGQLQuery, setup } from "./helpers.js";
 
 export class CustomWorld extends World {
   // A teamEditor for team1

--- a/e2e/tests/api-driven/src/sendWelcomeEmail/helpers.ts
+++ b/e2e/tests/api-driven/src/sendWelcomeEmail/helpers.ts
@@ -1,7 +1,9 @@
-import axios from "axios";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import axios from "axios";
+
 import { $admin } from "../client.js";
 import { createTeam, createUser } from "../globalHelpers.js";
 

--- a/e2e/tests/api-driven/src/sendWelcomeEmail/steps.ts
+++ b/e2e/tests/api-driven/src/sendWelcomeEmail/steps.ts
@@ -1,6 +1,8 @@
-import { When, Then, Before, After, World } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
-import { callWelcomeEndpoint, cleanup, setUpMocks, setup } from "./helpers.js";
+
+import { After, Before, Then, When, World } from "@cucumber/cucumber";
+
+import { callWelcomeEndpoint, cleanup, setup, setUpMocks } from "./helpers.js";
 
 export class CustomWorld extends World {
   teamId!: number;

--- a/e2e/tests/api-driven/src/team/helpers.ts
+++ b/e2e/tests/api-driven/src/team/helpers.ts
@@ -1,7 +1,8 @@
+import { gql } from "graphql-tag";
+
 import { $admin } from "../client.js";
 import { createTeam, createUser } from "../globalHelpers.js";
 import { addUserToTeam } from "../permissions/helpers.js";
-import { gql } from "graphql-tag";
 
 const firstNames = [
   "Alice",

--- a/e2e/tests/api-driven/src/team/steps.ts
+++ b/e2e/tests/api-driven/src/team/steps.ts
@@ -1,10 +1,13 @@
-import { When, Then, Before, After, World } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
+
+import type { World } from "@cucumber/cucumber";
+import { After, Before, Then, When } from "@cucumber/cucumber";
+
 import { $admin } from "../client.js";
 import {
-  setup20ActiveMembers,
-  setup19ActiveAnd2ArchivedMembers,
   cleanup,
+  setup19ActiveAnd2ArchivedMembers,
+  setup20ActiveMembers,
 } from "./helpers.js";
 import { CREATE_AND_ADD_USER_TO_TEAM } from "./queries.js";
 

--- a/e2e/tests/ui-driven/playwright.config.ts
+++ b/e2e/tests/ui-driven/playwright.config.ts
@@ -1,6 +1,6 @@
-import dotenv from "dotenv";
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
+import dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
 

--- a/e2e/tests/ui-driven/src/a11y-flows/focus-navigation.spec.ts
+++ b/e2e/tests/ui-driven/src/a11y-flows/focus-navigation.spec.ts
@@ -1,16 +1,17 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
 } from "../helpers/context.js";
+import type { TestContext } from "../helpers/types.js";
 import {
-  fillInEmail,
   answerQuestion,
   clickContinue,
+  fillInEmail,
 } from "../helpers/userActions.js";
 import { simpleSendFlow } from "../mocks/flows/save-and-return-flows.js";
-import { TestContext } from "../helpers/types.js";
 
 test.describe("Focus navigation accessibility", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -1,21 +1,10 @@
 import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
 } from "./helpers/context.js";
-import { getTeamPage } from "./helpers/getPage.js";
-import { answerQuestion, clickContinue } from "./helpers/userActions.js";
-import { PlaywrightEditor } from "./pages/Editor.js";
-import {
-  makeFlowAService,
-  navigateToService,
-  navigateToFlowSettings,
-  publishService,
-  turnServiceOnline,
-} from "./helpers/navigateAndPublish.js";
-import { TestContext } from "./helpers/types.js";
-import { serviceProps } from "./helpers/serviceData.js";
 import {
   alterDrawGeoJson,
   checkGeoJsonContent,
@@ -25,24 +14,36 @@ import {
   waitForMapComponent,
 } from "./helpers/geospatialChecks.js";
 import {
-  GeoJsonChangeHandler,
+  answerFindProperty,
+  userChallengesPlanningConstraint,
+} from "./helpers/geoSpatialUserActions.js";
+import { getTeamPage } from "./helpers/getPage.js";
+import {
+  makeFlowAService,
+  navigateToFlowSettings,
+  navigateToService,
+  publishService,
+  turnServiceOnline,
+} from "./helpers/navigateAndPublish.js";
+import { serviceProps } from "./helpers/serviceData.js";
+import type { TestContext } from "./helpers/types.js";
+import { answerQuestion, clickContinue } from "./helpers/userActions.js";
+import type { GeoJsonChangeHandler } from "./mocks/geospatialMocks.js";
+import {
   mockChangedMapGeoJson,
   mockPropertyTypeOptions,
   mockTitleBoundaryGeoJson,
 } from "./mocks/geospatialMocks.js";
-import {
-  setupOSMapsStyles,
-  setupOSMapsVectorTiles,
-} from "./mocks/osMapsResponse.js";
 import {
   planningConstraintHeadersMock,
   setupGISMockResponse,
   setupRoadsMockResponse,
 } from "./mocks/gisResponse.js";
 import {
-  answerFindProperty,
-  userChallengesPlanningConstraint,
-} from "./helpers/geoSpatialUserActions.js";
+  setupOSMapsStyles,
+  setupOSMapsVectorTiles,
+} from "./mocks/osMapsResponse.js";
+import { PlaywrightEditor } from "./pages/Editor.js";
 
 test.describe("Flow creation, publish and preview", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/create-flow.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow.spec.ts
@@ -1,4 +1,6 @@
-import { Browser, expect, test } from "@playwright/test";
+import type { Browser } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { createExternalPortal } from "./helpers/addComponent.js";
 import {
   contextDefaults,
@@ -13,8 +15,8 @@ import {
 } from "./helpers/globalHelpers.js";
 import {
   makeFlowAService,
-  navigateToService,
   navigateToFlowSettings,
+  navigateToService,
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
@@ -22,7 +24,7 @@ import {
   externalPortalFlowData,
   externalPortalServiceProps,
 } from "./helpers/serviceData.js";
-import { TestContext } from "./helpers/types.js";
+import type { TestContext } from "./helpers/types.js";
 import {
   answerAddressInput,
   answerChecklist,

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -1,7 +1,9 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
-import { expect, Locator, Page } from "@playwright/test";
-import { OptionWithDataValues } from "./types.js";
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
 import { selectedFlag } from "./globalHelpers.js";
+import type { OptionWithDataValues } from "./types.js";
 
 export type TemplateNodeConfig = {
   instructions: string;

--- a/e2e/tests/ui-driven/src/helpers/context.ts
+++ b/e2e/tests/ui-driven/src/helpers/context.ts
@@ -1,8 +1,11 @@
-import { CoreDomainClient } from "@opensystemslab/planx-core";
-import { GraphQLClient, gql } from "graphql-request";
-import jwt from "jsonwebtoken";
 import assert from "node:assert";
-import { TestContext } from "./types.js";
+
+import { CoreDomainClient } from "@opensystemslab/planx-core";
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+import jwt from "jsonwebtoken";
+
+import type { TestContext } from "./types.js";
 
 export const contextDefaults: TestContext = {
   user: {

--- a/e2e/tests/ui-driven/src/helpers/geoSpatialUserActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/geoSpatialUserActions.ts
@@ -1,6 +1,8 @@
-import { expect, Page } from "@playwright/test";
-import { setupOSMockResponse } from "../mocks/osPlacesResponse.js";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
 import { setupPlanningDataMockResponse } from "../mocks/gisResponse.js";
+import { setupOSMockResponse } from "../mocks/osPlacesResponse.js";
 
 export async function answerFindProperty(page: Page) {
   await setupOSMockResponse(page);

--- a/e2e/tests/ui-driven/src/helpers/geospatialChecks.ts
+++ b/e2e/tests/ui-driven/src/helpers/geospatialChecks.ts
@@ -1,5 +1,6 @@
-import { expect, Page } from "@playwright/test";
-import { Feature, MultiPolygon, Polygon } from "geojson";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import type { Feature, MultiPolygon, Polygon } from "geojson";
 
 export const waitForMapComponent = async (page: Page) => {
   await page.waitForFunction(() => {

--- a/e2e/tests/ui-driven/src/helpers/getPage.ts
+++ b/e2e/tests/ui-driven/src/helpers/getPage.ts
@@ -1,4 +1,5 @@
-import { Browser, Page } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
+
 import { createAuthenticatedSession } from "./globalHelpers.js";
 
 export async function getAdminPage({

--- a/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
+++ b/e2e/tests/ui-driven/src/helpers/globalHelpers.ts
@@ -1,9 +1,10 @@
-import { FlowGraph } from "@opensystemslab/planx-core/types";
+import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { flatFlags } from "@opensystemslab/planx-core/types";
 import { type Browser, type Page, type Request } from "@playwright/test";
 import { gql } from "graphql-request";
+
 import { generateAuthenticationToken, getGraphQLClient } from "./context.js";
-import { TestContext } from "./types.js";
-import { flatFlags } from "@opensystemslab/planx-core/types";
+import type { TestContext } from "./types.js";
 
 // Test card numbers to be used in gov.uk sandbox environment
 // reference: https://docs.payments.service.gov.uk/testing_govuk_pay/#if-you-39-re-using-a-test-39-sandbox-39-account

--- a/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
+++ b/e2e/tests/ui-driven/src/helpers/navigateAndPublish.ts
@@ -1,4 +1,6 @@
-import { expect, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
 import { contextDefaults } from "./context.js";
 
 export const navigateToService = async (page: Page, slug: string) => {

--- a/e2e/tests/ui-driven/src/helpers/types.ts
+++ b/e2e/tests/ui-driven/src/helpers/types.ts
@@ -1,5 +1,5 @@
-import { CoreDomainClient } from "@opensystemslab/planx-core";
-import { User } from "@opensystemslab/planx-core/types";
+import type { CoreDomainClient } from "@opensystemslab/planx-core";
+import type { User } from "@opensystemslab/planx-core/types";
 
 type NewTeam = Parameters<CoreDomainClient["team"]["create"]>[0];
 

--- a/e2e/tests/ui-driven/src/helpers/userActions.ts
+++ b/e2e/tests/ui-driven/src/helpers/userActions.ts
@@ -1,8 +1,9 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
+
 import { findSessionId, getGraphQLClient } from "./context.js";
-import { TEST_EMAIL, log, waitForDebugLog } from "./globalHelpers.js";
-import { TestContext } from "./types.js";
+import { log, TEST_EMAIL, waitForDebugLog } from "./globalHelpers.js";
+import type { TestContext } from "./types.js";
 
 export async function saveSession({
   page,

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -1,4 +1,6 @@
-import { BrowserContext, Page, expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   getGraphQLClient,
@@ -6,6 +8,7 @@ import {
   tearDownTestContext,
 } from "../helpers/context.js";
 import { addSessionToContext, modifyFlow } from "../helpers/globalHelpers.js";
+import type { TestContext } from "../helpers/types.js";
 import {
   clickContinue,
   returnToSession,
@@ -19,7 +22,6 @@ import {
   navigateToPayComponent,
 } from "./helpers.js";
 import { mockPaymentRequest, modifiedInviteToPayFlow } from "./mocks.js";
-import { TestContext } from "../helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/helpers.ts
@@ -1,18 +1,20 @@
-import { PaymentRequest } from "@opensystemslab/planx-core/types";
+import type { PaymentRequest } from "@opensystemslab/planx-core/types";
 import { expect, type Page } from "@playwright/test";
-import { GraphQLClient, gql } from "graphql-request";
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+
+import { answerFindProperty } from "../helpers/geoSpatialUserActions.js";
 import {
-  TEST_EMAIL,
   addSessionToContext,
   log,
+  TEST_EMAIL,
 } from "../helpers/globalHelpers.js";
+import type { TestContext } from "../helpers/types.js";
 import {
   answerChecklist,
   answerContactInput,
   fillInEmail,
 } from "../helpers/userActions.js";
-import { TestContext } from "../helpers/types.js";
-import { answerFindProperty } from "../helpers/geoSpatialUserActions.js";
 
 /**
  * Navigates to pay component whilst completing the minimum requirements for an Invite to Pay flow

--- a/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/mocks.ts
@@ -1,9 +1,10 @@
-import {
-  ComponentType,
+import type {
   FlowGraph,
   PaymentRequest,
   SessionData,
 } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
+
 import { TEST_EMAIL } from "../helpers/globalHelpers.js";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
 

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -1,7 +1,10 @@
-import { PaymentRequest, Session } from "@opensystemslab/planx-core/types";
-import { APIRequestContext, Page, expect, test } from "@playwright/test";
-import { GraphQLClient, gql } from "graphql-request";
+import type { PaymentRequest, Session } from "@opensystemslab/planx-core/types";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
 import { v4 as uuidV4 } from "uuid";
+
 import {
   contextDefaults,
   getGraphQLClient,
@@ -9,11 +12,11 @@ import {
   tearDownTestContext,
 } from "../helpers/context.js";
 import { cards } from "../helpers/globalHelpers.js";
+import type { TestContext } from "../helpers/types.js";
 import { fillGovUkCardDetails } from "../helpers/userActions.js";
 import inviteToPayFlow from "../mocks/flows/invite-to-pay-flow.js";
 import { getPaymentRequestBySessionId } from "./helpers.js";
 import { mockPaymentRequestDetails, mockSessionData } from "./mocks.js";
-import { TestContext } from "../helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/login.spec.ts
+++ b/e2e/tests/ui-driven/src/login.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
 } from "./helpers/context.js";
 import { createAuthenticatedSession } from "./helpers/globalHelpers.js";
-import { TestContext } from "./helpers/types.js";
+import type { TestContext } from "./helpers/types.js";
 
 test.describe("Login", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/mocks/flows/invite-to-pay-flow.ts
+++ b/e2e/tests/ui-driven/src/mocks/flows/invite-to-pay-flow.ts
@@ -1,5 +1,5 @@
-import { ComponentType } from "@opensystemslab/planx-core/types";
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 
 const flow: FlowGraph = {
   _root: {

--- a/e2e/tests/ui-driven/src/mocks/flows/sections-flow.ts
+++ b/e2e/tests/ui-driven/src/mocks/flows/sections-flow.ts
@@ -1,5 +1,5 @@
-import { ComponentType } from "@opensystemslab/planx-core/types";
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
 
 export const flow: FlowGraph = {
   _root: {

--- a/e2e/tests/ui-driven/src/mocks/geospatialMocks.ts
+++ b/e2e/tests/ui-driven/src/mocks/geospatialMocks.ts
@@ -1,5 +1,6 @@
-import { OptionWithDataValues } from "../helpers/types.js";
-import { Feature, MultiPolygon, Polygon } from "geojson";
+import type { Feature, MultiPolygon, Polygon } from "geojson";
+
+import type { OptionWithDataValues } from "../helpers/types.js";
 
 type ChangeHandlerProperties = {
   label: string;

--- a/e2e/tests/ui-driven/src/mocks/gisResponse.ts
+++ b/e2e/tests/ui-driven/src/mocks/gisResponse.ts
@@ -1,7 +1,9 @@
-import { expect, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
 import { mockRoadData } from "./geospatialMocks.js";
-import propertyConstraintsResponse from "./propertyConstraintResponse.json" with { type: "json" };
 import planningDataResponse from "./planningDataResponse.json" with { type: "json" };
+import propertyConstraintsResponse from "./propertyConstraintResponse.json" with { type: "json" };
 
 export async function setupGISMockResponse(page: Page) {
   const gisDigitalLandEndpoint = "**/gis/E2E?geom*";

--- a/e2e/tests/ui-driven/src/mocks/osMapsResponse.ts
+++ b/e2e/tests/ui-driven/src/mocks/osMapsResponse.ts
@@ -1,4 +1,5 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
 import { osMapsStylesResponse } from "./osMapsMockData.js";
 
 export async function setupOSMapsStyles(page: Page) {

--- a/e2e/tests/ui-driven/src/mocks/osPlacesResponse.ts
+++ b/e2e/tests/ui-driven/src/mocks/osPlacesResponse.ts
@@ -1,4 +1,4 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 export const mockOSPlacesResponse = {
   header: {

--- a/e2e/tests/ui-driven/src/pages/Editor.ts
+++ b/e2e/tests/ui-driven/src/pages/Editor.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+
 import {
   createAddressInput,
   createChecklist,
@@ -27,8 +28,8 @@ import {
   createTextInput,
   createUploadAndLabel,
 } from "../helpers/addComponent.js";
-import { OptionWithDataValues } from "../helpers/types.js";
 import { selectedFlag } from "../helpers/globalHelpers.js";
+import type { OptionWithDataValues } from "../helpers/types.js";
 
 export class PlaywrightEditor {
   readonly page: Page;

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -1,7 +1,9 @@
 import type { SessionData } from "@opensystemslab/planx-core/types";
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import { GraphQLClient, gql } from "graphql-request";
+import type { GraphQLClient } from "graphql-request";
+import { gql } from "graphql-request";
+
 import {
   contextDefaults,
   getGraphQLClient,
@@ -14,13 +16,13 @@ import {
   log,
   waitForPaymentResponse,
 } from "./helpers/globalHelpers.js";
+import type { TestContext } from "./helpers/types.js";
 import {
   fillGovUkCardDetails,
   fillInEmail,
   submitCardDetails,
 } from "./helpers/userActions.js";
 import payFlow from "./mocks/flows/pay-flow.json" with { type: "json" };
-import { TestContext } from "./helpers/types.js";
 
 let context: TestContext = {
   ...contextDefaults,

--- a/e2e/tests/ui-driven/src/refresh-page.spec.ts
+++ b/e2e/tests/ui-driven/src/refresh-page.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   setUpTestContext,
@@ -8,7 +9,7 @@ import {
   createAuthenticatedSession,
   isGetUserRequest,
 } from "./helpers/globalHelpers.js";
-import { TestContext } from "./helpers/types.js";
+import type { TestContext } from "./helpers/types.js";
 
 test.describe("Refresh page", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/save-and-return.spec.ts
+++ b/e2e/tests/ui-driven/src/save-and-return.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "@playwright/test";
+
 import {
   contextDefaults,
   setUpTestContext,
   tearDownTestContext,
 } from "./helpers/context.js";
 import { modifyFlow } from "./helpers/globalHelpers.js";
+import type { TestContext } from "./helpers/types.js";
 import {
   answerQuestion,
   clickContinue,
@@ -17,7 +19,6 @@ import {
   modifiedSimpleSendFlow,
   simpleSendFlow,
 } from "./mocks/flows/save-and-return-flows.js";
-import { TestContext } from "./helpers/types.js";
 
 test.describe("Save and return", () => {
   let context: TestContext = {

--- a/e2e/tests/ui-driven/src/sections.spec.ts
+++ b/e2e/tests/ui-driven/src/sections.spec.ts
@@ -1,12 +1,14 @@
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { expect, test } from "@playwright/test";
 import { gql } from "graphql-request";
+
 import {
   contextDefaults,
   getGraphQLClient,
   setUpTestContext,
   tearDownTestContext,
 } from "./helpers/context.js";
+import type { TestContext } from "./helpers/types.js";
 import {
   answerChecklist,
   answerQuestion,
@@ -20,7 +22,6 @@ import {
   saveSession,
 } from "./helpers/userActions.js";
 import { flow, updatedQuestionAnswers } from "./mocks/flows/sections-flow.js";
-import { TestContext } from "./helpers/types.js";
 
 // TODO: move this type to planx-core
 // also defined in apps/editor.planx.uk/src/types.ts

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -1,5 +1,10 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { expect, test } from "@playwright/test";
+
+import {
+  createNotice,
+  createTemplatedComponent,
+} from "./helpers/addComponent.js";
 import {
   contextDefaults,
   setUpTestContext,
@@ -8,17 +13,13 @@ import {
 import { getTeamPage } from "./helpers/getPage.js";
 import {
   makeFlowAService,
-  navigateToService,
   navigateToFlowSettings,
+  navigateToService,
   navigateToTeamPage,
   publishService,
   turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
-import {
-  createNotice,
-  createTemplatedComponent,
-} from "./helpers/addComponent.js";
-import { TestContext } from "./helpers/types.js";
+import type { TestContext } from "./helpers/types.js";
 import { PlaywrightEditor } from "./pages/Editor.js";
 
 const SOURCE_TEMPLATE_NAME = "E2E Source Template";

--- a/e2e/tests/ui-driven/src/utils.ts
+++ b/e2e/tests/ui-driven/src/utils.ts
@@ -1,5 +1,5 @@
-import jwt from "jsonwebtoken";
 import Axios from "axios";
+import jwt from "jsonwebtoken";
 
 export const gqlAdmin = async (query, variables = {}) => {
   const HASURA_GRAPHQL_ADMIN_SECRET = process.env.HASURA_GRAPHQL_ADMIN_SECRET;


### PR DESCRIPTION
## What does this PR do?
 - Builds on https://github.com/theopensystemslab/planx-new/pull/6919
 - Applies the linting rule `@typescript-eslint/consistent-type-imports` across the E2E tests (matching `base.js` - already in place in the API)