### PR TITLE
feat: Council or template branded badge + storybook

### DIFF
--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.stories.tsx
@@ -1,0 +1,96 @@
+import Box from "@mui/material/Box";
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import EditorIcon from "ui/icons/Editor";
+
+import { Badge } from "./Badge";
+import { BadgeVariant } from "./types";
+
+// Example OSL logo for Storybook testing
+const MOCK_OSL_LOGO =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg id="c" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="#FFFFFF"><polygon points="17.94 6.31 21.82 6.31 21.82 2.43 17.94 2.43 14.06 2.43 10.18 2.43 10.18 6.31 14.06 6.31 17.94 6.31 17.94 6.31"/><polygon points="21.82 6.31 21.82 10.18 21.82 14.06 21.82 17.94 21.82 21.82 21.82 25.69 25.69 25.69 25.69 21.82 25.69 17.94 25.69 14.06 25.69 10.18 25.69 6.31 21.82 6.31"/><polygon points="10.18 17.94 10.18 14.06 10.18 10.18 10.18 6.31 6.31 6.31 6.31 10.18 6.31 14.06 6.31 17.94 6.31 21.82 6.31 25.69 10.18 25.69 10.18 21.82 10.18 17.94"/><polygon points="14.06 25.69 10.18 25.69 10.18 29.57 14.06 29.57 17.94 29.57 21.82 29.57 21.82 25.69 17.94 25.69 14.06 25.69"/></svg>`,
+  );
+
+const meta = {
+  title: "Editor Components/Explore/Badge",
+  component: Badge,
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SourceTemplate: Story = {
+  args: {
+    variant: BadgeVariant.SourceTemplate,
+  },
+};
+
+export const TeamWithoutLogo: Story = {
+  args: {
+    variant: BadgeVariant.Team,
+    team: {
+      name: "Open Systems Lab",
+      theme: { primaryColour: "#0010A4", logo: null },
+    },
+  },
+};
+
+export const TeamWithLogo: Story = {
+  args: {
+    variant: BadgeVariant.Team,
+    team: {
+      name: "Open Systems Lab",
+      theme: { primaryColour: "#0010A4", logo: MOCK_OSL_LOGO },
+    },
+  },
+};
+
+export const Custom: Story = {
+  args: {
+    variant: BadgeVariant.Custom,
+    backgroundColour: "#D6FFD7",
+    iconColour: "#2E5F2F",
+    icon: <EditorIcon />,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    variant: BadgeVariant.Team,
+    size: "compact",
+    team: {
+      name: "Open Systems Lab",
+      theme: { primaryColour: "#0010A4", logo: MOCK_OSL_LOGO },
+    },
+  },
+};
+
+export const AllStates: Story = {
+  args: {
+    variant: BadgeVariant.SourceTemplate,
+  },
+  render: () => (
+    <Box sx={{ display: "flex", gap: 2 }}>
+      <Badge variant={BadgeVariant.SourceTemplate} />
+      <Badge
+        variant={BadgeVariant.Team}
+        team={{ name: "Open Systems Lab", theme: { primaryColour: "#0010A4" } }}
+      />
+      <Badge
+        variant={BadgeVariant.Team}
+        team={{
+          name: "Open Systems Lab",
+          theme: { primaryColour: "#0010A4", logo: MOCK_OSL_LOGO },
+        }}
+      />
+      <Badge
+        variant={BadgeVariant.Custom}
+        backgroundColour="#D6FFD7"
+        iconColour="#2E5F2F"
+        icon={<EditorIcon />}
+      />
+    </Box>
+  ),
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -1,0 +1,104 @@
+import StarIcon from "@mui/icons-material/Star";
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import React from "react";
+import { getContrastTextColor } from "styleUtils";
+import { DEFAULT_PRIMARY_COLOR } from "theme";
+
+import type { BadgeProps, BadgeSize } from "./types";
+import { BadgeVariant } from "./types";
+
+const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
+  default: { box: 54, borderRadius: 6 },
+  compact: { box: 46, borderRadius: 4 },
+};
+
+const Root = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "size",
+})<{ size: BadgeSize }>(({ size }) => ({
+  width: DIMENSIONS[size].box,
+  height: DIMENSIONS[size].box,
+  minWidth: DIMENSIONS[size].box,
+  borderRadius: DIMENSIONS[size].borderRadius,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  overflow: "hidden",
+  flexShrink: 0,
+}));
+
+const Logo = styled("img")({
+  maxWidth: "70%",
+  maxHeight: "70%",
+  objectFit: "contain",
+});
+
+const Initial = styled("span", {
+  shouldForwardProp: (prop) => prop !== "size",
+})<{ size: BadgeSize }>(({ size }) => ({
+  fontSize: size === "compact" ? "1.33rem" : "2rem",
+  lineHeight: 1,
+}));
+
+export const Badge: React.FC<BadgeProps> = (props) => {
+  const { size = "default" } = props;
+
+  if (props.variant === BadgeVariant.SourceTemplate) {
+    return (
+      <Root
+        size={size}
+        sx={{ backgroundColor: "template.light" }}
+        aria-label="Source template"
+        data-testid="badge-source-template"
+      >
+        <StarIcon sx={{ color: "template.icon" }} />
+      </Root>
+    );
+  }
+
+  if (props.variant === BadgeVariant.Custom) {
+    return (
+      <Root
+        size={size}
+        sx={{
+          backgroundColor: props.backgroundColour,
+          color: props.iconColour,
+        }}
+        data-testid="badge-custom"
+      >
+        {props.icon}
+      </Root>
+    );
+  }
+
+  const { team } = props;
+  const backgroundColour = team.theme.primaryColour || DEFAULT_PRIMARY_COLOR;
+
+  if (team.theme.logo) {
+    return (
+      <Root
+        size={size}
+        sx={{ backgroundColor: backgroundColour }}
+        aria-label={team.name}
+        data-testid="badge-team-logo"
+      >
+        <Logo src={team.theme.logo} alt={`${team.name} logo`} />
+      </Root>
+    );
+  }
+
+  const textColour = getContrastTextColor(backgroundColour, "#FFFFFF");
+
+  return (
+    <Root
+      size={size}
+      sx={{ backgroundColor: backgroundColour }}
+      aria-label={team.name}
+      data-testid="badge-team-initial"
+    >
+      <Initial size={size} sx={{ color: textColour }} aria-hidden>
+        {team.name.charAt(0).toUpperCase()}
+      </Initial>
+    </Root>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -48,6 +48,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
       <Root
         size={size}
         sx={{ backgroundColor: "template.light" }}
+        role="img"
         aria-label="Source template"
         data-testid="badge-source-template"
       >
@@ -79,10 +80,11 @@ export const Badge: React.FC<BadgeProps> = (props) => {
       <Root
         size={size}
         sx={{ backgroundColor: backgroundColour }}
+        role="img"
         aria-label={team.name}
         data-testid="badge-team-logo"
       >
-        <Logo src={team.theme.logo} alt={`${team.name} logo`} />
+        <Logo src={team.theme.logo} alt="" />
       </Root>
     );
   }
@@ -93,6 +95,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     <Root
       size={size}
       sx={{ backgroundColor: backgroundColour }}
+      role="img"
       aria-label={team.name}
       data-testid="badge-team-initial"
     >

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
@@ -1,0 +1,44 @@
+import type React from "react";
+
+export const BadgeVariant = {
+  SourceTemplate: "sourceTemplate",
+  Team: "team",
+  Custom: "custom",
+} as const;
+
+type ObjectValues<T> = T[keyof T];
+
+export type BadgeVariant = ObjectValues<typeof BadgeVariant>;
+
+export type BadgeSize = "default" | "compact";
+
+interface BadgeTeam {
+  name: string;
+  theme: {
+    primaryColour?: string | null;
+    logo?: string | null;
+  };
+}
+
+interface BadgeBaseProps {
+  size?: BadgeSize;
+}
+
+interface SourceTemplateBadgeProps extends BadgeBaseProps {
+  variant: typeof BadgeVariant.SourceTemplate;
+}
+
+interface TeamBadgeProps extends BadgeBaseProps {
+  variant: typeof BadgeVariant.Team;
+  team: BadgeTeam;
+}
+
+interface CustomBadgeProps extends BadgeBaseProps {
+  variant: typeof BadgeVariant.Custom;
+  icon: React.ReactNode;
+  backgroundColour: string;
+  iconColour: string;
+}
+
+export type BadgeProps =
+  SourceTemplateBadgeProps | TeamBadgeProps | CustomBadgeProps;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/NotificationCard.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Notifications/NotificationCard.tsx
@@ -97,7 +97,7 @@ const NotificationCardItem = ({
           }}
         >
           <TemplateChip>
-            <StarIcon sx={{ color: "#380F77", fontSize: "1rem" }} />
+            <StarIcon sx={{ color: "template.icon", fontSize: "1rem" }} />
             <Typography
               variant="body3"
               sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/CheckForChangesButton.tsx
@@ -114,7 +114,10 @@ export const CheckForChangesToPublishButton: React.FC<{
               alignItems: "flex-start",
             }}
           >
-            <StarIcon sx={{ color: "#380F77", mr: 0.5 }} fontSize="small" />
+            <StarIcon
+              sx={{ color: "template.icon", mr: 0.5 }}
+              fontSize="small"
+            />
             <Box>
               <Typography variant="body2">
                 {`Templated from ${template.team.name}`}

--- a/apps/editor.planx.uk/src/pages/Flows/components/FlowTemplateIndicator.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/FlowTemplateIndicator.tsx
@@ -24,7 +24,7 @@ export const FlowTemplateIndicator: React.FC<Props> = ({
       {isTemplatedFlow && (
         <StarIcon
           data-testid="templated-flow-star"
-          sx={{ color: "#380F77", fontSize: "1rem" }}
+          sx={{ color: "template.icon", fontSize: "1rem" }}
         />
       )}
       <Typography variant="body3" sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -102,6 +102,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     main: "#E6D6FF",
     light: "#EDE2FF",
     dark: "#C099FF",
+    icon: "#380F77",
   },
   tonalOffset: DEFAULT_TONAL_OFFSET,
   contrastThreshold: DEFAULT_CONTRAST_THRESHOLD,

--- a/apps/editor.planx.uk/src/themeOverrides.d.ts
+++ b/apps/editor.planx.uk/src/themeOverrides.d.ts
@@ -47,6 +47,7 @@ declare module "@mui/material/styles" {
       main: string;
       light: string;
       dark: string;
+      icon: string;
     };
   }
 
@@ -76,6 +77,7 @@ declare module "@mui/material/styles" {
       main: string;
       light: string;
       dark: string;
+      icon: string;
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

Introduces UI only `Badge` that will be used for search results and the explore page.

Badge can have the following states:
- Source template (styled with template lilac background + star icon)
- Council without logo (uses first initial of council name)
- Council with logo
- Custom (accepts an icon, background colour and icon colour)

<img width="388" height="243" alt="image" src="https://github.com/user-attachments/assets/a5f95d4b-3a81-4248-abec-6151e3aae6c1" />

**Testing:**
https://storybook.6987.planx.pizza/?path=/docs/editor-components-explore-badge--docs