### PR TITLE
fix: ensure "change" property link navigates correctly

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/changeAnswer.test.ts
@@ -21,10 +21,12 @@ describe("changeAnswer", () => {
       rCjETwjwE3: {
         auto: false,
         answers: ["b0qdvLAxIL"],
+        seq: 1,
       },
       vgj2UNYK9r: {
         answers: ["X9JjnbPpnd"],
         auto: true,
+        seq: 2,
       },
     } as Store.Breadcrumbs;
     const cachedBreadcrumbs = {} as Store.CachedBreadcrumbs;
@@ -47,6 +49,7 @@ describe("changeAnswer", () => {
     record("rCjETwjwE3", {
       answers: ["ykNZocRJtQ"],
       auto: false,
+      seq: 3,
     });
 
     expect(getState().changedNode).toEqual("rCjETwjwE3");
@@ -62,6 +65,7 @@ describe("changeAnswer", () => {
       vgj2UNYK9r: {
         answers: ["X9JjnbPpnd"],
         auto: true,
+        seq: 2,
       },
     } as Store.CachedBreadcrumbs;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/hasPaid.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/hasPaid.test.ts
@@ -36,12 +36,12 @@ test("hasPaid is updated if a Pay component has been recorded", () => {
       answers: ["c"],
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 1,
     },
     c: {
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 2,
     },
   });
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
@@ -17,13 +17,13 @@ test("it clears the correct breadcrumb and navigates back to the right node", as
   );
 
   // override answer ("I'm in a flat not a house")
+  expect(getCurrentCard()?.id).toEqual("PropertyInformationNodeId");
   overrideAnswer("property.type");
 
   // confirm we've cleared the provided passport variable from the first node that set it but added an audit variable `_overrides`
   const afterOverrideBreadcrumb = getState().breadcrumbs;
   const addressBreadcrumb: any =
     afterOverrideBreadcrumb?.["FindPropertyNodeId"]?.data;
-  expect(Object.keys(addressBreadcrumb)).toHaveLength(4);
   expect(addressBreadcrumb).not.toHaveProperty(["property.type"]);
   expect(addressBreadcrumb).toHaveProperty(["_overrides"]);
 
@@ -58,6 +58,7 @@ test("it clears the correct breadcrumb and navigates back to the right node", as
 const propertySearchBreadcrumb = {
   FindPropertyNodeId: {
     auto: false,
+    seq: 1,
     data: {
       _address: {
         uprn: "100081281679",
@@ -86,10 +87,12 @@ const propertySearchBreadcrumb = {
   SecondPropertyTypeQuestionNodeId: {
     answers: ["SemiDetachedResponseNodeId"],
     auto: true,
+    seq: 3,
   },
   FirstPropertyTypeQuestionNodeId: {
     answers: ["HouseResponseNodeId"],
     auto: true,
+    seq: 2,
   },
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/overrideAnswer.test.ts
@@ -17,15 +17,15 @@ test("it clears the correct breadcrumb and navigates back to the right node", as
   );
 
   // override answer ("I'm in a flat not a house")
-  expect(getCurrentCard()?.id).toEqual("PropertyInformationNodeId");
   overrideAnswer("property.type");
 
   // confirm we've cleared the provided passport variable from the first node that set it but added an audit variable `_overrides`
   const afterOverrideBreadcrumb = getState().breadcrumbs;
   const addressBreadcrumb: any =
-    afterOverrideBreadcrumb?.["FindPropertyNodeId"]?.data;
-  expect(addressBreadcrumb).not.toHaveProperty(["property.type"]);
-  expect(addressBreadcrumb).toHaveProperty(["_overrides"]);
+    afterOverrideBreadcrumb?.["FindPropertyNodeId"];
+  expect(addressBreadcrumb.data).not.toHaveProperty(["property.type"]);
+  expect(addressBreadcrumb.data).toHaveProperty(["_overrides"]);
+  expect(addressBreadcrumb.seq).toEqual(1);
 
   const afterOverridePassport = getState().computePassport();
   expect(afterOverridePassport.data).toBeDefined();

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/record.test.ts
@@ -62,13 +62,13 @@ test("record(id, undefined) clears up breadcrumbs", () => {
       answers: ["c"],
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 1,
     },
     d: {
       answers: ["e", "f"],
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 2,
     },
   });
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeNodesDependentOnPassport.test.ts
@@ -102,7 +102,7 @@ describe("nodesDependentOnPassport with record", () => {
       },
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 1,
     };
 
     setState({
@@ -150,7 +150,7 @@ describe("nodesDependentOnPassport with record", () => {
       },
       auto: false,
       createdAt: expect.any(String),
-      seq: expect.any(Number),
+      seq: 1,
     };
 
     setState({
@@ -361,26 +361,31 @@ const mockBreadcrumbs = {
   mBFPszBssY: {
     auto: false,
     answers: ["IzT93uCmyF", "4FRZMfNlXf"],
+    seq: 1,
   },
   "1eJjMmhGBU": {
     auto: false,
     answers: ["GxcDrNTW26"],
+    seq: 2,
   },
   J5SvQgzuK0: {
     auto: false,
     answers: ["DTXNs02JmU"],
+    seq: 3,
   },
   AHOdMRaRGK: {
     auto: false,
     data: {
       AHOdMRaRGK: "Answer",
     },
+    seq: 4,
   },
   OjcsvOxVum: {
     auto: false,
     data: {
       OjcsvOxVum: "Test",
     },
+    seq: 5,
   },
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/preview/removeOrphansFromBreadcrumbs.test.ts
@@ -9,26 +9,31 @@ describe("simple flow", () => {
     mBFPszBssY: {
       auto: false,
       answers: ["IzT93uCmyF", "4FRZMfNlXf"],
+      seq: 1,
     },
     "1eJjMmhGBU": {
       auto: false,
       answers: ["GxcDrNTW26"],
+      seq: 2,
     },
     J5SvQgzuK0: {
       auto: false,
       answers: ["DTXNs02JmU"],
+      seq: 3,
     },
     AHOdMRaRGK: {
       auto: false,
       data: {
         AHOdMRaRGK: "Answer",
       },
+      seq: 4,
     },
     OjcsvOxVum: {
       auto: false,
       data: {
         OjcsvOxVum: "Test",
       },
+      seq: 5,
     },
   };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/preview.ts
@@ -326,13 +326,20 @@ export const previewStore: StateCreator<
     if (!flow[id]) throw new Error(`id "${id}" not found`);
 
     if (userData) {
-      // add breadcrumb
-      const { answers = [], data = {}, auto = false, override } = userData;
+      // When navigating forwards, record adds a breadcrumb
+      const {
+        answers = [],
+        data = {},
+        auto = false,
+        override,
+        seq,
+        createdAt,
+      } = userData;
 
       const breadcrumb: Store.UserData = {
         auto: Boolean(auto),
-        createdAt: new Date().toISOString(),
-        seq: Object.keys(breadcrumbs).length + 1,
+        createdAt: createdAt ?? new Date().toISOString(),
+        seq: seq ?? Object.keys(breadcrumbs).length + 1,
       };
       if (answers?.length > 0) breadcrumb.answers = answers;
 
@@ -388,7 +395,7 @@ export const previewStore: StateCreator<
         changedNode: shouldRemovedChangedNode ? undefined : changedNode,
       });
     } else {
-      // remove breadcrumbs that were stored from id onwards because user has 'gone back'
+      // When navigating backwards or via "change", do not expect userData and remove any breadcrumbs that were stored from id onwards
       const breadcrumbIds = Object.keys(breadcrumbs);
       const idx = breadcrumbIds.indexOf(id);
       const remainingBreadcrumbs = pick(
@@ -407,8 +414,8 @@ export const previewStore: StateCreator<
         });
       }
     }
-    setCurrentCard();
 
+    setCurrentCard();
     updateSectionData();
   },
 
@@ -822,6 +829,9 @@ export const previewStore: StateCreator<
           ...omit(breadcrumbs?.[originalNodeId]?.data, fn),
           _overrides: { [fn]: breadcrumbs?.[originalNodeId]?.data?.[fn] },
         },
+        // Retain original sequence to ensure correct navigation
+        seq: breadcrumbs?.[originalNodeId]?.seq,
+        createdAt: breadcrumbs?.[originalNodeId]?.createdAt,
       });
     }
 


### PR DESCRIPTION
Flagged by DAC when reviewing accessibility test flow. 

Likely a regression since adding breadcrumb `seq` and has gone unnoticed for quite awhile!! Full details below as in-line comments.

**To test, compare navigation of following equivalent flows:** 
- Prod https://editor.planx.uk/testing/default-property-type-testing/preview
  - Answer "Full content" > "SE5 OHU", "47, COBOURG ROAD" > Click "Change" link > :x: Navigates back to FindProperty
- Pizza https://7006.planx.pizza/testing/default-property-type-testing/preview
  - Answer "Full content" > "SE5 OHU", "47, COBOURG ROAD" > Click "Change" link > :white_check_mark: Navigates back to question "Which of these best describes the use of the property?" with "Residential" pre-filled