### PR TITLE
fix: Design settings team name

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/ThemeAndLogo/index.tsx
@@ -1,8 +1,8 @@
 import Link from "@mui/material/Link";
-import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import ColorPicker from "ui/editor/ColorPicker/ColorPicker";
 import ImgInput from "ui/editor/ImgInput/ImgInput";
 import InputRow from "ui/shared/InputRow";
@@ -17,11 +17,10 @@ import { defaultValues, validationSchema } from "../shared/validationSchema";
 import type { FormValues, MutationVars } from "./types";
 
 const ThemeAndLogo: React.FC = () => {
-  const [teamId, teamSlug] = useStore((state) => [
+  const [teamId, teamName] = useStore((state) => [
     state.teamId,
-    state.teamSlug,
+    state.teamName,
   ]);
-  const muiTheme = useTheme();
 
   return (
     <SettingsFormContainer<GetTeamTheme, MutationVars, FormValues>
@@ -44,8 +43,8 @@ const ThemeAndLogo: React.FC = () => {
           {formik.values.logo ? (
             <img width="140" src={formik.values.logo} alt="council logo" />
           ) : (
-            <Typography color={muiTheme.palette.primary.contrastText}>
-              Plan✕ / {teamSlug}
+            <Typography variant="h4" sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}>
+              {teamName}
             </Typography>
           )}
         </DesignPreview>,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/styles.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/styles.ts
@@ -7,4 +7,5 @@ export const DesignPreview = styled(Box)(({ theme }) => ({
   boxShadow: "4px 4px 0px rgba(150, 150, 150, 0.5)",
   display: "flex",
   justifyContent: "center",
+  color: theme.palette.primary.contrastText,
 }));

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/styles.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Design/shared/styles.ts
@@ -4,6 +4,7 @@ import { styled } from "@mui/material/styles";
 export const DesignPreview = styled(Box)(({ theme }) => ({
   border: `2px solid ${theme.palette.border.input}`,
   padding: theme.spacing(2),
+  marginRight: theme.spacing(0.5),
   boxShadow: "4px 4px 0px rgba(150, 150, 150, 0.5)",
   display: "flex",
   justifyContent: "center",


### PR DESCRIPTION
## What does this PR do?

Fixes display of team name on settings page:
- Ensures text is visible with `contrastText`
- Drops `PlanX /` prefix, as we removed this on the public header a few months back

**Before:**
<img width="997" height="373" alt="image" src="https://github.com/user-attachments/assets/6cfbcb84-8969-4938-b6dd-44c837bdff5f" />

**After:**
<img width="997" height="373" alt="image" src="https://github.com/user-attachments/assets/dbdbfc56-caf5-45a0-91fb-e2b87d890594" />

**Testing:**
https://7005.planx.pizza/app/a-new-team/settings/design