### PR TITLE
fix(storybook): Stop constant re-render via `Date.now()`

### DIFF
--- a/apps/editor.planx.uk/.storybook/preview.tsx
+++ b/apps/editor.planx.uk/.storybook/preview.tsx
@@ -1,18 +1,19 @@
-import React from "react";
-import CssBaseline from "@mui/material/CssBaseline";
-import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
-import { defaultTheme } from "../src/theme";
-import { MyMap } from "@opensystemslab/map";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { initialize, mswLoader } from "msw-storybook-addon";
 import {
   ApolloClient,
   ApolloProvider,
   HttpLink,
   InMemoryCache,
 } from "@apollo/client";
+import CssBaseline from "@mui/material/CssBaseline";
+import { StyledEngineProvider,ThemeProvider } from "@mui/material/styles";
+import { MyMap } from "@opensystemslab/map";
+import type { Decorator } from "@storybook/tanstack-react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { initialize, mswLoader } from "msw-storybook-addon";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+import { defaultTheme } from "../src/theme";
 
 if (!window.customElements.get("my-map")) {
   window.customElements.define("my-map", MyMap);
@@ -44,14 +45,14 @@ const testApolloClient = new ApolloClient({
 
 initialize();
 
-export const decorators = [
-  (Story) => (
+export const decorators: Decorator[] = [
+  (Story, context) => (
     <ApolloProvider client={testApolloClient}>
       <QueryClientProvider client={testQueryClient}>
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={defaultTheme}>
             <CssBaseline />
-            <DndProvider backend={HTML5Backend} key={Date.now()}>
+            <DndProvider backend={HTML5Backend} key={context.id}>
               <Story />
             </DndProvider>
           </ThemeProvider>


### PR DESCRIPTION
Odd / incorrect setup I noticed when working on https://github.com/theopensystemslab/planx-new/pull/7032

Using `Date.now()` should leave to many more re-renders than needed - the stable `context.id` is a better fit here.