### PR TITLE
chore: omit `flows.status` and `is_service` columns in sync

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1783336034412_fix_team_member_limit_count_distinct/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1783336034412_fix_team_member_limit_count_distinct/down.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION check_team_member_limit()
+RETURNS trigger AS $$
+DECLARE
+  member_count INTEGER;
+BEGIN
+  SELECT COUNT(tm.user_id)
+    INTO member_count
+    FROM team_members tm
+    JOIN users u ON u.id = tm.user_id
+   WHERE tm.team_id = NEW.team_id
+     AND u.email IS NOT NULL;
+
+  IF member_count >= 20 THEN
+    RAISE EXCEPTION
+      USING ERRCODE = '22000',
+            MESSAGE = 'Team cannot have more than 20 members';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/apps/hasura.planx.uk/migrations/default/1783336034412_fix_team_member_limit_count_distinct/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1783336034412_fix_team_member_limit_count_distinct/up.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION check_team_member_limit()
+RETURNS trigger AS $$
+DECLARE
+  member_count INTEGER;
+BEGIN
+  SELECT COUNT(DISTINCT tm.user_id)
+    INTO member_count
+    FROM team_members tm
+    JOIN users u ON u.id = tm.user_id
+   WHERE tm.team_id = NEW.team_id
+     AND u.email IS NOT NULL;
+
+  IF member_count >= 20 THEN
+    RAISE EXCEPTION
+      USING ERRCODE = '22000',
+            MESSAGE = 'Team cannot have more than 20 members';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -87,7 +87,6 @@ SET
   version = EXCLUDED.version,
   settings = EXCLUDED.settings,
   copied_from = EXCLUDED.copied_from,
-  status = EXCLUDED.status,
   name = EXCLUDED.name,
   description = EXCLUDED.description,
   templated_from = EXCLUDED.templated_from,
@@ -99,8 +98,7 @@ SET
   category = EXCLUDED.category,
   submission_email_id = NULL,
   deleted_at = EXCLUDED.deleted_at,
-  email_template = EXCLUDED.email_template,
-  is_service = EXCLUDED.is_service;
+  email_template = EXCLUDED.email_template;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;

--- a/scripts/seed-database/write/team_members.sql
+++ b/scripts/seed-database/write/team_members.sql
@@ -13,8 +13,4 @@ INSERT INTO
 SELECT
   id, user_id, team_id, role
 FROM
-  sync_team_members ON CONFLICT (id) DO UPDATE
-SET
-  user_id = EXCLUDED.user_id,
-  team_id = EXCLUDED.team_id,
-  role = EXCLUDED.role;
+  sync_team_members ON CONFLICT (user_id, team_id, role) DO NOTHING;


### PR DESCRIPTION
To aid testing--we don't want these values to overwritten on staging every night. If a service is frequently being tested on staging, we don't want editors to have to make `is_service -> true` and then `status -> online` each day.

Since `status` depends on `is_service` (eg no nestable flow should ever be online) I thought it made more sense to exclude both columns from being overwritten on conflict (eg to avoid a scenario where `status = online` persists but `is_service = true` gets overwritten with prod value `is_service = false`).

I tested this locally by updating certain `is_service` and `status` values, syncing data, and seeing that they persisted as expected. 

`sync-data` was failing locally so there's also a fix in here for that. 