### PR TITLE
fix(ci): Typo in `pnpmworkspace` setup

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,7 @@ jobs:
       infrastructure: ${{ steps.filter.outputs.infrastructure }}
       sharedb: ${{ steps.filter.outputs.sharedb }}
       localplanning: ${{ steps.filter.outputs.localplanning }}
-      pnpmworkspace: $${{ steps.filter.outputs.pnpmworkspace }}
+      pnpmworkspace: ${{ steps.filter.outputs.pnpmworkspace }}
       commit: ${{ steps.commit.outputs.commit }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Just spotted a typo from https://github.com/theopensystemslab/planx-new/pull/7002

The double `$$` will be outputting `$true` or `$false` - not `true` / `false` (always truthy currently!)