### PR TITLE
feat: Linting and test coverage for `useEffect()` implicit return causing crash on unmount

### DIFF
--- a/apps/editor.planx.uk/eslint.config.mjs
+++ b/apps/editor.planx.uk/eslint.config.mjs
@@ -1,4 +1,4 @@
-import react, { noProcessEnv } from "@planx/eslint-config/react";
+import react, { noImplicitEffectReturn, noProcessEnv } from "@planx/eslint-config/react";
 
 export default [
   {
@@ -82,6 +82,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         noProcessEnv,
+        noImplicitEffectReturn,
         {
           selector:
             "JSXAttribute[name.name=/^(color|bgcolor|backgroundColor|borderColor|fill|stroke)$/] Literal[value=/\\./]",

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -462,6 +462,23 @@ describe("Confirm component with inviteToPay", () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  it("does not crash on unmount when window.scrollTo returns a non-function value", async () => {
+    const originalScrollTo = window.scrollTo;
+    window.scrollTo = vi.fn(() => "someString" as unknown as void);
+
+    try {
+      const { user } = await setup(<Confirm {...inviteProps} />);
+
+      await user.click(screen.getByText(invitePrompt));
+      expect(screen.getByText("Details of your nominee")).toBeInTheDocument();
+
+      await user.click(screen.getByText(payPrompt));
+      expect(screen.getByText("How to pay")).toBeInTheDocument();
+    } finally {
+      window.scrollTo = originalScrollTo;
+    }
+  });
 });
 
 describe("Confirm component in information-only mode", () => {

--- a/apps/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/RichTextInput/components/MentionList.tsx
@@ -37,7 +37,9 @@ export const MentionList = forwardRef((props: MentionListProps, ref) => {
     selectItem(selectedIndex);
   };
 
-  useEffect(() => setSelectedIndex(0), [props.items]);
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [props.items]);
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }: any) => {

--- a/apps/editor.planx.uk/src/ui/editor/RichTextInput/components/emoji/EmojiList.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/RichTextInput/components/emoji/EmojiList.tsx
@@ -80,7 +80,9 @@ export const EmojiList = forwardRef<EmojiListRef, EmojiListProps>(
       selectItem(selectedIndex);
     }, [selectItem, selectedIndex]);
 
-    useEffect(() => setSelectedIndex(0), [items]);
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items]);
 
     useImperativeHandle(ref, () => {
       return {

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -11,6 +11,13 @@ export const noProcessEnv = {
   message: "Use import.meta.env instead of process.env in client-side code",
 };
 
+export const noImplicitEffectReturn = {
+  selector:
+    "CallExpression[callee.name=/^(useEffect|useLayoutEffect|useInsertionEffect)$/] > ArrowFunctionExpression[body.type='CallExpression']",
+  message:
+    "Give effect callbacks a block body. An implicit return crashes on unmount if it isn't a function. Use `() => { someFunction(); }`.",
+};
+
 /**
  * Config for React apps
  *
@@ -30,7 +37,7 @@ export default [
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
       "@tanstack/query/exhaustive-deps": "warn",
-      "no-restricted-syntax": ["error", noProcessEnv],
+      "no-restricted-syntax": ["error", noProcessEnv, noImplicitEffectReturn],
     },
   },
   ...vitestConfig(["expect"]),


### PR DESCRIPTION
Follow up to the quick fix in #7030 