### PR TITLE
fix: ensure Submissions log always displays an address

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1783614492150_update_submission_services_log_address/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1783614492150_update_submission_services_log_address/down.sql
@@ -1,0 +1,80 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%?notify=false%'::text) THEN 'Upload to AWS S3 (no notification)'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE ((seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone) AND (((se.webhook_conf)::text ~~ '%bops%'::text) OR ((se.webhook_conf)::text ~~ '%uniform%'::text) OR ((se.webhook_conf)::text ~~ '%email-submission%'::text) OR ((se.webhook_conf)::text ~~ '%?notify=false%'::text) OR ((se.webhook_conf)::text ~~ '%upload-submission%'::text) OR ((se.webhook_conf)::text ~~ '%idox%'::text)))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name,
+    ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text) AS address
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1783614492150_update_submission_services_log_address/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1783614492150_update_submission_services_log_address/up.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%?notify=false%'::text) THEN 'Upload to AWS S3 (no notification)'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE ((seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone) AND (((se.webhook_conf)::text ~~ '%bops%'::text) OR ((se.webhook_conf)::text ~~ '%uniform%'::text) OR ((se.webhook_conf)::text ~~ '%email-submission%'::text) OR ((se.webhook_conf)::text ~~ '%?notify=false%'::text) OR ((se.webhook_conf)::text ~~ '%upload-submission%'::text) OR ((se.webhook_conf)::text ~~ '%idox%'::text)))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name,
+    coalesce(
+      ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), 
+      ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)
+   )  AS address
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;


### PR DESCRIPTION
Submissions logs currently have a number of blank "address" column values. If you check payloads, these are always for cases where the site address is _proposed_, rather than an existing OS site address. 

According to our address types, _all_ addresses have a `"title"`, but only existing OS addresses have a `"single_line_address"`. This updates the query to use `coalesce()` and always fallback to title ! 

See https://trello.com/c/LxU8rBR9/3664-handle-propose-a-new-address-journeys-in-submissions-table-and-on-overviewhtml