### PR TITLE
fix: restrict analyst access and redirect to admin panel

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.test.tsx
@@ -107,6 +107,16 @@ describe("globalLayoutRoutes", () => {
     expect(menuItems).toHaveLength(4);
     expect(within(menuItems[0]).getByText("Select a team")).toBeInTheDocument();
   });
+
+  it("only displays the admin panel for analysts", async () => {
+    mockGetUserRoleForCurrentTeam.mockReturnValue("analyst");
+
+    const { getAllByRole, queryByText } = await setup(<EditorNavMenu />);
+    const menuItems = getAllByRole("listitem");
+    expect(menuItems).toHaveLength(1);
+    expect(within(menuItems[0]).getByText("Admin panel")).toBeInTheDocument();
+    expect(queryByText("Select a team")).not.toBeInTheDocument();
+  });
 });
 
 describe("teamLayoutRoutes", () => {

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -111,7 +111,12 @@ function EditorNavMenu() {
           title: "Select a team",
           Icon: FormatListBulletedIcon,
           route: "/app",
-          accessibleBy: "*",
+          accessibleBy: [
+            "platformAdmin",
+            "teamAdmin",
+            "teamEditor",
+            "teamViewer",
+          ],
         },
         {
           title: "Global settings",

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
@@ -1,7 +1,14 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  notFound,
+  Outlet,
+  redirect,
+  rootRouteId,
+} from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import gql from "graphql-tag";
 import { CatchAllComponent } from "routes/$";
+import { isAnalystOnly } from "utils/routeUtils/analystAccess";
 
 import { useStore } from "../../../pages/FlowEditor/lib/store";
 import type { TeamSummary } from "../../../pages/FlowEditor/lib/store/team";
@@ -10,6 +17,12 @@ import AuthenticatedLayout from "../../../pages/layout/AuthenticatedLayout";
 export const Route = createFileRoute("/_authenticated/app")({
   pendingComponent: DelayedLoadingIndicator,
   loader: async () => {
+    const user = useStore.getState().user;
+
+    if (isAnalystOnly(user)) {
+      return { teams: [] };
+    }
+
     const { client } = await import("lib/graphql");
     const { data } = await client.query<{ teams: TeamSummary[] }>({
       query: gql`
@@ -40,6 +53,20 @@ export const Route = createFileRoute("/_authenticated/app")({
     useStore.getState().setPreviewEnvironment("editor");
 
     const user = useStore.getState().user;
+
+    if (isAnalystOnly(user)) {
+      if (pathname === "/app/admin-panel") {
+        return { user, isPublicRoute: false };
+      }
+
+      if (pathname === "/app" || pathname === "/app/") {
+        throw redirect({
+          to: "/app/admin-panel",
+        });
+      }
+
+      throw notFound({ routeId: rootRouteId });
+    }
 
     // Handle default team redirect for initial session load
     if (pathname === "/app" && user?.defaultTeamId) {

--- a/apps/editor.planx.uk/src/utils/routeUtils/analystAccess.test.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/analystAccess.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { isAnalystOnly } from "./analystAccess";
+
+describe("isAnalystOnly", () => {
+  it("returns true for platform analysts", () => {
+    expect(
+      isAnalystOnly({
+        id: 1,
+        email: "analyst@example.com",
+        firstName: "Ana",
+        lastName: "Lyst",
+        isAnalyst: true,
+        isPlatformAdmin: false,
+        teams: [],
+        defaultTeamId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for platform admins who are also analysts", () => {
+    expect(
+      isAnalystOnly({
+        id: 1,
+        email: "admin@example.com",
+        firstName: "Admin",
+        lastName: "User",
+        isAnalyst: true,
+        isPlatformAdmin: true,
+        teams: [],
+        defaultTeamId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for other users", () => {
+    expect(
+      isAnalystOnly({
+        id: 1,
+        email: "editor@example.com",
+        firstName: "Team",
+        lastName: "Editor",
+        isAnalyst: false,
+        isPlatformAdmin: false,
+        teams: [],
+        defaultTeamId: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/editor.planx.uk/src/utils/routeUtils/analystAccess.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/analystAccess.ts
@@ -1,0 +1,5 @@
+import type { User } from "@opensystemslab/planx-core/types";
+
+// Platform analysts without admin access are limited to the admin panel
+export const isAnalystOnly = (user: User | undefined | null): boolean =>
+  Boolean(user?.isAnalyst && !user.isPlatformAdmin);


### PR DESCRIPTION
Analyst users should only have access to /app/admin-panel, so this PR adds an auto-redirect to take them there. It also adds guards round other routes to show the 404 page if they try access them. Also adds some tests for the util function and sidebar rendering.