### PR TITLE
feat: notes frontend

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -1,0 +1,87 @@
+import { gql, useSubscription } from "@apollo/client";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+export const DEFAULT_NOTE_COLOR = "#fffdb0";
+
+export interface NotePlacement {
+  parent: string;
+  before?: string;
+}
+
+export interface FlowNote {
+  id: string;
+  flowId: string;
+  nodeId: string | null;
+  placement: NotePlacement | null;
+  text: string;
+  color: string;
+  createdBy: number;
+  updatedBy: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const GET_FLOW_NOTES = gql`
+  subscription GetFlowNotes($flowId: uuid!) {
+    flow_notes(where: { flow_id: { _eq: $flowId } }) {
+      id
+      flow_id
+      node_id
+      placement
+      text
+      color
+      created_by
+      updated_by
+      created_at
+      updated_at
+    }
+  }
+`;
+
+interface FlowNoteRow {
+  id: string;
+  flow_id: string;
+  node_id: string | null;
+  placement: NotePlacement | null;
+  text: string;
+  color: string;
+  created_by: number;
+  updated_by: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface QueryResult {
+  flow_notes: FlowNoteRow[];
+}
+
+const toFlowNote = (row: FlowNoteRow): FlowNote => ({
+  id: row.id,
+  flowId: row.flow_id,
+  nodeId: row.node_id,
+  placement: row.placement,
+  text: row.text,
+  color: row.color,
+  createdBy: row.created_by,
+  updatedBy: row.updated_by,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+interface UseFlowNotesResult {
+  notes: FlowNote[];
+  loading: boolean;
+}
+
+export const useFlowNotes = (): UseFlowNotesResult => {
+  const flowId = useStore((state) => state.id);
+
+  const { data, loading } = useSubscription<QueryResult>(GET_FLOW_NOTES, {
+    variables: { flowId },
+    skip: !flowId,
+  });
+
+  const notes = (data?.flow_notes ?? []).map(toFlowNote);
+
+  return { notes, loading };
+};

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -6,6 +6,8 @@ export const DEFAULT_NOTE_COLOR = "#fffdb0";
 export interface NotePlacement {
   parent: string;
   before?: string;
+  /** True when `parent` is the container to insert into (leading/first-child slot), not a preceding sibling to anchor after */
+  parentIsContainer?: boolean;
 }
 
 export interface FlowNote {

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -6,8 +6,10 @@ export const DEFAULT_NOTE_COLOR = "#fffdb0";
 export interface NotePlacement {
   parent: string;
   before?: string;
-  /** True when `parent` is the container to insert into (leading/first-child slot), not a preceding sibling to anchor after */
+  /** True when `parent` is the container to insert into (leading/first-child slot) */
   parentIsContainer?: boolean;
+  /** The container `parent` was resolved against at creation time - disambiguates `parent` when it's a cloned node referenced from multiple containers */
+  container?: string;
 }
 
 export interface FlowNote {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -16,6 +16,7 @@ import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
+import { AttachedNotes } from "../notes/AttachedNotes";
 import { DataField } from "./DataField";
 import Hanger from "./Hanger";
 import Node from "./Node";
@@ -155,6 +156,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
+          <AttachedNotes nodeId={props.id} />
         </TemplatedNodeContainer>
         {groupedOptions ? (
           <ol className="categories">

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import ContentCutIcon from "@mui/icons-material/ContentCut";
 import ContentPaste from "@mui/icons-material/ContentPaste";
 import HelpTextIcon from "@mui/icons-material/Help";
+import StickyNote2Icon from "@mui/icons-material/StickyNote2";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Menu from "@mui/material/Menu";
@@ -17,6 +18,8 @@ import {
 import * as React from "react";
 import CloneIcon from "ui/icons/Clone";
 import CopyIcon from "ui/icons/Copy";
+
+import { resolveNotePlacement } from "../notes/lib/notePlacement";
 
 export type ContextMenuSource = "node" | "hanger" | null;
 
@@ -56,6 +59,7 @@ export const ContextMenu: React.FC = () => {
     copyHelpText,
     getCopiedHelpText,
     pasteHelpText,
+    openNoteEditor,
   ] = useStore((state) => [
     state.contextMenuSource,
     state.contextMenuPosition,
@@ -78,6 +82,7 @@ export const ContextMenu: React.FC = () => {
     state.copyHelpText,
     state.getCopiedHelpText(),
     state.pasteHelpText,
+    state.openNoteEditor,
   ]);
 
   const handleCopy = () => {
@@ -123,6 +128,24 @@ export const ContextMenu: React.FC = () => {
   const handlePasteHelp = () => {
     if (!self) return;
     pasteHelpText(self);
+    closeMenu();
+  };
+
+  const handleAttachNote = () => {
+    if (!self)
+      return alert(
+        "Unable to attach note, missing value for relationship 'self' (nodeId)",
+      );
+
+    openNoteEditor({ mode: "create", nodeId: self });
+    closeMenu();
+  };
+
+  const handleAddNote = () => {
+    openNoteEditor({
+      mode: "create",
+      placement: resolveNotePlacement(flow, parent, before),
+    });
     closeMenu();
   };
 
@@ -237,11 +260,26 @@ export const ContextMenu: React.FC = () => {
         });
       }
 
+      actions.push({
+        id: "attach-note",
+        label: "Attach note",
+        icon: <StickyNote2Icon fontSize="small" />,
+        disabled: false,
+        onClick: handleAttachNote,
+      });
+
       return actions;
     }
 
     if (source === "hanger") {
       return [
+        {
+          id: "add-note",
+          label: "Add note",
+          icon: <StickyNote2Icon fontSize="small" />,
+          disabled: false,
+          onClick: handleAddNote,
+        },
         {
           id: "paste",
           label: "Paste",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
@@ -214,6 +214,13 @@ export const ContextMenu: React.FC = () => {
 
       const actions: ContextMenuAction[] = [
         {
+          id: "attach-note",
+          label: "Add note",
+          icon: <StickyNote2Icon fontSize="small" />,
+          disabled: false,
+          onClick: handleAttachNote,
+        },
+        {
           id: "copy",
           label: "Copy",
           icon: <CopyIcon fontSize="small" />,
@@ -259,14 +266,6 @@ export const ContextMenu: React.FC = () => {
           onClick: handlePasteHelp,
         });
       }
-
-      actions.push({
-        id: "attach-note",
-        label: "Attach note",
-        icon: <StickyNote2Icon fontSize="small" />,
-        disabled: false,
-        onClick: handleAttachNote,
-      });
 
       return actions;
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
@@ -9,6 +9,7 @@ import { useDrag } from "react-dnd";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
+import { AttachedNotes } from "../notes/AttachedNotes";
 import Hanger from "./Hanger";
 import Node from "./Node";
 
@@ -82,6 +83,7 @@ const Filter: React.FC<Props> = React.memo((props) => {
           {Icon && <Icon />}
           <span>{props.text}</span>
         </Link>
+        <AttachedNotes nodeId={props.id} />
         <ol className="options">
           {childNodes.map((child) => (
             <Node

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, screen } from "@testing-library/react";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { setup } from "test/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FlowNotesContext } from "../notes/FlowNotesContext";
+import { placementKey } from "../notes/lib/partitionNotes";
+import Hanger from "./Hanger";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual("@tanstack/react-router");
+  return {
+    ...actual,
+    useParams: () => ({ team: "test-team", flow: "test-flow" }),
+  };
+});
+
+const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => ({
+  id: "note-1",
+  flowId: "flow-1",
+  nodeId: null,
+  placement: { parent: "root" },
+  text: "A positioned note",
+  color: "#fffdb0",
+  createdBy: 1,
+  updatedBy: 1,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const renderHanger = (
+  props: React.ComponentProps<typeof Hanger>,
+  positioned: Map<string, FlowNote[]> = new Map(),
+) =>
+  setup(
+    <DndProvider backend={HTML5Backend}>
+      <FlowNotesContext.Provider
+        value={{ attached: new Map(), positioned, loading: false }}
+      >
+        <ol>
+          <Hanger {...props} />
+        </ol>
+      </FlowNotesContext.Provider>
+    </DndProvider>,
+  );
+
+beforeEach(() => {
+  useStore.setState({
+    flow: {},
+    orderedFlow: undefined,
+    isTemplatedFrom: false,
+    showNotes: true,
+    user: {
+      id: 1,
+      isPlatformAdmin: true,
+      isAnalyst: false,
+      teams: [],
+      firstName: "Test",
+      lastName: "User",
+      email: "test@example.com",
+      defaultTeamId: null,
+    } as any,
+    componentSelectorOpen: false,
+    componentSelectorParent: undefined,
+    componentSelectorBefore: undefined,
+    contextMenuSource: null,
+    contextMenuPosition: null,
+  });
+});
+
+describe("positioned notes", () => {
+  it("renders a note-card for each note at this hanger's coordinate", async () => {
+    const positioned = new Map([
+      [placementKey("root", "node-a"), [makeNote({ text: "First" })]],
+    ]);
+
+    await renderHanger({ parent: "root", before: "node-a" }, positioned);
+
+    expect(screen.getByText("First")).toBeInTheDocument();
+  });
+
+  it("does not render notes belonging to a different coordinate", async () => {
+    const positioned = new Map([
+      [placementKey("root", "node-b"), [makeNote({ text: "Elsewhere" })]],
+    ]);
+
+    await renderHanger({ parent: "root", before: "node-a" }, positioned);
+
+    expect(screen.queryByText("Elsewhere")).not.toBeInTheDocument();
+  });
+
+  it("hides positioned notes when showNotes is false", async () => {
+    useStore.setState({ showNotes: false });
+    const positioned = new Map([
+      [placementKey("root", "node-a"), [makeNote({ text: "Hidden note" })]],
+    ]);
+
+    await renderHanger({ parent: "root", before: "node-a" }, positioned);
+
+    expect(screen.queryByText("Hidden note")).not.toBeInTheDocument();
+  });
+
+  it("renders a decorative connector line separating the note from the preceding node", async () => {
+    const positioned = new Map([
+      [placementKey("root", "node-a"), [makeNote({ text: "First" })]],
+    ]);
+
+    const { container } = await renderHanger(
+      { parent: "root", before: "node-a" },
+      positioned,
+    );
+
+    expect(container.querySelector("li.note-connector")).toBeInTheDocument();
+  });
+
+  it("does not render a connector line when there are no notes to show", async () => {
+    const { container } = await renderHanger({
+      parent: "root",
+      before: "node-a",
+    });
+
+    expect(
+      container.querySelector("li.note-connector"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("hanger interactions", () => {
+  it("opens the component selector on click, unchanged", async () => {
+    await renderHanger({ parent: "root", before: "node-a" });
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(useStore.getState().componentSelectorOpen).toBe(true);
+  });
+
+  it("sets the context menu source to hanger on right-click", async () => {
+    await renderHanger({ parent: "root", before: "node-a" });
+
+    fireEvent.contextMenu(screen.getByRole("button"));
+
+    expect(useStore.getState().contextMenuSource).toBe("hanger");
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
@@ -100,8 +100,8 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
 
   return (
     <>
-      {/* decoartive only - connector between parent node and note*/}
       {showNoteCards && (
+        /* decoartive only - connector between parent node and note*/
         <li className="hanger note-connector" aria-hidden="true" />
       )}
       {showNoteCards &&

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
@@ -12,6 +12,9 @@ import { useDrop } from "react-dnd";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
+import { useFlowNotesContext } from "../notes/FlowNotesContext";
+import { placementKey } from "../notes/lib/partitionNotes";
+import { PositionedNoteCard } from "../notes/PositionedNoteCard";
 
 interface HangerProps {
   hidden?: boolean;
@@ -31,12 +34,18 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
     from: "/_authenticated/app/$team/$flow",
   });
 
-  const [moveNode, isTemplatedFrom, flow, orderedFlow] = useStore((state) => [
-    state.moveNode,
-    state.isTemplatedFrom,
-    state.flow,
-    state.orderedFlow,
-  ]);
+  const [moveNode, isTemplatedFrom, flow, orderedFlow, showNotes] = useStore(
+    (state) => [
+      state.moveNode,
+      state.isTemplatedFrom,
+      state.flow,
+      state.orderedFlow,
+      state.showNotes,
+    ],
+  );
+
+  const { positioned } = useFlowNotesContext();
+  const notes = positioned.get(placementKey(parent, before)) ?? [];
 
   // When working in a templated flow, if any internal portal is marked as "isTemplatedNode", then the Hanger should be visible to add children
   const indexedParent = orderedFlow?.find(({ id }) => id === parent);
@@ -87,20 +96,32 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
     [parent, before],
   );
 
+  const showNoteCards = showNotes && notes.length > 0;
+
   return (
-    <li
-      className={classnames("hanger", { hidden: hidden || hideHangerFromUser })}
-      ref={(el) => {
-        drop(el);
-      }}
-    >
-      <button
-        onContextMenu={handleContextMenu}
-        onClick={handleHangerButtonClick}
+    <>
+      {/* decoartive only - connector between parent node and note*/}
+      {showNoteCards && (
+        <li className="hanger note-connector" aria-hidden="true" />
+      )}
+      {showNoteCards &&
+        notes.map((note) => <PositionedNoteCard key={note.id} note={note} />)}
+      <li
+        className={classnames("hanger", {
+          hidden: hidden || hideHangerFromUser,
+        })}
+        ref={(el) => {
+          drop(el);
+        }}
       >
-        {canDrop && item && item.text}
-      </button>
-    </li>
+        <button
+          onContextMenu={handleContextMenu}
+          onClick={handleHangerButtonClick}
+        >
+          {canDrop && item && item.text}
+        </button>
+      </li>
+    </>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -6,6 +6,7 @@ import classNames from "classnames";
 import React from "react";
 
 import { useStore } from "../../../lib/store";
+import { AttachedNotes } from "../notes/AttachedNotes";
 import { DataField } from "./DataField";
 import { FlagBand, NoFlagBand } from "./FlagBand";
 import Hanger from "./Hanger";
@@ -68,6 +69,7 @@ const Option: React.FC<any> = (props) => {
           <DataField value={props.data.val} variant="child" />
         )}
       </Link>
+      <AttachedNotes nodeId={props.id} />
       <ol className="decisions">
         {childNodes.map((child) => (
           <Node

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -3,9 +3,11 @@ import { flatFlags } from "@opensystemslab/planx-core/types";
 import { Link } from "@tanstack/react-router";
 import { useParams } from "@tanstack/react-router";
 import classNames from "classnames";
+import { useContextMenu } from "hooks/useContextMenu";
 import React from "react";
 
 import { useStore } from "../../../lib/store";
+import { getParentId } from "../lib/utils";
 import { AttachedNotes } from "../notes/AttachedNotes";
 import { DataField } from "./DataField";
 import { FlagBand, NoFlagBand } from "./FlagBand";
@@ -16,6 +18,17 @@ import { Thumbnail } from "./Thumbnail";
 const Option: React.FC<any> = (props) => {
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
   const childNodes = useStore((state) => state.childNodesOf(props.id));
+
+  const parent = getParentId(props.parent);
+
+  const handleContextMenu = useContextMenu({
+    source: "node",
+    relationships: {
+      parent,
+      before: props.id,
+      self: props.id,
+    },
+  });
 
   let flags: Flag[] | undefined;
 
@@ -39,7 +52,6 @@ const Option: React.FC<any> = (props) => {
   return (
     <li
       className={classNames("card", "option", { wasVisited: props.wasVisited })}
-      onContextMenu={(e) => e.preventDefault()}
     >
       <Link
         to="/app/$team/$flow/nodes/$id/edit"
@@ -50,6 +62,7 @@ const Option: React.FC<any> = (props) => {
         }}
         hash={props.id}
         preload={false}
+        onContextMenu={handleContextMenu}
       >
         {props.data?.img && (
           <Thumbnail

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -16,6 +16,7 @@ import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 import EditorIcon from "ui/icons/Editor";
 
 import { getParentId } from "../lib/utils";
+import { AttachedNotes } from "../notes/AttachedNotes";
 import Hanger from "./Hanger";
 import Question from "./Question";
 import { Tag } from "./Tag";
@@ -171,6 +172,7 @@ const ExternalPortal: React.FC<any> = (props) => {
               ))}
             </Box>
           )}
+          <AttachedNotes nodeId={props.id} />
         </Box>
       </li>
     </>
@@ -270,6 +272,7 @@ const InternalPortal: React.FC<any> = (props) => {
                 ))}
               </Box>
             )}
+            <AttachedNotes nodeId={props.id} />
           </TemplatedNodeContainer>
         </Box>
       </li>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -13,6 +13,7 @@ import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
+import { AttachedNotes } from "../notes/AttachedNotes";
 import { DataField } from "./DataField";
 import Hanger from "./Hanger";
 import Node from "./Node";
@@ -131,6 +132,7 @@ const Question: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
+          <AttachedNotes nodeId={props.id} />
         </TemplatedNodeContainer>
         <ol className="options">
           {childNodes.map((child: any) => (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/index.tsx
@@ -9,6 +9,7 @@ import EndPoint from "./components/EndPoint";
 import Hanger from "./components/Hanger";
 import Node from "./components/Node";
 import { GetStarted } from "./GetStarted";
+import { FlowNotesProvider } from "./notes/FlowNotesContext";
 
 export enum FlowLayout {
   TOP_DOWN = "top-down",
@@ -44,7 +45,7 @@ const Flow: React.FC<Props> = ({ lockedFlow, showTemplatedNodeStatus }) => {
   const flowName = useStore((state) => state.flowName);
 
   return (
-    <>
+    <FlowNotesProvider>
       <ol
         id="flow"
         data-layout={flowLayout}
@@ -115,7 +116,7 @@ const Flow: React.FC<Props> = ({ lockedFlow, showTemplatedNodeStatus }) => {
         <EndPoint text="end" />
       </ol>
       <ContextMenu />
-    </>
+    </FlowNotesProvider>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/AttachedNotes.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/AttachedNotes.test.tsx
@@ -1,0 +1,84 @@
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { setup } from "test/utils";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AttachedNotes } from "./AttachedNotes";
+import { FlowNotesContext } from "./FlowNotesContext";
+
+const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => ({
+  id: "note-1",
+  flowId: "flow-1",
+  nodeId: "node-a",
+  placement: null,
+  text: "Remember to check this",
+  color: "#fffdb0",
+  createdBy: 1,
+  updatedBy: 1,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const renderWithNotes = async (
+  nodeId: string,
+  attached: Map<string, FlowNote[]>,
+) =>
+  setup(
+    <FlowNotesContext.Provider
+      value={{ attached, positioned: new Map(), loading: false }}
+    >
+      <AttachedNotes nodeId={nodeId} />
+    </FlowNotesContext.Provider>,
+  );
+
+beforeEach(() => {
+  useStore.setState({ showNotes: true });
+});
+
+describe("AttachedNotes", () => {
+  it("renders the note text directly, for a node with an attached note", async () => {
+    const attached = new Map([
+      ["node-a", [makeNote({ text: "Remember to check this" })]],
+    ]);
+
+    const { getByText } = await renderWithNotes("node-a", attached);
+
+    expect(getByText("Remember to check this")).toBeInTheDocument();
+  });
+
+  it("renders nothing for a node with no attached notes", async () => {
+    const attached = new Map([["node-a", [makeNote()]]]);
+
+    const { queryByText } = await renderWithNotes("node-b", attached);
+
+    expect(queryByText("Remember to check this")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when showNotes is false", async () => {
+    useStore.setState({ showNotes: false });
+    const attached = new Map([["node-a", [makeNote()]]]);
+
+    const { queryByText } = await renderWithNotes("node-a", attached);
+
+    expect(queryByText("Remember to check this")).not.toBeInTheDocument();
+  });
+
+  it("renders a row for each attached note when there are several", async () => {
+    const attached = new Map([
+      [
+        "node-a",
+        [
+          makeNote({ id: "note-1", text: "First note" }),
+          makeNote({ id: "note-2", text: "Second note" }),
+        ],
+      ],
+    ]);
+
+    const { getByText } = await renderWithNotes("node-a", attached);
+
+    expect(getByText("First note")).toBeInTheDocument();
+    expect(getByText("Second note")).toBeInTheDocument();
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/AttachedNotes.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/AttachedNotes.tsx
@@ -1,0 +1,39 @@
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+import { useFlowNotesContext } from "./FlowNotesContext";
+
+interface Props {
+  nodeId: string;
+}
+
+export const AttachedNotes: React.FC<Props> = ({ nodeId }) => {
+  const { attached } = useFlowNotesContext();
+  const [showNotes, openNoteEditor] = useStore((state) => [
+    state.showNotes,
+    state.openNoteEditor,
+  ]);
+  const notes = attached.get(nodeId) ?? [];
+
+  if (!showNotes || notes.length === 0) return null;
+
+  return (
+    <>
+      {notes.map((note: FlowNote) => (
+        <button
+          key={note.id}
+          type="button"
+          className="attached-note"
+          style={{ background: note.color }}
+          onClick={(event) => {
+            event.stopPropagation();
+            openNoteEditor({ mode: "edit", note });
+          }}
+        >
+          {note.text || "Untitled note"}
+        </button>
+      ))}
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/FlowNotesContext.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/FlowNotesContext.tsx
@@ -1,0 +1,44 @@
+import { useFlowNotes } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { createContext, useContext, useMemo } from "react";
+
+import type { PartitionedNotes } from "./lib/partitionNotes";
+import { partitionNotes } from "./lib/partitionNotes";
+
+interface FlowNotesContextValue extends PartitionedNotes {
+  loading: boolean;
+}
+
+const emptyContextValue: FlowNotesContextValue = {
+  attached: new Map(),
+  positioned: new Map(),
+  loading: false,
+};
+
+export const FlowNotesContext =
+  createContext<FlowNotesContextValue>(emptyContextValue);
+
+export const useFlowNotesContext = (): FlowNotesContextValue =>
+  useContext(FlowNotesContext);
+
+export const FlowNotesProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { notes, loading } = useFlowNotes();
+  const flow = useStore((state) => state.flow);
+  const { attached, positioned } = useMemo(
+    () => partitionNotes(notes, flow),
+    [notes, flow],
+  );
+
+  const value = useMemo(
+    () => ({ attached, positioned, loading }),
+    [attached, positioned, loading],
+  );
+
+  return (
+    <FlowNotesContext.Provider value={value}>
+      {children}
+    </FlowNotesContext.Provider>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.test.tsx
@@ -1,0 +1,155 @@
+import { screen } from "@testing-library/react";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { setup } from "test/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NoteEditorDialog } from "./NoteEditorDialog";
+
+const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => ({
+  id: "note-1",
+  flowId: "flow-1",
+  nodeId: "node-a",
+  placement: null,
+  text: "Existing note text",
+  color: "#fffdb0",
+  createdBy: 1,
+  updatedBy: 1,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const currentUser = {
+  id: 1,
+  isPlatformAdmin: false,
+  isAnalyst: false,
+  teams: [],
+  firstName: "Test",
+  lastName: "User",
+  email: "test@example.com",
+  defaultTeamId: null,
+} as any;
+
+beforeEach(() => {
+  useStore.setState({
+    user: currentUser,
+    noteEditorOpen: true,
+    noteEditorMode: null,
+    noteEditorNote: undefined,
+    noteEditorNodeId: undefined,
+    noteEditorPlacement: undefined,
+    createFlowNote: vi.fn().mockResolvedValue("new-id"),
+    updateFlowNote: vi.fn().mockResolvedValue(undefined),
+    deleteFlowNote: vi.fn().mockResolvedValue(undefined),
+  });
+});
+
+describe("create mode", () => {
+  it("shows a Create button, not Update", async () => {
+    useStore.setState({ noteEditorMode: "create" });
+
+    await setup(<NoteEditorDialog />);
+
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /update/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls createFlowNote with the node id and entered text on save", async () => {
+    useStore.setState({
+      noteEditorMode: "create",
+      noteEditorNodeId: "node-a",
+    });
+
+    const { user } = await setup(<NoteEditorDialog />);
+
+    await user.type(screen.getByRole("textbox"), "A brand new note");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    expect(useStore.getState().createFlowNote).toHaveBeenCalledWith(
+      expect.objectContaining({ nodeId: "node-a", text: "A brand new note" }),
+    );
+  });
+
+  it("closes the editor after saving", async () => {
+    useStore.setState({
+      noteEditorMode: "create",
+      noteEditorPlacement: { parent: "root", before: "node-a" },
+    });
+
+    const { user } = await setup(<NoteEditorDialog />);
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    expect(useStore.getState().noteEditorOpen).toBe(false);
+  });
+
+  it("has no delete button", async () => {
+    useStore.setState({ noteEditorMode: "create" });
+
+    await setup(<NoteEditorDialog />);
+
+    expect(
+      screen.queryByRole("button", { name: /delete/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("edit mode - own note", () => {
+  it("pre-fills the existing note text", async () => {
+    useStore.setState({ noteEditorMode: "edit", noteEditorNote: makeNote() });
+
+    await setup(<NoteEditorDialog />);
+
+    expect(screen.getByDisplayValue("Existing note text")).toBeInTheDocument();
+  });
+
+  it("calls updateFlowNote with the note id on save", async () => {
+    useStore.setState({ noteEditorMode: "edit", noteEditorNote: makeNote() });
+
+    const { user } = await setup(<NoteEditorDialog />);
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "Updated text");
+    await user.click(screen.getByRole("button", { name: /update/i }));
+
+    expect(useStore.getState().updateFlowNote).toHaveBeenCalledWith(
+      "note-1",
+      expect.objectContaining({ text: "Updated text" }),
+    );
+  });
+
+  it("calls deleteFlowNote and closes the editor when Delete is clicked", async () => {
+    useStore.setState({ noteEditorMode: "edit", noteEditorNote: makeNote() });
+
+    const { user } = await setup(<NoteEditorDialog />);
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(useStore.getState().deleteFlowNote).toHaveBeenCalledWith("note-1");
+    expect(useStore.getState().noteEditorOpen).toBe(false);
+  });
+});
+
+describe("edit mode - another author's note", () => {
+  it("still allows editing and deleting, since notes are shared across the team", async () => {
+    useStore.setState({
+      noteEditorMode: "edit",
+      noteEditorNote: makeNote({ createdBy: 999 }),
+    });
+
+    const { user } = await setup(<NoteEditorDialog />);
+
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /update/i })).toBeEnabled();
+
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "Edited by another user");
+    await user.click(screen.getByRole("button", { name: /update/i }));
+
+    expect(useStore.getState().updateFlowNote).toHaveBeenCalledWith(
+      "note-1",
+      expect.objectContaining({ text: "Edited by another user" }),
+    );
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -1,0 +1,137 @@
+import Close from "@mui/icons-material/CloseOutlined";
+import DeleteIcon from "@mui/icons-material/Delete";
+import StickyNote2Icon from "@mui/icons-material/StickyNote2";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import { DEFAULT_NOTE_COLOR } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import ColorPicker from "ui/editor/ColorPicker/ColorPicker";
+import Input from "ui/shared/Input/Input";
+
+export const NoteEditorDialog: React.FC = () => {
+  const [
+    noteEditorOpen,
+    noteEditorMode,
+    note,
+    nodeId,
+    placement,
+    closeNoteEditor,
+    createFlowNote,
+    updateFlowNote,
+    deleteFlowNote,
+    userId,
+  ] = useStore((state) => [
+    state.noteEditorOpen,
+    state.noteEditorMode,
+    state.noteEditorNote,
+    state.noteEditorNodeId,
+    state.noteEditorPlacement,
+    state.closeNoteEditor,
+    state.createFlowNote,
+    state.updateFlowNote,
+    state.deleteFlowNote,
+    state.user?.id,
+  ]);
+
+  const [text, setText] = useState(note?.text ?? "");
+  const [color, setColor] = useState(note?.color ?? DEFAULT_NOTE_COLOR);
+
+  if (!noteEditorOpen) return null;
+
+  const isEditing = noteEditorMode === "edit";
+
+  const handleSave = async () => {
+    if (isEditing && note) {
+      await updateFlowNote(note.id, { text, color });
+    } else {
+      await createFlowNote({ nodeId, placement, text, color });
+    }
+    closeNoteEditor();
+  };
+
+  const handleDelete = async () => {
+    if (!note) return;
+    await deleteFlowNote(note.id);
+    closeNoteEditor();
+  };
+
+  return (
+    <Dialog open fullWidth onClose={closeNoteEditor}>
+      <DialogTitle
+        sx={{
+          py: 1,
+          px: 2.5,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <StickyNote2Icon sx={{ color: "text.primary", fontSize: "1.6rem" }} />
+          <Typography variant="h3" component="h1">
+            Note
+          </Typography>
+        </Box>
+        <IconButton
+          aria-label="close"
+          onClick={closeNoteEditor}
+          size="large"
+          sx={{ color: "grey.600" }}
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Input
+          multiline
+          rows={5}
+          name="note-text"
+          placeholder="Write a note..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <Box sx={{ mt: 2 }}>
+          <ColorPicker
+            label="Colour"
+            inline
+            color={color}
+            onChange={setColor}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions
+        disableSpacing
+        sx={{ justifyContent: "flex-start", alignItems: "stretch" }}
+      >
+        {isEditing && (
+          <Button
+            color="secondary"
+            variant="contained"
+            onClick={handleDelete}
+            sx={{ backgroundColor: "background.default", gap: 1 }}
+          >
+            <DeleteIcon color="warning" fontSize="medium" />
+            Delete
+          </Button>
+        )}
+        <Box sx={{ marginLeft: "auto" }}>
+          <Button
+            type="button"
+            variant="contained"
+            color="primary"
+            onClick={handleSave}
+          >
+            {isEditing ? "Update" : "Create"}
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -26,7 +26,6 @@ export const NoteEditorDialog: React.FC = () => {
     createFlowNote,
     updateFlowNote,
     deleteFlowNote,
-    userId,
   ] = useStore((state) => [
     state.noteEditorOpen,
     state.noteEditorMode,
@@ -37,7 +36,6 @@ export const NoteEditorDialog: React.FC = () => {
     state.createFlowNote,
     state.updateFlowNote,
     state.deleteFlowNote,
-    state.user?.id,
   ]);
 
   const [text, setText] = useState(note?.text ?? "");

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.tsx
@@ -1,0 +1,23 @@
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+
+interface Props {
+  note: FlowNote;
+}
+
+export const PositionedNoteCard: React.FC<Props> = ({ note }) => {
+  const openNoteEditor = useStore((state) => state.openNoteEditor);
+
+  return (
+    <li className="note-card">
+      <button
+        type="button"
+        style={{ background: note.color }}
+        onClick={() => openNoteEditor({ mode: "edit", note })}
+      >
+        {note.text || "Untitled note"}
+      </button>
+    </li>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   findContainerOf,
+  repositionPlacementAfterDeletion,
   resolveNotePlacement,
   resolveNoteRenderCoordinate,
 } from "./notePlacement";
@@ -99,5 +100,89 @@ describe("resolveNoteRenderCoordinate (decode)", () => {
       );
       expect(resolveNoteRenderCoordinate(linearFlow, placement)).toEqual(gap);
     }
+  });
+});
+
+describe("repositionPlacementAfterDeletion", () => {
+  it("re-anchors to the surviving sibling before the deleted anchor", () => {
+    // nodeB deleted; a note anchored to nodeB (i.e. after nodeB) should
+    // move to being anchored after nodeA instead
+    const after = {
+      _root: { edges: ["nodeA", "nodeC"] },
+      nodeA: linearFlow.nodeA,
+      nodeC: linearFlow.nodeC,
+    };
+
+    expect(
+      repositionPlacementAfterDeletion(
+        linearFlow,
+        after,
+        "nodeB",
+        new Set(["nodeB"]),
+      ),
+    ).toEqual({ parent: "nodeA" });
+  });
+
+  it("walks back past other siblings deleted in the same operation", () => {
+    // nodeA and nodeB both deleted (e.g. a cascade); a note anchored to
+    // nodeB should fall back to leading position in _root
+    const after = { _root: { edges: ["nodeC"] }, nodeC: linearFlow.nodeC };
+
+    expect(
+      repositionPlacementAfterDeletion(
+        linearFlow,
+        after,
+        "nodeB",
+        new Set(["nodeA", "nodeB"]),
+      ),
+    ).toEqual({ parent: "_root", before: "nodeC" });
+  });
+
+  it("falls back to leading-in-container when the deleted anchor had no preceding sibling", () => {
+    const after = {
+      _root: { edges: ["nodeB", "nodeC"] },
+      nodeB: linearFlow.nodeB,
+      nodeC: linearFlow.nodeC,
+    };
+
+    expect(
+      repositionPlacementAfterDeletion(
+        linearFlow,
+        after,
+        "nodeA",
+        new Set(["nodeA"]),
+      ),
+    ).toEqual({ parent: "_root", before: "nodeB" });
+  });
+
+  it("returns an empty-container leading placement when nothing survives", () => {
+    const after = { _root: {} };
+
+    expect(
+      repositionPlacementAfterDeletion(
+        linearFlow,
+        after,
+        "nodeA",
+        new Set(["nodeA", "nodeB", "nodeC"]),
+      ),
+    ).toEqual({ parent: "_root", before: undefined });
+  });
+
+  it("returns null when the deleted anchor's own container was also deleted", () => {
+    const flow = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: ["child"] },
+      child: { type: 8 },
+    };
+    const after = { _root: {} };
+
+    expect(
+      repositionPlacementAfterDeletion(
+        flow,
+        after,
+        "child",
+        new Set(["folder", "child"]),
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -1,0 +1,103 @@
+import type { Graph } from "@planx/graph";
+import { describe, expect, it } from "vitest";
+
+import {
+  findContainerOf,
+  resolveNotePlacement,
+  resolveNoteRenderCoordinate,
+} from "./notePlacement";
+
+// _root -> nodeA -> nodeB -> nodeC (a plain linear root-level sequence,
+const linearFlow: Graph = {
+  _root: { edges: ["nodeA", "nodeB", "nodeC"] },
+  nodeA: { type: 8, data: { title: "Node A" } },
+  nodeB: { type: 8, data: { title: "Node B" } },
+  nodeC: { type: 8, data: { title: "Node C" } },
+};
+
+describe("findContainerOf", () => {
+  it("finds the node whose edges contain the given id", () => {
+    expect(findContainerOf(linearFlow, "nodeB")).toBe("_root");
+  });
+
+  it("returns undefined for a node with no container (e.g. _root itself)", () => {
+    expect(findContainerOf(linearFlow, "_root")).toBeUndefined();
+  });
+});
+
+describe("resolveNotePlacement (encode)", () => {
+  it("anchors to the preceding sibling when one exists", () => {
+    // note between nodeA and nodeB
+    expect(resolveNotePlacement(linearFlow, "_root", "nodeB")).toEqual({
+      parent: "nodeA",
+    });
+  });
+
+  it("anchors to the last child when trailing (no `before` given, preceding sibling exists)", () => {
+    expect(resolveNotePlacement(linearFlow, "_root", undefined)).toEqual({
+      parent: "nodeC",
+    });
+  });
+
+  it("falls back to container + before when there is no preceding sibling (leading position)", () => {
+    expect(resolveNotePlacement(linearFlow, "_root", "nodeA")).toEqual({
+      parent: "_root",
+      before: "nodeA",
+    });
+  });
+
+  it("falls back to container with no before when the container is empty", () => {
+    const flow: Graph = { _root: {} };
+    expect(resolveNotePlacement(flow, "_root", undefined)).toEqual({
+      parent: "_root",
+      before: undefined,
+    });
+  });
+});
+
+describe("resolveNoteRenderCoordinate (decode)", () => {
+  it("resolves a sibling-anchored placement to (its container, the next sibling)", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "nodeA" }),
+    ).toEqual({ container: "_root", before: "nodeB" });
+  });
+
+  it("resolves a trailing sibling anchor (last child) to (container, undefined)", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "nodeC" }),
+    ).toEqual({ container: "_root", before: undefined });
+  });
+
+  it("resolves a container-anchored (leading) placement directly", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, {
+        parent: "_root",
+        before: "nodeA",
+      }),
+    ).toEqual({ container: "_root", before: "nodeA" });
+  });
+
+  it("treats parent === _root as a container even with no before", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "_root" }),
+    ).toEqual({ container: "_root", before: undefined });
+  });
+
+  it("round-trips through encode then decode back to the original gap", () => {
+    const gaps: Array<{ container: string; before?: string }> = [
+      { container: "_root", before: "nodeA" },
+      { container: "_root", before: "nodeB" },
+      { container: "_root", before: "nodeC" },
+      { container: "_root", before: undefined },
+    ];
+
+    for (const gap of gaps) {
+      const placement = resolveNotePlacement(
+        linearFlow,
+        gap.container,
+        gap.before,
+      );
+      expect(resolveNoteRenderCoordinate(linearFlow, placement)).toEqual(gap);
+    }
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -31,12 +31,14 @@ describe("resolveNotePlacement (encode)", () => {
     // note between nodeA and nodeB
     expect(resolveNotePlacement(linearFlow, "_root", "nodeB")).toEqual({
       parent: "nodeA",
+      container: "_root",
     });
   });
 
   it("anchors to the last child when trailing (no `before` given, preceding sibling exists)", () => {
     expect(resolveNotePlacement(linearFlow, "_root", undefined)).toEqual({
       parent: "nodeC",
+      container: "_root",
     });
   });
 
@@ -155,6 +157,50 @@ describe("resolveNoteRenderCoordinate (decode)", () => {
     const placement = resolveNotePlacement(flow, gap.container, gap.before);
     expect(resolveNoteRenderCoordinate(flow, placement)).toEqual(gap);
   });
+
+  describe("cloned anchor nodes", () => {
+    // "shared" is a cloned node i.e. referenced from two different parents ("b" and "a")
+    // key order would place the note before b due to order but actually we want it to use a
+    const cloneFlow: Graph = {
+      _root: { edges: ["a", "b"] },
+      b: { type: 8, edges: ["shared"] },
+      a: { type: 8, edges: ["shared"] },
+      shared: { type: 8 },
+    };
+
+    it("encode stores the container a cloned sibling was resolved against", () => {
+      expect(resolveNotePlacement(cloneFlow, "a", undefined)).toEqual({
+        parent: "shared",
+        container: "a",
+      });
+    });
+
+    it("decode uses the stored container rather than guessing via findContainerOf", () => {
+      expect(findContainerOf(cloneFlow, "shared")).toBe("b");
+      expect(
+        resolveNoteRenderCoordinate(cloneFlow, {
+          parent: "shared",
+          container: "a",
+        }),
+      ).toEqual({ container: "a", before: undefined });
+    });
+
+    it("falls back to findContainerOf's (possibly wrong) match for legacy placements with no stored container", () => {
+      expect(
+        resolveNoteRenderCoordinate(cloneFlow, { parent: "shared" }),
+      ).toEqual({ container: "b", before: undefined });
+    });
+
+    it("round-trips a note anchored after a cloned sibling", () => {
+      const gap = { container: "a", before: undefined };
+      const placement = resolveNotePlacement(
+        cloneFlow,
+        gap.container,
+        gap.before,
+      );
+      expect(resolveNoteRenderCoordinate(cloneFlow, placement)).toEqual(gap);
+    });
+  });
 });
 
 describe("repositionPlacementAfterDeletion", () => {
@@ -174,7 +220,7 @@ describe("repositionPlacementAfterDeletion", () => {
         "nodeB",
         new Set(["nodeB"]),
       ),
-    ).toEqual({ parent: "nodeA" });
+    ).toEqual({ parent: "nodeA", container: "_root" });
   });
 
   it("walks back past other siblings deleted in the same operation", () => {
@@ -224,6 +270,34 @@ describe("repositionPlacementAfterDeletion", () => {
       before: undefined,
       parentIsContainer: true,
     });
+  });
+
+  it("carries the container through when the re-anchored sibling is itself a clone", () => {
+    // "shared" is referenced from both "x" and "y" - the note being repositioned lives under "y" (anchored to "deleteMe", which is being removed); it must re-anchor to "shared" WITHIN "y", not resolve to "x"
+    const before: Graph = {
+      _root: { edges: ["x", "y"] },
+      x: { type: 8, edges: ["shared"] },
+      y: { type: 8, edges: ["shared", "deleteMe"] },
+      shared: { type: 8 },
+      deleteMe: { type: 8 },
+    };
+    const after = {
+      _root: { edges: ["x", "y"] },
+      x: { type: 8, edges: ["shared"] },
+      y: { type: 8, edges: ["shared"] },
+      shared: { type: 8 },
+    };
+
+    expect(findContainerOf(before, "shared")).toBe("x");
+
+    expect(
+      repositionPlacementAfterDeletion(
+        before,
+        after,
+        "deleteMe",
+        new Set(["deleteMe"]),
+      ),
+    ).toEqual({ parent: "shared", container: "y" });
   });
 
   it("returns null when the deleted anchor's own container was also deleted", () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -44,6 +44,7 @@ describe("resolveNotePlacement (encode)", () => {
     expect(resolveNotePlacement(linearFlow, "_root", "nodeA")).toEqual({
       parent: "_root",
       before: "nodeA",
+      parentIsContainer: true,
     });
   });
 
@@ -52,6 +53,19 @@ describe("resolveNotePlacement (encode)", () => {
     expect(resolveNotePlacement(flow, "_root", undefined)).toEqual({
       parent: "_root",
       before: undefined,
+      parentIsContainer: true,
+    });
+  });
+
+  it("marks the placement as container-anchored when added as the first child of an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    expect(resolveNotePlacement(flow, "folder", undefined)).toEqual({
+      parent: "folder",
+      before: undefined,
+      parentIsContainer: true,
     });
   });
 });
@@ -74,14 +88,43 @@ describe("resolveNoteRenderCoordinate (decode)", () => {
       resolveNoteRenderCoordinate(linearFlow, {
         parent: "_root",
         before: "nodeA",
+        parentIsContainer: true,
       }),
     ).toEqual({ container: "_root", before: "nodeA" });
   });
 
-  it("treats parent === _root as a container even with no before", () => {
+  it("treats parent === _root as a container even with no before (legacy placement without the flag)", () => {
     expect(
       resolveNoteRenderCoordinate(linearFlow, { parent: "_root" }),
     ).toEqual({ container: "_root", before: undefined });
+  });
+
+  it("resolves a container-anchored placement into an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    expect(
+      resolveNoteRenderCoordinate(flow, {
+        parent: "folder",
+        before: undefined,
+        parentIsContainer: true,
+      }),
+    ).toEqual({ container: "folder", before: undefined });
+  });
+
+  it("still resolves a sibling-anchored placement pointing at an (empty) folder to after that folder, not inside it", () => {
+    // folder is the last child of _root and happens to be empty - without
+    // `parentIsContainer` this must NOT be mistaken for "insert inside folder"
+    const flow: Graph = {
+      _root: { edges: ["nodeA", "folder"] },
+      nodeA: linearFlow.nodeA,
+      folder: { type: 300, edges: [] },
+    };
+    expect(resolveNoteRenderCoordinate(flow, { parent: "folder" })).toEqual({
+      container: "_root",
+      before: undefined,
+    });
   });
 
   it("round-trips through encode then decode back to the original gap", () => {
@@ -100,6 +143,17 @@ describe("resolveNoteRenderCoordinate (decode)", () => {
       );
       expect(resolveNoteRenderCoordinate(linearFlow, placement)).toEqual(gap);
     }
+  });
+
+  it("round-trips a note added as the first child of an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    const gap = { container: "folder", before: undefined };
+
+    const placement = resolveNotePlacement(flow, gap.container, gap.before);
+    expect(resolveNoteRenderCoordinate(flow, placement)).toEqual(gap);
   });
 });
 
@@ -135,7 +189,7 @@ describe("repositionPlacementAfterDeletion", () => {
         "nodeB",
         new Set(["nodeA", "nodeB"]),
       ),
-    ).toEqual({ parent: "_root", before: "nodeC" });
+    ).toEqual({ parent: "_root", before: "nodeC", parentIsContainer: true });
   });
 
   it("falls back to leading-in-container when the deleted anchor had no preceding sibling", () => {
@@ -152,7 +206,7 @@ describe("repositionPlacementAfterDeletion", () => {
         "nodeA",
         new Set(["nodeA"]),
       ),
-    ).toEqual({ parent: "_root", before: "nodeB" });
+    ).toEqual({ parent: "_root", before: "nodeB", parentIsContainer: true });
   });
 
   it("returns an empty-container leading placement when nothing survives", () => {
@@ -165,7 +219,11 @@ describe("repositionPlacementAfterDeletion", () => {
         "nodeA",
         new Set(["nodeA", "nodeB", "nodeC"]),
       ),
-    ).toEqual({ parent: "_root", before: undefined });
+    ).toEqual({
+      parent: "_root",
+      before: undefined,
+      parentIsContainer: true,
+    });
   });
 
   it("returns null when the deleted anchor's own container was also deleted", () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -57,3 +57,33 @@ export const resolveNoteRenderCoordinate = (
   const index = siblings.indexOf(placement.parent);
   return { container, before: siblings[index + 1] };
 };
+
+/**
+ * Given a set of just-deleted node ids, re-position a note's placement if it was a child (via `placement.parent`) of one of them.
+ *
+ * Walks back through the flow as it was before the deletion to find the nearest surviving sibling and re-positions there.
+ *
+ * Skips nodes that were deleted in the same operation.
+ *
+ * Falls back to the container if nothing precedes the deleted node.
+ *
+ * Returns `null` if the container itself was also deleted, in which case there's no valid position left.
+ */
+export const repositionPlacementAfterDeletion = (
+  flowBeforeDelete: Graph,
+  flowAfterDelete: Graph,
+  deletedAnchorId: string,
+  deletedIds: Set<string>,
+): NotePlacement | null => {
+  const container = findContainerOf(flowBeforeDelete, deletedAnchorId);
+  if (!container || deletedIds.has(container)) return null;
+
+  const oldSiblings = flowBeforeDelete[container]?.edges ?? [];
+  let index = oldSiblings.indexOf(deletedAnchorId) - 1;
+
+  while (index >= 0 && deletedIds.has(oldSiblings[index])) index -= 1;
+
+  if (index >= 0) return { parent: oldSiblings[index] };
+
+  return { parent: container, before: flowAfterDelete[container]?.edges?.[0] };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -31,7 +31,7 @@ export const resolveNotePlacement = (
     : containerEdges[containerEdges.length - 1];
 
   if (precedingId) {
-    return { parent: precedingId };
+    return { parent: precedingId, container };
   }
 
   return { parent: container, before, parentIsContainer: true };
@@ -52,7 +52,8 @@ export const resolveNoteRenderCoordinate = (
     return { container: placement.parent, before: placement.before };
   }
 
-  const container = findContainerOf(flow, placement.parent);
+  const container =
+    placement.container ?? findContainerOf(flow, placement.parent);
   if (!container) {
     return { container: placement.parent, before: undefined };
   }
@@ -87,7 +88,7 @@ export const repositionPlacementAfterDeletion = (
 
   while (index >= 0 && deletedIds.has(oldSiblings[index])) index -= 1;
 
-  if (index >= 0) return { parent: oldSiblings[index] };
+  if (index >= 0) return { parent: oldSiblings[index], container };
 
   return {
     parent: container,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -1,0 +1,59 @@
+import type { Graph } from "@planx/graph";
+import { ROOT_NODE_KEY } from "@planx/graph";
+import type { NotePlacement } from "hooks/data/useFlowNotes";
+
+/**
+ * Find the id of the node whose `edges` contains `nodeId`
+ */
+export const findContainerOf = (
+  flow: Graph,
+  nodeId: string,
+): string | undefined => {
+  for (const [id, node] of Object.entries(flow)) {
+    if (node.edges?.includes(nodeId)) {
+      return id;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Given a graph gap `{container, before?}` (i.e. Hanger co-ordinate), returns a `NotePlacement` to store
+ */
+export const resolveNotePlacement = (
+  flow: Graph,
+  container: string,
+  before?: string,
+): NotePlacement => {
+  const containerEdges = flow[container]?.edges ?? [];
+  const precedingId = before
+    ? containerEdges[containerEdges.indexOf(before) - 1]
+    : containerEdges[containerEdges.length - 1];
+
+  if (precedingId) {
+    return { parent: precedingId };
+  }
+
+  return { parent: container, before };
+};
+
+/**
+ * Reverses `resolveNotePlacement` - given a stored placement, finds the graph gap `{container, before?}` to render it
+ */
+export const resolveNoteRenderCoordinate = (
+  flow: Graph,
+  placement: NotePlacement,
+): { container: string; before?: string } => {
+  if (placement.parent === ROOT_NODE_KEY || placement.before !== undefined) {
+    return { container: placement.parent, before: placement.before };
+  }
+
+  const container = findContainerOf(flow, placement.parent);
+  if (!container) {
+    return { container: placement.parent, before: undefined };
+  }
+
+  const siblings = flow[container]?.edges ?? [];
+  const index = siblings.indexOf(placement.parent);
+  return { container, before: siblings[index + 1] };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -34,7 +34,7 @@ export const resolveNotePlacement = (
     return { parent: precedingId };
   }
 
-  return { parent: container, before };
+  return { parent: container, before, parentIsContainer: true };
 };
 
 /**
@@ -44,7 +44,11 @@ export const resolveNoteRenderCoordinate = (
   flow: Graph,
   placement: NotePlacement,
 ): { container: string; before?: string } => {
-  if (placement.parent === ROOT_NODE_KEY || placement.before !== undefined) {
+  if (
+    placement.parentIsContainer ||
+    placement.parent === ROOT_NODE_KEY ||
+    placement.before !== undefined
+  ) {
     return { container: placement.parent, before: placement.before };
   }
 
@@ -85,5 +89,9 @@ export const repositionPlacementAfterDeletion = (
 
   if (index >= 0) return { parent: oldSiblings[index] };
 
-  return { parent: container, before: flowAfterDelete[container]?.edges?.[0] };
+  return {
+    parent: container,
+    before: flowAfterDelete[container]?.edges?.[0],
+    parentIsContainer: true,
+  };
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
@@ -1,0 +1,109 @@
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { describe, expect, it } from "vitest";
+
+import { partitionNotes, placementKey } from "./partitionNotes";
+
+let noteCounter = 0;
+
+const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => {
+  noteCounter += 1;
+  return {
+    id: `note-${noteCounter}`,
+    flowId: "flow-1",
+    nodeId: null,
+    placement: null,
+    text: `Note ${noteCounter}`,
+    color: "#fffdb0",
+    createdBy: 1,
+    updatedBy: 1,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+};
+
+describe("partitionNotes", () => {
+  it("returns empty maps for empty input", () => {
+    const { attached, positioned } = partitionNotes([], {});
+    expect(attached.size).toBe(0);
+    expect(positioned.size).toBe(0);
+  });
+
+  it("buckets a node_id-set note under attached, keyed by nodeId", () => {
+    const note = makeNote({ nodeId: "node-a" });
+    const { attached, positioned } = partitionNotes([note], {});
+
+    expect(attached.get("node-a")).toEqual([note]);
+    expect(positioned.size).toBe(0);
+  });
+
+  it("never places an attached note in the positioned map", () => {
+    const note = makeNote({ nodeId: "node-a" });
+    const { positioned } = partitionNotes([note], {});
+
+    expect(positioned.get(placementKey("node-a"))).toBeUndefined();
+  });
+
+  it("buckets a container-anchored placement note under its exact (parent, before) key", () => {
+    const note = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const { positioned } = partitionNotes([note], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([note]);
+  });
+
+  it("buckets a placement note with no `before` into a distinct trailing bucket", () => {
+    const before = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const trailing = makeNote({ placement: { parent: "container-a" } });
+    const { positioned } = partitionNotes([before, trailing], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([before]);
+    expect(positioned.get(placementKey("container-a"))).toEqual([trailing]);
+    expect(placementKey("container-a")).not.toBe(
+      placementKey("container-a", "X"),
+    );
+  });
+
+  it("does not leak notes across different parents sharing the same `before`", () => {
+    const noteA = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const noteB = makeNote({
+      placement: { parent: "container-b", before: "X" },
+    });
+    const { positioned } = partitionNotes([noteA, noteB], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([noteA]);
+    expect(positioned.get(placementKey("container-b", "X"))).toEqual([noteB]);
+  });
+
+  it("preserves insertion order for multiple notes at the same coordinate", () => {
+    const first = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const second = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const { positioned } = partitionNotes([first, second], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it("decodes a sibling-anchored placement (no before) using the current flow", () => {
+    const flow = {
+      _root: { edges: ["nodeA", "nodeB"] },
+      nodeA: { type: 8 },
+      nodeB: { type: 8 },
+    };
+    const note = makeNote({ placement: { parent: "nodeA" } });
+    const { positioned } = partitionNotes([note], flow);
+
+    expect(positioned.get(placementKey("_root", "nodeB"))).toEqual([note]);
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
@@ -1,0 +1,39 @@
+import type { Graph } from "@planx/graph";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+
+import { resolveNoteRenderCoordinate } from "./notePlacement";
+
+export interface PartitionedNotes {
+  attached: Map<string, FlowNote[]>;
+  positioned: Map<string, FlowNote[]>;
+}
+
+export const placementKey = (parent: string, before?: string): string =>
+  `${parent}::${before ?? ""}`;
+
+export const partitionNotes = (
+  notes: FlowNote[],
+  flow: Graph,
+): PartitionedNotes => {
+  const attached = new Map<string, FlowNote[]>();
+  const positioned = new Map<string, FlowNote[]>();
+
+  for (const note of notes) {
+    if (note.nodeId) {
+      const bucket = attached.get(note.nodeId) ?? [];
+      bucket.push(note);
+      attached.set(note.nodeId, bucket);
+    } else if (note.placement) {
+      const { container, before } = resolveNoteRenderCoordinate(
+        flow,
+        note.placement,
+      );
+      const key = placementKey(container, before);
+      const bucket = positioned.get(key) ?? [];
+      bucket.push(note);
+      positioned.set(key, bucket);
+    }
+  }
+
+  return { attached, positioned };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal.tsx
@@ -1,9 +1,12 @@
+import StickyNote2Icon from "@mui/icons-material/StickyNote2";
 import Box from "@mui/material/Box";
 import Popover from "@mui/material/Popover";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ICONS } from "@planx/components/shared/icons";
+import { ROOT_NODE_KEY } from "@planx/graph";
 import { useNavigate, useParams } from "@tanstack/react-router";
+import { resolveNotePlacement } from "pages/FlowEditor/components/Flow/notes/lib/notePlacement";
 import { hangerAnchor } from "pages/FlowEditor/lib/hangerAnchor";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, {
@@ -90,13 +93,67 @@ const ComponentRow: React.FC<ComponentRowProps> = ({
   );
 };
 
+interface NoteRowProps {
+  onClick: () => void;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const NoteRow: React.FC<NoteRowProps> = ({ onClick, scrollContainerRef }) => {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const onScroll = () => setTooltipOpen(false);
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [scrollContainerRef]);
+
+  return (
+    <Tooltip
+      title="Add a note"
+      placement="right"
+      arrow
+      open={tooltipOpen}
+      onOpen={() => setTooltipOpen(true)}
+      onClose={() => setTooltipOpen(false)}
+      slotProps={{ tooltip: { sx: { maxWidth: 240 } } }}
+    >
+      <Box
+        onClick={onClick}
+        data-component-type="note"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.5,
+          py: 0.875,
+          cursor: "pointer",
+          "&:hover": {
+            backgroundColor: "action.hover",
+            "& .component-title": { fontWeight: FONT_WEIGHT_SEMI_BOLD },
+          },
+        }}
+      >
+        <Box sx={{ flexShrink: 0, lineHeight: 0, color: "text.primary" }}>
+          <StickyNote2Icon sx={{ fontSize: 20 }} />
+        </Box>
+        <Typography variant="body2" className="component-title">
+          Note
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+};
+
 interface AddComponentModalContentProps {
   onSelect: (slug: string) => void;
+  onSelectNote?: () => void;
 }
 
 export const AddComponentModalContent: React.FC<
   AddComponentModalContentProps
-> = ({ onSelect }) => {
+> = ({ onSelect, onSelectNote }) => {
   const [searchedItems, setSearchedItems] = useState<ComponentItem[] | null>(
     null,
   );
@@ -140,6 +197,9 @@ export const AddComponentModalContent: React.FC<
         />
       </Box>
       <Box ref={listRef} sx={{ overflowY: "auto", pb: 2 }}>
+        {onSelectNote && (
+          <NoteRow onClick={onSelectNote} scrollContainerRef={listRef} />
+        )}
         {filteredCategories.length === 0 ? (
           <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>
             No components match your search.
@@ -186,6 +246,7 @@ const AddComponentModal: React.FC<AddComponentModalProps> = ({
 }) => {
   const navigate = useNavigate();
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
+  const flowGraph = useStore((state) => state.flow);
 
   const handleSelect = useCallback(
     (slug: string) => {
@@ -203,6 +264,18 @@ const AddComponentModal: React.FC<AddComponentModalProps> = ({
     },
     [navigate, team, flow, parent, before],
   );
+
+  const handleSelectNote = useCallback(() => {
+    useStore.getState().closeComponentSelector();
+    useStore.getState().openNoteEditor({
+      mode: "create",
+      placement: resolveNotePlacement(
+        flowGraph,
+        parent ?? ROOT_NODE_KEY,
+        before,
+      ),
+    });
+  }, [flowGraph, parent, before]);
 
   const handleClose = useCallback(() => {
     useStore.getState().closeComponentSelector();
@@ -258,7 +331,10 @@ const AddComponentModal: React.FC<AddComponentModalProps> = ({
         },
       }}
     >
-      <AddComponentModalContent onSelect={handleSelect} />
+      <AddComponentModalContent
+        onSelect={handleSelect}
+        onSelectNote={handleSelectNote}
+      />
     </Popover>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -294,6 +294,44 @@ $fontMonospace: "Source Code Pro", monospace;
     border-top: none;
   }
 
+  // A note attached directly to a node - rendered as an extra row
+  & .attached-note {
+    position: relative;
+    display: block;
+    width: 100%;
+    font: inherit;
+    text-align: left;
+    appearance: none;
+    padding: 8px 20px 8px 8px;
+    border: $nodeBorderWidth solid $nodeBorder;
+    border-top: none;
+    cursor: pointer;
+    overflow-wrap: break-word;
+    word-break: break-word;
+
+    // Triangle shapes to simulate a paper fold on the note's corner
+    &::before {
+      content: "";
+      position: absolute;
+      right: -$nodeBorderWidth;
+      bottom: -$nodeBorderWidth;
+      width: 0;
+      height: 0;
+      border-bottom: 12px solid #fff;
+      border-left: 12px solid transparent;
+    }
+    &::after {
+      content: "";
+      position: absolute;
+      right: -$nodeBorderWidth;
+      bottom: -$nodeBorderWidth;
+      width: 0;
+      height: 0;
+      border-top: 12px solid #555;
+      border-right: 12px solid transparent;
+    }
+  }
+
   & .card-tag {
     &.automation {
       width: 100%;
@@ -458,6 +496,18 @@ $fontMonospace: "Source Code Pro", monospace;
     @include disabledHanger();
   }
 
+  // decorative connector
+  &.note-connector {
+    [data-layout="top-down"] & {
+      min-height: $padding * 2;
+      min-width: $hangerWidth;
+    }
+    [data-layout="left-right"] & {
+      min-width: $padding * 2;
+      min-height: $hangerWidth;
+    }
+  }
+
   > a,
   > button {
     $size: $hangerWidth;
@@ -490,6 +540,47 @@ $fontMonospace: "Source Code Pro", monospace;
 
     &:empty {
       padding: 0;
+    }
+  }
+}
+
+// positioned note i.e. rendered on a container line
+.note-card {
+  align-self: center;
+
+  > button {
+    position: relative;
+    display: inline-block;
+    font: inherit;
+    text-align: left;
+    appearance: none;
+    border: $nodeBorderWidth solid $nodeBorder;
+    cursor: pointer;
+    max-width: $nodeMaxWidth;
+    padding: 8px 20px 8px 8px;
+    overflow-wrap: break-word;
+    word-break: break-word;
+
+    // Triangle shapes to simulate a paper fold on the note's corner
+    &::before {
+      content: "";
+      position: absolute;
+      right: -$nodeBorderWidth;
+      bottom: -$nodeBorderWidth;
+      width: 0;
+      height: 0;
+      border-bottom: 10px solid #fff;
+      border-left: 10px solid transparent;
+    }
+    &::after {
+      content: "";
+      position: absolute;
+      right: -$nodeBorderWidth;
+      bottom: -$nodeBorderWidth;
+      width: 0;
+      height: 0;
+      border-top: 10px solid #999;
+      border-right: 10px solid transparent;
     }
   }
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -59,6 +59,29 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
+// Triangle shapes to simulate a paper fold on a note's corner
+@mixin paperFoldFront($size: 12px, $background: #fff) {
+  content: "";
+  position: absolute;
+  right: -$nodeBorderWidth;
+  bottom: -$nodeBorderWidth;
+  width: 0;
+  height: 0;
+  border-bottom: $size solid $background;
+  border-left: $size solid transparent;
+}
+
+@mixin paperFoldBack($size: 12px, $foldColor: #555) {
+  content: "";
+  position: absolute;
+  right: -$nodeBorderWidth;
+  bottom: -$nodeBorderWidth;
+  width: 0;
+  height: 0;
+  border-top: $size solid $foldColor;
+  border-right: $size solid transparent;
+}
+
 @mixin cloneStyle {
   content: "";
   position: absolute;
@@ -309,26 +332,11 @@ $fontMonospace: "Source Code Pro", monospace;
     overflow-wrap: break-word;
     word-break: break-word;
 
-    // Triangle shapes to simulate a paper fold on the note's corner
     &::before {
-      content: "";
-      position: absolute;
-      right: -$nodeBorderWidth;
-      bottom: -$nodeBorderWidth;
-      width: 0;
-      height: 0;
-      border-bottom: 12px solid #fff;
-      border-left: 12px solid transparent;
+      @include paperFoldFront;
     }
     &::after {
-      content: "";
-      position: absolute;
-      right: -$nodeBorderWidth;
-      bottom: -$nodeBorderWidth;
-      width: 0;
-      height: 0;
-      border-top: 12px solid #555;
-      border-right: 12px solid transparent;
+      @include paperFoldBack;
     }
   }
 
@@ -561,26 +569,11 @@ $fontMonospace: "Source Code Pro", monospace;
     overflow-wrap: break-word;
     word-break: break-word;
 
-    // Triangle shapes to simulate a paper fold on the note's corner
     &::before {
-      content: "";
-      position: absolute;
-      right: -$nodeBorderWidth;
-      bottom: -$nodeBorderWidth;
-      width: 0;
-      height: 0;
-      border-bottom: 10px solid #fff;
-      border-left: 10px solid transparent;
+      @include paperFoldFront(10px);
     }
     &::after {
-      content: "";
-      position: absolute;
-      right: -$nodeBorderWidth;
-      bottom: -$nodeBorderWidth;
-      width: 0;
-      height: 0;
-      border-top: 10px solid #999;
-      border-right: 10px solid transparent;
+      @include paperFoldBack(10px, #999);
     }
   }
 }
@@ -763,27 +756,13 @@ $fontMonospace: "Source Code Pro", monospace;
     // Triangle shapes to simulate paper fold on sticky note
     &:not(.isClone) a {
       &::before {
-        content: "";
-        position: absolute;
-        right: -$nodeBorderWidth;
-        bottom: -$nodeBorderWidth;
-        width: 0;
-        height: 0;
-        border-bottom: 12px solid #fff;
-        border-left: 12px solid transparent;
+        @include paperFoldFront;
         .flow-locked & {
           border-bottom-color: $lockedNodeBackground;
         }
       }
       &::after {
-        content: "";
-        position: absolute;
-        right: -$nodeBorderWidth;
-        bottom: -$nodeBorderWidth;
-        width: 0;
-        height: 0;
-        border-top: 12px solid #555;
-        border-right: 12px solid transparent;
+        @include paperFoldBack;
       }
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -25,6 +25,7 @@ import {
 } from "@planx/graph";
 import type { OT } from "@planx/graph/types";
 import type { RegisteredRouter } from "@tanstack/react-router";
+import type { FlowNote, NotePlacement } from "hooks/data/useFlowNotes";
 import { client } from "lib/graphql";
 import debounce from "lodash/debounce";
 import { type } from "ot-json0";
@@ -40,6 +41,7 @@ import { FlowLayout } from "../../components/Flow";
 import { getFlowDoc, subscribeToDoc } from "./../sharedb";
 import { type Store } from ".";
 import type { NavigationStore } from "./navigation";
+import type { NotesStore } from "./notes";
 import type { SharedStore } from "./shared";
 
 let doc: Doc;
@@ -94,6 +96,17 @@ export interface EditorUIStore {
   componentSelectorBefore?: string;
   openComponentSelector: (params: { parent?: string; before?: string }) => void;
   closeComponentSelector: () => void;
+  noteEditorOpen: boolean;
+  noteEditorMode: "create" | "edit" | null;
+  noteEditorNote?: FlowNote;
+  noteEditorNodeId?: string;
+  noteEditorPlacement?: NotePlacement;
+  openNoteEditor: (
+    params:
+      | { mode: "create"; nodeId?: string; placement?: NotePlacement }
+      | { mode: "edit"; note: FlowNote },
+  ) => void;
+  closeNoteEditor: () => void;
 }
 
 export const editorUIStore: StateCreator<
@@ -224,6 +237,40 @@ export const editorUIStore: StateCreator<
         componentSelectorOpen: false,
         componentSelectorParent: undefined,
         componentSelectorBefore: undefined,
+      }),
+
+    noteEditorOpen: false,
+    noteEditorMode: null,
+    noteEditorNote: undefined,
+    noteEditorNodeId: undefined,
+    noteEditorPlacement: undefined,
+
+    openNoteEditor: (params) =>
+      set(
+        params.mode === "edit"
+          ? {
+              noteEditorOpen: true,
+              noteEditorMode: "edit",
+              noteEditorNote: params.note,
+              noteEditorNodeId: undefined,
+              noteEditorPlacement: undefined,
+            }
+          : {
+              noteEditorOpen: true,
+              noteEditorMode: "create",
+              noteEditorNote: undefined,
+              noteEditorNodeId: params.nodeId,
+              noteEditorPlacement: params.placement,
+            },
+      ),
+
+    closeNoteEditor: () =>
+      set({
+        noteEditorOpen: false,
+        noteEditorMode: null,
+        noteEditorNote: undefined,
+        noteEditorNodeId: undefined,
+        noteEditorPlacement: undefined,
       }),
   }),
   {
@@ -364,7 +411,7 @@ export interface EditorStore extends Store.Store {
 }
 
 export const editorStore: StateCreator<
-  SharedStore & EditorStore & NavigationStore,
+  SharedStore & EditorStore & NavigationStore & NotesStore,
   [],
   [],
   EditorStore
@@ -658,6 +705,8 @@ export const editorStore: StateCreator<
     toParent = undefined,
   ) {
     try {
+      // TODO(deferred): reconcile note positions for the moved node - see
+      // components/Flow/notes/_deferred/reconcileNotesForMovedNode.ts
       const [, ops] = move(id, parent as unknown as string, {
         toParent,
         toBefore,
@@ -765,8 +814,14 @@ export const editorStore: StateCreator<
   },
 
   removeNode: (id, parent) => {
-    const [, ops] = remove(id, parent)(get().flow);
+    const before = get().flow;
+    const [after, ops] = remove(id, parent)(before);
     send(ops);
+
+    const deletedNodeIds = Object.keys(before).filter((k) => !after[k]);
+    if (deletedNodeIds.length > 0) {
+      get().reconcileNotesForDeletedNodes(deletedNodeIds, before, after);
+    }
   },
 
   updateNode: ({ id, data }, { children = undefined } = {}) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -705,8 +705,7 @@ export const editorStore: StateCreator<
     toParent = undefined,
   ) {
     try {
-      // TODO(deferred): reconcile note positions for the moved node - see
-      // components/Flow/notes/_deferred/reconcileNotesForMovedNode.ts
+      // TODO: reposition notes for the moved node - see
       const [, ops] = move(id, parent as unknown as string, {
         toParent,
         toBefore,
@@ -814,10 +813,14 @@ export const editorStore: StateCreator<
   },
 
   removeNode: (id, parent) => {
-    // TODO(deferred): reconcile note positions for deleted nodes - see
-    // components/Flow/notes/_deferred/reconcileNotesForDeletedNodes.ts
-    const [, ops] = remove(id, parent)(get().flow);
+    const before = get().flow;
+    const [after, ops] = remove(id, parent)(before);
     send(ops);
+
+    const deletedNodeIds = Object.keys(before).filter((k) => !after[k]);
+    if (deletedNodeIds.length > 0) {
+      get().repositionNotesForDeletedNodes(deletedNodeIds, before, after);
+    }
   },
 
   updateNode: ({ id, data }, { children = undefined } = {}) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -814,14 +814,10 @@ export const editorStore: StateCreator<
   },
 
   removeNode: (id, parent) => {
-    const before = get().flow;
-    const [after, ops] = remove(id, parent)(before);
+    // TODO(deferred): reconcile note positions for deleted nodes - see
+    // components/Flow/notes/_deferred/reconcileNotesForDeletedNodes.ts
+    const [, ops] = remove(id, parent)(get().flow);
     send(ops);
-
-    const deletedNodeIds = Object.keys(before).filter((k) => !after[k]);
-    if (deletedNodeIds.length > 0) {
-      get().reconcileNotesForDeletedNodes(deletedNodeIds, before, after);
-    }
   },
 
   updateNode: ({ id, data }, { children = undefined } = {}) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -705,12 +705,20 @@ export const editorStore: StateCreator<
     toParent = undefined,
   ) {
     try {
-      // TODO: reposition notes for the moved node - see
-      const [, ops] = move(id, parent as unknown as string, {
+      const [after, ops] = move(id, parent as unknown as string, {
         toParent,
         toBefore,
       })(get().flow);
       send(ops);
+
+      if (parent) {
+        const oldParent = parent as unknown as string;
+        get().repositionNotesForMovedNode(
+          id,
+          oldParent,
+          after[oldParent]?.edges?.[0],
+        );
+      }
     } catch (err: any) {
       alert(err.message);
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/index.ts
@@ -14,6 +14,8 @@ import type { EditorStore, EditorUIStore } from "./editor";
 import { editorStore, editorUIStore } from "./editor";
 import type { NavigationStore } from "./navigation";
 import { navigationStore } from "./navigation";
+import type { NotesStore } from "./notes";
+import { notesStore } from "./notes";
 import type { PreviewStore } from "./preview";
 import { previewStore } from "./preview";
 import type { SettingsStore } from "./settings";
@@ -68,7 +70,8 @@ export type FullStore = PublicStore &
   EditorStore &
   EditorUIStore &
   UserStore &
-  AuthStore;
+  AuthStore &
+  NotesStore;
 
 /**
  * If accessing the public preview, don't load editor store files
@@ -97,6 +100,7 @@ const createFullStore = () => {
     ...teamStore(...args),
     ...userStore(...args),
     ...authStore(...args),
+    ...notesStore(...args),
   }));
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
@@ -1,0 +1,51 @@
+import { graphql, HttpResponse } from "msw";
+import server from "test/mockServer";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useStore } from ".";
+
+beforeEach(() => {
+  useStore.setState({
+    id: "flow-1",
+    jwt: "test-jwt",
+    user: {
+      id: 42,
+      firstName: "Test",
+      lastName: "User",
+      email: "test@example.com",
+      isPlatformAdmin: false,
+      isAnalyst: false,
+      defaultTeamId: null,
+      teams: [],
+    } as any,
+  });
+});
+
+describe("createFlowNote", () => {
+  it("sets created_by and updated_by from the current user", async () => {
+    let capturedObject: any;
+
+    server.use(
+      graphql.mutation("CreateFlowNote", ({ variables }) => {
+        capturedObject = variables.object;
+        return HttpResponse.json({
+          data: { insert_flow_notes_one: { id: "new-note-id" } },
+        });
+      }),
+    );
+
+    const id = await useStore
+      .getState()
+      .createFlowNote({ nodeId: "node-a", text: "Hello" });
+
+    expect(id).toBe("new-note-id");
+    expect(capturedObject).toMatchObject({
+      flow_id: "flow-1",
+      node_id: "node-a",
+      placement: null,
+      text: "Hello",
+      created_by: 42,
+      updated_by: 42,
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
@@ -49,3 +49,204 @@ describe("createFlowNote", () => {
     });
   });
 });
+
+describe("repositionNotesForDeletedNodes", () => {
+  it("deletes all attached notes whose node was deleted, regardless of author", async () => {
+    let deleteIds: string[] | undefined;
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({
+          data: {
+            flow_notes: [
+              {
+                id: "note-attached",
+                node_id: "deleted-node",
+                placement: null,
+                created_by: 42,
+              },
+              {
+                id: "note-other-author",
+                node_id: "deleted-node",
+                placement: null,
+                created_by: 999,
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation("DeleteFlowNotes", ({ variables }) => {
+        deleteIds = variables.ids;
+        return HttpResponse.json({
+          data: { delete_flow_notes: { affected_rows: variables.ids.length } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForDeletedNodes(["deleted-node"], {}, {});
+
+    expect(deleteIds).toEqual(
+      expect.arrayContaining(["note-attached", "note-other-author"]),
+    );
+    expect(deleteIds).toHaveLength(2);
+  });
+
+  it("re-anchors a sibling-anchored positioned note to the surviving preceding sibling", async () => {
+    const flowBefore = {
+      _root: { edges: ["survivor", "deleted-node"] },
+      survivor: { type: 8 },
+      "deleted-node": { type: 8 },
+    };
+    const flowAfter = { _root: { edges: ["survivor"] } };
+    let reanchored: any;
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({
+          data: {
+            flow_notes: [
+              {
+                id: "note-after-deleted",
+                node_id: null,
+                placement: { parent: "deleted-node" },
+                created_by: 42,
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation("ReanchorFlowNote", ({ variables }) => {
+        reanchored = variables;
+        return HttpResponse.json({
+          data: { update_flow_notes_by_pk: { id: variables.id } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForDeletedNodes(["deleted-node"], flowBefore, flowAfter);
+
+    expect(reanchored).toEqual({
+      id: "note-after-deleted",
+      placement: { parent: "survivor" },
+    });
+  });
+
+  it("re-anchors a leading positioned note to the container's new first child when its before-target is deleted", async () => {
+    const flowBefore = {
+      _root: { edges: ["parent-container"] },
+      "parent-container": { edges: ["deleted-node", "other-child"] },
+      "deleted-node": { type: 200 },
+      "other-child": { type: 200 },
+    };
+    const flowAfter = {
+      _root: { edges: ["parent-container"] },
+      "parent-container": { edges: ["other-child"] },
+      "other-child": { type: 200 },
+    };
+    let reanchored: any;
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({
+          data: {
+            flow_notes: [
+              {
+                id: "note-leading",
+                node_id: null,
+                placement: {
+                  parent: "parent-container",
+                  before: "deleted-node",
+                },
+                created_by: 42,
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation("ReanchorFlowNote", ({ variables }) => {
+        reanchored = variables;
+        return HttpResponse.json({
+          data: { update_flow_notes_by_pk: { id: variables.id } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForDeletedNodes(["deleted-node"], flowBefore, flowAfter);
+
+    expect(reanchored).toEqual({
+      id: "note-leading",
+      placement: { parent: "parent-container", before: "other-child" },
+    });
+  });
+
+  it("deletes a positioned note when its entire container was also deleted", async () => {
+    const flowBefore = {
+      _root: { edges: ["folder"] },
+      folder: { edges: ["child"] },
+      child: { type: 8 },
+    };
+    const flowAfter = { _root: {} };
+    let deleteIds: string[] | undefined;
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({
+          data: {
+            flow_notes: [
+              {
+                id: "note-orphaned",
+                node_id: null,
+                placement: { parent: "child" },
+                created_by: 42,
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation("DeleteFlowNotes", ({ variables }) => {
+        deleteIds = variables.ids;
+        return HttpResponse.json({
+          data: { delete_flow_notes: { affected_rows: variables.ids.length } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForDeletedNodes(
+        ["folder", "child"],
+        flowBefore,
+        flowAfter,
+      );
+
+    expect(deleteIds).toEqual(["note-orphaned"]);
+  });
+
+  it("issues no mutations when there is nothing to reposition", async () => {
+    let mutationCalled = false;
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({ data: { flow_notes: [] } }),
+      ),
+      graphql.mutation("DeleteFlowNotes", () => {
+        mutationCalled = true;
+        return HttpResponse.json({
+          data: { delete_flow_notes: { affected_rows: 0 } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForDeletedNodes(["deleted-node"], {}, {});
+
+    expect(mutationCalled).toBe(false);
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
@@ -181,7 +181,11 @@ describe("repositionNotesForDeletedNodes", () => {
 
     expect(reanchored).toEqual({
       id: "note-leading",
-      placement: { parent: "parent-container", before: "other-child" },
+      placement: {
+        parent: "parent-container",
+        before: "other-child",
+        parentIsContainer: true,
+      },
     });
   });
 
@@ -295,7 +299,11 @@ describe("repositionNotesForMovedNode", () => {
     expect(reanchored).toEqual([
       {
         id: "note-before-moved",
-        placement: { parent: "old-parent", before: "new-first-child" },
+        placement: {
+          parent: "old-parent",
+          before: "new-first-child",
+          parentIsContainer: true,
+        },
       },
     ]);
   });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
@@ -131,7 +131,7 @@ describe("repositionNotesForDeletedNodes", () => {
 
     expect(reanchored).toEqual({
       id: "note-after-deleted",
-      placement: { parent: "survivor" },
+      placement: { parent: "survivor", container: "_root" },
     });
   });
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.test.ts
@@ -250,3 +250,53 @@ describe("repositionNotesForDeletedNodes", () => {
     expect(mutationCalled).toBe(false);
   });
 });
+
+describe("repositionNotesForMovedNode", () => {
+  it("re-anchors own leading notes to the new first child of the old parent", async () => {
+    const reanchored: any[] = [];
+
+    server.use(
+      graphql.query("GetFlowNotesForReposition", () =>
+        HttpResponse.json({
+          data: {
+            flow_notes: [
+              {
+                id: "note-before-moved",
+                node_id: null,
+                placement: { parent: "old-parent", before: "moved-node" },
+                created_by: 42,
+              },
+              {
+                id: "note-elsewhere",
+                node_id: null,
+                placement: { parent: "old-parent", before: "some-other-node" },
+                created_by: 42,
+              },
+            ],
+          },
+        }),
+      ),
+      graphql.mutation("ReanchorFlowNote", ({ variables }) => {
+        reanchored.push(variables);
+        return HttpResponse.json({
+          data: { update_flow_notes_by_pk: { id: variables.id } },
+        });
+      }),
+    );
+
+    await useStore
+      .getState()
+      .repositionNotesForMovedNode(
+        "moved-node",
+        "old-parent",
+        "new-first-child",
+      );
+
+    expect(reanchored).toEqual([
+      {
+        id: "note-before-moved",
+        placement: { parent: "old-parent", before: "new-first-child" },
+      },
+    ]);
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
@@ -1,0 +1,94 @@
+import { gql } from "@apollo/client";
+import type { NotePlacement } from "hooks/data/useFlowNotes";
+import { client } from "lib/graphql";
+import type { StateCreator } from "zustand";
+
+import type { AuthStore } from "./auth";
+import type { SharedStore } from "./shared";
+
+const CREATE_FLOW_NOTE = gql`
+  mutation CreateFlowNote($object: flow_notes_insert_input!) {
+    insert_flow_notes_one(object: $object) {
+      id
+    }
+  }
+`;
+
+const UPDATE_FLOW_NOTE = gql`
+  mutation UpdateFlowNote($id: uuid!, $set: flow_notes_set_input!) {
+    update_flow_notes_by_pk(pk_columns: { id: $id }, _set: $set) {
+      id
+    }
+  }
+`;
+
+const DELETE_FLOW_NOTE = gql`
+  mutation DeleteFlowNote($id: uuid!) {
+    delete_flow_notes_by_pk(id: $id) {
+      id
+    }
+  }
+`;
+
+export interface CreateFlowNoteInput {
+  nodeId?: string;
+  placement?: NotePlacement;
+  text: string;
+  color?: string;
+}
+
+export interface NotesStore {
+  createFlowNote: (input: CreateFlowNoteInput) => Promise<string | undefined>;
+  updateFlowNote: (
+    id: string,
+    patch: { text?: string; color?: string },
+  ) => Promise<void>;
+  deleteFlowNote: (id: string) => Promise<void>;
+}
+
+export const notesStore: StateCreator<
+  SharedStore & AuthStore & NotesStore,
+  [],
+  [],
+  NotesStore
+> = (_set, get) => ({
+  createFlowNote: async ({ nodeId, placement, text, color }) => {
+    const flowId = get().id;
+    const userId = get().user?.id;
+    if (!flowId || !userId) return undefined;
+
+    const { data } = await client.mutate({
+      mutation: CREATE_FLOW_NOTE,
+      variables: {
+        object: {
+          flow_id: flowId,
+          node_id: nodeId ?? null,
+          placement: placement ?? null,
+          text,
+          ...(color && { color }),
+          created_by: userId,
+          updated_by: userId,
+        },
+      },
+    });
+
+    return data?.insert_flow_notes_one?.id;
+  },
+
+  updateFlowNote: async (id, patch) => {
+    const userId = get().user?.id;
+    if (!userId) return;
+
+    await client.mutate({
+      mutation: UPDATE_FLOW_NOTE,
+      variables: { id, set: { ...patch, updated_by: userId } },
+    });
+  },
+
+  deleteFlowNote: async (id) => {
+    await client.mutate({
+      mutation: DELETE_FLOW_NOTE,
+      variables: { id },
+    });
+  },
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
@@ -92,6 +92,15 @@ export interface NotesStore {
     flowBeforeDelete: Graph,
     flowAfterDelete: Graph,
   ) => Promise<void>;
+
+  /**
+   * Called after a node is moved to a new parent
+   */
+  repositionNotesForMovedNode: (
+    movedId: string,
+    oldParent: string,
+    newFirstChildOfOldParent: string | undefined,
+  ) => Promise<void>;
 }
 
 export const notesStore: StateCreator<
@@ -214,5 +223,42 @@ export const notesStore: StateCreator<
         }),
       ),
     ]);
+  },
+
+  repositionNotesForMovedNode: async (
+    movedId,
+    oldParent,
+    newFirstChildOfOldParent,
+  ) => {
+    const flowId = get().id;
+    const userId = get().user?.id;
+    if (!flowId || !userId) return;
+
+    const { data } = await client.query<{
+      flow_notes: FlowNoteRowForReposition[];
+    }>({
+      query: GET_FLOW_NOTES_FOR_REPOSITION,
+      variables: { flowId },
+      fetchPolicy: "network-only",
+    });
+
+    const notesToReposition = (data?.flow_notes ?? []).filter(
+      (note) =>
+        note.created_by === userId &&
+        note.placement?.parent === oldParent &&
+        note.placement?.before === movedId,
+    );
+
+    await Promise.all(
+      notesToReposition.map((note) =>
+        client.mutate({
+          mutation: REANCHOR_FLOW_NOTE,
+          variables: {
+            id: note.id,
+            placement: { parent: oldParent, before: newFirstChildOfOldParent },
+          },
+        }),
+      ),
+    );
   },
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
@@ -187,6 +187,7 @@ export const notesStore: StateCreator<
           placement: {
             parent: note.placement.parent,
             before: flowAfterDelete[note.placement.parent]?.edges?.[0],
+            parentIsContainer: true,
           },
         });
         continue;
@@ -255,7 +256,11 @@ export const notesStore: StateCreator<
           mutation: REANCHOR_FLOW_NOTE,
           variables: {
             id: note.id,
-            placement: { parent: oldParent, before: newFirstChildOfOldParent },
+            placement: {
+              parent: oldParent,
+              before: newFirstChildOfOldParent,
+              parentIsContainer: true,
+            },
           },
         }),
       ),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts
@@ -1,10 +1,30 @@
 import { gql } from "@apollo/client";
+import type { Graph } from "@planx/graph";
 import type { NotePlacement } from "hooks/data/useFlowNotes";
 import { client } from "lib/graphql";
+import { repositionPlacementAfterDeletion } from "pages/FlowEditor/components/Flow/notes/lib/notePlacement";
 import type { StateCreator } from "zustand";
 
 import type { AuthStore } from "./auth";
 import type { SharedStore } from "./shared";
+
+interface FlowNoteRowForReposition {
+  id: string;
+  node_id: string | null;
+  placement: NotePlacement | null;
+  created_by: number;
+}
+
+const GET_FLOW_NOTES_FOR_REPOSITION = gql`
+  query GetFlowNotesForReposition($flowId: uuid!) {
+    flow_notes(where: { flow_id: { _eq: $flowId } }) {
+      id
+      node_id
+      placement
+      created_by
+    }
+  }
+`;
 
 const CREATE_FLOW_NOTE = gql`
   mutation CreateFlowNote($object: flow_notes_insert_input!) {
@@ -30,6 +50,25 @@ const DELETE_FLOW_NOTE = gql`
   }
 `;
 
+const DELETE_FLOW_NOTES = gql`
+  mutation DeleteFlowNotes($ids: [uuid!]!) {
+    delete_flow_notes(where: { id: { _in: $ids } }) {
+      affected_rows
+    }
+  }
+`;
+
+const REANCHOR_FLOW_NOTE = gql`
+  mutation ReanchorFlowNote($id: uuid!, $placement: jsonb!) {
+    update_flow_notes_by_pk(
+      pk_columns: { id: $id }
+      _set: { placement: $placement }
+    ) {
+      id
+    }
+  }
+`;
+
 export interface CreateFlowNoteInput {
   nodeId?: string;
   placement?: NotePlacement;
@@ -44,6 +83,15 @@ export interface NotesStore {
     patch: { text?: string; color?: string },
   ) => Promise<void>;
   deleteFlowNote: (id: string) => Promise<void>;
+
+  /**
+   * Called after a node is removed from the flow, with the flow as it was immediately before and immediately after.
+   */
+  repositionNotesForDeletedNodes: (
+    deletedNodeIds: string[],
+    flowBeforeDelete: Graph,
+    flowAfterDelete: Graph,
+  ) => Promise<void>;
 }
 
 export const notesStore: StateCreator<
@@ -90,5 +138,81 @@ export const notesStore: StateCreator<
       mutation: DELETE_FLOW_NOTE,
       variables: { id },
     });
+  },
+
+  repositionNotesForDeletedNodes: async (
+    deletedNodeIds,
+    flowBeforeDelete,
+    flowAfterDelete,
+  ) => {
+    const flowId = get().id;
+    const userId = get().user?.id;
+    if (!flowId || !userId || deletedNodeIds.length === 0) return;
+
+    const deleted = new Set(deletedNodeIds);
+
+    const { data } = await client.query<{
+      flow_notes: FlowNoteRowForReposition[];
+    }>({
+      query: GET_FLOW_NOTES_FOR_REPOSITION,
+      variables: { flowId },
+      fetchPolicy: "network-only",
+    });
+
+    const toDelete: string[] = [];
+    const toReanchor: Array<{ id: string; placement: NotePlacement }> = [];
+
+    for (const note of data.flow_notes) {
+      if (note.node_id) {
+        if (deleted.has(note.node_id)) toDelete.push(note.id);
+        continue;
+      }
+
+      if (!note.placement) continue;
+
+      // Leading-position note whose `before` target was removed, but whose
+      // container survives - re-anchor to the container's new first child
+      if (note.placement.before && deleted.has(note.placement.before)) {
+        toReanchor.push({
+          id: note.id,
+          placement: {
+            parent: note.placement.parent,
+            before: flowAfterDelete[note.placement.parent]?.edges?.[0],
+          },
+        });
+        continue;
+      }
+
+      if (deleted.has(note.placement.parent)) {
+        const repositioned = repositionPlacementAfterDeletion(
+          flowBeforeDelete,
+          flowAfterDelete,
+          note.placement.parent,
+          deleted,
+        );
+        if (repositioned) {
+          toReanchor.push({ id: note.id, placement: repositioned });
+        } else {
+          toDelete.push(note.id);
+        }
+      }
+    }
+
+    await Promise.all([
+      ...(toDelete.length > 0
+        ? [
+            client.mutate({
+              mutation: DELETE_FLOW_NOTES,
+              variables: { ids: toDelete },
+            }),
+          ]
+        : []),
+      ...toReanchor.map(({ id, placement }) =>
+        client.mutate({
+          mutation: REANCHOR_FLOW_NOTE,
+          variables: { id, placement },
+        }),
+      ),
+    ]);
   },
 });

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/route.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import ErrorFallback from "components/Error/ErrorFallback";
 import FlowEditor from "pages/FlowEditor";
+import { NoteEditorDialog } from "pages/FlowEditor/components/Flow/notes/NoteEditorDialog";
 import AddComponentModal from "pages/FlowEditor/components/forms/AddComponentModal";
 import { RecentFlowsProvider } from "pages/FlowEditor/components/RecentFlows/RecentFlowsContext";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -16,10 +17,11 @@ export const Route = createFileRoute(
  * Ensure a single, persistant, instance of FlowEditor is mounted
  */
 function FlowEditorLayout() {
-  const [open, parent, before] = useStore((s) => [
+  const [open, parent, before, noteEditorOpen] = useStore((s) => [
     s.componentSelectorOpen,
     s.componentSelectorParent,
     s.componentSelectorBefore,
+    s.noteEditorOpen,
   ]);
 
   return (
@@ -27,6 +29,7 @@ function FlowEditorLayout() {
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <FlowEditor />
         {open && <AddComponentModal parent={parent} before={before} />}
+        {noteEditorOpen && <NoteEditorDialog />}
         <Outlet />
       </ErrorBoundary>
     </RecentFlowsProvider>

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_notes.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_notes.yaml
@@ -125,11 +125,23 @@ update_permissions:
         - color
         - updated_by
       filter:
-        created_by:
-          _eq: x-hasura-user-id
+        flow:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
       check:
-        created_by:
-          _eq: x-hasura-user-id
+        flow:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
     comment: ""
 delete_permissions:
   - role: platformAdmin
@@ -139,15 +151,12 @@ delete_permissions:
   - role: teamEditor
     permission:
       filter:
-        _and:
-          - created_by:
-              _eq: x-hasura-user-id
-          - flow:
-              team:
-                members:
-                  _and:
-                    - user_id:
-                        _eq: x-hasura-user-id
-                    - role:
-                        _eq: teamEditor
+        flow:
+          team:
+            members:
+              _and:
+                - user_id:
+                    _eq: x-hasura-user-id
+                - role:
+                    _eq: teamEditor
     comment: ""

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_notes.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_notes.yaml
@@ -40,6 +40,7 @@ insert_permissions:
         - text
         - color
         - created_by
+        - updated_by
     comment: ""
   - role: teamEditor
     permission:
@@ -62,6 +63,7 @@ insert_permissions:
         - text
         - color
         - created_by
+        - updated_by
     comment: ""
 select_permissions:
   - role: platformAdmin


### PR DESCRIPTION
### What's in this PR?
The core functionality for the new notes frontend:
- Add notes attached to nodes (incl options)
- Add notes via hangers to the graph itself
- Notes can be added via the context menu on right click or via the new component popup menu
- When deleting a node: 
    - notes attached to it are also deleted
    - notes after it are re-positioned after the next preceding node
- Some unit and UI tests for key functionality

### What's not in this PR?
- script to convert notes from old format to new
- handle notes when copy+pasting nodes
These are both in progress and coming in separate PRs

### Key files in this PR
It's pretty big in terms of lines and files touched but there's a bunch of boilerplate/tests/less interesting stuff. Most of the logic can be found in:
- `apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts` - graph traversal for figuring out `{before, parent}` values for notes
- `apps/editor.planx.uk/src/pages/FlowEditor/lib/store/notes.ts` - queries and business logic for calling the above functions

### Some assumptions I've made which are up for discussion
- Notes are editable and deleteable by any member of the team, not just the creator
- When you move a node that has a note following it (not attached), the note following it moves with the parent
- Notes cannot be attached directly after a question and before an option as we do not render hangers here - this one I feel like maybe we do want, but I was having issues with adding new hangers so wanted to check before spending more time on i
t.
- We do not insert new hangers before notes either, so if you want multiple notes in the same graph position they just stack on each other. I think it'd add a new level of complexity to do this because notes are no longer real nodes so they cannot be positioned relative to one another 

