### PR TITLE
feat: Setup Turborepo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -161,8 +161,10 @@ jobs:
           cache: ${{ steps.cache-localplanning-build-assets.outputs.cache-hit != 'true' && 'pnpm' || '' }}
       - run: pnpm install --frozen-lockfile
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
-      - run: pnpm build --site "https://localplanning.${{ env.FULL_DOMAIN }}" --mode pizza
+      - run: pnpm build
         env:
+          BUILD_MODE: pizza
+          SITE_URL: https://localplanning.${{ env.FULL_DOMAIN }}
           ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
         if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ __pycache__
 # Tooling
 .aider*
 .claude
+.turbo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,13 @@ Shared dependency versions are pinned via `catalog:`/`catalog:<name>` entries in
 The full write-up lives at [`doc/guides/data-fetching-and-state-management.md`](doc/guides/data-fetching-and-state-management.md) and [ADR 0011](doc/architecture/decisions/0011-standardised-data-fetching-and-state-management.md) — read those before touching store code. Summary:
 
 **Decision tree for new state:**
+
 - GraphQL data (Hasura) → Apollo Client `useQuery`/`useMutation`
 - REST data → TanStack Query, via the typed API layer in `src/lib/api`, never `axios` directly in components
 - UI state (modals, sidebar, clipboard) → Zustand
 - Flow-graph state (breadcrumbs, passport, current node) → Zustand
 
-**Critical rule: do not put server data in Zustand.** Storing `teamSettings`, `teamMembers`, `planningConstraints`, etc. in the global store is the "God Store" anti-pattern that ADR 0011 is actively migrating *away* from — don't add more of it. Server data belongs in the Apollo/TanStack Query cache; Zustand is for client/UI state and derived flow data.
+**Critical rule: do not put server data in Zustand.** Storing `teamSettings`, `teamMembers`, `planningConstraints`, etc. in the global store is the "God Store" anti-pattern that ADR 0011 is actively migrating _away_ from — don't add more of it. Server data belongs in the Apollo/TanStack Query cache; Zustand is for client/UI state and derived flow data.
 
 **Structure** — the store lives in `apps/editor.planx.uk/src/pages/FlowEditor/lib/store/` as a set of slices combined in `index.ts`:
 
@@ -35,6 +36,7 @@ The full write-up lives at [`doc/guides/data-fetching-and-state-management.md`](
 - `editor.ts`, `user.ts`, `auth.ts` — editor-only (do things like connect to ShareDB; not loaded on public preview domains)
 
 `index.ts` builds two stores depending on context (`isPreviewOnlyDomain` / URL contains `/published`):
+
 - `createPublicStore()` — only the public slices, typed as `PublicStore`
 - `createFullStore()` — every slice, typed as `FullStore`
 
@@ -51,6 +53,7 @@ Some slices use the `zustand/persist` middleware (e.g. `editorUIStore` in `edito
 **Dates — `date-fns`, not `Date` methods or Moment/Luxon.** Used throughout both `editor.planx.uk` and `api.planx.uk` (e.g. `format`, `subDays`). Prefer composing `date-fns` functions over manual date arithmetic or custom formatting strings.
 
 **MUI v9** (`^9.0.0`, not v5 — this is a common trap): sub-component prop APIs have moved to `slotProps`.
+
 - `PaperProps` on `Dialog` → `slotProps={{ paper: {...} }}`
 - `InputProps` on `TextField` → `slotProps={{ input: {...} }}`
 - Don't set `fontWeight="bold"` directly on `Typography` — use `sx={{ fontWeight: "bold" }}`
@@ -64,7 +67,9 @@ Some slices use the `zustand/persist` middleware (e.g. `editorUIStore` in `edito
 
 **Testing** — Vitest everywhere (`editor.planx.uk`, `api.planx.uk`), Playwright + Gherkin for `e2e`. `api.planx.uk` tests run with `TZ=Europe/London` pinned — don't assume UTC when writing date-sensitive backend tests.
 
-**Linting/formatting** — ESLint (flat config, `eslint.config.*`) + Prettier per-package, wired into `lint-staged`/Husky at the repo root. Run `pnpm lint:fix` (or the package's `check` script, which also runs `tsc --noEmit`) rather than hand-formatting.
+**Task running** — [Turborepo](https://turborepo.com) (`turbo.json`) orchestrates tasks over the workspace. From the repo root, `pnpm typecheck` / `pnpm lint` / `pnpm check` / `pnpm build` fan out across all packages with caching; use `--filter` to scope. `test` is intentionally not a root Turbo task currently (some tests are container dependent).
+
+**Linting/formatting** — ESLint (flat config, `eslint.config.*`) + Prettier per-package, wired into `lint-staged`/Husky at the repo root. Run `pnpm lint:fix` (or a package's `check` script, which also runs `tsc --noEmit`) rather than hand-formatting.
 
 **Hasura clients** (`api.planx.uk`) — multiple clients exported from `client/index.ts` (`$api`, `$public`, `$admin`, ...) for different auth contexts; pick the least-privileged one that works, don't default to an elevated client out of convenience.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ The root of the project has several scripts set up to help you manage your docke
 - `pnpm analytics` will recreate your docker containers and include [Metabase](https://www.metabase.com/)
 - `pnpm logs` will print docker log entries (this can be filtered by appending `-- [service name]`, for example `pnpm logs -- api`)
 
+### Task running (Turborepo)
+
+[Turborepo](https://turborepo.com) runs and caches tasks across the pnpm workspace. From the project root:
+
+- `pnpm typecheck` - type-check every workspace (`tsc --noEmit` / `astro check`)
+- `pnpm lint` - ESLint + Prettier checks (Editor, API, E2E)
+- `pnpm check` - `typecheck` and `lint` together
+- `pnpm build` - build the Editor, API and LPS
+
+Turbo caches by content hash, so re-running an unchanged task is near-instant (`>>> FULL TURBO`). This can be scoped to one package with `--filter` (e.g. `pnpm turbo run build --filter=api.planx.uk`).
+
 ### Documentation
 
 This project uses Architecture Decision Records (ADRs) to record significant changes and decisions. Further details of this can be [found here](https://github.com/theopensystemslab/planx-new/blob/main/doc/architecture/decisions/0001-record-architecture-decisions.md).

--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -61,18 +61,19 @@
     "zod": "^3.25.76"
   },
   "scripts": {
+    "build": "rimraf ./dist && npx tsc && pnpm copy-swagger-files && pnpm copy-prompt-files",
+    "check": "pnpm typecheck && pnpm lint",
+    "copy-prompt-files": "copyfiles 'modules/ai/**/*.md' dist",
+    "copy-swagger-files": "copyfiles '**/docs.yaml' dist",
     "dev": "tsx watch index.ts",
-    "start": "node --enable-source-maps ./dist/index.js",
-    "lint": "eslint '**/*.{js,ts}' && prettier -c .",
-    "lint:fix": "eslint --fix '**/*.{js,ts}' && prettier -w .",
     "lint:error": "eslint --quiet '**/*.{js,ts}' && prettier -c . --ignore-path ../../.prettierignore",
-    "check": "tsc --noEmit && pnpm lint",
-    "test": "TZ=Europe/London vitest run",
+    "lint:fix": "eslint --fix '**/*.{js,ts}' && prettier -w .",
+    "lint": "eslint '**/*.{js,ts}' && prettier -c .",
+    "start": "node --enable-source-maps ./dist/index.js",
     "test:coverage": "TZ=Europe/London vitest run --coverage && open coverage/lcov-report/index.html",
     "test:watch": "TZ=Europe/London vitest --ui --coverage",
-    "build": "rimraf ./dist && npx tsc && pnpm copy-swagger-files && pnpm copy-prompt-files",
-    "copy-swagger-files": "copyfiles '**/docs.yaml' dist",
-    "copy-prompt-files": "copyfiles 'modules/ai/**/*.md' dist"
+    "test": "TZ=Europe/London vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "prettier": "@planx/prettier-config",
   "devDependencies": {

--- a/apps/editor.planx.uk/.gitignore
+++ b/apps/editor.planx.uk/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/storybook-static
 
 # misc
 .DS_Store

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -145,18 +145,19 @@
     "vitest": "^4.1.9"
   },
   "scripts": {
-    "prestart": "../../scripts/check-containers.sh dev",
-    "start": "vite --open",
-    "build": "tsc && NODE_OPTIONS=--max-old-space-size=4096 vite build",
-    "serve": "vite preview",
-    "test": "vitest",
-    "test:silent": "vitest --silent",
-    "storybook": "storybook dev -p 6006",
     "build-storybook": "mkdir -p build && storybook build --quiet --output-dir ./build/storybook",
-    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}' && prettier -c ./src --ignore-path ../../.prettierignore",
+    "build": "tsc && NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "check": "pnpm typecheck && pnpm lint",
     "lint:error": "eslint --quiet 'src/**/*.{js,jsx,ts,tsx}' && prettier -c ./src --ignore-path ../../.prettierignore",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx,ts,tsx}' && prettier -w ./src --ignore-path ../../.prettierignore",
-    "check": "tsc --noEmit && pnpm lint"
+    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}' && prettier -c ./src --ignore-path ../../.prettierignore",
+    "prestart": "../../scripts/check-containers.sh dev",
+    "serve": "vite preview",
+    "start": "vite --open",
+    "storybook": "storybook dev -p 6006",
+    "test:silent": "vitest --silent",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "prettier": "@planx/prettier-config",
   "browserslist": {

--- a/apps/editor.planx.uk/turbo.json
+++ b/apps/editor.planx.uk/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["build/**"],
+      "env": ["VITE_*"]
+    }
+  }
+}

--- a/apps/localplanning.services/astro.config.mjs
+++ b/apps/localplanning.services/astro.config.mjs
@@ -1,16 +1,19 @@
+/* eslint-disable no-restricted-syntax */
+
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, envField, fontProviders } from "astro/config";
 import icon from "astro-icon";
 
-// Check args to access Astro mode
-// Env var is not available in Astro config files
-const mode = process.argv.at(-1).replaceAll("-", "");
+// BUILD_MODE must be an env var for Turbo caching
+// The dev / pizza / staging / prod builds must have their own cache-key
+const mode = process.env.BUILD_MODE ?? "dev";
 const isCloudfrontBuild = ["staging", "production"].includes(mode);
 
 // https://astro.build/config
 export default defineConfig({
+  site: process.env.SITE_URL,
   integrations: [react(), icon(), sitemap()],
   env: {
     schema: {

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "astro": "astro",
     "build": "astro check && astro build",
-    "check": "astro check && pnpm lint",
+    "check": "pnpm typecheck",
     "dev": "astro dev --mode dev --open",
     "lint": "eslint . && prettier -c . --ignore-path ../../.prettierignore",
     "lint:fix": "eslint --fix . && prettier -w . --ignore-path ../../.prettierignore",
     "preview": "astro preview --open",
-    "storybook": "storybook dev -p 6006"
+    "storybook": "storybook dev -p 6006",
+    "typecheck": "astro check"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "astro": "astro",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build --mode ${BUILD_MODE:-dev}",
     "check": "pnpm typecheck",
     "dev": "astro dev --mode dev --open",
     "lint": "eslint . && prettier -c . --ignore-path ../../.prettierignore",

--- a/apps/localplanning.services/turbo.json
+++ b/apps/localplanning.services/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "env": ["BUILD_MODE", "SITE_URL", "ROOT_DOMAIN"]
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,17 +2,18 @@
   "name": "@planx/e2e",
   "private": true,
   "scripts": {
+    "check": "pnpm typecheck && pnpm lint",
+    "lint:fix": "eslint --fix './tests/**/*.{js,ts}' && prettier -w ./tests",
+    "lint": "eslint './tests/**/*.{js,ts}' && prettier -c ./tests",
     "pretest": "../scripts/check-containers.sh e2e",
-    "test": "pnpm test:api && pnpm test:ui",
-    "test:ui": "cd tests/ui-driven && pnpm test",
+    "test:api-regression": "cd tests/api-driven && pnpm test:regression",
     "test:api": "cd tests/api-driven && pnpm test",
+    "test:debug": "DEBUG_LOG=true pnpm test",
     "test:regression": "pnpm test:api-regression && pnpm test:ui-regression",
     "test:ui-regression": "cd tests/ui-driven && pnpm test:regression",
-    "test:api-regression": "cd tests/api-driven && pnpm test:regression",
-    "test:debug": "DEBUG_LOG=true pnpm test",
-    "lint": "eslint './tests/**/*.{js,ts}' && prettier -c ./tests",
-    "lint:fix": "eslint --fix './tests/**/*.{js,ts}' && prettier -w ./tests",
-    "check": "tsc && pnpm lint"
+    "test:ui": "cd tests/ui-driven && pnpm test",
+    "test": "pnpm test:api && pnpm test:ui",
+    "typecheck": "tsc --noEmit"
   },
   "prettier": "@planx/prettier-config",
   "devDependencies": {

--- a/infrastructure/application/package.json
+++ b/infrastructure/application/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-application",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@nodelib/fs.walk": "^3.0.1",

--- a/infrastructure/certificates/package.json
+++ b/infrastructure/certificates/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-certificates",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@planx/infrastructure-common": "workspace:*",

--- a/infrastructure/common/package.json
+++ b/infrastructure/common/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-common",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",

--- a/infrastructure/data/package.json
+++ b/infrastructure/data/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-data",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@planx/infrastructure-common": "workspace:*",

--- a/infrastructure/ml/package.json
+++ b/infrastructure/ml/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-ml",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",

--- a/infrastructure/networking/package.json
+++ b/infrastructure/networking/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@planx/infrastructure-networking",
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "pnpm typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@pulumi/aws": "catalog:infrastructure",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
     "prettier": "catalog:",
+    "turbo": "^2.10.2",
     "typescript": "catalog:typescript"
   },
   "packageManager": "pnpm@10.30.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
-    "check": "turbo run typecheck lint"
+    "check": "turbo run typecheck lint",
+    "build": "turbo run build"
   },
   "lint-staged": {
     "apps/editor.planx.uk/src/**/*.{js,jsx,ts,tsx}": "eslint --fix --flag v10_config_lookup_from_file",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "tests": "./scripts/start-containers-for-tests.sh",
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",
     "logs": "docker compose logs --tail 30 -f",
-    "prepare": "husky"
+    "prepare": "husky",
+    "typecheck": "turbo run typecheck",
+    "lint": "turbo run lint",
+    "check": "turbo run typecheck lint"
   },
   "lint-staged": {
     "apps/editor.planx.uk/src/**/*.{js,jsx,ts,tsx}": "eslint --fix --flag v10_config_lookup_from_file",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.9.3
+      turbo:
+        specifier: ^2.10.2
+        version: 2.10.2
       typescript:
         specifier: catalog:typescript
         version: 5.9.3
@@ -5544,6 +5547,36 @@ packages:
   '@tufjs/models@4.1.0':
     resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@turbo/darwin-64@2.10.2':
+    resolution: {integrity: sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.2':
+    resolution: {integrity: sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.2':
+    resolution: {integrity: sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.10.2':
+    resolution: {integrity: sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.10.2':
+    resolution: {integrity: sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.2':
+    resolution: {integrity: sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg==}
+    cpu: [arm64]
+    os: [win32]
 
   '@turf/area@7.3.5':
     resolution: {integrity: sha512-sSn80wPT7XfBIDN3vurCPxhk9W4U8ozS/XImSqeLN8qveTICOxzZkhsGDMp0CuncaN+plWut4a2TdNM7mzZB6Q==}
@@ -11795,6 +11828,10 @@ packages:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  turbo@2.10.2:
+    resolution: {integrity: sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -17152,6 +17189,24 @@ snapshots:
     dependencies:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 10.2.5
+
+  '@turbo/darwin-64@2.10.2':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.2':
+    optional: true
+
+  '@turbo/linux-64@2.10.2':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.2':
+    optional: true
+
+  '@turbo/windows-64@2.10.2':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.2':
+    optional: true
 
   '@turf/area@7.3.5':
     dependencies:
@@ -24807,6 +24862,15 @@ snapshots:
       make-fetch-happen: 15.0.6
     transitivePeerDependencies:
       - supports-color
+
+  turbo@2.10.2:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.10.2
+      '@turbo/darwin-arm64': 2.10.2
+      '@turbo/linux-64': 2.10.2
+      '@turbo/linux-arm64': 2.10.2
+      '@turbo/windows-64': 2.10.2
+      '@turbo/windows-arm64': 2.10.2
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/deploy-lps.sh
+++ b/scripts/deploy-lps.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 set -e
 
-REQUIRED_VARS=("BUCKET_NAME" "DIST_ID" "SITE_URL" "BUILD_MODE")
-
-for var in "${REQUIRED_VARS[@]}"; do
-  if [ -z "${!var}" ]; then
-    echo "Error: Environment variable '$var' is not set."
-  fi
-done
+# Fail loudly if any required variable are missing or empty
+: "${BUCKET_NAME:?is not set}"
+: "${DIST_ID:?is not set}"
+: "${SITE_URL:?is not set}"
+: "${BUILD_MODE:?is not set}"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "$SCRIPT_DIR/../apps/localplanning.services"
@@ -18,7 +16,7 @@ echo "Starting Deployment..."
 echo "Site: $SITE_URL ($BUILD_MODE)"
 
 echo "Building LPS..."
-pnpm build --site "$SITE_URL" --mode "$BUILD_MODE"
+pnpm build
 
 echo "Syncing Astro assets..."
 aws s3 sync $BUILD_DIR/_astro s3://$BUCKET_NAME/_astro \

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "typecheck": {}
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
-    "typecheck": {}
+    "typecheck": {},
+    "lint": {}
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://turborepo.com/schema.json",
+  "globalDependencies": [
+    "packages/typescript-config/*.json",
+    "packages/eslint-config/*.js",
+    "packages/prettier-config/*.json",
+    ".prettierignore"
+  ],
   "tasks": {
     "typecheck": {},
-    "lint": {}
+    "lint": {},
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?
Adopts [Turborepo](https://turborepo.com) as a task runner over the existing pnpm workspace. Turbo doesn't replace pnpm - it reads the existing workspace structure from `pnpm-workspace.yaml`, runs their existing `package.json` scripts, and caches each task's inputs and outputs.

This PR is just for local dev - CI/CD, Docker builds, and remote caching will be follow up steps.
- ⚠️ Apart from LPS which does need a change which touches CI/CD - see comment below

<img width="330" height="27" alt="image" src="https://github.com/user-attachments/assets/c0e78686-3554-4081-ad01-2b4b70b76b03" />


## Motivation
Wec now have one single command from the root to `typecheck` / `lint` / `build` the whole repo, with caching. This means re-runs are basically instant - not a huge win right now but will have a big impact once we have more `/packages` (e.g. `planx-core`).

## Testing
This is worth trying out locally - currently this is not running anywhere else. Commands below all run from root.

### Type-checking every workspace
```sh
# First run - will take maybe a minute
pnpm typecheck

# Second run - basically instant, not repeated (>>> FULL TURBO 🌈 )
pnpm typecheck

# Make a change to some code (e.g. modify a file in api.planx.uk)
# Only API type-check will be repeated, much quicker than first run (9/10 cached)
pnpm typecheck
```

This pattern of first run, second run, change files, additional run can be repeated for the commands below to test them. You can also delete the `/.turbo` directory to clear the cache or add the `--force` flag to skip a cache ([docs](https://turborepo.dev/docs/reference/run#--force)).

### Other tasks and commands
```sh
# Linting
pnpm lint

# Combined typecheck + lint
pnpm check

# Build Editor / API / LPS
pnpm build

# Scope to a single package
pnpm turbo run build --filter=api.planx.uk
```

## Next steps...
- CI integration
- Remote caching - caches can be shared across runs via Vercel (or self-hosted). This should have a significant impact on CI times (as well as local dev)
- Use Turbo for Docker builds