### PR TITLE
chore(iac): Setup Stockport domain

### DIFF
--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -117,7 +117,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "stockport-metropolitan",
           domain: "planningservices.stockport.gov.uk",
-          cloudFrontState: "validation-only",
+          cloudFrontState: "shared-final",
         },
         {
           name: "east-riding-of-yorkshire",


### PR DESCRIPTION
Stockport have confirmed that the CNAME records are set up, and [following the guide](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md) I can see a status of `Success ✅` as expected on `customDomainsCertArn`

<img width="432" height="104" alt="image" src="https://github.com/user-attachments/assets/4d3910c7-2a45-4051-932a-d6bdd334ee17" />


