### PR TITLE
chore: Sync new `flows.is_pattern` column

### DIFF
--- a/scripts/seed-database/write/flows.sql
+++ b/scripts/seed-database/write/flows.sql
@@ -24,7 +24,8 @@ CREATE TEMPORARY TABLE sync_flows (
   submission_email_id uuid,
   deleted_at timestamptz,
   email_template text,
-  is_service boolean
+  is_service boolean,
+  is_pattern boolean
   );
 \copy sync_flows FROM '/tmp/flows.csv' WITH (FORMAT csv, DELIMITER ';');
 
@@ -51,7 +52,8 @@ INSERT INTO flows (
   submission_email_id,
   deleted_at,
   email_template,
-  is_service
+  is_service,
+  is_pattern
 )
 SELECT
   id,
@@ -76,7 +78,8 @@ SELECT
   submission_email_id,
   deleted_at,
   email_template,
-  is_service
+  is_service,
+  is_pattern
 FROM sync_flows
 ON CONFLICT (id) DO UPDATE
 SET
@@ -98,7 +101,9 @@ SET
   category = EXCLUDED.category,
   submission_email_id = NULL,
   deleted_at = EXCLUDED.deleted_at,
-  email_template = EXCLUDED.email_template;
+  email_template = EXCLUDED.email_template,
+  is_service = EXCLUDED.is_service,
+  is_pattern = EXCLUDED.is_pattern;
 
 -- ensure that original flows.version is overwritten to match new operation inserted below, else sharedb will fail
 UPDATE flows SET version = 1;


### PR DESCRIPTION
## What's the problem?
When the `flows.is_pattern` column was added, it was not added to the sync script. This means that syncs from prod to staging / pizza / local dev will fail

## What's the solution?
Update `flows.sql` to include the new column.

## How can I test this?
As we don't have patterns yet on prod, the only way of verifying this currently it to check the sync script had passed here (the db is populated - you can login to the. Pizza). 

You can also run `pnpm test-sync` locally on this branch - it fails on `main` currently.