### PR TITLE
feat: Exclude system teams from dashboard

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -140,7 +140,7 @@ function EditorNavMenu() {
     () => [
       {
         routes: [
-          ...(team && !isSystemTeam(team.name)
+          ...(teamSlug && !isSystemTeam(teamSlug)
             ? [
                 {
                   title: "Dashboard",
@@ -260,7 +260,7 @@ function EditorNavMenu() {
         ],
       },
     ],
-    [teamSlug, lpsBaseUrl, referenceCode, teamAnalyticsLink, team],
+    [teamSlug, lpsBaseUrl, referenceCode, teamAnalyticsLink],
   );
 
   const flowLayoutSections: MenuSection[] = useMemo(

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -26,6 +26,7 @@ import AccountMenu from "components/AccountMenu";
 import { useFlowAnalyticsLink } from "hooks/analyticsLinks/useFlowAnalyticsLink";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
 import { AVAILABLE_FEATURE_FLAGS, hasFeatureFlag } from "lib/featureFlags";
+import { isSystemTeam } from "lib/systemTeams";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useMemo, useRef, useState } from "react";
 import EditorIcon from "ui/icons/Editor";
@@ -139,12 +140,16 @@ function EditorNavMenu() {
     () => [
       {
         routes: [
-          {
-            title: "Dashboard",
-            Icon: DashboardIcon,
-            route: `/app/${teamSlug}/dashboard`,
-            accessibleBy: "*" as const,
-          },
+          ...(team && !isSystemTeam(team.name)
+            ? [
+                {
+                  title: "Dashboard",
+                  Icon: DashboardIcon,
+                  route: `/app/${teamSlug}/dashboard`,
+                  accessibleBy: "*" as const,
+                },
+              ]
+            : []),
           {
             title: "Flows",
             Icon: EditorIcon,
@@ -255,7 +260,7 @@ function EditorNavMenu() {
         ],
       },
     ],
-    [teamSlug, lpsBaseUrl, referenceCode, teamAnalyticsLink],
+    [teamSlug, lpsBaseUrl, referenceCode, teamAnalyticsLink, team],
   );
 
   const flowLayoutSections: MenuSection[] = useMemo(

--- a/apps/editor.planx.uk/src/lib/systemTeams.ts
+++ b/apps/editor.planx.uk/src/lib/systemTeams.ts
@@ -1,0 +1,13 @@
+/**
+ * Internal PlanX teams (not LPAs/councils) which should not start on
+ * (or be shown) the team Dashboard - they start on the flows page instead.
+ */
+export const SYSTEM_TEAMS = [
+  "Open Systems Lab",
+  "Testing",
+  "PlanX Academy",
+  "Templates",
+];
+
+export const isSystemTeam = (teamName: string): boolean =>
+  SYSTEM_TEAMS.includes(teamName);

--- a/apps/editor.planx.uk/src/lib/systemTeams.ts
+++ b/apps/editor.planx.uk/src/lib/systemTeams.ts
@@ -1,13 +1,15 @@
 /**
  * Internal PlanX teams (not LPAs/councils) which should not start on
  * (or be shown) the team Dashboard - they start on the flows page instead.
+ * Matched by slug rather than name, since team names can contain special
+ * characters (e.g. "Plan✕ Academy" uses a multiplication-sign glyph, not "X").
  */
 export const SYSTEM_TEAMS = [
-  "Open Systems Lab",
-  "Testing",
-  "PlanX Academy",
-  "Templates",
+  "opensystemslab",
+  "testing",
+  "planx-academy",
+  "templates",
 ];
 
-export const isSystemTeam = (teamName: string): boolean =>
-  SYSTEM_TEAMS.includes(teamName);
+export const isSystemTeam = (teamSlug: string): boolean =>
+  SYSTEM_TEAMS.includes(teamSlug);

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
@@ -1,6 +1,12 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { isSystemTeam } from "lib/systemTeams";
 import Dashboard from "pages/Dashboard";
 
 export const Route = createFileRoute("/_authenticated/app/$team/dashboard")({
+  beforeLoad: ({ params, context }) => {
+    if (isSystemTeam(context.team.name)) {
+      throw redirect({ to: "/app/$team/flows", params: { team: params.team } });
+    }
+  },
   component: Dashboard,
 });

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/dashboard.tsx
@@ -4,7 +4,7 @@ import Dashboard from "pages/Dashboard";
 
 export const Route = createFileRoute("/_authenticated/app/$team/dashboard")({
   beforeLoad: ({ params, context }) => {
-    if (isSystemTeam(context.team.name)) {
+    if (isSystemTeam(context.team.slug)) {
       throw redirect({ to: "/app/$team/flows", params: { team: params.team } });
     }
   },

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { isSystemTeam } from "lib/systemTeams";
 
 export const Route = createFileRoute("/_authenticated/app/$team/")({
-  beforeLoad: ({ params }) => {
+  beforeLoad: ({ params, context }) => {
     throw redirect({
-      to: "/app/$team/dashboard",
+      to: isSystemTeam(context.team.name)
+        ? "/app/$team/flows"
+        : "/app/$team/dashboard",
       params: { team: params.team },
     });
   },

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/index.tsx
@@ -4,7 +4,7 @@ import { isSystemTeam } from "lib/systemTeams";
 export const Route = createFileRoute("/_authenticated/app/$team/")({
   beforeLoad: ({ params, context }) => {
     throw redirect({
-      to: isSystemTeam(context.team.name)
+      to: isSystemTeam(context.team.slug)
         ? "/app/$team/flows"
         : "/app/$team/dashboard",
       params: { team: params.team },


### PR DESCRIPTION
## What does this PR do?

As [discussed in Slack](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1783509114465439?thread_ts=1783507676.099849&cid=C01E3AC0C03), for some admin/system teams we don't need a dashboard, and it's better to directly access the flows page.

- Set up allow-list `systemTeams` which exports the helper `isSystemTeam`
- List includes
  - Open Systems Lab
  - Testing
  - PlanX Academy
  - Templates (obsolete team, but included as it still exists)
- Council Onboarding has not been included as it contains live flows