### PR TITLE
feat: add team settings email as Confirmation component default

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -3,6 +3,7 @@ import Collapse from "@mui/material/Collapse";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { EditorProps } from "@planx/components/shared/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
+import { useStore } from "pages/FlowEditor/lib/store";
 import type { ChangeEvent } from "react";
 import React from "react";
 import type { EditorProps as ListManagerEditorProps } from "ui/editor/ListManager/ListManager";
@@ -62,9 +63,10 @@ function NextStepEditor(props: ListManagerEditorProps<Step>) {
 
 export default function ConfirmationEditor(props: Props) {
   const type = TYPES.Confirmation;
+  const helpEmail = useStore((state) => state.teamSettings?.helpEmail);
   const formik = useFormikWithRef<Confirmation>(
     {
-      initialValues: parseConfirmation(props.node?.data),
+      initialValues: parseConfirmation(props.node?.data, helpEmail),
       onSubmit: (values) => {
         if (props.handleSubmit) {
           props.handleSubmit({ type, data: values });

--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/model.test.ts
@@ -1,0 +1,16 @@
+import { parseConfirmation } from "./model";
+
+describe("parseConfirmation", () => {
+  it("uses the team settings reply-to email for default contact information", () => {
+    const confirmation = parseConfirmation(undefined, "example@council.gov.uk");
+
+    expect(confirmation.contactInfo).toContain("example@council.gov.uk");
+    expect(confirmation.contactInfo).not.toContain("ADD YOUR COUNCIL CONTACT");
+  });
+
+  it("falls back to the placeholder when no help email is available", () => {
+    const confirmation = parseConfirmation(undefined);
+
+    expect(confirmation.contactInfo).toContain("ADD YOUR COUNCIL CONTACT");
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/model.ts
@@ -22,6 +22,7 @@ export interface Confirmation extends BaseNodeData {
 
 export const parseConfirmation = (
   data: Record<string, any> | undefined,
+  helpEmail?: string,
 ): Confirmation => ({
   heading: data?.heading || "Form sent",
   description:
@@ -37,7 +38,11 @@ export const parseConfirmation = (
         </ul>`,
   contactInfo:
     data?.contactInfo ||
-    `You can contact us at <em>ADD YOUR COUNCIL CONTACT</em>
+    `You can contact us at ${
+      helpEmail
+        ? `<a href="mailto:${helpEmail}">${helpEmail}</a>.`
+        : `<em>ADD YOUR COUNCIL CONTACT</em>.`
+    }
           <br><br>
           <p>What did you think of this service? Please give us your feedback on the next page.</p>`,
   nextSteps: data?.nextSteps || [],


### PR DESCRIPTION
This PR adds responsive default content to the Confirmation component.

Instead of defaulting to the placeholder 'ADD YOUR COUNCIL CONTACT', which has unintentionally ended up in live services, the Confirmation component now reads from the team settings helpEmail and set it as the default contact. Principally a QoL change that makes it easier adding Confirmation components to flows.

helpEmail should always be available for all teams, but I still retained the placeholder as a fallback just in case.

Limitation: If helpEmail itself is a placeholder (e.g. example@council.gov.uk) or not available, this still doesn't prevent inadequate content from potentially going live.