### PR TITLE
feat(ci/cd): Integrate Turbo into CI processes

### DIFF
--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -36,6 +36,10 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   build_planx_frontend:
     name: Build PlanX frontend
@@ -44,8 +48,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-        working-directory: ${{ inputs.editor-directory }}
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: pnpm turbo run build --filter=editor.planx.uk
         env:
           VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}

--- a/.github/workflows/build-planx-frontend.yml
+++ b/.github/workflows/build-planx-frontend.yml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - run: pnpm turbo run build --filter=editor.planx.uk
         env:
           VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}

--- a/.github/workflows/deploy-lps-production.yml
+++ b/.github/workflows/deploy-lps-production.yml
@@ -21,6 +21,8 @@ env:
   BUILD_MODE: production
   SITE_URL: https://localplanning.services
   DIST_ID: ${{ secrets.LPS_PROD_DIST_ID }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-lps-staging.yml
+++ b/.github/workflows/deploy-lps-staging.yml
@@ -19,6 +19,8 @@ env:
   BUILD_MODE: staging
   SITE_URL: https://localplanning.editor.planx.dev
   DIST_ID: ${{ secrets.LPS_STAGING_DIST_ID }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   deploy:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -141,8 +141,13 @@ jobs:
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: pnpm turbo run build --filter=editor.planx.uk
       - run: pnpm test:silent --retry=1
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
@@ -466,28 +471,25 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PIZZA_AWS_SECRET_ACCESS_KEY }}
-      - name: Get editor git tree hash
-        id: editor-hash
-        run: echo "hash=$(git rev-parse HEAD:apps/editor.planx.uk)" >> $GITHUB_OUTPUT
-      - name: Restore editor build cache
-        id: cache-e2e-editor-build
-        uses: actions/cache@v6
-        with:
-          path: apps/editor.planx.uk/build
-          key: editor-e2e-pr-${{ github.event.number }}-${{ steps.editor-hash.outputs.hash }}
-          restore-keys: editor-e2e-pr-${{ github.event.number }}-
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - name: Install Playwright Dependencies
         run: pnpm playwright install --with-deps chromium
         working-directory: e2e/tests/ui-driven
       - name: Start test containers
         run: ./scripts/start-containers-for-tests.sh
       - name: Build editor (test mode)
-        run: VITE_APP_ENV=test pnpm build
-        working-directory: apps/editor.planx.uk
+        run: pnpm turbo run build --filter=editor.planx.uk
+        env:
+          VITE_APP_ENV: test
       - name: End-to-end Tests
         run: pnpm test
         working-directory: e2e

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,6 +74,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
@@ -83,7 +85,9 @@ jobs:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
-      - run: pnpm turbo run typecheck lint
+      - run: pnpm turbo run typecheck lint --affected
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
   integration_tests:
     name: Run Integration tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -67,6 +67,22 @@ jobs:
               - 'pnpm-workspace.yaml'
             
 
+  verify:
+    name: Verify (typecheck + lint)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: pnpm turbo run typecheck lint
+
   integration_tests:
     name: Run Integration tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -182,20 +182,17 @@ jobs:
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     steps:
       - uses: actions/checkout@v7
-      - name: Cache PlanX frontend build assets
-        id: cache-planx-frontend-build-assets
-        uses: actions/cache@v6
-        with:
-          path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
-        with:
-          cache: ${{ steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true' && 'pnpm' || '' }}
       - run: pnpm install --frozen-lockfile
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
-      - run: pnpm build
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - name: Build editor + Storybook
+        run: pnpm turbo run build build-storybook --filter=editor.planx.uk
         env:
           VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
           VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
@@ -208,9 +205,7 @@ jobs:
           VITE_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
           VITE_APP_MICROSOFT_OAUTH_OVERRIDE: https://api.editor.planx.dev
           VITE_APP_ENV: pizza
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
       - name: Upload source maps to Airbrake
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
         working-directory: ${{ env.EDITOR_DIRECTORY }}
         env:
           AB_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
@@ -224,21 +219,6 @@ jobs:
               -F "file=@${mapfile}" \
               -F "name=https://${{ env.FULL_DOMAIN }}/assets/${jsname}"
           done
-      - run: pnpm build-storybook
-        if: steps.cache-planx-frontend-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
-        env:
-          # same env as above, if it's job.env it can't access existing env.[variable]
-          VITE_APP_AIRBRAKE_PROJECT_ID: ${{ secrets.AIRBRAKE_PROJECT_ID }}
-          VITE_APP_AIRBRAKE_PROJECT_KEY: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-          VITE_APP_API_URL: https://api.${{ env.FULL_DOMAIN }}
-          VITE_APP_HASURA_URL: https://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          VITE_APP_HASURA_WEBSOCKET: wss://hasura.${{ env.FULL_DOMAIN }}/v1/graphql
-          VITE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          VITE_APP_SHAREDB_URL: wss://sharedb.${{ env.FULL_DOMAIN }}
-          VITE_APP_GOOGLE_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          VITE_APP_MICROSOFT_OAUTH_OVERRIDE: https://api.editor.planx.dev
-          VITE_APP_ENV: pizza
       - name: Upload PlanX frontend build artifact
         uses: actions/upload-artifact@v7
         with:
@@ -407,11 +387,10 @@ jobs:
 
       - uses: actions/checkout@v7
       - name: Download React build assets
-        id: cache-react-build-assets
-        uses: actions/cache@v6
+        uses: actions/download-artifact@v8
         with:
+          name: planx_frontend_build
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-          key: ${{ runner.os }}-${{ hashFiles(format('{0}/**', env.EDITOR_DIRECTORY)) }}
       - name: upload built editor
         uses: appleboy/scp-action@v1
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -146,20 +146,6 @@ jobs:
       - run: pnpm test:silent --retry=1
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
-  check_localplanning_services:
-    name: Check localplanning.services (types + lint)
-    runs-on: ubuntu-24.04
-    needs: [changes]
-    if: ${{ needs.changes.outputs.localplanning == 'true' }}
-    steps:
-      - uses: actions/checkout@v7
-      - name: Setup Node and PNPM
-        uses: ./.github/actions/setup-node-pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Type-check and lint
-        run: pnpm check
-        working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
-
   build_localplanning_services:
     name: Build localplanning.services
     runs-on: ubuntu-24.04
@@ -168,28 +154,26 @@ jobs:
     if: "${{ !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     steps:
       - uses: actions/checkout@v7
-      - name: Cache localplanning build assets
-        id: cache-localplanning-build-assets
-        uses: actions/cache@v6
-        with:
-          path: ./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/dist
-          key: ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-            ${{ runner.os }}-
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
-        with:
-          cache: ${{ steps.cache-localplanning-build-assets.outputs.cache-hit != 'true' && 'pnpm' || '' }}
       - run: pnpm install --frozen-lockfile
-        if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
-      - run: pnpm build
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: pnpm turbo run build --filter=localplanning.services
         env:
           BUILD_MODE: pizza
           SITE_URL: https://localplanning.${{ env.FULL_DOMAIN }}
           ROOT_DOMAIN: ${{ env.FULL_DOMAIN }}
-        if: steps.cache-localplanning-build-assets.outputs.cache-hit != 'true'
-        working-directory: ${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}
+      - name: Upload localplanning.services build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: localplanning_services_build
+          path: ./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/dist
+          if-no-files-found: error
 
   build_planx_frontend:
     name: Build PlanX frontend
@@ -267,7 +251,7 @@ jobs:
   pulumi_preview:
     name: Run Pulumi Preview
     runs-on: ubuntu-24.04
-    needs: [changes, build_planx_frontend]
+    needs: [changes, build_planx_frontend, build_localplanning_services]
     if: ${{ needs.changes.outputs.infrastructure == 'true' }}
     steps:
       - uses: actions/checkout@v7
@@ -285,15 +269,11 @@ jobs:
         with:
           name: planx_frontend_build
           path: ./${{ env.EDITOR_DIRECTORY }}/build
-      - name: Download LPS build assets
-        id: cache-localplanning-build-assets
-        uses: actions/cache@v6
+      - name: Download localplanning.services build artifact
+        uses: actions/download-artifact@v8
         with:
+          name: localplanning_services_build
           path: ./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/dist
-          key: ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-            ${{ runner.os }}-
       - uses: pulumi/actions@v7
         with:
           command: preview
@@ -331,7 +311,7 @@ jobs:
 
   create_or_update_vultr_instance:
     name: Upsert Vultr Instance
-    needs: [changes, build_planx_frontend]
+    needs: [changes, build_planx_frontend, build_localplanning_services]
     runs-on: ubuntu-24.04
     if: "${{ success() && !contains(needs.changes.outputs.commit, '[skip pizza]') }}"
     steps:
@@ -442,15 +422,11 @@ jobs:
           target: "planx-new/"
           overwrite: true
 
-      - name: Download localplanning.services build assets
-        id: cache-localplanning-build-assets-restore
-        uses: actions/cache/restore@v6
+      - name: Download localplanning.services build artifact
+        uses: actions/download-artifact@v8
         with:
+          name: localplanning_services_build
           path: ./${{ env.LOCALPLANNING_SERVICES_DIRECTORY }}/dist
-          key: ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', format('{0}/src/**', env.LOCALPLANNING_SERVICES_DIRECTORY), format('{0}/public/**', env.LOCALPLANNING_SERVICES_DIRECTORY)) }}
-            ${{ runner.os }}-
 
       - name: upload built localplanning.services
         continue-on-error: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -127,9 +127,14 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - name: Run API Tests
-        run: pnpm test
-        working-directory: ${{ env.API_DIRECTORY }}
+        run: pnpm turbo run test --filter=api.planx.uk
 
   test_react:
     name: Run React Tests
@@ -152,8 +157,7 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
       - run: pnpm turbo run build --filter=editor.planx.uk
-      - run: pnpm test:silent --retry=1
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm turbo run test --filter=editor.planx.uk
 
   build_localplanning_services:
     name: Build localplanning.services

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,8 @@ env:
   LOCALPLANNING_SERVICES_DIRECTORY: apps/localplanning.services
   API_DIRECTORY: apps/api.planx.uk
   HASURA_DIRECTORY: apps/hasura.planx.uk
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   changes:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run API Tests
-        run: pnpm check && pnpm test
+        run: pnpm test
         working-directory: ${{ env.API_DIRECTORY }}
 
   test_react:
@@ -480,9 +480,6 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
       - name: PNPM Install
         run: pnpm install --frozen-lockfile
-      - name: Code checks
-        run: pnpm check
-        working-directory: e2e
       - name: Install Playwright Dependencies
         run: pnpm playwright install --with-deps chromium
         working-directory: e2e/tests/ui-driven

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -83,8 +83,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - run: pnpm turbo run typecheck lint --affected
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
@@ -131,8 +131,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Run API Tests
         run: pnpm turbo run test --filter=api.planx.uk
 
@@ -154,8 +154,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - run: pnpm turbo run build --filter=editor.planx.uk
       - run: pnpm turbo run test --filter=editor.planx.uk
 
@@ -174,8 +174,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - run: pnpm turbo run build --filter=localplanning.services
         env:
           BUILD_MODE: pizza
@@ -202,8 +202,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Build editor + Storybook
         run: pnpm turbo run build build-storybook --filter=editor.planx.uk
         env:
@@ -487,8 +487,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Install Playwright Dependencies
         run: pnpm playwright install --with-deps chromium
         working-directory: e2e/tests/ui-driven

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -115,8 +115,6 @@ jobs:
     name: Run API Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: [changes]
-    if: ${{ needs.changes.outputs.api == 'true' || needs.changes.outputs.pnpmworkspace == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-pizza-env
@@ -139,8 +137,6 @@ jobs:
   test_react:
     name: Run React Tests
     runs-on: ubuntu-24.04
-    needs: [changes]
-    if: ${{ needs.changes.outputs.editor == 'true' || needs.changes.outputs.pnpmworkspace == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-pizza-env

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -55,9 +55,14 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - name: Run API Tests
-        run: pnpm check --quiet && pnpm test
-        working-directory: ${{ env.API_DIRECTORY }}
+        run: pnpm turbo run test --filter=api.planx.uk
 
   test_react:
     name: Run React Tests
@@ -78,8 +83,7 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: ${{ runner.os }}-turbo-
       - run: pnpm turbo run build --filter=editor.planx.uk
-      - run: pnpm test:silent --retry=1
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - run: pnpm turbo run test --filter=editor.planx.uk
 
   end_to_end_tests:
     name: E2E tests

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,6 +17,8 @@ env:
   EDITOR_DIRECTORY: apps/editor.planx.uk
   API_DIRECTORY: apps/api.planx.uk
   HASURA_DIRECTORY: apps/hasura.planx.uk
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   integration_tests:
@@ -69,8 +71,13 @@ jobs:
       - name: Setup Node and PNPM
         uses: ./.github/actions/setup-node-pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-        working-directory: ${{ env.EDITOR_DIRECTORY }}
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      - run: pnpm turbo run build --filter=editor.planx.uk
       - run: pnpm test:silent --retry=1
         working-directory: ${{ env.EDITOR_DIRECTORY }}
 
@@ -94,9 +101,16 @@ jobs:
       - name: Install Playwright Dependencies
         run: pnpm playwright install --with-deps chromium
         working-directory: e2e/tests/ui-driven
+      - name: Restore Turbo cache
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
       - name: Build editor (test mode)
-        run: VITE_APP_ENV=test pnpm build
-        working-directory: apps/editor.planx.uk
+        run: pnpm turbo run build --filter=editor.planx.uk
+        env:
+          VITE_APP_ENV: test
       - name: Start test containers
         run: ./scripts/start-containers-for-tests.sh
       - name: End-to-end Tests

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -59,8 +59,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Run API Tests
         run: pnpm turbo run test --filter=api.planx.uk
 
@@ -80,8 +80,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - run: pnpm turbo run build --filter=editor.planx.uk
       - run: pnpm turbo run test --filter=editor.planx.uk
 
@@ -109,8 +109,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-${{ github.job }}-
       - name: Build editor (test mode)
         run: pnpm turbo run build --filter=editor.planx.uk
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ __pycache__
 .aider*
 .claude
 .turbo/
+
+# Output of turbo prune
+/out

--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -1,3 +1,11 @@
+## PRUNE ##
+# Produce a pruned monorepo containing only api.planx.uk + its workspace dependencies
+FROM node:24.14.0-alpine AS pruner
+WORKDIR /app
+RUN npm install -g pnpm@10.30.2 turbo@2.10.2
+COPY . .
+RUN turbo prune api.planx.uk --docker
+
 ## BASE ##
 FROM node:24.14.0-alpine AS base
 
@@ -8,12 +16,14 @@ COPY .gitconfig /root/.gitconfig
 WORKDIR /app
 RUN npm install -g pnpm@10.30.2
 
-# Fetch before copying source to maximise layer cache reuse
-COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+# Install from the pruned lockfile + package.jsons only. This layer is cached
+# unless the API's dependencies change (not on every monorepo source change).
+COPY --from=pruner /app/out/json/ ./
 RUN pnpm fetch
-
-COPY . .
 RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Build from the pruned full source
+COPY --from=pruner /app/out/full/ ./
 RUN pnpm --filter api.planx.uk build
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE
 # It's not exposed as a CLI flag, so we set it via npm's `npm_config_<key>` env-var convention

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -156,7 +156,8 @@
     "start": "vite --open",
     "storybook": "storybook dev -p 6006",
     "test:silent": "vitest --silent",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "prettier": "@planx/prettier-config",

--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -94,10 +94,9 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
     useStore((state) => state.path) === ApplicationPath.SingleSession;
   const isInitialLoad = useRef(true);
 
-  useEffect(
-    () => setPreviewEnvironment(previewEnvironment),
-    [previewEnvironment, setPreviewEnvironment],
-  );
+  useEffect(() => {
+    setPreviewEnvironment(previewEnvironment);
+  }, [previewEnvironment, setPreviewEnvironment]);
 
   // Initial setup
   useEffect(() => {

--- a/apps/editor.planx.uk/turbo.json
+++ b/apps/editor.planx.uk/turbo.json
@@ -4,7 +4,12 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["build/**"],
+      "outputs": ["build/**", "!build/storybook/**"],
+      "env": ["VITE_*"]
+    },
+    "build-storybook": {
+      "dependsOn": ["build"],
+      "outputs": ["build/storybook/**"],
       "env": ["VITE_*"]
     }
   }

--- a/apps/editor.planx.uk/vitest.config.ts
+++ b/apps/editor.planx.uk/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     clearMocks: true,
+    retry: 1,
     setupFiles: [
       "./src/test/jsdom.ts",
       "./src/test/mockServer.ts",

--- a/apps/hasura.planx.uk/tests/flow_notes.test.js
+++ b/apps/hasura.planx.uk/tests/flow_notes.test.js
@@ -1,4 +1,4 @@
-import { introspectAs } from "./utils";
+import { introspectAs } from "./utils.js";
 
 describe("flow notes", () => {
   describe("public", () => {

--- a/apps/hasura.planx.uk/tests/turbo.json
+++ b/apps/hasura.planx.uk/tests/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "cache": false
+    }
+  }
+}

--- a/apps/localplanning.services/turbo.json
+++ b/apps/localplanning.services/turbo.json
@@ -5,7 +5,8 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "env": ["BUILD_MODE", "SITE_URL", "ROOT_DOMAIN"]
+      "env": ["BUILD_MODE", "SITE_URL", "ROOT_DOMAIN"],
+      "cache": false
     }
   }
 }

--- a/e2e/turbo.json
+++ b/e2e/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "cache": false
+    }
+  }
+}

--- a/scripts/deploy-lps.sh
+++ b/scripts/deploy-lps.sh
@@ -16,7 +16,8 @@ echo "Starting Deployment..."
 echo "Site: $SITE_URL ($BUILD_MODE)"
 
 echo "Building LPS..."
-pnpm build
+# Build via Turbo from the repo root
+( cd "$SCRIPT_DIR/.." && pnpm turbo run build --filter=localplanning.services )
 
 echo "Syncing Astro assets..."
 aws s3 sync $BUILD_DIR/_astro s3://$BUCKET_NAME/_astro \

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,7 @@
   "tasks": {
     "typecheck": {},
     "lint": {},
+    "test": {},
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**"]


### PR DESCRIPTION
## What does this PR do?
This PR wires up  Turborepo (with a Vercel remote cache) through the CI pipeline so that unchanged work is restored instead of recomputed at each step - shared across jobs, runs, branches, and local dev. 

## Caching
```mermaid
flowchart LR
  T[Turbo task] --> L{Is there a local<br/>.turbo cache?}
  L -- hit --> R[Skip task]
  L -- miss --> V{Is there a <br/>remote cache?}
  V -- hit --> R
  V -- miss --> X[Run task] --> S[Save to local<br/>+ remote]
```

We have two caches set up here - 
- **Remote** - Held by Vercel, this is the cross-job / cross-run cache
- **Local** - Held per-job, synched to remote. Held in `.turbo` folder

## Changes
- Added a `verify` job which runs once across all workspaces - previous the Editor and Pulumi did not have this as part of CI
- Turbo now handles test runs
  - Editor and API can be cached - there's no external inputs, these are always deterministic
  - Hasura and E2E tests are marked as `cache: false` - because they rely on containerised services we can't reliable hash results
 - Turbo now handles build processes

## How to test...
- CI is passing on this PR, Pizza is building
- GHA action logs show that the remote cache is hit (`Remote caching enabled` → `>>> FULL TURBO`)
- Local dev still works as before