### PR TITLE
fix(editor): Manage overflow in `AddFlow` modal

### DIFF
--- a/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/index.tsx
@@ -114,41 +114,45 @@ export const AddFlow: React.FC = () => {
             <DialogTitle variant="h3" component="h1" id="dialog-heading">
               Add a new flow
             </DialogTitle>
-            <Box>
-              <Form>
-                <DialogContent dividers>
-                  <ErrorWrapper error={status?.error}>
-                    <Box
-                      sx={{
-                        gap: 2,
-                        display: "flex",
-                        flexDirection: "column",
-                      }}
-                    >
-                      <BaseFormSection />
-                    </Box>
-                  </ErrorWrapper>
-                </DialogContent>
-                <DialogActions>
-                  <Button
-                    onClick={() => setDialogOpen(false)}
-                    disabled={isSubmitting}
-                    variant="contained"
-                    color="secondary"
+            <Form
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+              }}
+            >
+              <DialogContent dividers>
+                <ErrorWrapper error={status?.error}>
+                  <Box
+                    sx={{
+                      gap: 2,
+                      display: "flex",
+                      flexDirection: "column",
+                    }}
                   >
-                    Back
-                  </Button>
-                  <Button
-                    type="submit"
-                    color="primary"
-                    variant="contained"
-                    disabled={isSubmitting}
-                  >
-                    Add flow
-                  </Button>
-                </DialogActions>
-              </Form>
-            </Box>
+                    <BaseFormSection />
+                  </Box>
+                </ErrorWrapper>
+              </DialogContent>
+              <DialogActions>
+                <Button
+                  onClick={() => setDialogOpen(false)}
+                  disabled={isSubmitting}
+                  variant="contained"
+                  color="secondary"
+                >
+                  Back
+                </Button>
+                <Button
+                  type="submit"
+                  color="primary"
+                  variant="contained"
+                  disabled={isSubmitting}
+                >
+                  Add flow
+                </Button>
+              </DialogActions>
+            </Form>
           </Dialog>
         )}
       </Formik>


### PR DESCRIPTION
Small visual issue I spotted when testing https://github.com/theopensystemslab/planx-new/pull/7009

The `AddFlow` modal has an invisible overflow, instead of the standard fixed `DialogAction` element (like `FormModal`). Removing the redundant wrapping `Box` solves this. 

_`EditorModal` for reference showing how this is usually handled_
<img width="879" height="734" alt="image" src="https://github.com/user-attachments/assets/05e07c44-6722-4c5f-931d-a6284a513211" />

| Before | After |
|--------|--------|
| <img width="890" height="743" alt="image" src="https://github.com/user-attachments/assets/52f8259c-8e07-4152-82f2-e5ae62a54c82" /> | <img width="883" height="740" alt="image" src="https://github.com/user-attachments/assets/35633897-a472-4ceb-9e80-ceae00f1be53" /> | 



