### PR TITLE
fix(editor): Remove empty `<ModalSection/>` from `SetFee` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/SetFee/Editor.tsx
@@ -62,9 +62,6 @@ function SetFeeComponent(props: Props) {
         }
       />
       <ModalSection>
-        <ModalSectionContent />
-      </ModalSection>
-      <ModalSection>
         <ModalSectionContent title="Application fee VAT">
           <InputRow>
             <Switch


### PR DESCRIPTION
The `SetFee` component has an empty `<ModalSection/>` - this PR tidies this up. 

This regression introduced here - https://github.com/theopensystemslab/planx-new/pull/6902/changes#diff-7f3b084aedd55a8da47c6bee8fb1dd5d5cd96c7aacb1b52d5d572c33c575e441

A quick search shows this is the only empty instance of `<ModalSectionContent />` in the codebase ✅ 

| Before | After |
|--------|--------|
| <img width="874" height="910" alt="image" src="https://github.com/user-attachments/assets/98d5dd2f-c5d1-45b6-97a0-a089f9510a42" /> | <img width="873" height="911" alt="image" src="https://github.com/user-attachments/assets/ddd7ee36-49f3-4e6d-899a-fb18a3355369" /> | 