### PR TITLE
fix(api): Restore email submission Slack notifications

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/docs.yaml
+++ b/apps/api.planx.uk/modules/webhooks/docs.yaml
@@ -79,11 +79,8 @@ components:
                     request:
                       type: object
                       properties:
-                        personalisation:
-                          type: object
-                          properties:
-                            serviceName:
-                              type: string
+                        serviceName:
+                          type: string
       required:
         - event
     S3Submission:

--- a/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.test.ts
@@ -1,8 +1,9 @@
-import supertest from "supertest";
-import app from "../../../../server.js";
 import SlackNotify from "slack-notify";
-import type { BOPSBody, EmailBody, S3Body, UniformBody } from "./types.js";
+import supertest from "supertest";
+
 import { $api } from "../../../../client/index.js";
+import app from "../../../../server.js";
+import type { BOPSBody, EmailBody, S3Body, UniformBody } from "./types.js";
 
 const mockSessionWithFee = {
   data: {
@@ -287,9 +288,7 @@ describe("Send Slack notifications endpoint", () => {
             session_id: "abc123",
             team_slug: "testTeam",
             request: {
-              personalisation: {
-                serviceName: "testServiceName",
-              },
+              serviceName: "testServiceName",
             },
           },
         },

--- a/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendNotification/index.ts
@@ -1,4 +1,7 @@
 import { Passport } from "@opensystemslab/planx-core";
+
+import { $api } from "../../../../client/index.js";
+import { sendSlackMessage } from "../../../slack/utils.js";
 import type {
   BOPSEventData,
   EmailEventData,
@@ -7,8 +10,6 @@ import type {
   S3EventData,
   UniformEventData,
 } from "./types.js";
-import { $api } from "../../../../client/index.js";
-import { sendSlackMessage } from "../../../slack/utils.js";
 
 export const sendSlackNotification = async (
   data: EventData,
@@ -80,7 +81,7 @@ const getMessageForEventType = (data: EventData, type: EventType) => {
 
   if (type === "email-submission") {
     const { request, session_id, team_slug } = data as EmailEventData;
-    return `New email submission "${request.personalisation.serviceName}" *${session_id}* [${team_slug}]`;
+    return `New email submission "${request.serviceName}" *${session_id}* [${team_slug}]`;
   }
 
   if (type === "s3-submission") {

--- a/apps/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sendNotification/schema.ts
@@ -46,9 +46,7 @@ export const emailSubmissionSchema = z.object({
           session_id: z.string(),
           team_slug: z.string(),
           request: z.object({
-            personalisation: z.object({
-              serviceName: z.string(),
-            }),
+            serviceName: z.string(),
           }),
         }),
       }),


### PR DESCRIPTION
## What's the problem?
The `setup_email_applications_notifications` event has been failing since April 20th

<img width="1852" height="539" alt="image" src="https://github.com/user-attachments/assets/88805b8c-08cd-4271-ae4a-d6f58072173d" />


Hasura logs show a type error on submission - the incorrect request body is getting passed by Hasura to the API, validation fails, and then Slack is never hit.

## What's the cause?
Looking at the date of submission and comparing to merges on production points to this diff - https://github.com/theopensystemslab/planx-new/commits/production/?since=2026-04-20&until=2026-04-20

The likely candidate here stood out to me as https://github.com/theopensystemslab/planx-new/pull/6458

This changes the request type to remove the `personalisation` wrapper, but I never went and updated the API docs and types to match this. Tests didn't catch this as they're not E2E - there's no real relationship between the change and the webhook endpoint.

We even discussed the breaking change here 🤦‍♂️ https://github.com/theopensystemslab/planx-new/pull/6458#discussion_r3078256054

## What's the solution?
Update the API types to match the body currently being sent - without the `personalisation` wrapper.