### PR TITLE
feat: add 'Customise' tab to source templates

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
@@ -5,13 +5,25 @@ import Typography from "@mui/material/Typography";
 import { sortIdsDepthFirst } from "@planx/graph";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useEffect } from "react";
 
 import { CustomisationCard } from "./CustomisationCard";
 import type { FlowEdits } from "./types";
 
 const Customisations = () => {
-  const [flowId, flow] = useStore((state) => [state.id, state.flow]);
+  const [flowId, flow, isTemplatedFrom, isTemplate, setOrderedFlow] = useStore(
+    (state) => [
+      state.id,
+      state.flow,
+      state.isTemplatedFrom,
+      state.isTemplate,
+      state.setOrderedFlow,
+    ],
+  );
+
+  useEffect(() => {
+    if (flow) setOrderedFlow();
+  }, [flow, setOrderedFlow]);
 
   // Get the nodes within this flow that are customisable and sort them top-down to match graph
   const customisableNodeIds = new Set(
@@ -37,6 +49,7 @@ const Customisations = () => {
       variables: {
         flow_id: flowId,
       },
+      skip: !isTemplatedFrom,
     },
   );
 
@@ -60,12 +73,24 @@ const Customisations = () => {
 
   return (
     <Box sx={{ p: 2, backgroundColor: "background.paper", minHeight: "100%" }}>
-      <Typography variant="h4" sx={{ mb: 1 }}>
-        {`Customise`}
-      </Typography>
-      <Typography variant="body2">
-        {`When editing a templated flow, this tab tracks your progress updating nodes that can be customised`}
-      </Typography>
+      {isTemplatedFrom && (
+        <>
+          <Typography variant="h4" sx={{ mb: 1 }}>
+            Customise
+          </Typography>
+          <Typography variant="body2">
+            When editing a templated flow, this tab tracks your progress
+            updating nodes that can be customised
+          </Typography>
+        </>
+      )}
+      {isTemplate && (
+        <>
+          <Typography variant="h4" sx={{ mb: 1 }}>
+            Nodes set to 'Allow edits'
+          </Typography>
+        </>
+      )}
       <List sx={{ mt: 1 }}>
         {sortedCustomisableNodeIds.map((nodeId) => (
           <CustomisationCard

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/index.tsx
@@ -99,13 +99,17 @@ const TabList = styled(Box)(({ theme }) => ({
 }));
 
 const Sidebar: React.FC = React.memo(() => {
-  const [toggleSidebar, showSidebar, isTemplatedFrom] = useStore((state) => [
-    state.toggleSidebar,
-    state.showSidebar,
-    state.isTemplatedFrom,
-  ]);
+  const [toggleSidebar, showSidebar, isTemplatedFrom, isTemplate] = useStore(
+    (state) => [
+      state.toggleSidebar,
+      state.showSidebar,
+      state.isTemplatedFrom,
+      state.isTemplate,
+    ],
+  );
 
-  const defaultActiveTab = isTemplatedFrom ? "Customise" : "PreviewBrowser";
+  const defaultActiveTab =
+    isTemplatedFrom || isTemplate ? "Customise" : "PreviewBrowser";
   const [activeTab, setActiveTab] = useState<SidebarTabs>(defaultActiveTab);
   const { team } = useParams({ from: "/_authenticated/app/$team/$flow" });
   const { rootFlow } = useRouteContext({
@@ -149,10 +153,12 @@ const Sidebar: React.FC = React.memo(() => {
 
           <TabList>
             <Tabs onChange={handleChange} value={activeTab} aria-label="">
-              {isTemplatedFrom && (
+              {(isTemplatedFrom || isTemplate) && (
                 <StyledTab value="Customise" label="Customise" />
               )}
-              <StyledTab value="PreviewBrowser" label="Preview" />
+              {!isTemplate && (
+                <StyledTab value="PreviewBrowser" label="Preview" />
+              )}
               <StyledTab value="History" label="History" />
               <StyledTab value="Search" label="Search" />
               {!isTemplatedFrom && (

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -232,7 +232,9 @@ test.describe("Templates", () => {
       );
 
       await navigateToService(page, SOURCE_TEMPLATE_SLUG);
-      await expect(page.getByText(TEMPLATED_FOLDER_NAME)).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: TEMPLATED_FOLDER_NAME }),
+      ).toBeVisible();
     });
 
     test("can publish the source template", async ({ browser }) => {


### PR DESCRIPTION
This PR adds a 'Customise' tab to the side bar of source templates.

Removes the 'Preview' tab from Source Templates, principally to space the new tab and given current inability to actually test source templates directly. Potentially to be re-introduced following future 'source template testing' feature suite.