### PR TITLE
chore: Update Lambeth custom domain state

### DIFF
--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -18,7 +18,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "lambeth",
           domain: "planningservices.lambeth.gov.uk",
-          cloudFrontState: "legacy-with-validation",
+          cloudFrontState: "cutover-ongoing",
           certificateLocation: "pulumiConfig",
         },
         {


### PR DESCRIPTION
Step B3 here - https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md#appendix-b-cloudfront-routing

Lambeth IT have confirmed they've "submitted the DNS request to our provider and waiting for confirmation once change is in place". 

~~Currently this is still showing as "Pending validation" on AWS Production so this PR is just draft until this point. I've also verified via `dig {validateRecord} CNAME +short` which returns no response.~~

Update - now showing as "Success" and the above `dig` command is returning the expected result ✅ 