### PR TITLE
feat: new notes placement logic

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -29,7 +29,10 @@ type FlowNoteRow = SnakeCasedProperties<FlowNote>;
 
 const GET_FLOW_NOTES = gql`
   subscription GetFlowNotes($flowId: uuid!) {
-    flow_notes(where: { flow_id: { _eq: $flowId } }) {
+    flow_notes(
+      where: { flow_id: { _eq: $flowId } }
+      order_by: { created_at: asc, id: asc }
+    ) {
       id
       flow_id
       node_id

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -67,17 +67,21 @@ const toFlowNote = (row: FlowNoteRow): FlowNote => ({
 interface UseFlowNotesResult {
   notes: FlowNote[];
   loading: boolean;
+  error: unknown;
 }
 
 export const useFlowNotes = (): UseFlowNotesResult => {
   const flowId = useStore((state) => state.id);
 
-  const { data, loading } = useSubscription<QueryResult>(GET_FLOW_NOTES, {
-    variables: { flowId },
-    skip: !flowId,
-  });
+  const { data, loading, error } = useSubscription<QueryResult>(
+    GET_FLOW_NOTES,
+    {
+      variables: { flowId },
+      skip: !flowId,
+    },
+  );
 
   const notes = (data?.flow_notes ?? []).map(toFlowNote);
 
-  return { notes, loading };
+  return { notes, loading, error };
 };

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -2,8 +2,6 @@ import { gql, useSubscription } from "@apollo/client";
 import { useStore } from "pages/FlowEditor/lib/store";
 import type { SnakeCasedProperties } from "type-fest";
 
-export const DEFAULT_NOTE_COLOR = "#fffdb0";
-
 /** Anchored immediately after a sibling node */
 export interface SiblingAnchoredPlacement {
   /** id of the preceding sibling node */

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -1,0 +1,91 @@
+import { gql, useSubscription } from "@apollo/client";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+export const DEFAULT_NOTE_COLOR = "#fffdb0";
+
+export interface NotePlacement {
+  parent: string;
+  before?: string;
+  /** True when `parent` is the container to insert into (leading/first-child slot) */
+  parentIsContainer?: boolean;
+  /** The container `parent` was resolved against at creation time - disambiguates `parent` when it's a cloned node referenced from multiple containers */
+  container?: string;
+}
+
+export interface FlowNote {
+  id: string;
+  flowId: string;
+  nodeId: string | null;
+  placement: NotePlacement | null;
+  text: string;
+  color: string;
+  createdBy: number;
+  updatedBy: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const GET_FLOW_NOTES = gql`
+  subscription GetFlowNotes($flowId: uuid!) {
+    flow_notes(where: { flow_id: { _eq: $flowId } }) {
+      id
+      flow_id
+      node_id
+      placement
+      text
+      color
+      created_by
+      updated_by
+      created_at
+      updated_at
+    }
+  }
+`;
+
+interface FlowNoteRow {
+  id: string;
+  flow_id: string;
+  node_id: string | null;
+  placement: NotePlacement | null;
+  text: string;
+  color: string;
+  created_by: number;
+  updated_by: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface QueryResult {
+  flow_notes: FlowNoteRow[];
+}
+
+const toFlowNote = (row: FlowNoteRow): FlowNote => ({
+  id: row.id,
+  flowId: row.flow_id,
+  nodeId: row.node_id,
+  placement: row.placement,
+  text: row.text,
+  color: row.color,
+  createdBy: row.created_by,
+  updatedBy: row.updated_by,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+interface UseFlowNotesResult {
+  notes: FlowNote[];
+  loading: boolean;
+}
+
+export const useFlowNotes = (): UseFlowNotesResult => {
+  const flowId = useStore((state) => state.id);
+
+  const { data, loading } = useSubscription<QueryResult>(GET_FLOW_NOTES, {
+    variables: { flowId },
+    skip: !flowId,
+  });
+
+  const notes = (data?.flow_notes ?? []).map(toFlowNote);
+
+  return { notes, loading };
+};

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -4,20 +4,31 @@ import type { SnakeCasedProperties } from "type-fest";
 
 export const DEFAULT_NOTE_COLOR = "#fffdb0";
 
-export interface NotePlacement {
+/** Anchored immediately after a sibling node */
+export interface SiblingAnchoredPlacement {
+  /** id of the preceding sibling node */
   parent: string;
-  before?: string;
-  /** True when `parent` is the container to insert into (leading/first-child slot) */
-  parentIsContainer?: boolean;
   /** The container `parent` was resolved against at creation time - disambiguates `parent` when it's a cloned node referenced from multiple containers */
   container?: string;
+  parentIsContainer?: false;
+  before?: undefined;
 }
 
-export interface FlowNote {
+/** Anchored to a container's leading/first-child slot (no preceding sibling to anchor to) */
+export interface ContainerAnchoredPlacement {
+  /** id of the container to insert into */
+  parent: string;
+  parentIsContainer: true;
+  before?: string;
+  container?: undefined;
+}
+
+export type NotePlacement =
+  SiblingAnchoredPlacement | ContainerAnchoredPlacement;
+
+interface FlowNoteBase {
   id: string;
   flowId: string;
-  nodeId: string | null;
-  placement: NotePlacement | null;
   text: string;
   color: string;
   createdBy: number;
@@ -25,6 +36,18 @@ export interface FlowNote {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface AttachedNote extends FlowNoteBase {
+  nodeId: string;
+  placement: null;
+}
+
+export interface PositionedNote extends FlowNoteBase {
+  nodeId: null;
+  placement: NotePlacement;
+}
+
+export type FlowNote = AttachedNote | PositionedNote;
 type FlowNoteRow = SnakeCasedProperties<FlowNote>;
 
 const GET_FLOW_NOTES = gql`
@@ -51,18 +74,22 @@ interface QueryResult {
   flow_notes: FlowNoteRow[];
 }
 
-const toFlowNote = (row: FlowNoteRow): FlowNote => ({
-  id: row.id,
-  flowId: row.flow_id,
-  nodeId: row.node_id,
-  placement: row.placement,
-  text: row.text,
-  color: row.color,
-  createdBy: row.created_by,
-  updatedBy: row.updated_by,
-  createdAt: row.created_at,
-  updatedAt: row.updated_at,
-});
+const toFlowNote = (row: FlowNoteRow): FlowNote => {
+  const base = {
+    id: row.id,
+    flowId: row.flow_id,
+    text: row.text,
+    color: row.color,
+    createdBy: row.created_by,
+    updatedBy: row.updated_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+
+  return row.node_id
+    ? { ...base, nodeId: row.node_id, placement: null }
+    : { ...base, nodeId: null, placement: row.placement as NotePlacement };
+};
 
 interface UseFlowNotesResult {
   notes: FlowNote[];

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -1,5 +1,6 @@
 import { gql, useSubscription } from "@apollo/client";
 import { useStore } from "pages/FlowEditor/lib/store";
+import type { SnakeCasedProperties } from "type-fest";
 
 export const DEFAULT_NOTE_COLOR = "#fffdb0";
 
@@ -24,6 +25,7 @@ export interface FlowNote {
   createdAt: string;
   updatedAt: string;
 }
+type FlowNoteRow = SnakeCasedProperties<FlowNote>;
 
 const GET_FLOW_NOTES = gql`
   subscription GetFlowNotes($flowId: uuid!) {
@@ -41,19 +43,6 @@ const GET_FLOW_NOTES = gql`
     }
   }
 `;
-
-interface FlowNoteRow {
-  id: string;
-  flow_id: string;
-  node_id: string | null;
-  placement: NotePlacement | null;
-  text: string;
-  color: string;
-  created_by: number;
-  updated_by: number;
-  created_at: string;
-  updated_at: string;
-}
 
 interface QueryResult {
   flow_notes: FlowNoteRow[];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -69,6 +69,16 @@ describe("resolveNotePlacement (encode)", () => {
       parentIsContainer: true,
     });
   });
+
+  it("throws an error when before node is not found in container", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: ["nodeA"] },
+    };
+    expect(() => resolveNotePlacement(flow, "folder", "nodeB")).toThrow(
+      "before node nodeB not found in container folder",
+    );
+  });
 });
 
 describe("resolveNoteRenderCoordinate (decode)", () => {
@@ -201,4 +211,3 @@ describe("resolveNoteRenderCoordinate (decode)", () => {
     });
   });
 });
-

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.test.ts
@@ -1,0 +1,204 @@
+import type { Graph } from "@planx/graph";
+import { describe, expect, it } from "vitest";
+
+import {
+  findContainerOf,
+  resolveNotePlacement,
+  resolveNoteRenderCoordinate,
+} from "./notePlacement";
+
+// _root -> nodeA -> nodeB -> nodeC (a plain linear root-level sequence,
+const linearFlow: Graph = {
+  _root: { edges: ["nodeA", "nodeB", "nodeC"] },
+  nodeA: { type: 8, data: { title: "Node A" } },
+  nodeB: { type: 8, data: { title: "Node B" } },
+  nodeC: { type: 8, data: { title: "Node C" } },
+};
+
+describe("findContainerOf", () => {
+  it("finds the node whose edges contain the given id", () => {
+    expect(findContainerOf(linearFlow, "nodeB")).toBe("_root");
+  });
+
+  it("returns undefined for a node with no container (e.g. _root itself)", () => {
+    expect(findContainerOf(linearFlow, "_root")).toBeUndefined();
+  });
+});
+
+describe("resolveNotePlacement (encode)", () => {
+  it("anchors to the preceding sibling when one exists", () => {
+    // note between nodeA and nodeB
+    expect(resolveNotePlacement(linearFlow, "_root", "nodeB")).toEqual({
+      parent: "nodeA",
+      container: "_root",
+    });
+  });
+
+  it("anchors to the last child when trailing (no `before` given, preceding sibling exists)", () => {
+    expect(resolveNotePlacement(linearFlow, "_root", undefined)).toEqual({
+      parent: "nodeC",
+      container: "_root",
+    });
+  });
+
+  it("falls back to container + before when there is no preceding sibling (leading position)", () => {
+    expect(resolveNotePlacement(linearFlow, "_root", "nodeA")).toEqual({
+      parent: "_root",
+      before: "nodeA",
+      parentIsContainer: true,
+    });
+  });
+
+  it("falls back to container with no before when the container is empty", () => {
+    const flow: Graph = { _root: {} };
+    expect(resolveNotePlacement(flow, "_root", undefined)).toEqual({
+      parent: "_root",
+      before: undefined,
+      parentIsContainer: true,
+    });
+  });
+
+  it("marks the placement as container-anchored when added as the first child of an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    expect(resolveNotePlacement(flow, "folder", undefined)).toEqual({
+      parent: "folder",
+      before: undefined,
+      parentIsContainer: true,
+    });
+  });
+});
+
+describe("resolveNoteRenderCoordinate (decode)", () => {
+  it("resolves a sibling-anchored placement to (its container, the next sibling)", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "nodeA" }),
+    ).toEqual({ container: "_root", before: "nodeB" });
+  });
+
+  it("resolves a trailing sibling anchor (last child) to (container, undefined)", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "nodeC" }),
+    ).toEqual({ container: "_root", before: undefined });
+  });
+
+  it("resolves a container-anchored (leading) placement directly", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, {
+        parent: "_root",
+        before: "nodeA",
+        parentIsContainer: true,
+      }),
+    ).toEqual({ container: "_root", before: "nodeA" });
+  });
+
+  it("treats parent === _root as a container even with no before (legacy placement without the flag)", () => {
+    expect(
+      resolveNoteRenderCoordinate(linearFlow, { parent: "_root" }),
+    ).toEqual({ container: "_root", before: undefined });
+  });
+
+  it("resolves a container-anchored placement into an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    expect(
+      resolveNoteRenderCoordinate(flow, {
+        parent: "folder",
+        before: undefined,
+        parentIsContainer: true,
+      }),
+    ).toEqual({ container: "folder", before: undefined });
+  });
+
+  it("still resolves a sibling-anchored placement pointing at an (empty) folder to after that folder, not inside it", () => {
+    // folder is the last child of _root and happens to be empty - without
+    // `parentIsContainer` this must NOT be mistaken for "insert inside folder"
+    const flow: Graph = {
+      _root: { edges: ["nodeA", "folder"] },
+      nodeA: linearFlow.nodeA,
+      folder: { type: 300, edges: [] },
+    };
+    expect(resolveNoteRenderCoordinate(flow, { parent: "folder" })).toEqual({
+      container: "_root",
+      before: undefined,
+    });
+  });
+
+  it("round-trips through encode then decode back to the original gap", () => {
+    const gaps: Array<{ container: string; before?: string }> = [
+      { container: "_root", before: "nodeA" },
+      { container: "_root", before: "nodeB" },
+      { container: "_root", before: "nodeC" },
+      { container: "_root", before: undefined },
+    ];
+
+    for (const gap of gaps) {
+      const placement = resolveNotePlacement(
+        linearFlow,
+        gap.container,
+        gap.before,
+      );
+      expect(resolveNoteRenderCoordinate(linearFlow, placement)).toEqual(gap);
+    }
+  });
+
+  it("round-trips a note added as the first child of an empty, non-root folder", () => {
+    const flow: Graph = {
+      _root: { edges: ["folder"] },
+      folder: { type: 300, edges: [] },
+    };
+    const gap = { container: "folder", before: undefined };
+
+    const placement = resolveNotePlacement(flow, gap.container, gap.before);
+    expect(resolveNoteRenderCoordinate(flow, placement)).toEqual(gap);
+  });
+
+  describe("cloned anchor nodes", () => {
+    // "shared" is a cloned node i.e. referenced from two different parents ("b" and "a")
+    // key order would place the note before b due to order but actually we want it to use a
+    const cloneFlow: Graph = {
+      _root: { edges: ["a", "b"] },
+      b: { type: 8, edges: ["shared"] },
+      a: { type: 8, edges: ["shared"] },
+      shared: { type: 8 },
+    };
+
+    it("encode stores the container a cloned sibling was resolved against", () => {
+      expect(resolveNotePlacement(cloneFlow, "a", undefined)).toEqual({
+        parent: "shared",
+        container: "a",
+      });
+    });
+
+    it("decode uses the stored container rather than guessing via findContainerOf", () => {
+      expect(findContainerOf(cloneFlow, "shared")).toBe("b");
+      expect(
+        resolveNoteRenderCoordinate(cloneFlow, {
+          parent: "shared",
+          container: "a",
+        }),
+      ).toEqual({ container: "a", before: undefined });
+    });
+
+    it("falls back to findContainerOf's (possibly wrong) match for legacy placements with no stored container", () => {
+      expect(
+        resolveNoteRenderCoordinate(cloneFlow, { parent: "shared" }),
+      ).toEqual({ container: "b", before: undefined });
+    });
+
+    it("round-trips a note anchored after a cloned sibling", () => {
+      const gap = { container: "a", before: undefined };
+      const placement = resolveNotePlacement(
+        cloneFlow,
+        gap.container,
+        gap.before,
+      );
+      expect(resolveNoteRenderCoordinate(cloneFlow, placement)).toEqual(gap);
+    });
+  });
+});
+

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -1,0 +1,64 @@
+import type { Graph } from "@planx/graph";
+import { ROOT_NODE_KEY } from "@planx/graph";
+import type { NotePlacement } from "hooks/data/useFlowNotes";
+
+/**
+ * Find the id of the node whose `edges` contains `nodeId`
+ */
+export const findContainerOf = (
+  flow: Graph,
+  nodeId: string,
+): string | undefined => {
+  for (const [id, node] of Object.entries(flow)) {
+    if (node.edges?.includes(nodeId)) {
+      return id;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Given a graph gap `{container, before?}` (i.e. Hanger co-ordinate), returns a `NotePlacement` to store
+ */
+export const resolveNotePlacement = (
+  flow: Graph,
+  container: string,
+  before?: string,
+): NotePlacement => {
+  const containerEdges = flow[container]?.edges ?? [];
+  const precedingId = before
+    ? containerEdges[containerEdges.indexOf(before) - 1]
+    : containerEdges[containerEdges.length - 1];
+
+  if (precedingId) {
+    return { parent: precedingId, container };
+  }
+
+  return { parent: container, before, parentIsContainer: true };
+};
+
+/**
+ * Reverses `resolveNotePlacement` - given a stored placement, finds the graph gap `{container, before?}` to render it
+ */
+export const resolveNoteRenderCoordinate = (
+  flow: Graph,
+  placement: NotePlacement,
+): { container: string; before?: string } => {
+  if (
+    placement.parentIsContainer ||
+    placement.parent === ROOT_NODE_KEY ||
+    placement.before !== undefined
+  ) {
+    return { container: placement.parent, before: placement.before };
+  }
+
+  const container =
+    placement.container ?? findContainerOf(flow, placement.parent);
+  if (!container) {
+    return { container: placement.parent, before: undefined };
+  }
+
+  const siblings = flow[container]?.edges ?? [];
+  const index = siblings.indexOf(placement.parent);
+  return { container, before: siblings[index + 1] };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/notePlacement.ts
@@ -26,6 +26,13 @@ export const resolveNotePlacement = (
   before?: string,
 ): NotePlacement => {
   const containerEdges = flow[container]?.edges ?? [];
+
+  if (before && !containerEdges.includes(before)) {
+    throw new Error(
+      `before node ${before} not found in container ${container}`,
+    );
+  }
+
   const precedingId = before
     ? containerEdges[containerEdges.indexOf(before) - 1]
     : containerEdges[containerEdges.length - 1];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
@@ -1,0 +1,109 @@
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import { describe, expect, it } from "vitest";
+
+import { partitionNotes, placementKey } from "./partitionNotes";
+
+let noteCounter = 0;
+
+const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => {
+  noteCounter += 1;
+  return {
+    id: `note-${noteCounter}`,
+    flowId: "flow-1",
+    nodeId: null,
+    placement: null,
+    text: `Note ${noteCounter}`,
+    color: "#fffdb0",
+    createdBy: 1,
+    updatedBy: 1,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+};
+
+describe("partitionNotes", () => {
+  it("returns empty maps for empty input", () => {
+    const { attached, positioned } = partitionNotes([], {});
+    expect(attached.size).toBe(0);
+    expect(positioned.size).toBe(0);
+  });
+
+  it("buckets a node_id-set note under attached, keyed by nodeId", () => {
+    const note = makeNote({ nodeId: "node-a" });
+    const { attached, positioned } = partitionNotes([note], {});
+
+    expect(attached.get("node-a")).toEqual([note]);
+    expect(positioned.size).toBe(0);
+  });
+
+  it("never places an attached note in the positioned map", () => {
+    const note = makeNote({ nodeId: "node-a" });
+    const { positioned } = partitionNotes([note], {});
+
+    expect(positioned.get(placementKey("node-a"))).toBeUndefined();
+  });
+
+  it("buckets a container-anchored placement note under its exact (parent, before) key", () => {
+    const note = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const { positioned } = partitionNotes([note], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([note]);
+  });
+
+  it("buckets a placement note with no `before` into a distinct trailing bucket", () => {
+    const before = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const trailing = makeNote({ placement: { parent: "container-a" } });
+    const { positioned } = partitionNotes([before, trailing], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([before]);
+    expect(positioned.get(placementKey("container-a"))).toEqual([trailing]);
+    expect(placementKey("container-a")).not.toBe(
+      placementKey("container-a", "X"),
+    );
+  });
+
+  it("does not leak notes across different parents sharing the same `before`", () => {
+    const noteA = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const noteB = makeNote({
+      placement: { parent: "container-b", before: "X" },
+    });
+    const { positioned } = partitionNotes([noteA, noteB], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([noteA]);
+    expect(positioned.get(placementKey("container-b", "X"))).toEqual([noteB]);
+  });
+
+  it("preserves insertion order for multiple notes at the same coordinate", () => {
+    const first = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const second = makeNote({
+      placement: { parent: "container-a", before: "X" },
+    });
+    const { positioned } = partitionNotes([first, second], {});
+
+    expect(positioned.get(placementKey("container-a", "X"))).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it("decodes a sibling-anchored placement (no before) using the current flow", () => {
+    const flow = {
+      _root: { edges: ["nodeA", "nodeB"] },
+      nodeA: { type: 8 },
+      nodeB: { type: 8 },
+    };
+    const note = makeNote({ placement: { parent: "nodeA" } });
+    const { positioned } = partitionNotes([note], flow);
+
+    expect(positioned.get(placementKey("_root", "nodeB"))).toEqual([note]);
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.test.ts
@@ -1,26 +1,35 @@
-import type { FlowNote } from "hooks/data/useFlowNotes";
+import type { FlowNote, NotePlacement } from "hooks/data/useFlowNotes";
 import { describe, expect, it } from "vitest";
 
 import { partitionNotes, placementKey } from "./partitionNotes";
 
 let noteCounter = 0;
 
-const makeNote = (overrides: Partial<FlowNote> = {}): FlowNote => {
+const baseNote = () => {
   noteCounter += 1;
   return {
     id: `note-${noteCounter}`,
     flowId: "flow-1",
-    nodeId: null,
-    placement: null,
     text: `Note ${noteCounter}`,
     color: "#fffdb0",
     createdBy: 1,
     updatedBy: 1,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
-    ...overrides,
   };
 };
+
+const makeAttachedNote = (nodeId: string): FlowNote => ({
+  ...baseNote(),
+  nodeId,
+  placement: null,
+});
+
+const makePositionedNote = (placement: NotePlacement): FlowNote => ({
+  ...baseNote(),
+  nodeId: null,
+  placement,
+});
 
 describe("partitionNotes", () => {
   it("returns empty maps for empty input", () => {
@@ -30,7 +39,7 @@ describe("partitionNotes", () => {
   });
 
   it("buckets a node_id-set note under attached, keyed by nodeId", () => {
-    const note = makeNote({ nodeId: "node-a" });
+    const note = makeAttachedNote("node-a");
     const { attached, positioned } = partitionNotes([note], {});
 
     expect(attached.get("node-a")).toEqual([note]);
@@ -38,15 +47,17 @@ describe("partitionNotes", () => {
   });
 
   it("never places an attached note in the positioned map", () => {
-    const note = makeNote({ nodeId: "node-a" });
+    const note = makeAttachedNote("node-a");
     const { positioned } = partitionNotes([note], {});
 
     expect(positioned.get(placementKey("node-a"))).toBeUndefined();
   });
 
   it("buckets a container-anchored placement note under its exact (parent, before) key", () => {
-    const note = makeNote({
-      placement: { parent: "container-a", before: "X" },
+    const note = makePositionedNote({
+      parent: "container-a",
+      before: "X",
+      parentIsContainer: true,
     });
     const { positioned } = partitionNotes([note], {});
 
@@ -54,10 +65,12 @@ describe("partitionNotes", () => {
   });
 
   it("buckets a placement note with no `before` into a distinct trailing bucket", () => {
-    const before = makeNote({
-      placement: { parent: "container-a", before: "X" },
+    const before = makePositionedNote({
+      parent: "container-a",
+      before: "X",
+      parentIsContainer: true,
     });
-    const trailing = makeNote({ placement: { parent: "container-a" } });
+    const trailing = makePositionedNote({ parent: "container-a" });
     const { positioned } = partitionNotes([before, trailing], {});
 
     expect(positioned.get(placementKey("container-a", "X"))).toEqual([before]);
@@ -68,11 +81,15 @@ describe("partitionNotes", () => {
   });
 
   it("does not leak notes across different parents sharing the same `before`", () => {
-    const noteA = makeNote({
-      placement: { parent: "container-a", before: "X" },
+    const noteA = makePositionedNote({
+      parent: "container-a",
+      before: "X",
+      parentIsContainer: true,
     });
-    const noteB = makeNote({
-      placement: { parent: "container-b", before: "X" },
+    const noteB = makePositionedNote({
+      parent: "container-b",
+      before: "X",
+      parentIsContainer: true,
     });
     const { positioned } = partitionNotes([noteA, noteB], {});
 
@@ -81,11 +98,15 @@ describe("partitionNotes", () => {
   });
 
   it("preserves insertion order for multiple notes at the same coordinate", () => {
-    const first = makeNote({
-      placement: { parent: "container-a", before: "X" },
+    const first = makePositionedNote({
+      parent: "container-a",
+      before: "X",
+      parentIsContainer: true,
     });
-    const second = makeNote({
-      placement: { parent: "container-a", before: "X" },
+    const second = makePositionedNote({
+      parent: "container-a",
+      before: "X",
+      parentIsContainer: true,
     });
     const { positioned } = partitionNotes([first, second], {});
 
@@ -101,7 +122,7 @@ describe("partitionNotes", () => {
       nodeA: { type: 8 },
       nodeB: { type: 8 },
     };
-    const note = makeNote({ placement: { parent: "nodeA" } });
+    const note = makePositionedNote({ parent: "nodeA" });
     const { positioned } = partitionNotes([note], flow);
 
     expect(positioned.get(placementKey("_root", "nodeB"))).toEqual([note]);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
@@ -11,6 +11,14 @@ export interface PartitionedNotes {
 export const placementKey = (parent: string, before?: string): string =>
   `${parent}::${before ?? ""}`;
 
+/**
+ * Notes render at two different kinds of location, so the flow renderer needs two different lookups
+ * attached notes are keyed by the nodeId they're pinned to
+ * positioned notes sit in a gap between nodes and must be keyed by the resolved render coordinate instead (container, before)
+ *
+ * a note's stored `placement` doesn't map 1:1 to that coordinate (e.g. a cloned anchor can resolve differently depending its parent)
+ * so this resolution has to happen once, up front, rather than per-render.
+ */
 export const partitionNotes = (
   notes: FlowNote[],
   flow: Graph,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/partitionNotes.ts
@@ -1,0 +1,39 @@
+import type { Graph } from "@planx/graph";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+
+import { resolveNoteRenderCoordinate } from "./notePlacement";
+
+export interface PartitionedNotes {
+  attached: Map<string, FlowNote[]>;
+  positioned: Map<string, FlowNote[]>;
+}
+
+export const placementKey = (parent: string, before?: string): string =>
+  `${parent}::${before ?? ""}`;
+
+export const partitionNotes = (
+  notes: FlowNote[],
+  flow: Graph,
+): PartitionedNotes => {
+  const attached = new Map<string, FlowNote[]>();
+  const positioned = new Map<string, FlowNote[]>();
+
+  for (const note of notes) {
+    if (note.nodeId) {
+      const bucket = attached.get(note.nodeId) ?? [];
+      bucket.push(note);
+      attached.set(note.nodeId, bucket);
+    } else if (note.placement) {
+      const { container, before } = resolveNoteRenderCoordinate(
+        flow,
+        note.placement,
+      );
+      const key = placementKey(container, before);
+      const bucket = positioned.get(key) ?? [];
+      bucket.push(note);
+      positioned.set(key, bucket);
+    }
+  }
+
+  return { attached, positioned };
+};


### PR DESCRIPTION
**What's in this PR **
As per @DafyddLlyr's suggestion, this is the first of a few PRs comprising the new notes feature. This one has the core logic around how to place notes in a flow, i.e. going from a visual hanger -> `NotePlacement` object, and back. 

**How to review?**
There's no UI here so really just looking for eyes on the logic, the test coverage etc.

Later there will be extra logic for moving/cloning etc that will introduce further behaviour in these files.