### PR TITLE
chore: CVE-2026-6322 & CVE-2026-6321

### DIFF
--- a/e2e/tests/ui-driven/package.json
+++ b/e2e/tests/ui-driven/package.json
@@ -17,7 +17,7 @@
     "graphql": "catalog:graphql",
     "isomorphic-fetch": "^3.0.0",
     "jsonwebtoken": "catalog:jwt",
-    "serve": "^14.2.5",
+    "serve": "^14.2.6",
     "uuid": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,7 +1102,7 @@ importers:
         specifier: catalog:jwt
         version: 9.0.3
       serve:
-        specifier: ^14.2.5
+        specifier: ^14.2.6
         version: 14.2.6
       uuid:
         specifier: 'catalog:'
@@ -7880,9 +7880,6 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
@@ -18197,7 +18194,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20124,8 +20121,6 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-
-  fast-uri@3.1.0: {}
 
   fast-uri@3.1.3: {}
 


### PR DESCRIPTION
Resolves https://github.com/theopensystemslab/planx-new/security/dependabot/1048 and https://github.com/theopensystemslab/planx-new/security/dependabot/1049 by bumping `serve`.

Locally running `pnpm why fast-uri -r ` from root - 

**Before** (two versions, one non-compliant)
```sh
fast-uri@3.1.0
└─┬ ajv@8.18.0
  └─┬ serve@14.2.6
    └── @planx/e2e-ui (dependencies)

fast-uri@3.1.3
└─┬ ajv@8.20.0
  ├─┬ @apidevtools/swagger-parser@12.1.0
  │ └─┬ swagger-jsdoc@6.3.0
  │   └── api.planx.uk (dependencies)
  ├─┬ @opensystemslab/planx-core@1.0.0
  │ ├── @planx/e2e-api (dependencies)
  │ ├── @planx/e2e-ui (dependencies)
  │ ├── api.planx.uk (dependencies)
  │ ├── editor.planx.uk (dependencies)
  │ └── encrypt@1.0.0 (dependencies)
  ├─┬ ajv-draft-04@1.0.0
  │ ├── @apidevtools/swagger-parser@12.1.0 [deduped]
  │ └─┬ yaml-language-server@1.20.0
  │   └─┬ volar-service-yaml@0.0.70
  │     └─┬ @astrojs/language-server@2.16.10
  │       └─┬ @astrojs/check@0.9.9
  │         ├─┬ astro-seo@1.1.0
  │         │ └── localplanning.services@0.0.1 (dependencies)
  │         └── localplanning.services@0.0.1 (dependencies)
  ├─┬ ajv-formats@2.1.1
  │ └── @opensystemslab/planx-core@1.0.0 [deduped]
  └── yaml-language-server@1.20.0 [deduped]

Found 2 versions of fast-uri
```

**After** (one version, without open CVEs)
```sh
fast-uri@3.1.3
├─┬ ajv@8.18.0
│ └─┬ serve@14.2.6
│   └── @planx/e2e-ui (dependencies)
└─┬ ajv@8.20.0
  ├─┬ @apidevtools/swagger-parser@12.1.0
  │ └─┬ swagger-jsdoc@6.3.0
  │   └── api.planx.uk (dependencies)
  ├─┬ @opensystemslab/planx-core@1.0.0
  │ ├── @planx/e2e-api (dependencies)
  │ ├── @planx/e2e-ui (dependencies)
  │ ├── api.planx.uk (dependencies)
  │ ├── editor.planx.uk (dependencies)
  │ └── encrypt@1.0.0 (dependencies)
  ├─┬ ajv-draft-04@1.0.0
  │ ├── @apidevtools/swagger-parser@12.1.0 [deduped]
  │ └─┬ yaml-language-server@1.20.0
  │   └─┬ volar-service-yaml@0.0.70
  │     └─┬ @astrojs/language-server@2.16.10
  │       └─┬ @astrojs/check@0.9.9
  │         ├─┬ astro-seo@1.1.0
  │         │ └── localplanning.services@0.0.1 (dependencies)
  │         └── localplanning.services@0.0.1 (dependencies)
  ├─┬ ajv-formats@2.1.1
  │ └── @opensystemslab/planx-core@1.0.0 [deduped]
  └── yaml-language-server@1.20.0 [deduped]
  ```