### PR TITLE
fix(editor): Implicit return in useEffect causing crash on ITP

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/InviteToPayForm.tsx
@@ -121,7 +121,9 @@ const InviteToPayForm: React.FC<InviteToPayFormProps> = ({
   });
 
   // Scroll to top when loading component
-  useEffect(() => window.scrollTo(0, 0), []);
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const formik = useFormik<FormValues>({
     initialValues: {


### PR DESCRIPTION
## What's the problem?
As reported here, the ITP component is crashing on mount/unmount - https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1784541583945219

## What's the cause?
Because the `useEffect()` in question is relying on an implicit return for `window.scrollTo()`, it calls this on clean up. This implicitly returns a promise ([docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#return_value)), which is leading an an issue here. I've not quite worked out when / how this was introduced - there's no recent change, no failing tests - maybe a browser version issue + React upgrade? It's only hit on unmount of the ITP form, so there's a chance it's been around for a while and we've just not hit this.

## Testing
 - Load https://storybook.planx.uk/?path=/story/planx-components-pay--with-invite-to-pay in an incognito window - fails to load, thows matching error ❌ 
 - Load https://storybook.7032.planx.pizza/?path=/story/planx-components-pay--with-invite-to-pay in an incognito window - no issue ✅ 

## Next steps...
I'll check for other instances of this, and set up a linting rule to try and catch instances of this in future. Ideally some test coverage also if I can work this out.

**Update:** This is now covered here https://github.com/theopensystemslab/planx-new/pull/7034