### PR TITLE
chore: CVE-2026-53550

### DIFF
--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-query": "^5.101.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "astro": "^6.3.0",
+    "astro": "^6.4.7",
     "astro-icon": "^1.1.5",
     "astro-seo": "^1.1.0",
     "graphql": "catalog:graphql",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,11 +63,11 @@ catalogs:
       version: 2.12.6
   infrastructure:
     '@pulumi/aws':
-      specifier: ^7.24.0
-      version: 7.34.0
+      specifier: ^7.35.0
+      version: 7.35.0
     '@pulumi/awsx':
-      specifier: ^3.4.0
-      version: 3.6.0
+      specifier: ^3.7.0
+      version: 3.7.0
     '@pulumi/cloudflare':
       specifier: ^6.14.0
       version: 6.17.0
@@ -75,8 +75,8 @@ catalogs:
       specifier: ^3.16.2
       version: 3.17.0
     '@pulumi/pulumi':
-      specifier: ^3.229.0
-      version: 3.247.0
+      specifier: ^3.250.0
+      version: 3.251.0
   jwt:
     '@types/jsonwebtoken':
       specifier: ^9.0.10
@@ -900,7 +900,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       astro:
-        specifier: ^6.3.0
+        specifier: ^6.4.7
         version: 6.4.7(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(rollup@4.62.2)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)
       astro-icon:
         specifier: ^1.1.5
@@ -1133,10 +1133,10 @@ importers:
         version: link:../common
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/awsx':
         specifier: catalog:infrastructure
-        version: 3.6.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.7.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/cloudflare':
         specifier: catalog:infrastructure
         version: 6.17.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
@@ -1145,7 +1145,7 @@ importers:
         version: 3.17.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       tldjs:
         specifier: ^2.3.2
         version: 2.3.2
@@ -1173,13 +1173,13 @@ importers:
         version: link:../common
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/cloudflare':
         specifier: catalog:infrastructure
         version: 6.17.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@planx/typescript-config':
         specifier: workspace:*
@@ -1195,10 +1195,10 @@ importers:
     dependencies:
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@planx/typescript-config':
         specifier: workspace:*
@@ -1217,10 +1217,10 @@ importers:
         version: link:../common
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@planx/typescript-config':
         specifier: workspace:*
@@ -1236,10 +1236,10 @@ importers:
     dependencies:
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@planx/typescript-config':
         specifier: workspace:*
@@ -1255,13 +1255,13 @@ importers:
     dependencies:
       '@pulumi/aws':
         specifier: catalog:infrastructure
-        version: 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/awsx':
         specifier: catalog:infrastructure
-        version: 3.6.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.7.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: catalog:infrastructure
-        version: 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@planx/typescript-config':
         specifier: workspace:*
@@ -3750,10 +3750,6 @@ packages:
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -4232,11 +4228,11 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
-  '@pulumi/aws@7.34.0':
-    resolution: {integrity: sha512-lWsOuo1EoMk3QkIdSE0XmA+x1uw/fYWr+a2dipkKqznwSdvD3hhMWLoQvrZ/Lk+4uxcSJo9wPBZAeFShD5Q06Q==}
+  '@pulumi/aws@7.35.0':
+    resolution: {integrity: sha512-DiU5/71xNgyi+o/Vef2k678syNM8PdsoxOEQyVT+aFhWkiiN9JyNLSqpvGZiV8hO1h7mW64mDoDSbJbHCViUww==}
 
-  '@pulumi/awsx@3.6.0':
-    resolution: {integrity: sha512-7xxLOhbgBQIi1IvpvV54J+vjacgUE7YvsBEG38TK/ufVA26O6llTa5HFyVcwoPZ82KBzVEpoiAFPwjt0tZSQyQ==}
+  '@pulumi/awsx@3.7.0':
+    resolution: {integrity: sha512-nrCMm8DRcKLz8MFYK4nMnSejlorV4bdAlo/Pm66l7j92jnCi4SP/fZWiPX/1r2L4nVsh6hxrxeFf/lMOJaHEuw==}
 
   '@pulumi/cloudflare@6.17.0':
     resolution: {integrity: sha512-sIL1rfjNavy+yZQ/OjyFHD4owe2E/TpHLFCVsogQJOC+Y6Bj7JxrhoTfsJdxVEXEFBGlNCu68T+g9im8iEZM9A==}
@@ -4253,9 +4249,9 @@ packages:
   '@pulumi/postgresql@3.17.0':
     resolution: {integrity: sha512-3+rX1wq7JCkTQ5OIwuvMC85DXNCxvfT6BfSOsHs+RsjxHrM7VUKOcQ6DbWWR+oJdZtWh9srQBu13v0JkrbiFkA==}
 
-  '@pulumi/pulumi@3.247.0':
-    resolution: {integrity: sha512-JaXgWfRaT8XLQaqy6MriSxnphuyE56EjD8enZcNSEZ9nWthuTLV6i+w7q1KdcDJKGuMEn6yBeZuBoNafQtx4XA==}
-    engines: {node: '>=20'}
+  '@pulumi/pulumi@3.251.0':
+    resolution: {integrity: sha512-gtpkmQRPsEv8ll0fPHDqIDqSa8mapFqeV06QWYOMLDHj28/wNE13pNZ6jYcteYDdNCgsf4qesw8toOlWqEDQig==}
+    engines: {node: '>=22'}
     peerDependencies:
       ts-node: '>= 7.0.1 < 12'
       typescript: '>= 3.8.3 < 7'
@@ -4383,15 +4379,6 @@ packages:
 
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/pluginutils@5.3.0':
-    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -5930,9 +5917,6 @@ packages:
   '@types/tldjs@2.3.4':
     resolution: {integrity: sha512-QVjtDOA3H6c+6uB+8018XwXUMR9WJ0zaA68lqXmzXETKkp/XD3t0GGyo6OWoKhVT9qVX28RW+zcOuyonIxqEbQ==}
 
-  '@types/tmp@0.2.6':
-    resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
-
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -6403,9 +6387,6 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -7553,9 +7534,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-module-lexer@2.2.0:
     resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
@@ -8837,14 +8815,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -9184,10 +9154,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.3.5:
-    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -11279,9 +11245,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   ssri@13.0.1:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -11609,10 +11572,6 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -11660,10 +11619,6 @@ packages:
   tldts@7.0.28:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
-
-  tmp@0.2.7:
-    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
-    engines: {node: '>=14.14'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -12872,7 +12827,7 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
+      lru-cache: 11.5.1
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -15575,51 +15530,49 @@ snapshots:
 
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-
-  '@opentelemetry/api@1.9.0': {}
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-zipkin@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/exporter-zipkin@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/instrumentation-grpc@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-grpc@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
@@ -15629,75 +15582,75 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       protobufjs: 7.6.4
 
-  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       semver: 7.8.5
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
@@ -15930,22 +15883,22 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@pulumi/aws@7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/aws@7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/awsx@3.6.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/awsx@3.7.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@aws-sdk/client-ecs': 3.1075.0
-      '@pulumi/aws': 7.34.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/aws': 7.35.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/docker': 4.11.2(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/docker-build': 0.0.14(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       '@types/aws-lambda': 8.10.162
       docker-classic: '@pulumi/docker@3.6.1(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)'
       mime: 2.6.0
@@ -15956,7 +15909,7 @@ snapshots:
 
   '@pulumi/cloudflare@6.17.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -15964,7 +15917,7 @@ snapshots:
 
   '@pulumi/docker-build@0.0.14(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -15972,7 +15925,7 @@ snapshots:
 
   '@pulumi/docker@3.6.1(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       semver: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -15981,7 +15934,7 @@ snapshots:
 
   '@pulumi/docker@4.11.2(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
       semver: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -15990,40 +15943,36 @@ snapshots:
 
   '@pulumi/postgresql@3.17.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@pulumi/pulumi': 3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/pulumi@3.247.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/pulumi@3.251.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@logdna/tail-file': 2.2.0
       '@npmcli/arborist': 9.8.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-grpc': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.1)
       '@types/google-protobuf': 3.15.12
       '@types/semver': 7.7.1
-      '@types/tmp': 0.2.6
       execa: 5.1.1
-      fdir: 6.5.0(picomatch@4.0.4)
       google-protobuf: 3.21.4
       ini: 2.0.0
-      js-yaml: 3.14.2
+      js-yaml: 4.3.0
       minimist: 1.2.8
       normalize-package-data: 6.0.2
-      picomatch: 4.0.4
       require-from-string: 2.0.2
-      semver: 7.7.4
+      semver: 7.8.5
       source-map-support: 0.5.21
-      tmp: 0.2.7
       upath: 1.2.0
     optionalDependencies:
       ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@24.10.15)(typescript@5.9.3)
@@ -16099,14 +16048,6 @@ snapshots:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       estree-walker: 2.0.2
       magic-string: 0.30.21
-    optionalDependencies:
-      rollup: 4.62.2
-
-  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
-    dependencies:
-      '@types/estree': 1.0.9
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.62.2
 
@@ -17608,8 +17549,6 @@ snapshots:
 
   '@types/tldjs@2.3.4': {}
 
-  '@types/tmp@0.2.6': {}
-
   '@types/tough-cookie@4.0.5': {}
 
   '@types/trusted-types@2.0.7': {}
@@ -17864,7 +17803,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -17880,7 +17819,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.9)':
     dependencies:
@@ -17985,7 +17924,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.15)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.15)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(vite@6.4.3(@types/node@24.10.15)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -18195,10 +18134,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -18316,7 +18251,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.5.1
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       aria-query: 5.3.2
       axobject-query: 4.1.0
       ci-info: 4.4.0
@@ -18326,7 +18261,7 @@ snapshots:
       devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.2.0
       esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
@@ -18334,26 +18269,26 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      obug: 2.1.1
+      obug: 2.1.3
       p-limit: 7.3.0
       p-queue: 9.3.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
       picomatch: 4.0.4
       rehype: 13.0.2
-      semver: 7.7.4
+      semver: 7.8.5
       shiki: 4.2.0
       smol-toml: 1.6.1
       svgo: 4.0.1
       tinyclip: 0.1.14
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -19187,7 +19122,7 @@ snapshots:
       '@asamuzakjp/css-color': 5.1.11
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       css-tree: 3.2.1
-      lru-cache: 11.3.5
+      lru-cache: 11.5.1
 
   csstype@3.2.3: {}
 
@@ -19588,8 +19523,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.2.0: {}
 
@@ -21115,15 +21048,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
@@ -21509,8 +21433,6 @@ snapshots:
       tslib: 2.8.1
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.3.5: {}
 
   lru-cache@11.5.1: {}
 
@@ -24250,8 +24172,6 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sprintf-js@1.0.3: {}
-
   ssri@13.0.1:
     dependencies:
       minipass: 7.1.3
@@ -24629,8 +24549,6 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
-  tinyexec@1.1.1: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -24670,8 +24588,6 @@ snapshots:
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
-
-  tmp@0.2.7: {}
 
   to-buffer@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,11 +31,11 @@ catalogs:
     graphql-request: 4.3.0
     graphql-tag: ^2.12.6
   infrastructure:
-    '@pulumi/aws': ^7.24.0
-    '@pulumi/awsx': ^3.4.0
+    '@pulumi/aws': ^7.35.0
+    '@pulumi/awsx': ^3.7.0
     '@pulumi/cloudflare': ^6.14.0
     '@pulumi/postgresql': ^3.16.2
-    '@pulumi/pulumi': ^3.229.0
+    '@pulumi/pulumi': ^3.250.0
   jwt:
     '@types/jsonwebtoken': ^9.0.10
     jsonwebtoken: ^9.0.3


### PR DESCRIPTION
Fixes https://github.com/theopensystemslab/planx-new/security/dependabot/1079 & https://github.com/theopensystemslab/planx-new/security/dependabot/1080 by bumping packages with `js-yaml` as a dependency.