### PR TITLE
chore(e2e): Tighten up linting rules

### DIFF
--- a/e2e/tests/api-driven/src/jwt.ts
+++ b/e2e/tests/api-driven/src/jwt.ts
@@ -48,7 +48,6 @@ const getAllowedRolesForUser = (user: User): Role[] => {
  * This is the role of least privilege for the user
  */
 const getDefaultRoleForUser = (user: User): Role => {
-  const teamRoles = user.teams.map((teamRole) => teamRole.role);
   if (user.isPlatformAdmin) return "platformAdmin";
 
   return "teamEditor";

--- a/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
+++ b/e2e/tests/ui-driven/src/create-flow-with-geospatial.spec.ts
@@ -268,9 +268,9 @@ test.describe("Flow creation, publish and preview", () => {
       .getByRole("button", { name: "Constraints that don't apply" })
       .click();
 
-    const dontApplyHeadings = await page.getByRole("heading").allTextContents();
+    const dontApplyHeadings = page.getByRole("heading");
 
-    expect(dontApplyHeadings).toEqual(planningConstraintHeadersMock);
+    await expect(dontApplyHeadings).toHaveText(planningConstraintHeadersMock);
 
     // TODO: answer uploadAndLabel
     // TODO: answerPropertyInfo, answerPlanningConstraints

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -183,12 +183,12 @@ const createBaseComponent = async (
   }
 
   if (templateConfig) {
-    await page.getByLabel("Allow edits").click({ force: true });
+    await page.getByLabel("Allow edits").click();
     await page
       .locator("#templatedNodeInstructions")
       .fill(templateConfig.instructions);
     if (templateConfig.required) {
-      await page.getByLabel("Require edits").click({ force: true });
+      await page.getByLabel("Require edits").click();
     }
   }
 

--- a/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/agent.spec.ts
@@ -34,7 +34,7 @@ let context: TestContext = {
   sessionIds: [], // used to collect and clean up sessions
 };
 
-test.describe("Agent journey @regression", async () => {
+test.describe("Agent journey @regression", () => {
   const adminGQLClient = getGraphQLClient();
 
   test.beforeAll(async () => {

--- a/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
+++ b/e2e/tests/ui-driven/src/invite-to-pay/nominee.spec.ts
@@ -33,7 +33,7 @@ const PAYMENT_NOT_FOUND_TEXT = "Sorry, we can't find that payment link";
 
 const adminGQLClient = getGraphQLClient();
 
-test.describe("Nominee journey @regression", async () => {
+test.describe("Nominee journey @regression", () => {
   test.beforeAll(async () => {
     try {
       context = await setUpTestContext(context);

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -39,7 +39,7 @@ const previewURL = `/${context.team!.slug!}/${context.flow?.slug}/published?anal
 
 const payButtonText = "Pay now using GOV.UK Pay";
 
-test.describe("Gov Pay integration @regression", async () => {
+test.describe("Gov Pay integration @regression", () => {
   const adminGQLClient = getGraphQLClient();
 
   test.beforeAll(async () => {

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -17,7 +17,6 @@ import {
   navigateToService,
   navigateToTeamPage,
   publishService,
-  turnServiceOnline,
 } from "./helpers/navigateAndPublish.js";
 import type { TestContext } from "./helpers/types.js";
 import { PlaywrightEditor } from "./pages/Editor.js";
@@ -110,12 +109,12 @@ test.describe("Templates", () => {
       // check "allow edits" control is visible then click it
       const allowEditsControl = page.getByLabel("Allow edits");
       await expect(allowEditsControl).toBeVisible();
-      await allowEditsControl.click({ force: true });
+      await allowEditsControl.click();
 
       // check "require edits" control and instructions fields are now visible after clicking "allow edits"
       await expect(page.getByLabel("Require edits")).toBeVisible();
       await expect(page.getByText("Instructions")).toBeVisible();
-      await page.getByLabel("Require edits").click({ force: true });
+      await page.getByLabel("Require edits").click();
 
       // Close modal without saving
       await page.locator('button[aria-label="close"]').click();

--- a/packages/eslint-config/playwright.js
+++ b/packages/eslint-config/playwright.js
@@ -19,8 +19,6 @@ export default [
         },
       ],
       "playwright/no-networkidle": "warn",
-      // TODO: refactor and promote back to "error"
-      "playwright/valid-describe-callback": "warn",
     },
   },
 ];

--- a/packages/eslint-config/playwright.js
+++ b/packages/eslint-config/playwright.js
@@ -21,9 +21,6 @@ export default [
       "playwright/no-networkidle": "warn",
       // TODO: refactor and promote back to "error"
       "playwright/valid-describe-callback": "warn",
-      // Auto-fixable rule kept OFF so pre-commit `--fix` doesn't rewrite tests
-      // TODO: enable + fix
-      "playwright/prefer-web-first-assertions": "off",
     },
   },
 ];


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/6919

This PR turns on stricter linting for the E2E tests (Playwright only) and resolves the small number of issues here.

Regression tests passing here - https://github.com/theopensystemslab/planx-new/actions/runs/28867923374 ✅ 