### PR TITLE
fix(editor): Correct sync of `Restore to this point` for history events

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -9,6 +9,7 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { ROOT_NODE_KEY } from "@planx/graph";
 import type { OT } from "@planx/graph/types";
 import type {
   CommentHistoryItem,
@@ -87,10 +88,16 @@ export const EditHistoryTimeline = ({
     const hasNewerOperation = events
       .slice(0, i)
       .some((e) => e.type === "operation");
+
+    // Once the flow is already empty, do not allow restoring to the initial "Created flow" operation
+    const isAlreadyAtInitialState =
+      !event.actorId && !flow[ROOT_NODE_KEY]?.edges?.length;
+
     return (
       event.type === "operation" &&
       canUserEditTeam(teamSlug) &&
-      hasNewerOperation
+      hasNewerOperation &&
+      !isAlreadyAtInitialState
     );
   };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -83,22 +83,22 @@ export const EditHistoryTimeline = ({
     return ["operation", "comment"].includes(type);
   };
 
+  // Show restore only for editable, undoable operations that have something newer to undo
   const showUndoButton = (event: HistoryItem, i: number): boolean => {
-    // Only show the restore button for operations within teams I can edit, and only when an operation to actually restore from exists
+    if (event.type !== "operation") return false;
+    if (!canUserEditTeam(teamSlug)) return false;
+
     const hasNewerOperation = events
       .slice(0, i)
       .some((e) => e.type === "operation");
+    if (!hasNewerOperation) return false;
 
     // Once the flow is already empty, do not allow restoring to the initial "Created flow" operation
-    const isAlreadyAtInitialState =
-      !event.actorId && !flow[ROOT_NODE_KEY]?.edges?.length;
+    const isInitialOperation = !event.actorId;
+    const flowIsEmpty = !flow[ROOT_NODE_KEY]?.edges?.length;
+    if (isInitialOperation && flowIsEmpty) return false;
 
-    return (
-      event.type === "operation" &&
-      canUserEditTeam(teamSlug) &&
-      hasNewerOperation &&
-      !isAlreadyAtInitialState
-    );
+    return true;
   };
 
   return (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -48,8 +48,8 @@ export const EditHistoryTimeline = ({
     ]);
 
   const handleUndo = (i: number) => {
-    // Get all events since & including the selected one
-    const eventsToUndo = events.slice(0, i + 1);
+    // Get all events since the selected one, excluding it
+    const eventsToUndo = events.slice(0, i);
 
     const isOperation = (event: HistoryItem): event is OperationHistoryItem =>
       event.type === "operation";
@@ -82,12 +82,15 @@ export const EditHistoryTimeline = ({
     return ["operation", "comment"].includes(type);
   };
 
-  const showUndoButton = (event: HistoryItem): boolean => {
-    // Only show the restore button for operations within teams I can edit, omitting the intial default operation for new flows which won't have an actor
+  const showUndoButton = (event: HistoryItem, i: number): boolean => {
+    // Only show the restore button for operations within teams I can edit, and only when an operation to actually restore from exists
+    const hasNewerOperation = events
+      .slice(0, i)
+      .some((e) => e.type === "operation");
     return (
       event.type === "operation" &&
-      Boolean(event.actorId) &&
-      canUserEditTeam(teamSlug)
+      canUserEditTeam(teamSlug) &&
+      hasNewerOperation
     );
   };
 
@@ -177,7 +180,7 @@ export const EditHistoryTimeline = ({
                   {`${formatLastEditDate(op.createdAt)}`}
                 </Typography>
               </Box>
-              {showUndoButton(op) && (
+              {showUndoButton(op, i) && (
                 <Tooltip title="Restore to this point" placement="left">
                   <IconButton
                     aria-label="Restore to this point"

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -21,6 +21,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { formatLastEditDate } from "pages/FlowEditor/utils";
 import React, { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import Permission from "ui/editor/Permission";
 
 import {
   CommentTimelineItem,
@@ -39,14 +40,11 @@ export const EditHistoryTimeline = ({
     undefined,
   );
 
-  const [flow, teamSlug, canUserEditTeam, undoOperation, deleteFlowComment] =
-    useStore((state) => [
-      state.flow,
-      state.teamSlug,
-      state.canUserEditTeam,
-      state.undoOperation,
-      state.deleteFlowComment,
-    ]);
+  const [flow, undoOperation, deleteFlowComment] = useStore((state) => [
+    state.flow,
+    state.undoOperation,
+    state.deleteFlowComment,
+  ]);
 
   const handleUndo = (i: number) => {
     // Get all events since the selected one, excluding it
@@ -86,7 +84,6 @@ export const EditHistoryTimeline = ({
   // Show restore only for editable, undoable operations that have something newer to undo
   const showUndoButton = (event: HistoryItem, i: number): boolean => {
     if (event.type !== "operation") return false;
-    if (!canUserEditTeam(teamSlug)) return false;
 
     const hasNewerOperation = events
       .slice(0, i)
@@ -188,23 +185,25 @@ export const EditHistoryTimeline = ({
                 </Typography>
               </Box>
               {showUndoButton(op, i) && (
-                <Tooltip title="Restore to this point" placement="left">
-                  <IconButton
-                    aria-label="Restore to this point"
-                    onClick={() => handleUndo(i)}
-                    onMouseEnter={() => setFocusedOpIndex(i)}
-                    onMouseLeave={() => setFocusedOpIndex(undefined)}
-                  >
-                    <RestoreOutlined
-                      fontSize="medium"
-                      color={
-                        inUndoScope(i) && isUndoType(op.type)
-                          ? "inherit"
-                          : "primary"
-                      }
-                    />
-                  </IconButton>
-                </Tooltip>
+                <Permission.CanEdit>
+                  <Tooltip title="Restore to this point" placement="left">
+                    <IconButton
+                      aria-label="Restore to this point"
+                      onClick={() => handleUndo(i)}
+                      onMouseEnter={() => setFocusedOpIndex(i)}
+                      onMouseLeave={() => setFocusedOpIndex(undefined)}
+                    >
+                      <RestoreOutlined
+                        fontSize="medium"
+                        color={
+                          inUndoScope(i) && isUndoType(op.type)
+                            ? "inherit"
+                            : "primary"
+                        }
+                      />
+                    </IconButton>
+                  </Tooltip>
+                </Permission.CanEdit>
               )}
             </Box>
             {


### PR DESCRIPTION
## What does this PR do

Current the history "Restore to this point" function is one operation out of sync, and to restore to a point you need to select the subsequent operation.

A good demonstration of this is creating a single operation on a graph, "Restore to this point" is active on the operation rather than the initial state, and "restoring to" the operation will reset to the initial state ("Created flow"):

<img width="490" height="334" alt="image" src="https://github.com/user-attachments/assets/3ea36b51-016e-4da3-bf7c-15c6a38ba201" />

By adjusting the sequencing and making sure there is a "restore to" function on the initial Created flow state, we can ensure the "restore to" always returns to the correct operation state:

<img width="490" height="334" alt="image" src="https://github.com/user-attachments/assets/05f29080-a94b-4faa-b86d-c95e6ac5d6cd" />
