### PR TITLE
fix: Hide Notification and Feedback widgets from non team editors

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/index.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import { linkOptions } from "@tanstack/react-router";
 import { DEFAULT_PRIMARY_COLOR } from "theme";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
+import Permission from "ui/editor/Permission";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import ActivityWidget from "./components/ActivityWidget";
@@ -74,18 +75,20 @@ export default function Dashboard() {
           >
             <FlowsPanel />
           </DashboardWidget>
-          <ConnectedNotificationsWidget />
-          <DashboardWidget
-            title="Feedback"
-            link={linkOptions({
-              to: "/app/$team/feedback",
-              params: { team: team.slug },
-              label: "view all feedback",
-            })}
-          >
-            <FeedbackWidget />
-          </DashboardWidget>
-          <DashboardWidget title="User Activity" subtitle="Last 30 days">
+          <Permission.CanEdit>
+            <ConnectedNotificationsWidget />
+            <DashboardWidget
+              title="Feedback"
+              link={linkOptions({
+                to: "/app/$team/feedback",
+                params: { team: team.slug },
+                label: "view all feedback",
+              })}
+            >
+              <FeedbackWidget />
+            </DashboardWidget>
+          </Permission.CanEdit>
+          <DashboardWidget title="User activity" subtitle="Last 30 days">
             <ActivityWidget />
           </DashboardWidget>
         </Box>


### PR DESCRIPTION
## What does this PR do?

- Ensure only those with either `PlatformAdmin` or `TeamAdmin` / `TeamEditor` permissions for a given team can view the `NotificationsWidget` and `FeedbackWidget` (uses `CanEdit` from `Permission.tsx`)