### PR TITLE
fix: add router context decorator to FlowsPanel story

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/FlowsPanel.stories.tsx
@@ -1,4 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { subDays, subHours, subMinutes } from "date-fns";
 import type { FlowSummary } from "pages/FlowEditor/lib/store/editor";
 import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
@@ -11,7 +18,7 @@ const mockFlows: FlowSummary[] = [
     name: "Apply for planning permission",
     slug: "apply-for-planning-permission",
     status: "online",
-    updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    updatedAt: subMinutes(new Date(), 30).toISOString(),
     summary: "",
     operations: [],
     publishedFlows: [],
@@ -27,7 +34,7 @@ const mockFlows: FlowSummary[] = [
     name: "Apply for a lawful development certificate",
     slug: "apply-for-ldc",
     status: "online",
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+    updatedAt: subHours(new Date(), 3).toISOString(),
     summary: "",
     operations: [],
     publishedFlows: [],
@@ -43,7 +50,7 @@ const mockFlows: FlowSummary[] = [
     name: "Prior approval: larger home extension",
     slug: "prior-approval-larger-home-extension",
     status: "offline",
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    updatedAt: subDays(new Date(), 1).toISOString(),
     summary: "",
     operations: [],
     publishedFlows: [],
@@ -59,7 +66,7 @@ const mockFlows: FlowSummary[] = [
     name: "Report a planning breach",
     slug: "report-a-planning-breach",
     status: "offline",
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
+    updatedAt: subDays(new Date(), 2).toISOString(),
     summary: "",
     operations: [],
     publishedFlows: [],
@@ -76,18 +83,28 @@ const meta = {
   title: "Editor Components/Dashboard/FlowsPanel",
   component: FlowsPanel,
   decorators: [
-    (Story) => (
-      <DashboardWidget
-        title="Flows"
-        link={{
-          to: "/app/$team",
-          params: { team: "test-council" },
-          label: "view all flows",
-        }}
-      >
-        <Story />
-      </DashboardWidget>
-    ),
+    (Story) => {
+      const rootRoute = createRootRoute({
+        component: () => (
+          <DashboardWidget
+            title="Flows"
+            link={{
+              to: "/app/$team",
+              params: { team: "test-council" },
+              label: "view all flows",
+            }}
+          >
+            <Story />
+          </DashboardWidget>
+        ),
+      });
+      const router = createRouter({
+        routeTree: rootRoute,
+        history: createMemoryHistory({ initialEntries: ["/"] }),
+      });
+
+      return <RouterProvider router={router} />;
+    },
   ],
   args: {
     flows: mockFlows,


### PR DESCRIPTION
## What does this PR do?

- Follows the pattern used in https://github.com/theopensystemslab/planx-new/pull/6955 to fix rendering of `FlowsPanel` in storybook
- Also updates mock dates to use `date-fns` as used across the codebase

**Testing:**
https://storybook.6964.planx.pizza/?path=/docs/editor-components-dashboard-flowspanel--docs