### PR TITLE
feat: Improve usability of node drag and drop

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
@@ -8,7 +8,7 @@ import {
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
 import React, { useCallback } from "react";
-import { useDrop } from "react-dnd";
+import { useDragLayer, useDrop } from "react-dnd";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
@@ -24,6 +24,8 @@ interface Item {
   parent: string;
   text: string;
 }
+
+const DROPPABLE_TYPES = ["DECISION", "PORTAL", "PAGE"];
 
 const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
   parent = getParentId(parent);
@@ -56,8 +58,8 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
     ? hideHangerInTemplatedFlow
     : !useStore.getState().canUserEditTeam(teamSlug);
 
-  const [{ canDrop, item }, drop] = useDrop({
-    accept: ["DECISION", "PORTAL", "PAGE"],
+  const [{ isOver, canDrop, item }, drop] = useDrop({
+    accept: DROPPABLE_TYPES,
     drop: (item: Item) => {
       moveNode(item.id, item.parent, before, parent);
     },
@@ -67,6 +69,13 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
       item: monitor.isOver() && monitor.getItem(),
     }),
   });
+
+  // Highlight every valid hanger as a drop target while a node is being dragged on the canvas
+  const isDropTargetVisible = useDragLayer(
+    (monitor) =>
+      monitor.isDragging() &&
+      DROPPABLE_TYPES.includes(monitor.getItemType() as string),
+  );
 
   const handleContextMenu = useContextMenu({
     source: "hanger",
@@ -87,9 +96,16 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
     [parent, before],
   );
 
+  const isHidden = hidden || hideHangerFromUser;
+
   return (
     <li
-      className={classnames("hanger", { hidden: hidden || hideHangerFromUser })}
+      className={classnames("hanger", {
+        hidden: isHidden,
+        "hanger--drop-target": isDropTargetVisible && !isHidden,
+        "hanger--drop-target-active":
+          isDropTargetVisible && !isHidden && isOver && canDrop,
+      })}
       ref={(el) => {
         drop(el);
       }}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -10,6 +10,7 @@ $dataBackground: #f0f0f0;
 $lockedDataBackground: #e2e2e2;
 $folderBackground: #b5d1f7;
 $folderBorder: #2c4b88;
+$primaryAction: #0010a4;
 
 $endpointWidth: 50px;
 $hangerWidth: 16px;
@@ -183,9 +184,27 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 
   &.isDragging {
-    opacity: 0.3;
+    opacity: 0.5;
+    & > .card-wrapper > a {
+      border-style: dashed;
+    }
     & + .hanger {
       @include disabledHanger();
+
+      // Don't show sibling hangers as drop targets while dragging a node
+      &.hanger--drop-target,
+      &.hanger--drop-target-active {
+        > a,
+        > button {
+          background-color: $hangerBackground;
+          transform: none;
+
+          &::before,
+          &::after {
+            content: none;
+          }
+        }
+      }
     }
     > ol {
       visibility: hidden;
@@ -490,6 +509,60 @@ $fontMonospace: "Source Code Pro", monospace;
 
     &:empty {
       padding: 0;
+    }
+  }
+
+  // Highlight available hangers as drop targets while node is being dragged
+  &.hanger--drop-target {
+    $dropTargetScale: 1.5;
+
+    > a,
+    > button {
+      position: relative;
+      width: $hangerWidth;
+      background-color: white;
+      transform: scale($dropTargetScale);
+      transition:
+        background-color 0.2s,
+        transform 0.2s,
+        width 0.1s;
+
+      // Show a "+" indicator in the center of the hanger
+      &::before,
+      &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        background-color: $black;
+        transform: translate(-50%, -50%);
+      }
+      &::before {
+        width: 5px;
+        height: 1px;
+      }
+      &::after {
+        width: 1px;
+        height: 5px;
+      }
+    }
+
+    // Show a preview of the node while over a drop target hanger
+    &.hanger--drop-target-active {
+      > a,
+      > button {
+        transition: none;
+        width: auto;
+        min-width: 134px;
+        transform: none;
+        background-color: $hangerBackground;
+        border-radius: 0;
+
+        &::before,
+        &::after {
+          content: none;
+        }
+      }
     }
   }
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -198,11 +198,9 @@ $fontMonospace: "Source Code Pro", monospace;
         > button {
           background-color: $hangerBackground;
           transform: none;
-
-          &::before,
-          &::after {
-            content: none;
-          }
+          width: $hangerWidth;
+          border-style: solid;
+          transition: none;
         }
       }
     }
@@ -514,7 +512,7 @@ $fontMonospace: "Source Code Pro", monospace;
 
   // Highlight available hangers as drop targets while node is being dragged
   &.hanger--drop-target {
-    $dropTargetScale: 1.5;
+    $dropTargetScale: 1.3;
 
     > a,
     > button {
@@ -522,29 +520,12 @@ $fontMonospace: "Source Code Pro", monospace;
       width: $hangerWidth;
       background-color: white;
       transform: scale($dropTargetScale);
+      border-style: dashed;
+      width: 60px;
       transition:
         background-color 0.2s,
         transform 0.2s,
-        width 0.1s;
-
-      // Show a "+" indicator in the center of the hanger
-      &::before,
-      &::after {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        background-color: $black;
-        transform: translate(-50%, -50%);
-      }
-      &::before {
-        width: 5px;
-        height: 1px;
-      }
-      &::after {
-        width: 1px;
-        height: 5px;
-      }
+        width 0.2s;
     }
 
     // Show a preview of the node while over a drop target hanger
@@ -553,13 +534,12 @@ $fontMonospace: "Source Code Pro", monospace;
       > button {
         transition: none;
         width: auto;
-        min-width: 134px;
+        min-width: 150px;
         transform: none;
         background-color: $hangerBackground;
         border-radius: 0;
 
-        &::before,
-        &::after {
+        &::before {
           content: none;
         }
       }


### PR DESCRIPTION
## What does this PR do?

When dragging a component in the PlanX editor it is not immediacy communicated where the component can be moved to. We know the following is true:
- Immediate sibling hangers cannot be dropped into, as they would present no relative movement
- Other hangers can be dropped into, but they do not indicate as such

Update to give the droppable hangers a distinct style with + character, making it obvious where the potential drop targets are.


https://github.com/user-attachments/assets/bc90740f-a537-4a81-83f8-50ddb06e8d3f

