### PR TITLE
feat: Bump TOP_LIMIT in dashboard activity widget

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useActivityData.ts
@@ -45,7 +45,7 @@ export type ActivityItem = {
   count: number;
 };
 
-const TOP_LIMIT = 5;
+const TOP_LIMIT = 50;
 
 export const useActivityData = (): {
   sessions: ActivityItem[];


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Increases dashboard activity row limit from 5 to 50