### PR TITLE
feat: Highlight adding of new nodes into graph

### DIFF
--- a/apps/editor.planx.uk/src/hooks/flashHighlight.ts
+++ b/apps/editor.planx.uk/src/hooks/flashHighlight.ts
@@ -1,0 +1,15 @@
+import type { Theme } from "@mui/material/styles";
+
+export const flashHighlight = (el: HTMLElement, theme: Theme) => {
+  const keyframes: Keyframe[] = [
+    { outline: `12px solid ${theme.palette.action.focus}`, outlineOffset: 0 },
+    { outline: `4px solid transparent`, outlineOffset: 0 },
+  ];
+
+  const animationOptions: KeyframeAnimationOptions = {
+    duration: 5000,
+    easing: "ease-in",
+  };
+
+  el.animate(keyframes, animationOptions);
+};

--- a/apps/editor.planx.uk/src/hooks/flashHighlight.ts
+++ b/apps/editor.planx.uk/src/hooks/flashHighlight.ts
@@ -1,14 +1,16 @@
-import type { Theme } from "@mui/material/styles";
+import { alpha, type Theme } from "@mui/material/styles";
 
 export const flashHighlight = (el: HTMLElement, theme: Theme) => {
+  const flashColor = theme.palette.info.dark;
+
   const keyframes: Keyframe[] = [
-    { outline: `12px solid ${theme.palette.action.focus}`, outlineOffset: 0 },
-    { outline: `4px solid transparent`, outlineOffset: 0 },
+    { boxShadow: `0 0 0 0px ${alpha(flashColor, 1)}`, borderRadius: "2px" },
+    { boxShadow: `0 0 0 16px ${alpha(flashColor, 0)}`, borderRadius: "8px" },
   ];
 
   const animationOptions: KeyframeAnimationOptions = {
-    duration: 5000,
-    easing: "ease-in",
+    duration: 900,
+    easing: "ease-out",
   };
 
   el.animate(keyframes, animationOptions);

--- a/apps/editor.planx.uk/src/hooks/useFlashOnNodeAdded.ts
+++ b/apps/editor.planx.uk/src/hooks/useFlashOnNodeAdded.ts
@@ -1,0 +1,26 @@
+import { useTheme } from "@mui/material/styles";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { useEffect, useRef } from "react";
+
+import { flashHighlight } from "./flashHighlight";
+
+const useFlashOnNodeAdded = <T extends HTMLElement>(id: string) => {
+  const [lastAddedNodeId, clearLastAddedNodeId] = useStore((state) => [
+    state.lastAddedNodeId,
+    state.clearLastAddedNodeId,
+  ]);
+  const ref = useRef<T | null>(null);
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    if (lastAddedNodeId !== id) return;
+
+    flashHighlight(ref.current, theme);
+    clearLastAddedNodeId();
+  }, [lastAddedNodeId, id, theme, clearLastAddedNodeId]);
+
+  return ref;
+};
+
+export default useFlashOnNodeAdded;

--- a/apps/editor.planx.uk/src/hooks/useScrollOnPreviousURLMatch.ts
+++ b/apps/editor.planx.uk/src/hooks/useScrollOnPreviousURLMatch.ts
@@ -2,6 +2,8 @@ import { useTheme } from "@mui/material/styles";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { useEffect, useRef } from "react";
 
+import { flashHighlight } from "./flashHighlight";
+
 const useScrollOnPreviousURLMatch = <T extends HTMLElement>(
   urlMatcher: string,
 ) => {
@@ -22,17 +24,7 @@ const useScrollOnPreviousURLMatch = <T extends HTMLElement>(
     });
 
     // Visually highlight node
-    const keyframes: Keyframe[] = [
-      { outline: `4px solid ${theme.palette.action.focus}`, outlineOffset: 0 },
-      { outline: `4px solid transparent`, outlineOffset: 0 },
-    ];
-
-    const animationOptions: KeyframeAnimationOptions = {
-      duration: 1500,
-      easing: "ease-in",
-    };
-
-    ref.current.animate(keyframes, animationOptions);
+    flashHighlight(ref.current, theme);
   }, [previousURL, urlMatcher, theme]);
 
   return ref;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -9,6 +9,7 @@ import { Link } from "@tanstack/react-router";
 import { useParams } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useContextMenu } from "hooks/useContextMenu";
+import useFlashOnNodeAdded from "hooks/useFlashOnNodeAdded";
 import mapAccum from "ramda/src/mapAccum";
 import React, { useMemo } from "react";
 import { useDrag } from "react-dnd";
@@ -90,6 +91,8 @@ const Checklist: React.FC<Props> = React.memo((props) => {
   const hasHelpText =
     props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
+  const ref = useFlashOnNodeAdded<HTMLLIElement>(props.id);
+
   // Hide sticky notes when toggled off
   if (isStickyNote && !showNotes) {
     return null;
@@ -99,6 +102,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
+        ref={ref}
         className={classNames("card", "decision", "question", {
           isDragging,
           isClone: isClone(props.id),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { useParams } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useContextMenu } from "hooks/useContextMenu";
+import useFlashOnNodeAdded from "hooks/useFlashOnNodeAdded";
 import React from "react";
 import { useDrag } from "react-dnd";
 
@@ -50,10 +51,13 @@ const Filter: React.FC<Props> = React.memo((props) => {
 
   const Icon = ICONS[props.type];
 
+  const ref = useFlashOnNodeAdded<HTMLLIElement>(props.id);
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
+        ref={ref}
         className={classNames("card", "decision", "type-Filter", {
           isDragging,
           isClone: isClone(props.id),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -67,13 +67,12 @@ const Question: React.FC<Props> = React.memo((props) => {
   const hasHelpText =
     props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
-  const ref = useFlashOnNodeAdded<HTMLLIElement>(props.id);
+  const ref = useFlashOnNodeAdded<HTMLDivElement>(props.id);
 
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
-        ref={ref}
         className={classNames(
           "card",
           "decision",
@@ -87,6 +86,7 @@ const Question: React.FC<Props> = React.memo((props) => {
         )}
       >
         <TemplatedNodeContainer
+          ref={ref}
           isTemplatedNode={props.data?.isTemplatedNode}
           areTemplatedNodeInstructionsRequired={
             props.data?.areTemplatedNodeInstructionsRequired
@@ -107,7 +107,7 @@ const Question: React.FC<Props> = React.memo((props) => {
             }}
             preload={false}
             onContextMenu={handleContextMenu}
-            ref={(el) => {
+            ref={(el: HTMLAnchorElement | null) => {
               drag(el);
             }}
           >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -7,6 +7,7 @@ import { ICONS } from "@planx/components/shared/icons";
 import { Link, useParams } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useContextMenu } from "hooks/useContextMenu";
+import useFlashOnNodeAdded from "hooks/useFlashOnNodeAdded";
 import React from "react";
 import { useDrag } from "react-dnd";
 import { TemplatedNodeContainer } from "ui/editor/TemplatedNodeContainer";
@@ -66,10 +67,13 @@ const Question: React.FC<Props> = React.memo((props) => {
   const hasHelpText =
     props.data?.policyRef || props.data?.info || props.data?.howMeasured;
 
+  const ref = useFlashOnNodeAdded<HTMLLIElement>(props.id);
+
   return (
     <>
       <Hanger hidden={isDragging} before={props.id} parent={parent} />
       <li
+        ref={ref}
         className={classNames(
           "card",
           "decision",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -107,7 +107,7 @@ const Question: React.FC<Props> = React.memo((props) => {
             }}
             preload={false}
             onContextMenu={handleContextMenu}
-            ref={(el: HTMLAnchorElement | null) => {
+            ref={(el) => {
               drag(el);
             }}
           >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -301,7 +301,9 @@ export interface Template {
 export interface EditorStore extends Store.Store {
   cutNode: (id: NodeId, parent: NodeId) => void;
   getCutNode: () => CutPayload | null;
-  addNode: (node: any, relationships?: Relationships) => void;
+  addNode: (node: any, relationships?: Relationships) => NodeId;
+  lastAddedNodeId?: NodeId;
+  clearLastAddedNodeId: () => void;
   connect: (src: NodeId, tgt: NodeId, object?: any) => void;
   connectToFlow: (id: NodeId) => Promise<void>;
   disconnectFromFlow: () => void;
@@ -370,7 +372,7 @@ export const editorStore: StateCreator<
   EditorStore
 > = (set, get) => ({
   addNode: (
-    { id = undefined, type, data },
+    { id = uniqueId(), type, data },
     { children = undefined, parent = ROOT_NODE_KEY, before = undefined } = {},
   ) => {
     const [, ops] = add(
@@ -378,7 +380,13 @@ export const editorStore: StateCreator<
       { children, parent, before },
     )(get().flow);
     send(ops);
+    set({ lastAddedNodeId: id });
+    return id;
   },
+
+  lastAddedNodeId: undefined,
+
+  clearLastAddedNodeId: () => set({ lastAddedNodeId: undefined }),
 
   connect: (src, tgt, { before = undefined } = {}) => {
     try {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -94,6 +94,8 @@ export interface EditorUIStore {
   componentSelectorBefore?: string;
   openComponentSelector: (params: { parent?: string; before?: string }) => void;
   closeComponentSelector: () => void;
+  lastAddedNodeId?: NodeId;
+  clearLastAddedNodeId: () => void;
 }
 
 export const editorUIStore: StateCreator<
@@ -225,6 +227,10 @@ export const editorUIStore: StateCreator<
         componentSelectorParent: undefined,
         componentSelectorBefore: undefined,
       }),
+
+    lastAddedNodeId: undefined,
+
+    clearLastAddedNodeId: () => set({ lastAddedNodeId: undefined }),
   }),
   {
     name: "editorUIStore",
@@ -302,8 +308,6 @@ export interface EditorStore extends Store.Store {
   cutNode: (id: NodeId, parent: NodeId) => void;
   getCutNode: () => CutPayload | null;
   addNode: (node: any, relationships?: Relationships) => NodeId;
-  lastAddedNodeId?: NodeId;
-  clearLastAddedNodeId: () => void;
   connect: (src: NodeId, tgt: NodeId, object?: any) => void;
   connectToFlow: (id: NodeId) => Promise<void>;
   disconnectFromFlow: () => void;
@@ -366,7 +370,7 @@ export interface EditorStore extends Store.Store {
 }
 
 export const editorStore: StateCreator<
-  SharedStore & EditorStore & NavigationStore,
+  SharedStore & EditorStore & EditorUIStore & NavigationStore,
   [],
   [],
   EditorStore
@@ -383,10 +387,6 @@ export const editorStore: StateCreator<
     set({ lastAddedNodeId: id });
     return id;
   },
-
-  lastAddedNodeId: undefined,
-
-  clearLastAddedNodeId: () => set({ lastAddedNodeId: undefined }),
 
   connect: (src, tgt, { before = undefined } = {}) => {
     try {

--- a/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -3,7 +3,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import classNames from "classnames";
 import type { PropsWithChildren } from "react";
-import React from "react";
+import { forwardRef } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import CheckCircleIcon from "ui/icons/CheckCircle";
 
@@ -82,14 +82,20 @@ const getTemplatedNodeStatus = (
   return "Optional";
 };
 
-export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
-  children,
-  isTemplatedNode = false,
-  areTemplatedNodeInstructionsRequired = false,
-  isComplete = false,
-  showStatus = false,
-  className,
-}) => {
+export const TemplatedNodeContainer = forwardRef<
+  HTMLDivElement,
+  TemplatedNodeContainerProps
+>(function TemplatedNodeContainer(
+  {
+    children,
+    isTemplatedNode = false,
+    areTemplatedNodeInstructionsRequired = false,
+    isComplete = false,
+    showStatus = false,
+    className,
+  },
+  ref,
+) {
   const containerClasses = classNames(
     "card-wrapper",
     {
@@ -99,11 +105,16 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
   );
 
   if (!isTemplatedNode) {
-    return <Box className={containerClasses}>{children}</Box>;
+    return (
+      <Box ref={ref} className={containerClasses}>
+        {children}
+      </Box>
+    );
   }
 
   return (
     <StyledContainer
+      ref={ref}
       className={containerClasses}
       isTemplatedNode={isTemplatedNode}
       areTemplatedNodeInstructionsRequired={
@@ -134,4 +145,4 @@ export const TemplatedNodeContainer: React.FC<TemplatedNodeContainerProps> = ({
       {children}
     </StyledContainer>
   );
-};
+});

--- a/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/TemplatedNodeContainer.tsx
@@ -2,8 +2,7 @@ import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import classNames from "classnames";
-import type { PropsWithChildren } from "react";
-import { forwardRef } from "react";
+import type { PropsWithChildren, Ref } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import CheckCircleIcon from "ui/icons/CheckCircle";
 
@@ -13,6 +12,7 @@ interface TemplatedNodeContainerProps extends PropsWithChildren {
   isComplete?: boolean;
   showStatus?: boolean;
   className?: string;
+  ref?: Ref<HTMLDivElement>;
 }
 
 const StyledContainer = styled(Box, {
@@ -82,20 +82,15 @@ const getTemplatedNodeStatus = (
   return "Optional";
 };
 
-export const TemplatedNodeContainer = forwardRef<
-  HTMLDivElement,
-  TemplatedNodeContainerProps
->(function TemplatedNodeContainer(
-  {
-    children,
-    isTemplatedNode = false,
-    areTemplatedNodeInstructionsRequired = false,
-    isComplete = false,
-    showStatus = false,
-    className,
-  },
+export const TemplatedNodeContainer = ({
+  children,
+  isTemplatedNode = false,
+  areTemplatedNodeInstructionsRequired = false,
+  isComplete = false,
+  showStatus = false,
+  className,
   ref,
-) {
+}: TemplatedNodeContainerProps) => {
   const containerClasses = classNames(
     "card-wrapper",
     {
@@ -145,4 +140,4 @@ export const TemplatedNodeContainer = forwardRef<
       {children}
     </StyledContainer>
   );
-});
+};


### PR DESCRIPTION
## What does this PR do?

- Introduces a "pulse" style highlight when a new node is added or pasted into the graph
- Adds `useFlashOnNodeAdded` hook to flash a node's border when it's first added to the graph

https://github.com/user-attachments/assets/8a5481eb-f351-4615-9bb7-2b9b41a9d259
