### PR TITLE
feat: Shared TypeScript config across monorepo

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -80,6 +80,7 @@
     "@babel/preset-typescript": "catalog:typescript",
     "@planx/eslint-config": "workspace:*",
     "@planx/prettier-config": "workspace:*",
+    "@planx/typescript-config": "workspace:*",
     "@types/adm-zip": "^0.5.8",
     "@types/body-parser": "^1.19.6",
     "@types/cookie-parser": "^1.4.10",

--- a/apps/api.planx.uk/tsconfig.json
+++ b/apps/api.planx.uk/tsconfig.json
@@ -1,23 +1,12 @@
 {
-  // as of July 24, esnext == es2022 and nodenext == node16
+  "extends": "@planx/typescript-config/node.json",
   "compilerOptions": {
-    "allowJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["esnext"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "noImplicitAny": true,
     "outDir": "dist",
-    "sourceMap": true,
-    "resolveJsonModule": true,
     "rootDir": ".",
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "esnext",
-    "types": ["vitest/globals"],
+    "sourceMap": true,
     // ensure the code is ready for per-file transpilation by tsx (used in dev mode)
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "types": ["vitest/globals"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -102,6 +102,7 @@
     "@storybook/tanstack-react": "10.4.1",
     "@planx/eslint-config": "workspace:*",
     "@planx/prettier-config": "workspace:*",
+    "@planx/typescript-config": "workspace:*",
     "@tanstack/react-store": "0.11.0",
     "@tanstack/router-plugin": "^1.164.0",
     "@testing-library/dom": "^10.4.1",

--- a/apps/editor.planx.uk/tsconfig.json
+++ b/apps/editor.planx.uk/tsconfig.json
@@ -1,25 +1,8 @@
 {
+  "extends": "@planx/typescript-config/react.json",
   "compilerOptions": {
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "es6",
+    "allowSyntheticDefaultImports": true,
     "typeRoots": [
       "./types",
       "./node_modules/@types",

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -33,6 +33,7 @@
     "sharp": "^0.34.5",
     "tailwind-clamp": "^4.4.0",
     "tailwindcss": "^4.2.1",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "devDependencies": {

--- a/apps/localplanning.services/tsconfig.json
+++ b/apps/localplanning.services/tsconfig.json
@@ -1,4 +1,9 @@
 {
+  // Astro's `strictest` preset is listed last so it stays authoritative
+  "extends": [
+    "@planx/typescript-config/base.json",
+    "astro/tsconfigs/strictest"
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "jsx": "react-jsx",
@@ -13,9 +18,8 @@
       "@styles/*": ["src/styles/*"]
     }
   },
-  "exclude": ["dist"],
-  "extends": "astro/tsconfigs/strictest",
   "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"],
   "plugins": [
     {
       "name": "typescript-plugin-css-modules"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@planx/eslint-config": "workspace:*",
     "@planx/prettier-config": "workspace:*",
+    "@planx/typescript-config": "workspace:*",
     "@types/jsonwebtoken": "catalog:jwt",
     "@types/node": "catalog:",
     "eslint": "catalog:",

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,18 +1,10 @@
 {
+  "extends": "@planx/typescript-config/node.json",
   "compilerOptions": {
-    "allowJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "rootDir": "tests",
-    "skipLibCheck": true,
-    "strict": true,
-    "noImplicitAny": false,
-    "target": "es2021",
     "noEmit": true,
-    "lib": ["DOM", "ESNext"],
-    "module": "NodeNext",
-    "moduleResolution": "nodenext"
+    "rootDir": "tests",
+    "noImplicitAny": false,
+    "lib": ["DOM", "ESNext"]
   },
   "exclude": ["node_modules", "eslint.config.mjs"]
 }

--- a/infrastructure/application/package.json
+++ b/infrastructure/application/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@planx/infrastructure-application",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@nodelib/fs.walk": "^3.0.1",
     "@planx/infrastructure-common": "workspace:*",
@@ -14,6 +17,7 @@
     "@types/node": "catalog:",
     "@types/tldjs": "^2.3.4",
     "mime": "^4.1.0",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "private": true

--- a/infrastructure/application/tsconfig.json
+++ b/infrastructure/application/tsconfig.json
@@ -1,17 +1,5 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "bin",
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "pretty": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "@planx/typescript-config/pulumi.json",
   "files": [
     "index.ts",
     "utils/generateTeamSecrets.ts"

--- a/infrastructure/certificates/package.json
+++ b/infrastructure/certificates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@planx/infrastructure-certificates",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@planx/infrastructure-common": "workspace:*",
     "@pulumi/aws": "catalog:infrastructure",
@@ -8,6 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "main": "index.ts",

--- a/infrastructure/certificates/tsconfig.json
+++ b/infrastructure/certificates/tsconfig.json
@@ -1,16 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "bin",
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "pretty": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "@planx/typescript-config/pulumi.json",
   "files": ["index.ts"]
 }

--- a/infrastructure/common/package.json
+++ b/infrastructure/common/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@planx/infrastructure-common",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",
     "@pulumi/pulumi": "catalog:infrastructure"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "private": true

--- a/infrastructure/common/tsconfig.json
+++ b/infrastructure/common/tsconfig.json
@@ -1,16 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "bin",
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "pretty": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "@planx/typescript-config/pulumi.json",
   "files": ["teams.ts"]
 }

--- a/infrastructure/data/package.json
+++ b/infrastructure/data/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@planx/infrastructure-data",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@planx/infrastructure-common": "workspace:*",
     "@pulumi/aws": "catalog:infrastructure",
@@ -7,6 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "main": "index.ts",

--- a/infrastructure/data/tsconfig.json
+++ b/infrastructure/data/tsconfig.json
@@ -1,16 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "bin",
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "pretty": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "@planx/typescript-config/pulumi.json",
   "files": ["index.ts"]
 }

--- a/infrastructure/ml/package.json
+++ b/infrastructure/ml/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@planx/infrastructure-ml",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",
     "@pulumi/pulumi": "catalog:infrastructure"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "main": "index.ts",

--- a/infrastructure/ml/tsconfig.json
+++ b/infrastructure/ml/tsconfig.json
@@ -1,18 +1,4 @@
 {
-    "compilerOptions": {
-        "strict": true,
-        "outDir": "bin",
-        "target": "es2020",
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "experimentalDecorators": true,
-        "pretty": true,
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitReturns": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.ts"
-    ]
+  "extends": "@planx/typescript-config/pulumi.json",
+  "files": ["index.ts"]
 }

--- a/infrastructure/networking/package.json
+++ b/infrastructure/networking/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@planx/infrastructure-networking",
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",
     "@pulumi/awsx": "catalog:infrastructure",
@@ -7,6 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@planx/typescript-config": "workspace:*",
     "typescript": "catalog:typescript"
   },
   "main": "index.ts",

--- a/infrastructure/networking/tsconfig.json
+++ b/infrastructure/networking/tsconfig.json
@@ -1,16 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "bin",
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "pretty": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "@planx/typescript-config/pulumi.json",
   "files": ["index.ts"]
 }

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,49 @@
+# @planx/typescript-config
+
+Shared [TypeScript](https://www.typescriptlang.org) configs for the planx-new monorepo.
+
+## Configs
+
+The presets config files are split by toolchain, not by application, so each workspace extends the config that applies to it. `base` holds only the options that are universal across every workspace,. App-specific config (`include`/`exclude`/`paths`/`types` and per-app emit directories) stay in that workspace's own `tsconfig.json`.
+
+## Usage
+
+Add the dependency -
+
+```json
+{
+  "devDependencies": {
+    "@planx/typescript-config": "workspace:*",
+    "typescript": "catalog:typescript"
+  }
+}
+```
+
+Then extend the config from the workspace's `tsconfig.json`, keeping only the workspace-specific parts locally -
+
+```jsonc
+// apps/api.planx.uk/tsconfig.json
+{
+  "extends": "@planx/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "verbatimModuleSyntax": true,
+    "types": ["vitest/globals"],
+  },
+  "exclude": ["node_modules", "dist"],
+}
+```
+
+```jsonc
+// apps/localplanning.services/tsconfig.json
+// Astro config is added last to stay authoritative
+{
+  "extends": [
+    "@planx/typescript-config/base.json",
+    "astro/tsconfigs/strictest",
+  ],
+  "compilerOptions": { "paths": { "@lib/*": ["src/lib/*"] } },
+  "include": [".astro/types.d.ts", "**/*"],
+}
+```

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/typescript-config/node.json
+++ b/packages/typescript-config/node.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["esnext"]
+  }
+}

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@planx/typescript-config",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MPL-2.0",
+  "peerDependencies": {
+    "typescript": "catalog:typescript"
+  }
+}

--- a/packages/typescript-config/pulumi.json
+++ b/packages/typescript-config/pulumi.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "sourceMap": true,
+    "pretty": true,
+    "noImplicitReturns": true,
+    "outDir": "${configDir}/bin"
+  }
+}

--- a/packages/typescript-config/react.json
+++ b/packages/typescript-config/react.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "isolatedModules": true,
+    "noEmit": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       '@planx/prettier-config':
         specifier: workspace:*
         version: link:../../packages/prettier-config
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/adm-zip':
         specifier: ^0.5.8
         version: 0.5.8
@@ -683,6 +686,9 @@ importers:
       '@planx/prettier-config':
         specifier: workspace:*
         version: link:../../packages/prettier-config
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@storybook/addon-a11y':
         specifier: 10.4.1
         version: 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -873,6 +879,9 @@ importers:
       '@opensystemslab/map':
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.5(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -995,6 +1004,9 @@ importers:
       '@planx/prettier-config':
         specifier: workspace:*
         version: link:../packages/prettier-config
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../packages/typescript-config
       '@types/jsonwebtoken':
         specifier: catalog:jwt
         version: 9.0.10
@@ -1133,6 +1145,9 @@ importers:
         specifier: ^2.3.2
         version: 2.3.2
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1161,6 +1176,9 @@ importers:
         specifier: catalog:infrastructure
         version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1177,6 +1195,9 @@ importers:
         specifier: catalog:infrastructure
         version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1196,6 +1217,9 @@ importers:
         specifier: catalog:infrastructure
         version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1212,6 +1236,9 @@ importers:
         specifier: catalog:infrastructure
         version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1231,6 +1258,9 @@ importers:
         specifier: catalog:infrastructure
         version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
+      '@planx/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
@@ -1278,6 +1308,12 @@ importers:
         version: 8.62.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
   packages/prettier-config: {}
+
+  packages/typescript-config:
+    dependencies:
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
 
   scripts/encrypt:
     dependencies:
@@ -17833,7 +17869,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -17849,7 +17885,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.9)':
     dependencies:
@@ -17954,7 +17990,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## What does this PR do?
- Creates a single source of truth for shared TS config, within the new `@planx/typescript-config` package
- Replaces repeated `tsconfig.json` files with imports from shared package
- Adds `pnpm check` scripts to all `/infrastructure` projects - we've been caught out a few times by Pulumi type issues which only run on CI within `pulumi {up|preview}` is hit. This allows us to locally sense check issues. When Turborepo is setup we can automate this check as part of CI - didn't feel the need to add this in just now to strip it out in the next PR.

Inspired by / based upon https://github.com/vercel/turborepo/tree/main/examples/basic/packages/typescript-config

Docs: https://turborepo.dev/docs/guides/tools/typescript