### PR TITLE
docs: Update custom subdomain guide

### DIFF
--- a/doc/how-to/how-to-setup-custom-domains.md
+++ b/doc/how-to/how-to-setup-custom-domains.md
@@ -4,329 +4,353 @@
 
 Teams can access PlanX via a custom subdomain on their own domain (e.g. `https://planningservices.medway.gov.uk/`).
 
-Custom domains are ideally served by a **shared CloudFront distribution** backed by a single DNS-validated ACM certificate (which we abbreviate as 'cert' hereafter). This replaces the legacy model where each council's custom domain had its own dedicated CloudFront distribution and had to provide us with an SSL cert.
+Custom domains are served by a single **shared CloudFront distribution** ("shared CDN") backed by a single **DNS-validated ACM certificate** ("shared cert") that we provision. This replaces the legacy model where each council had its own dedicated CloudFront distribution backed by a council-provided SSL certificate.
 
-Because the shared cert is DNS-validated and managed by AWS, **it will auto-renew** — there is no manual renewal process (see [Appendix A](#appendix-a-automatic-certificate-renewal)). All that is required of council IT teams is for them to add 2 DNS records (usually, they can add both simultaneously).
+Because the shared cert is DNS-validated and managed by AWS, **it auto-renews** - there is no manual renewal (see [Appendix A](#appendix-a-automatic-certificate-renewal)). All a council's IT team ever has to do is add **two DNS records**, which they can add at the same time.
 
-Note that we have a [public-facing onboarding document](https://opensystemslab.notion.site/9-Set-up-custom-subdomains-3000ef5212cc43a5a88f46563142f82a) that you can send to councils for an abbreviated explanation of this system from their perspective.
+Related links:
 
-NB. We generally assume a 1-to-1 relationship between councils and their custom domains, so we sometimes use these terms in place of each other.
+- Public-facing [onboarding doc for councils](https://opensystemslab.notion.site/9-Set-up-custom-subdomains-3000ef5212cc43a5a88f46563142f82a) — an abbreviated explanation from their perspective.
+- Internal [PlanX CRM on Notion](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff) — tracks the `Auto-SSL` status per council.
 
-### Source of truth
+> We assume a 1-to-1 relationship between councils and custom domains, and sometimes use the terms interchangeably. We also use "CDN" and "[CloudFront] distribution" interchangeably.
 
-All custom domains are defined in [`infrastructure/common/customDomains.ts`](../../infrastructure/common/customDomains.ts). Each entry has a `cloudFrontState` string describing where it is in the lifecycle:
+## The lifecycle 🔄
 
-| `cloudFrontState` | Actual state of infrastructure |
-| --- | --- |
-| `validation-only` | Domain is not associated with any CDN, but is on the "mining" certificate (cert) to surface DNS validation records (which we will send to council). |
-| `legacy-with-validation` | Domain is associated with (i.e. is an alias of) legacy CDN, which is backed by a council-provided cert. Domain is also on mining cert. |
-| `cutover-ongoing` | Initially, domain is still associated with legacy CDN. We ensure shared CDN exists, and is backed by a shared cert provisioned by us, which includes the domain as an [SAN](https://support.dnsimple.com/articles/what-is-ssl-san/). Once the council swaps their DNS record, we associate the domain with the shared CDN. At this point, the legacy CDN still exists but has no aliases.
-| `shared-final` | Domain is associated with shared CDN. The legacy CDN, if this was a migration, has been torn down (otherwise, it never existed). This will be the eventual final state for all domains. |
+Every custom domain is defined in [`infrastructure/common/customDomains.ts`](../../infrastructure/common/customDomains.ts) - the single source of truth - with a `cloudFrontState` describing where it is in its lifecycle. There are two entry points and one shared destination -
 
-NB. We largely use 'CDN' and '[CloudFront] distribution' interchangeably throughout this document, although this is a simplification.
+```mermaid
+graph
+    Start((Start)) -->|New council| VO[validation-only]
+    Start -->|Existing legacy| LWV[legacy-with-validation]
 
-### Deploy ordering
+    VO -->|Process A: Onboard| SF[shared-final]
+    LWV -->|Process B: Migrate| CO[cutover-ongoing]
+    CO -->|Process B: Migrate| SF
 
-Correct sequencing is important! Usually, the `certificates` stack must be deployed (manually) _before_ the `application` stack, for example because it exports the shared certificate ARN via a Pulumi stack reference.
+    SF --> Done((Done))
+```
 
-However, there are exceptions. When it comes to tearing down legacy CloudFront distributions, we have to delete those first (i.e. deploy `application`) _before_ we delete the attached cert (i.e. deploy `certificates`).
+- **Process A** ([onboard a new council](#process-a-onboard-a-new-council)): `validation-only → shared-final`
+- **Process B** ([migrate a legacy council](#process-b-migrate-a-legacy-council)): `legacy-with-validation → cutover-ongoing → shared-final`
 
-- **Certificates** — manually deployed (see `infrastructure/README.md`)
-- **Application** — deployed by CI on every merge to `main` (staging) or on every `production` rollout
+### What each state actually means for the infrastructure
 
+The state controls which certs and distributions each domain is wired into. The helpers in [`customDomains.ts`](../../infrastructure/common/customDomains.ts) (`getPendingDomains`, `getValidatedDomains`, `getLegacyDomains`) turn the state into infra, so this table is the mental model to hold:
 
-## Process ⚙️
+| State                    |       On **mining** cert?        | On **shared** cert? |  Legacy CDN?  |    Alias on shared CDN?    | Live traffic served by               |
+| ------------------------ | :------------------------------: | :-----------------: | :-----------: | :------------------------: | ------------------------------------ |
+| `validation-only`        | ✅ (surfaces validation records) |          —          |       —       |             —              | not live yet                         |
+| `legacy-with-validation` |                ✅                |          —          |      ✅       |             —              | legacy CDN                           |
+| `cutover-ongoing`        |                —                 |         ✅          |   ✅ (idle)   | ❌ (deliberately held out) | legacy CDN, until you move the alias |
+| `shared-final`           |                —                 |         ✅          | — (torn down) |             ✅             | shared CDN                           |
 
-There are two paths here. You are either (A) [onboarding a new council](#a-onboarding-a-new-council) who have no existing custom domain, or (B) [migrating a council](#b-migrating-a-council-from-legacy-setup) with an existing custom domain from the legacy infrastructure setup to the new, shared CDN setup.
+Two key points from above -
 
-In either case, please read through all the steps before starting, for best results.
+- The **mining cert** (`sslCert-dns-mining`) is a throwaway cert that exists only to surface DNS validation records for domains that aren't yet on the shared cert. It is never attached to any CDN.
+- In `cutover-ongoing`, the shared cert already covers the domain, but the domain is **deliberately filtered out** of the shared CDN's alias list (see [`application/index.ts`](../../infrastructure/application/index.ts) — `d.cloudFrontState !== "cutover-ongoing"`). That's because a CloudFront alias can only live on one distribution at a time, and it's still on the legacy CDN. You move it across manually (see Process B) before advancing to `shared-final`.
 
-NB. We assume here that you want to run the relevant infra on production.
+## The two DNS records 🧭
 
+Every council adds two CNAME records. Send them both at once - they're independent, and both must stay in place forever.
 
-### A. Onboarding a new council
+| #   | Record         | Example name                              | Example target                          | Purpose                                                   | Live traffic? |
+| --- | -------------- | ----------------------------------------- | --------------------------------------- | --------------------------------------------------------- | ------------- |
+| 1   | **Validation** | `_abc123.planningservices.council.gov.uk` | `_def456.acm-validations.aws`           | Proves ownership so ACM can issue and auto-renew the cert | ❌ Never      |
+| 2   | **Routing**    | `planningservices.council.gov.uk`         | `d1234abcd.cloudfront.net` (shared CDN) | Points live traffic at the CDN                            | ✅ Yes        |
 
-Path: `validation-only` → `shared-final`
+For a migration, the routing record _replaces_ an existing one (legacy CDN → shared CDN). You can switch it at any point: CloudFront serves each request from whichever distribution owns the alias, so traffic keeps flowing through the legacy CDN until you move the alias - regardless of where the DNS points (see [Appendix B](#appendix-b-cloudfront-routing)).
 
-1. Update the [PlanX CRM on Notion](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff).
+## Deploy layers & ordering 🚦
 
-    Find the relevant council's page in our internal CRM, and set the 'Auto-SSL' column to "In progress".
+| Layer              | How it deploys                                                                       | Notes                                                          |
+| ------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| **`certificates`** | Manually — `pulumi up --refresh --stack production` (see `infrastructure/README.md`) | Provisions the mining and shared certs                         |
+| **`application`**  | By CI on merge to `main` / on a `production` rollout                                 | Attaches the shared cert to the shared CDN and manages aliases |
 
-2. Pull latest `main`, open a new branch, and add the desired new domain to the array in `infrastructure/common/customDomains.ts`:
+**Ordering:** deploy `certificates` **before** `application` - the application layer imports the shared cert ARN via a Pulumi stack reference, so the cert must exist first.
 
-    ```ts
-    {
-      name: "a-new-council",
-      domain: "planningservices.a-new-council.gov.uk",
-      cloudFrontState: "validation-only",
-    },
-    ```
+⚠️ **The one exception:** when _tearing down_ a legacy CDN, delete the distribution first (`application`) and only then the cert it used (`certificates`). Deleting a cert still attached to a live distribution fails.
 
-    Here `name` should match the `teams.slug` value in the [db](https://hasura.editor.planx.uk/console/data/default/schema/public/tables/teams/browse). Note also that `certificateLocation` is not necessary here. Then commit this change.
+## Process A: onboard a new council
 
-3. Deploy the `certificates` stack. Make sure you have the appropriate AWS credentials/profile exported in your terminal, then run:
+**Path: `validation-only → shared-final`.** The council has no existing custom domain.
 
-    ```sh
-    cd infrastructure/certificates
-    pulumi up --refresh --stack production
-    ```
+### 1. Add the domain to the source of truth
 
-    This creates or updates the mining certificate (called thus because we 'mine' it for DNS validation records) with the new domain as an SAN. AWS ACM generates a CNAME record the council must add to prove domain ownership.
+Pull latest `main`, branch, and add an entry to [`customDomains.ts`](../../infrastructure/common/customDomains.ts):
 
-4. Read the pending DNS records
+```ts
+{
+  name: "a-new-council",              // must match teams.slug in the db
+  domain: "planningservices.a-new-council.gov.uk",
+  cloudFrontState: "validation-only",  // certificateLocation is not needed
+},
+```
 
-    ```sh
-    pulumi stack output pendingCouncilDnsRecords --stack production --json
-    ```
+Set the council's `Auto-SSL` to **In progress** in the [CRM](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff). Commit, and open a PR so the source of truth on `main` stays accurate (get it merged once the entry is stable).
 
-    Output should look like:
+### 2. Deploy `certificates` to mint the validation record
 
-    ```json
-    [
-      {
-        "domain": "planningservices.a-new-council.gov.uk",
-        "validationCname": {
-          "name": "_abc123.planningservices.a-new-council.gov.uk.",
-          "target": "_def456.xyz.acm-validations.aws."
-        }
-      }
-    ]
-    ```
+```sh
+cd infrastructure/certificates
+pulumi up --refresh --stack production
+```
 
-5. Send validation CNAME to the council
+This adds the domain to the mining cert as an SAN; ACM generates the CNAME the council must add to prove ownership.
 
-    Ask the council IT team to create this DNS record on their nameserver:
+### 3. Send the council both DNS records
 
-    | Type | Name | Target |
-    | --- | --- | --- |
-    | CNAME | `_abc123.planningservices.a-new-council.gov.uk` | `_def456.acm-validations.aws` |
+Read the validation record:
 
-    This record proves they own the domain for purposes of certificate validation. It does not affect live traffic.
+```sh
+pulumi stack output pendingCouncilDnsRecords --stack production --json
+```
 
-    > NB. **If this is not the first domain on the shared CDN** and you want to expedite:
-    > - Do steps 12-13 **now** and send the council both DNS records together.
-    > - Do step 14 **now** and bundle the application-level changes into your current PR (to be merged in step 10).
-  
-6. **Wait** for the council to confirm they've added the record.
+Get the shared CDN domain for the routing record:
 
-    If this is likely to take a while, open a PR with your initial commit and get it merged, so that the `customDomains.ts` source of truth is accurate on `main`.
+```sh
+cd ../application
+pulumi stack output customDomainsCdnDomainName --stack production   # e.g. d1234abcd.cloudfront.net
+```
 
-    When it's done, you can then verify in the [AWS console](https://us-east-1.console.aws.amazon.com/acm/certificates/list) (make sure you're in the `us-east-1` region). The status of the specific domain on the mining cert should have changed from `Pending validation` to `Success`.
+Send the council both CNAMEs together.
 
-    NB. The mining certs will 'fail' after 72hrs of attempting to validate their assigned domains, in which case you cannot use it to verify a correct DNS record. However, they can be re-created by simply deploying `certificates` again, as in step 3. Note that when these certs fail, Pulumi loses track of them, so it will not clean them up on next deploy (i.e. we should do that manually).
+| Type  | Name                                            | Target                        |
+| ----- | ----------------------------------------------- | ----------------------------- |
+| CNAME | `_abc123.planningservices.a-new-council.gov.uk` | `_def456.acm-validations.aws` |
+| CNAME | `planningservices.a-new-council.gov.uk`         | `d1234abcd.cloudfront.net`    |
 
-7. Advance the state of the domain to `shared-final` by updating the entry in `customDomains.ts`:
+### 4. Wait for the validation record, then verify it
 
-    ```diff
-    - cloudFrontState: "validation-only",
-    + cloudFrontState: "shared-final",
-    ```
+Wait for the council to confirm. Then verify the record is actually live (don't rely on the ACM console alone - see [Troubleshooting](#troubleshooting)):
 
-    Commit this change, open a PR if you haven't already, and get the PR approved.
+```sh
+dig _abc123.planningservices.a-new-council.gov.uk CNAME +short @1.1.1.1
+# → returns the ...acm-validations.aws. target once it's in place
+```
 
-8. Deploy `certificates` again (as in step 3).
+In the [ACM console](https://us-east-1.console.aws.amazon.com/acm/certificates/list) (region **us-east-1**), the domain on the mining cert should flip from `Pending validation` to `Success`.
 
-    This deploy removes the domain from the mining cert and adds it to the shared cert proper. It does this by creating a new cert, but we **retain the old cert**, because for now the shared CDN still relies on it.
+> ⏳ Mining certs give up after ~72h of failing to validate and go to `Failed`; a `Failed` cert won't update no matter what the council does. Re-run `certificates` (step 2) to recreate it and restart the clock.
+>
+> Note: when a cert fails, Pulumi loses track of it, so clean it up manually.
 
-9.  Before we proceed, we need to **verify the new certificate has issued**.
+### 5. Advance to `shared-final` and provision the shared cert
 
-    **This will fail** if the council we are onboarding has not yet added the DNS validation record (which we should have already verified in step 6) - or if _any other council_ already using the shared CDN has removed their validation record since the last time the shared cert was replaced.
+Update the entry:
 
-    First get the ID of the new cert:
+```diff
+- cloudFrontState: "validation-only",
++ cloudFrontState: "shared-final",
+```
 
-    ```sh
-    cd infrastructure/certificates
-    pulumi stack output customDomainsCertArn --stack production
-    ```
+Deploy `certificates` again (as in step 2). This removes the domain from the mining cert and adds it to the shared cert (creating a **new** shared cert; the old one is retained because the shared CDN still relies on it for now).
 
-    This returns a value like `arn:aws:acm:us-east-1:123:certificate/[uuid]`. The cert ID is the UUID after the slash.
+### 6. Verify the new shared cert has issued
 
-    You can then check the [AWS console](https://us-east-1.console.aws.amazon.com/acm/certificates/list) (in the `us-east-1` region). The relevant cert should have status `Issued`. If not, identify which domain is not validated by clicking through on the cert ID, and contact that council to resolve.
-    
-    Note that at this point, the cert should display as **not** in use, because it's not yet attached to a CloudFront distribution.
+```sh
+cd infrastructure/certificates
+pulumi stack output customDomainsCertArn --stack production   # arn:aws:acm:us-east-1:…/<uuid>
+aws acm describe-certificate --region us-east-1 --certificate-arn <arn> \
+  --query 'Certificate.{Status:Status,SANs:SubjectAlternativeNames}'
+```
 
-10. Now **merge your PR to `main`** and **deploy your changes to `production`** to deploy the `application` layer via CI.
+Expect `Status: ISSUED` and the new domain present in `SANs`. It will show as **not in use** (not yet attached to a CDN) - that's expected.
 
-    This deploy attaches the new cert to the shared CDN (and will also create it first, if it doesn't already exist).
+> This step **fails to issue** if the council we're onboarding hasn't validated, _or_ if any other council already on the shared CDN has since removed their validation record. If it won't issue, identify the unvalidated domain via the cert's `DomainValidationOptions` and chase that council.
 
-11. Clean up the old shared cert with another run of `certificates`.
+### 7. Deploy `application` to attach the cert
 
-    NB. This may not work. Pulumi seems to keep track of the retained cert in some cases and not others. If the `pulumi up` run does not propose any changes, you can do this manually in the [AWS console](https://us-east-1.console.aws.amazon.com/acm/certificates/list?region=us-east-1#) instead. It's essentially harmless for these old shared certs to build up, but also confusing!
+Merge your PR to `main` and roll out to `production`. This attaches the new shared cert to the shared CDN (creating the shared CDN first if it somehow doesn't exist yet). Once the council's routing record (sent in step 3) has propagated, live traffic now flows to the shared CDN.
 
-12. Get the shared CDN domain name:
+### 8. Add application-level config
 
+In the same PR or a follow-up:
+
+1. **Frontend route detection** - add the domain to `PREVIEW_ONLY_DOMAINS` in [`apps/editor.planx.uk/src/utils/routeUtils/utils.ts`](../../apps/editor.planx.uk/src/utils/routeUtils/utils.ts).
+2. **Error reporting** - add a `case` for the domain in `getEnvForAllowedHosts()` in [`apps/editor.planx.uk/src/airbrake.ts`](../../apps/editor.planx.uk/src/airbrake.ts), mapping to `"production"`.
+3. **Database** - set `team.domain` to the domain in the Hasura production console (enables payment links and save-and-return URLs to use the custom domain).
+
+### 9. Clean up & finish
+
+- **Old shared cert** - re-run `certificates`; it _may_ propose deleting the retained old cert. If it proposes nothing, delete it manually in the [ACM console](https://us-east-1.console.aws.amazon.com/acm/certificates/list?region=us-east-1) (harmless to leave, but they accumulate).
+- **Monitoring** - if there are fewer than 5 monitors under `custom-domains-production` on [UptimeRobot](https://dashboard.uptimerobot.com/monitors), clone an existing one for this domain (preserves Slack SSL-expiry alerts). Login is in the 1Password 'PlanX' vault.
+- **CRM** - add the domain under `Custom Subdomain` and set `Auto-SSL` to **Done**.
+
+## Process B: migrate a legacy council
+
+**Path: `legacy-with-validation → cutover-ongoing → shared-final`.** The council already has a dedicated legacy CDN backed by a council-provided cert; we're moving them to the shared CDN + our DNS-validated cert.
+
+The usual trigger is an impending BYO-cert expiry, flagged in the `#planx-notifications-ssl` Slack channel (check dates in the [ACM console](https://us-east-1.console.aws.amazon.com/acm/certificates/list?region=us-east-1)).
+
+> No new councils are onboarded in legacy mode. When the last legacy council is migrated, delete this section.
+
+### 1. Send the council both DNS records
+
+Set the council's `Auto-SSL` to **In progress** in the [CRM](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff).
+
+A legacy council is already on the mining cert (`legacy-with-validation`), so the validation record is already available. Read it, and grab the shared CDN domain for the routing record:
+
+```sh
+cd infrastructure/certificates
+pulumi stack output pendingCouncilDnsRecords --stack production --json     # validation record
+
+cd ../application
+pulumi stack output customDomainsCdnDomainName --stack production          # routing target, e.g. d1234abcd.cloudfront.net
+```
+
+Send the council both CNAMEs together - the routing record replaces their existing one:
+
+### 2. Wait for the validation record, then verify it
+
+```sh
+dig _abc123.planningservices.an-existing-council.gov.uk CNAME +short @1.1.1.1
+# → returns the ...acm-validations.aws. target once live
+```
+
+Confirm `Success` on the mining cert in the [ACM console](https://us-east-1.console.aws.amazon.com/acm/certificates/list) (us-east-1). Don't advance until this is confirmed - the next step's cert won't issue otherwise.
+
+### 3. Advance to `cutover-ongoing` and provision the shared cert
+
+Update the entry and commit (open a PR, get it approved):
+
+```diff
+- cloudFrontState: "legacy-with-validation",
++ cloudFrontState: "cutover-ongoing",
+```
+
+Deploy `certificates` to move the domain off the mining cert and onto the shared cert:
+
+```sh
+cd infrastructure/certificates
+pulumi up --refresh --stack production
+```
+
+> 🚩 **Sanity-check the Pulumi preview before confirming.** A correct run _adds_ an SAN and **replaces** `sslCert-custom-domains` (Pulumi status - `retain[replace]`) - the SAN count should go **up**. If you see the shared cert or mining cert being **deleted outright**, or the SAN count shrinking, you are almost certainly on the wrong Pulumi stack or using the wrong AWS credentials. Do not proceed.
+
+### 4. Verify the shared cert issued and is attached to the shared CDN
+
+First confirm the new cert issued and covers the domain:
+
+```sh
+pulumi stack output customDomainsCertArn --stack production
+aws acm describe-certificate --region us-east-1 --certificate-arn <arn> \
+  --query 'Certificate.{Status:Status,SANs:SubjectAlternativeNames}'
+```
+
+Then **deploy `application`** (production rollout) so the shared CDN re-attaches to this new cert. This is essential - until it happens, the shared CDN can't serve the domain and the alias move in step 6 will fail. Confirm the cert now attached to the shared CDN includes the domain:
+
+```sh
+cd infrastructure/application
+DIST_ID=$(pulumi stack output customDomainsDistributionId --stack production)   # the shared CDN, e.g. E2E8DS0BTP89SI
+CERT_ARN=$(aws cloudfront get-distribution --id "$DIST_ID" \
+  --query 'Distribution.DistributionConfig.ViewerCertificate.ACMCertificateArn' --output text)
+aws acm describe-certificate --region us-east-1 --certificate-arn "$CERT_ARN" \
+  --query 'Certificate.SubjectAlternativeNames'
+# → the migrating domain must appear in this list
+```
+
+### 5. Move the alias from the legacy CDN to the shared CDN
+
+CloudFront won't let an alias live on two distributions, so you move it manually with [`update-domain-association`](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/update-domain-association.html). (Set up AWS CLI SSO first if needed — see `../how-to-setup-aws-sso-credentials.md`.)
+
+Confirm where the alias currently lives (should be the legacy CDN):
+
+```sh
+aws cloudfront list-distributions \
+  --query "DistributionList.Items[?contains(Aliases.Items, 'planningservices.an-existing-council.gov.uk')].{Id:Id,Status:Status}"
+```
+
+Then **fetch a fresh ETag of the target (shared) distribution every time** - it changes on every deploy and is a hash of the current object:
+
+```sh
+aws cloudfront get-distribution --id "$DIST_ID" --query '{ETag:ETag,Status:Distribution.Status}'
+```
+
+Wait until `Status` is `Deployed` (not `InProgress`), then move the alias:
+
+```sh
+aws cloudfront update-domain-association \
+  --domain planningservices.an-existing-council.gov.uk \
+  --target-resource DistributionId="$DIST_ID" \
+  --if-match <fresh-etag>
+```
+
+If it errors, see [Troubleshooting](#troubleshooting) - the two common failures (`InvalidArgument` and `PreconditionFailed`) both have simple causes.
+
+> ⚠️ **Once the alias is moved, finish the migration promptly (steps 6–7).** While the domain is still `cutover-ongoing`, it's held out of the shared CDN's alias list - so any `application` deploy that lands now will try to _remove_ the alias you just moved, reverting the cutover. Don't let an unrelated production deploy slip in before you've advanced to `shared-final`.
+
+### 6. Verify traffic has been re-routed
+
+```sh
+# The alias should now be owned by the shared CDN, not the legacy one:
+aws cloudfront list-distributions \
+  --query "DistributionList.Items[?contains(Aliases.Items, 'planningservices.an-existing-council.gov.uk')].{Id:Id}"
+
+dig planningservices.an-existing-council.gov.uk CNAME +short   # → the shared CDN domain
+```
+
+Also load the site in a browser and confirm it works. (Note: once the routing record points at the shared CDN, `dig` alone can't tell you which distribution is _serving_ - use the alias ownership check above.)
+
+### 7. Advance to `shared-final` and tear down the legacy CDN
+
+Update the entry - and remove `certificateLocation` if present (it's only used by the legacy CDN):
+
+```diff
+- cloudFrontState: "cutover-ongoing",
++ cloudFrontState: "shared-final",
+- certificateLocation: "pulumiConfig",
+```
+
+Merge and roll out to `production`. This `application` deploy tears down the now-redundant legacy CDN and its imported cert. No app-level config changes are needed — legacy councils already have them.
+
+### 8. Clean up & finish
+
+- **BYO cert artefacts** - depending on where the old cert lived:
+  - **AWS Secrets Manager** - delete (or schedule deletion of) the `ssl/[team]` secret in the [console](https://eu-west-2.console.aws.amazon.com/secretsmanager/listsecrets?region=eu-west-2#).
+  - **Pulumi config** -
     ```sh
     cd infrastructure/application
-    pulumi stack output customDomainsCdnDomainName --stack production
+    pulumi config rm ssl-<team>-key --stack production
+    pulumi config rm ssl-<team>-cert --stack production
+    pulumi config rm ssl-<team>-chain --stack production
     ```
+- **CRM** — clear the `SSL Expiry Date`, add the domain under `Custom Subdomain`, set `Auto-SSL` to **Done**.
 
-    This returns a value like `d1234abcd.cloudfront.net`.
+## Troubleshooting
 
-13. Send CloudFront CNAME to the council, i.e. ask them to create a second DNS record:
+### `update-domain-association` → `InvalidArgument: The request contains an invalid domain name`
 
-    | Type | Name | Target |
-    | --- | --- | --- |
-    | CNAME | `planningservices.a-new-council.gov.uk` | `d1234abcd.cloudfront.net` |
+The **target (shared) distribution's attached cert doesn't cover the domain** - so CloudFront won't let the alias point at a distribution that can't serve it. It is (almost) never an actual problem with the domain string.
 
-    As soon as this propagates, live traffic to the custom domain will be routed to the shared CloudFront PlanX distribution.
+Cause: `certificates` hasn't been deployed since the domain reached `cutover-ongoing` / `shared-final`, or `application` hasn't been redeployed to _attach_ the new cert. Fix by completing Process B step 4 (verify the cert attached to `$DIST_ID` lists the domain) before retrying.
 
-14. Application-level configuration should be included in the same PR or as a follow-up:
+### `update-domain-association` → `PreconditionFailed`
 
-    1. **Frontend route detection** — add the domain to `PREVIEW_ONLY_DOMAINS` in `apps/editor.planx.uk/src/utils/routeUtils/utils.ts`
+Your `--if-match` ETag is **stale**, or the target distribution is still `InProgress`. The ETag changes on every deploy. Re-fetch it immediately before the call, wait for `Status: Deployed`, then retry (Process B step 5).
 
-    2. **Error reporting** — add a `case` for the domain in `getEnvForAllowedHosts()` in `apps/editor.planx.uk/src/airbrake.ts`, mapping to `"production"`
+### Which distribution currently owns an alias?
 
-    3. **Database** — set `team.domain` to `planningservices.a-new-council.gov.uk` in the Hasura production console (this enables payment links and save-and-return URLs to use the custom domain)
+```sh
+aws cloudfront list-distributions \
+  --query "DistributionList.Items[?contains(Aliases.Items, 'planningservices.council.gov.uk')].{Id:Id,Status:Status,Aliases:Aliases.Items}"
+```
 
-15. Implement monitoring as needed.
+### `pulumi preview` on `certificates` proposes deletes
 
-    *If* there are fewer than 5 monitors under the `custom-domains-production` tab on [UptimeRobot](https://dashboard.uptimerobot.com/monitors), then add this new domain by cloning one of the existing monitors (to preserve integrations e.g. Slack alerts for SSL expiry)
+If a preview wants to **delete** `sslCert-custom-domains` or `sslCert-dns-mining` (rather than replace/update them), Pulumi thinks the desired domain set is empty or wrong - almost always the **wrong stack** or **wrong AWS credentials**. A correct run _adds_ SANs and _replaces_ certs; the SAN count never shrinks unexpectedly. Stop and check your context.
 
-    > **Note:** We share a single UptimeRobot login stored in the 1Password 'PlanX' vault. You may need to ask someone with access to do this step.
+### `dig` still shows `NXDOMAIN` after the council added the record
 
-16. Update the [PlanX CRM on Notion](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff).
+This is due to DNS negative-caching. The zone's SOA sets a negative-cache TTL (often 30 min), so a resolver that already saw `NXDOMAIN` keeps serving it. Query a public resolver directly to get a fresh answer:
 
-    Find the relevant council's page in our internal CRM, and do the following:
-    - Add the domain as it appears in our single source of truth (`customDomains.ts`) under the field 'Custom Subdomain'.
-    - Set the 'Auto-SSL' column to "Done"
+```sh
+dig _abc123.planningservices.council.gov.uk CNAME +short @1.1.1.1
+dig _abc123.planningservices.council.gov.uk CNAME +short @8.8.8.8
+```
 
-
-### B. Migrating a council from legacy setup
-
-Path: `legacy-with-validation` → `cutover-ongoing`  → `shared-final`
-
-Here we migrate a council from their own dedicated CloudFront distribution (backed by an SSL certificate they provided us) to the shared CloudFront distribution (backed by a DNS-validated ACM certificate which we provision ourselves).
-
-The usual prompt for this process will be an impending expiry of a council's SSL cert, as flagged in the `#planx-notifications-ssl` Slack channel. You can check these dates at source in the [AWS console](https://us-east-1.console.aws.amazon.com/acm/certificates/list?region=us-east-1).
-
-NB. No new councils will be onboarded in the legacy mode, so when we migrate the last council, we can revise our documentation (i.e. delete this section).
-
-1. Update the [PlanX CRM on Notion](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff).
-
-    Find the relevant council's page in our internal CRM, and set the 'Auto-SSL' column to "In progress".
-
-2. Do steps 4-6 from [flow A](#a-onboarding-a-new-council) (i.e. send the DNS validation record to the council).
-
-    > NB. **If this is not the first domain on the shared CDN** and you want to expedite:
-    > - Do steps 5-6 **now** and send the council both DNS records together (you still have to wait for them to add the records before proceeding to step 2).
-
-3. Advance the domain in question to the `cutover-ongoing` state by updating `customDomains.ts`:
-
-    ```diff
-    - cloudFrontState: "legacy-with-validation",
-    + cloudFrontState: "cutover-ongoing",
-    ```
-
-    Commit this, open a PR and get it approved.
-
-4. Do steps 8-11 from [flow A](#a-onboarding-a-new-council) (i.e. initialise a new shared cert and attach the shared CDN to it).
-
-5. Get the shared distribution domain name and ID:
-
-    ```sh
-    cd infrastructure/application
-    pulumi stack output customDomainsCdnDomainName --stack production
-    pulumi stack output customDomainsDistributionId --stack production
-    ```
-
-    This should return values like `d1234abcd.cloudfront.net` and `E1234ABCD56YZ` respectively.
-
-6. Ask the council to switch their DNS target for the domain.
-
-    That is, they will need to update their existing CNAME record to point at the shared CloudFront domain (replacing the old per-domain `xyz.cloudfront.net` value).
-
-    | Type | Name | Target |
-    | --- | --- | --- |
-    | CNAME | `planningservices.an-existing-council.gov.uk` | `d1234abcd.cloudfront.net` |
-
-7. **Wait** for the council to confirm they've added the record.
-
-    Because of the way CloudFront works, traffic redirected to the domain name of the shared CloudFront distribution will still be directed to the legacy distribution by AWS (until we do the next step). See [Appendix B](#appendix-b-cloudfront-routing)) for a more thorough explanation!
-    
-8. Run the AWS `update-domain-association` [command](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/update-domain-association.html) from your terminal to move the domain (known as an 'alias' in the context of CloudFront) from the legacy distribution to the shared distribution ([docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move.html)).
-
-    If you haven't used the AWS CLI from your terminal before, set that up first (see `../how-to-setup-aws-sso-credentials.md`). CloudFront distributions are global so the AWS region isn't important here.
-
-    We have to provide the domain we're migrating, the ID of the shared CloudFront distribution, and it's 'eTag' ([entity tag](https://docs.aws.amazon.com/sdk-for-swift/latest/api/awss3/documentation/awss3/s3clienttypes/object/etag/)). So first, we get the eTag for the shared CDN:
-
-    ```sh
-    aws cloudfront get-distribution \
-      --id E1234ABCD56YZ \
-      --query ETag \
-      --output text
-    ```
-
-    This should return a value like `E9876WXYZ12ABC`. Make sure to do this anew every time, since it's a hash of the object and will change.
-
-    Finally we can run the command to move the alias, supplying the eTag to the `--if-match` option:
-
-    ```sh
-    aws cloudfront update-domain-association \
-      --domain planningservices.an-existing-council.gov.uk \
-      --target-resource DistributionId=E1234ABCD56YZ \
-      --if-match E9876WXYZ12ABC
-    ```
-
-    If successful, this operation should return some json with the new `ETag` value. You can confirm in the [AWS console](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions) (check the _Alternate domain names_ column).
-
-    > **Warning**: As soon as you execute this step, you need to run through at least steps 8-10 immediately thereafter (or at the very least, before another production deploy can occur with the domain still in `cutover-ongoing` state).
-
-9. Verify traffic has been re-routed:
-
-    ```sh
-    dig planningservices.an-existing-council.gov.uk CNAME +short
-    ```
-
-    This should return the shared CDN name like `d1234abcd.cloudfront.net`.
-
-    It's also worth visiting the site in the browser and checking it works as expected.
-
-10. Finally, advance the domain to `shared-final`:
-
-    ```diff
-    - cloudFrontState: "single-plus-shared",
-    + cloudFrontState: "shared-final",
-    ```
-
-    If the entry has `certificateLocation`, remove it — it's only used by the legacy CDN:
-
-    ```diff
-    - certificateLocation: "pulumiConfig",
-    ```
-
-    Once again, commit these changes and open a PR.
-
-11. Deploy the `application` layer by merging said PR and rolling it out to prod.
-
-    This deploy tears down the legacy CloudFront distribution, which is now redundant because we have re-routed traffic to the shared distribution by virtue of the council swapping out the DNS record, and us then moving the alias across. It will also destroy the legacy (imported) cert with which the distribution was associated.
-
-    NB. Application-level config (see step 14 in [flow A](#a-onboarding-a-new-council)) is already in place for legacy councils, so no changes are needed in that regard.
-
-12. Clean up BYO certificate artefacts. Depending on where the old certificate was stored...
-
-    - **AWS Secrets Manager** - delete the `ssl/[team]` secret in the [AWS console](https://eu-west-2.console.aws.amazon.com/secretsmanager/listsecrets?region=eu-west-2#) (you may only be able to _schedule_ the deletion)
-    - **Pulumi config** - remove secrets via the terminal:
-
-      ```sh
-      cd infrastructure/application
-      pulumi config rm ssl-<team>-key --stack production
-      pulumi config rm ssl-<team>-cert --stack production
-      pulumi config rm ssl-<team>-chain --stack production
-      ```
-
-13. Implement monitoring as needed.
-
-    *If* there are more than 5 monitors under the `custom-domains-production` tab on [UptimeRobot](https://dashboard.uptimerobot.com/monitors), then delete the monitor for the domain you just migrated (we only maintain a few as canaries). Otherwise, do nothing.
-
-    > **Note:** We share a single UptimeRobot login stored in the 1Password 'PlanX' vault. You may need to ask someone with access to do this step.
-
-14. Update the [PlanX CRM on Notion](https://www.notion.so/opensystemslab/Plan-CRM-27c35d469ad1806c8f4dd95067ccf4ff).
-
-    Find the relevant council's page in our internal CRM, and do the following:
-    - Remove the date from the field 'SSL Expiry Date'.
-    - Add the domain as it appears in our single source of truth (`customDomains.ts`) under the field 'Custom Subdomain'.
-    - Set the 'Auto-SSL' column to "Done"
-
+If the validation record name looks wrong, re-pull the expected value with `pulumi stack output pendingCouncilDnsRecords --stack production --json` (the ACM validation name is a stable hash of the domain, so it shouldn't change between cert recreations).
 
 ## Appendix A. Automatic certificate renewal
 
@@ -335,7 +359,6 @@ DNS-validated ACM certificates are managed entirely by AWS and **renew automatic
 For legacy councils still on BYO certificate (`legacy-with-validation`), the preferred path is to **migrate them to the shared CDN** as above, rather than renewing the BYO certificate.
 
 If you must do the latter, you can find the old howto [here](https://github.com/theopensystemslab/planx-new/blob/356d052450ff24485a90df45b2741614418ccc38/doc/how-to/how-to-setup-custom-subdomains.md).
-
 
 ## Appendix B. CloudFront routing
 
@@ -348,15 +371,3 @@ Some corollaries relevant to our scenario follow:
 
 - We have to move our custom domain manually between two already existing CloudFront distributions, rather than adding the alias to the shared CDN while it's still on the legacy CDN. That is, if we are creating the shared CDN for the first time, we have to spin it up as 'empty' first, rather than provisioning it immediately with the alias.
 - While both CDNs are up, the council's DNS `CNAME` record can point at _either_ of them, as long as both are attached to a certificate which includes the custom domain in question. CloudFront will serve the request regardless. That is, once the correct certs are in place, the order in which the alias is moved and the DNS record is replaced is unimportant!
-
-
-## Troubleshooting
-
-### Councils need two CNAME records
-
-New councils must add **two** DNS records in total:
-
-1. An ACM validation CNAME (proves domain ownership, enables certificate issuance)
-2. A CloudFront routing CNAME (directs live traffic to CDN, which serves PlanX)
-
-These are independent — the first can be added long before the second. They both need to maintained indefinitely.


### PR DESCRIPTION
## What does this PR do?
Reworks `doc/how-to/how-to-setup-custom-domains.md` after running through the process last week and getting caught out in a few places.

The changes made in this PR can be read as markdown here - https://github.com/theopensystemslab/planx-new/blob/a93096360ce90a90c7418cbde1a6c7515cc22763/doc/how-to/how-to-setup-custom-domains.md

#### Dropped the two-part CNAME process
Councils just get both records (validation + routing) at once, with a single table explaining each. Removed the confusing "send this one now, that one later" notes scattered through both flows which are basically redundant. This is they key change and motivation for the rework.

#### Linear processes
There's a bit more text and repetition, but less jumping between steps and both processes are self-contained

#### Added state diagrams & explanation
A Mermaid lifecycle diagram plus a state → infrastructure table (mining cert / shared cert / legacy CDN / alias location / who serves traffic) so the `cloudFrontState` values are actually legible. I found myself coming to this process a little cold after each update from a council and it's helpful having a clear understanding of the states and high-level processes here.

#### Updated troubleshooting section
Covers a few additional things I hit...!