### PR TITLE
fix: Expose dashboard stats to `TeamViewer` and `Analyst` roles

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -290,12 +290,7 @@ function EditorNavMenu() {
             title: "Analytics",
             Icon: LeaderboardIcon,
             route: flowAnalyticsLink ? flowAnalyticsLink : `#`,
-            accessibleBy: [
-              "platformAdmin",
-              "teamAdmin",
-              "teamEditor",
-              "analyst",
-            ],
+            accessibleBy: "*",
             disabled: !flowAnalyticsLink,
           },
         ],

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -209,12 +209,7 @@ function EditorNavMenu() {
             title: "Analytics",
             Icon: LeaderboardIcon,
             route: teamAnalyticsLink ? teamAnalyticsLink : `#`,
-            accessibleBy: [
-              "platformAdmin",
-              "teamAdmin",
-              "teamEditor",
-              "analyst",
-            ],
+            accessibleBy: "*",
             disabled: !teamAnalyticsLink,
           },
           {

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -5,6 +5,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
 import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import Permission from "ui/editor/Permission";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import type { TeamDashboardStats } from "./useTeamDashboardStats";
@@ -110,22 +111,24 @@ export function StatsBanner({
         <Typography variant="h4" component="h2">
           Last 30 days
         </Typography>
-        {analyticsLink ? (
-          <AnalyticsLink
-            href={analyticsLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            underline="always"
-          >
-            view analytics
-          </AnalyticsLink>
-        ) : (
-          <Tooltip title="Analytics unavailable" placement="bottom">
-            <AnalyticsLinkDisabled variant="body2">
+        <Permission.CanEdit>
+          {analyticsLink ? (
+            <AnalyticsLink
+              href={analyticsLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="always"
+            >
               view analytics
-            </AnalyticsLinkDisabled>
-          </Tooltip>
-        )}
+            </AnalyticsLink>
+          ) : (
+            <Tooltip title="Analytics unavailable" placement="bottom">
+              <AnalyticsLinkDisabled variant="body2">
+                view analytics
+              </AnalyticsLinkDisabled>
+            </Tooltip>
+          )}
+        </Permission.CanEdit>
       </Header>
       <StatsGrid>
         {tiles.map(({ label, value, delta }) => (

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -5,7 +5,6 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
 import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
-import Permission from "ui/editor/Permission";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import type { TeamDashboardStats } from "./useTeamDashboardStats";
@@ -111,24 +110,22 @@ export function StatsBanner({
         <Typography variant="h4" component="h2">
           Last 30 days
         </Typography>
-        <Permission.CanEdit>
-          {analyticsLink ? (
-            <AnalyticsLink
-              href={analyticsLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              underline="always"
-            >
+        {analyticsLink ? (
+          <AnalyticsLink
+            href={analyticsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="always"
+          >
+            view analytics
+          </AnalyticsLink>
+        ) : (
+          <Tooltip title="Analytics unavailable" placement="bottom">
+            <AnalyticsLinkDisabled variant="body2">
               view analytics
-            </AnalyticsLink>
-          ) : (
-            <Tooltip title="Analytics unavailable" placement="bottom">
-              <AnalyticsLinkDisabled variant="body2">
-                view analytics
-              </AnalyticsLinkDisabled>
-            </Tooltip>
-          )}
-        </Permission.CanEdit>
+            </AnalyticsLinkDisabled>
+          </Tooltip>
+        )}
       </Header>
       <StatsGrid>
         {tiles.map(({ label, value, delta }) => (

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_dashboard_stats.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_dashboard_stats.yaml
@@ -12,6 +12,21 @@ object_relationships:
           name: teams
           schema: public
 select_permissions:
+  - role: analyst
+    permission:
+      columns:
+        - team_id
+        - team_slug
+        - sessions_current
+        - sessions_previous
+        - submissions_current
+        - submissions_previous
+        - guidance_sessions_current
+        - guidance_sessions_previous
+        - online_flows
+        - online_flows_previous
+      filter: {}
+    comment: ""
   - role: platformAdmin
     permission:
       columns:
@@ -40,12 +55,20 @@ select_permissions:
         - guidance_sessions_previous
         - online_flows
         - online_flows_previous
-      filter:
-        team:
-          members:
-            _and:
-              - user_id:
-                  _eq: x-hasura-user-id
-              - role:
-                  _eq: teamEditor
+      filter: {}
+    comment: ""
+  - role: teamViewer
+    permission:
+      columns:
+        - team_id
+        - team_slug
+        - sessions_current
+        - sessions_previous
+        - submissions_current
+        - submissions_previous
+        - guidance_sessions_current
+        - guidance_sessions_previous
+        - online_flows
+        - online_flows_previous
+      filter: {}
     comment: ""

--- a/apps/hasura.planx.uk/tests/team_dashboard_stats.test.js
+++ b/apps/hasura.planx.uk/tests/team_dashboard_stats.test.js
@@ -93,8 +93,23 @@ describe("team_dashboard_stats", () => {
       i = await introspectAs("analyst");
     });
 
-    test("cannot query team_dashboard_stats", () => {
-      expect(i.queries).not.toContain("team_dashboard_stats");
+    test("can query team_dashboard_stats", () => {
+      expect(i.queries).toContain("team_dashboard_stats");
+    });
+
+    test("cannot create, update, or delete team_dashboard_stats", () => {
+      expect(i).toHaveNoMutationsFor("team_dashboard_stats");
+    });
+  });
+
+  describe("teamViewer", () => {
+    let i;
+    beforeAll(async () => {
+      i = await introspectAs("teamViewer");
+    });
+
+    test("can query team_dashboard_stats", () => {
+      expect(i.queries).toContain("team_dashboard_stats");
     });
 
     test("cannot create, update, or delete team_dashboard_stats", () => {

--- a/apps/hasura.planx.uk/tests/utils.js
+++ b/apps/hasura.planx.uk/tests/utils.js
@@ -93,6 +93,7 @@ const introspectAs = async (role, userId = undefined) => {
     platformAdmin: gqlWithRole("platformAdmin", userId),
     teamEditor: gqlWithRole("teamEditor", userId),
     teamAdmin: gqlWithRole("teamAdmin", userId),
+    teamViewer: gqlWithRole("teamViewer", userId),
     api: gqlWithRole("api"),
     analyst: gqlWithRole("analyst", userId),
   }[role];


### PR DESCRIPTION
## What does this PR do

- Ensure all permission levels can see the `StatsBanner` dashboard stats summary for a given team
- Hide the `View analytics` link for permission group `CannotEdit`

Before (view of non `TeamEditor`):

<img width="1728" height="321" alt="image" src="https://github.com/user-attachments/assets/a469b49c-478d-4cc3-abf4-c8aa62868473" />


After:
<img width="1728" height="341" alt="image" src="https://github.com/user-attachments/assets/7248ae28-20e4-4cec-9344-f608d999e989" />
