### PR TITLE
feat: Set up UI and Storybook for PlanX in numbers widget

### DIFF
--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -5,6 +5,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
 import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { formatDelta } from "utils";
 
 import { useStore } from "../../FlowEditor/lib/store";
 import type { TeamDashboardStats } from "./useTeamDashboardStats";
@@ -43,11 +44,6 @@ const StatsGrid = styled(Box)(({ theme }) => ({
     gridTemplateColumns: "repeat(2, 1fr)",
   },
 }));
-
-function formatDelta(delta: number): string {
-  const formatted = Math.abs(delta).toLocaleString("en-GB");
-  return delta >= 0 ? `+${formatted}` : `-${formatted}`;
-}
 
 const analyticsLinkBase = (theme: Theme) => ({
   fontSize: theme.typography.body2.fontSize,

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -1,10 +1,11 @@
 import Box from "@mui/material/Box";
 import MuiLink from "@mui/material/Link";
-import { keyframes, styled, type Theme } from "@mui/material/styles";
+import { styled, type Theme } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useTeamAnalyticsLink } from "hooks/analyticsLinks/useTeamAnalyticsLink";
 import { cardBoxShadow, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { EmptyLoadingBar, LoadingBar } from "ui/editor/LoadingBar";
 import { formatDelta } from "utils";
 
 import { useStore } from "../../FlowEditor/lib/store";
@@ -31,11 +32,6 @@ const Header = styled(Box)(({ theme }) => ({
   borderBottom: `1px solid ${theme.palette.border.light}`,
 }));
 
-const pulse = keyframes`
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
-`;
-
 const StatsGrid = styled(Box)(({ theme }) => ({
   display: "grid",
   gridTemplateColumns: "repeat(4, 1fr)",
@@ -44,6 +40,41 @@ const StatsGrid = styled(Box)(({ theme }) => ({
     gridTemplateColumns: "repeat(2, 1fr)",
   },
 }));
+
+const LoadingBarContainer = styled(Box)(({ theme }) => ({
+  height: 80,
+  display: "flex-start",
+  paddingTop: theme.spacing(2),
+  alignItems: "center",
+}));
+
+interface StatValueProps {
+  loading: boolean;
+  value: number | null;
+  label: string;
+}
+
+function StatValue({ loading, value, label }: StatValueProps) {
+  if (loading) {
+    return (
+      <LoadingBarContainer>
+        <LoadingBar aria-label={`Loading ${label}`} />
+      </LoadingBarContainer>
+    );
+  }
+  if (value !== null) {
+    return (
+      <Typography variant="h1" component="p" sx={{ height: 56 }}>
+        {value.toLocaleString("en-GB")}
+      </Typography>
+    );
+  }
+  return (
+    <LoadingBarContainer>
+      <EmptyLoadingBar />
+    </LoadingBarContainer>
+  );
+}
 
 const analyticsLinkBase = (theme: Theme) => ({
   fontSize: theme.typography.body2.fontSize,
@@ -129,23 +160,14 @@ export function StatsBanner({
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
               {label}
             </Typography>
-            <Typography
-              variant="h1"
-              component="p"
-              sx={
-                loading
-                  ? { animation: `${pulse} 1.4s ease-in-out infinite` }
-                  : undefined
-              }
-            >
-              {value !== null ? value.toLocaleString("en-GB") : "—"}
-            </Typography>
+            <StatValue loading={loading} value={value} label={label} />
             {!loading && delta !== null && (
               <Typography
                 variant="body2"
                 sx={{
                   color: delta >= 0 ? "success.main" : "error.main",
                   fontWeight: "bold",
+                  height: 24,
                 }}
               >
                 {formatDelta(delta)}

--- a/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
+++ b/apps/editor.planx.uk/src/pages/Dashboard/components/StatsBanner.tsx
@@ -161,11 +161,11 @@ export function StatsBanner({
               {label}
             </Typography>
             <StatValue loading={loading} value={value} label={label} />
-            {!loading && delta !== null && (
+            {!loading && delta !== null && delta !== 0 && (
               <Typography
                 variant="body2"
                 sx={{
-                  color: delta >= 0 ? "success.main" : "error.main",
+                  color: delta > 0 ? "success.main" : "error.main",
                   fontWeight: "bold",
                   height: 24,
                 }}

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { NumbersWidget } from "./NumbersWidget";
+
+const meta = {
+  title: "Editor Components/Explore/NumbersWidget",
+  component: NumbersWidget,
+  decorators: [
+    (Story) => (
+      <DashboardWidget title="Plan✕ in numbers" subtitle="last 30 days">
+        <Story />
+      </DashboardWidget>
+    ),
+  ],
+  args: {
+    stats: {
+      lpasOnPlanX: 29,
+      lpasOnPlanXPrevious: 27,
+      onlineServices: 168,
+      onlineServicesPrevious: 149,
+      totalSessions: 12421,
+      totalSessionsPrevious: 12052,
+      totalSubmissions: 131,
+      totalSubmissionsPrevious: 123,
+    },
+  },
+} satisfies Meta<typeof NumbersWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: {
+    stats: undefined,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   args: {
     stats: {
       lpasOnPlanX: 29,
-      lpasOnPlanXPrevious: 27,
+      lpasOnPlanXPrevious: 29,
       onlineServices: 168,
       onlineServicesPrevious: 149,
       totalSessions: 12421,
@@ -35,6 +35,13 @@ export const Default: Story = {};
 
 export const Empty: Story = {
   args: {
+    stats: undefined,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
     stats: undefined,
   },
 };

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
@@ -1,0 +1,88 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+export interface NumbersWidgetStats {
+  lpasOnPlanX: number;
+  lpasOnPlanXPrevious: number;
+  onlineServices: number;
+  onlineServicesPrevious: number;
+  totalSessions: number;
+  totalSessionsPrevious: number;
+  totalSubmissions: number;
+  totalSubmissionsPrevious: number;
+}
+
+interface NumbersWidgetProps {
+  stats?: NumbersWidgetStats;
+}
+
+function formatDelta(delta: number): string {
+  const formatted = Math.abs(delta).toLocaleString("en-GB");
+  return delta >= 0 ? `+${formatted}` : `-${formatted}`;
+}
+
+export function NumbersWidget({ stats }: NumbersWidgetProps) {
+  const rows = [
+    {
+      label: "LPAs on PlanX",
+      value: stats?.lpasOnPlanX ?? null,
+      delta: stats ? stats.lpasOnPlanX - stats.lpasOnPlanXPrevious : null,
+    },
+    {
+      label: "online services",
+      value: stats?.onlineServices ?? null,
+      delta: stats ? stats.onlineServices - stats.onlineServicesPrevious : null,
+    },
+    {
+      label: "total sessions",
+      value: stats?.totalSessions ?? null,
+      delta: stats ? stats.totalSessions - stats.totalSessionsPrevious : null,
+    },
+    {
+      label: "total submissions",
+      value: stats?.totalSubmissions ?? null,
+      delta: stats
+        ? stats.totalSubmissions - stats.totalSubmissionsPrevious
+        : null,
+    },
+  ];
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
+      <Box sx={{ overflowY: "auto" }}>
+        {rows.map(({ label, value, delta }, index) => (
+          <React.Fragment key={label}>
+            <Box sx={{ px: 2, pb: 1, pt: 1.5 }}>
+              <Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
+                <Typography variant="h1" component="p">
+                  {value !== null ? value.toLocaleString("en-GB") : "—"}
+                </Typography>
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {label}
+                </Typography>
+                {delta !== null && (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: delta >= 0 ? "success.main" : "error.main",
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {formatDelta(delta)}
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+            {index < rows.length - 1 && <Divider />}
+          </React.Fragment>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export default function ConnectedNumbersWidget() {
+  return <NumbersWidget />;
+}

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import { formatDelta } from "utils";
 
 export interface NumbersWidgetStats {
   lpasOnPlanX: number;
@@ -16,11 +17,6 @@ export interface NumbersWidgetStats {
 
 interface NumbersWidgetProps {
   stats?: NumbersWidgetStats;
-}
-
-function formatDelta(delta: number): string {
-  const formatted = Math.abs(delta).toLocaleString("en-GB");
-  return delta >= 0 ? `+${formatted}` : `-${formatted}`;
 }
 
 export function NumbersWidget({ stats }: NumbersWidgetProps) {

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
@@ -110,11 +110,11 @@ export function NumbersWidget({ stats, loading = false }: NumbersWidgetProps) {
                 <Typography variant="body2" sx={{ color: "text.secondary" }}>
                   {label}
                 </Typography>
-                {!loading && delta !== null && (
+                {!loading && delta !== null && delta !== 0 && (
                   <Typography
                     variant="body2"
                     sx={{
-                      color: delta >= 0 ? "success.main" : "error.main",
+                      color: delta > 0 ? "success.main" : "error.main",
                       fontWeight: "bold",
                     }}
                   >

--- a/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/NumbersWidget.tsx
@@ -1,7 +1,9 @@
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import React from "react";
+import { EmptyLoadingBar, LoadingBar } from "ui/editor/LoadingBar";
 import { formatDelta } from "utils";
 
 export interface NumbersWidgetStats {
@@ -17,9 +19,55 @@ export interface NumbersWidgetStats {
 
 interface NumbersWidgetProps {
   stats?: NumbersWidgetStats;
+  loading?: boolean;
 }
 
-export function NumbersWidget({ stats }: NumbersWidgetProps) {
+// Container for loading bar to keep it aligned when data is present
+const LoadingBarContainer = styled(Box)({
+  height: 56,
+  display: "flex",
+  alignItems: "flex-end",
+  paddingBottom: "7px",
+});
+
+interface StatValueProps {
+  loading: boolean;
+  value: number | null;
+  label: string;
+}
+
+function StatValue({ loading, value, label }: StatValueProps) {
+  if (loading) {
+    return (
+      <LoadingBarContainer>
+        <LoadingBar aria-label={`Loading ${label}`} />
+      </LoadingBarContainer>
+    );
+  }
+  if (value !== null) {
+    return (
+      // Fixed size and height to keep layout consistent
+      <Typography
+        variant="h1"
+        component="p"
+        sx={{
+          height: 56,
+          lineHeight: 1.35,
+          fontSize: "3rem !important",
+        }}
+      >
+        {value.toLocaleString("en-GB")}
+      </Typography>
+    );
+  }
+  return (
+    <LoadingBarContainer>
+      <EmptyLoadingBar />
+    </LoadingBarContainer>
+  );
+}
+
+export function NumbersWidget({ stats, loading = false }: NumbersWidgetProps) {
   const rows = [
     {
       label: "LPAs on PlanX",
@@ -50,15 +98,19 @@ export function NumbersWidget({ stats }: NumbersWidgetProps) {
       <Box sx={{ overflowY: "auto" }}>
         {rows.map(({ label, value, delta }, index) => (
           <React.Fragment key={label}>
-            <Box sx={{ px: 2, pb: 1, pt: 1.5 }}>
-              <Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
-                <Typography variant="h1" component="p">
-                  {value !== null ? value.toLocaleString("en-GB") : "—"}
-                </Typography>
+            <Box sx={{ px: 2, pb: 1.25, pt: 1.25 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "flex-end",
+                  gap: 1,
+                }}
+              >
+                <StatValue loading={loading} value={value} label={label} />
                 <Typography variant="body2" sx={{ color: "text.secondary" }}>
                   {label}
                 </Typography>
-                {delta !== null && (
+                {!loading && delta !== null && (
                   <Typography
                     variant="body2"
                     sx={{

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -1,44 +1,59 @@
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import { linkOptions } from "@tanstack/react-router";
-import React from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
+import NumbersWidget from "./components/NumbersWidget";
 
 export default function Explore() {
   const team = useStore((state) => state.getTeam());
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-      <Typography variant="h2" component="h1" gutterBottom>
-        Explore
-      </Typography>
-      <Box
-        sx={(theme) => ({
-          display: "grid",
-          gap: theme.spacing(2),
-          gridTemplateColumns: "repeat(auto-fit, minmax(400px, 1fr))",
-        })}
-      >
-        <DashboardWidget title="Templates">
-          <i>templates content</i>
-        </DashboardWidget>
-        <DashboardWidget
-          title="Help and resources"
-          link={linkOptions({
-            to: "/app/$team/resources",
-            params: { team: team.slug },
-            label: "view all help and resources",
-          })}
+    <Box sx={{ bgcolor: "background.paper", flexGrow: 1 }}>
+      <Container maxWidth="contentWide">
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 2,
+            justifyContent: "space-between",
+            alignItems: "center",
+            pb: 2,
+          }}
         >
-          <i>resources content</i>
-        </DashboardWidget>
-        <DashboardWidget title="Available content">
-          <i>available content</i>
-        </DashboardWidget>
-      </Box>
-    </Container>
+          <Typography variant="h2" component="h1">
+            Explore Plan✕
+          </Typography>
+          {/* TODO: Style search button */}
+          <Button>Search PlanX</Button>
+        </Box>
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            py: 2,
+            gridTemplateColumns: "repeat(auto-fit, minmax(470px, 1fr))",
+          }}
+        >
+          <DashboardWidget title="Plan✕ in numbers" subtitle="last 30 days">
+            <NumbersWidget />
+          </DashboardWidget>
+          <DashboardWidget
+            title="Featured templates"
+            link={linkOptions({
+              // TODO: Update to point to filtered search view for templates
+              to: "/app/$team/flows",
+              params: { team: team.slug },
+              label: "view all templates",
+            })}
+          >
+            <i>templates content</i>
+          </DashboardWidget>
+        </Box>
+      </Container>
+    </Box>
   );
 }

--- a/apps/editor.planx.uk/src/ui/editor/LoadingBar.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/LoadingBar.tsx
@@ -1,0 +1,50 @@
+import Box from "@mui/material/Box";
+import LinearProgress, {
+  linearProgressClasses,
+} from "@mui/material/LinearProgress";
+import { keyframes, styled } from "@mui/material/styles";
+
+// Loading bar looping animation
+const loadFill = keyframes`
+  0% { transform: scaleX(0); }
+  50% { transform: scaleX(1); }
+  100% { transform: scaleX(1); }
+`;
+
+const loadFollow = keyframes`
+  0% { transform: scaleX(0); }
+  50% { transform: scaleX(0); }
+  100% { transform: scaleX(1); }
+`;
+
+const StyledBar = styled(LinearProgress)(({ theme }) => ({
+  width: 48,
+  height: 6,
+  backgroundColor: theme.palette.grey[300],
+  [`& .${linearProgressClasses.bar1}`]: {
+    width: "100%",
+    backgroundColor: theme.palette.common.black,
+    animation: `${loadFill} 1.6s ease-in-out infinite`,
+  },
+  [`& .${linearProgressClasses.bar2}`]: {
+    width: "100%",
+    backgroundColor: theme.palette.secondary.dark,
+    animation: `${loadFollow} 1.6s ease-in-out infinite`,
+  },
+}));
+
+interface LoadingBarProps {
+  "aria-label"?: string;
+}
+
+export function LoadingBar({ "aria-label": ariaLabel }: LoadingBarProps) {
+  return (
+    <StyledBar variant="indeterminate" aria-label={ariaLabel ?? "Loading"} />
+  );
+}
+
+export const EmptyLoadingBar = styled(Box)(({ theme }) => ({
+  width: 48,
+  height: 6,
+  backgroundColor: theme.palette.text.disabled,
+}));

--- a/apps/editor.planx.uk/src/ui/editor/LoadingBar.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/LoadingBar.tsx
@@ -28,7 +28,7 @@ const StyledBar = styled(LinearProgress)(({ theme }) => ({
   },
   [`& .${linearProgressClasses.bar2}`]: {
     width: "100%",
-    backgroundColor: theme.palette.secondary.dark,
+    backgroundColor: theme.palette.grey[300],
     animation: `${loadFollow} 1.6s ease-in-out infinite`,
   },
 }));

--- a/apps/editor.planx.uk/src/utils.ts
+++ b/apps/editor.planx.uk/src/utils.ts
@@ -89,3 +89,8 @@ export const removeSessionIdSearchParam = async (flowId: string) => {
 export const exhaustiveCheck = (type: never): never => {
   throw new Error(`Missing type ${type}`);
 };
+
+export function formatDelta(delta: number): string {
+  const formatted = Math.abs(delta).toLocaleString("en-GB");
+  return delta >= 0 ? `+${formatted}` : `-${formatted}`;
+}

--- a/apps/editor.planx.uk/src/utils.ts
+++ b/apps/editor.planx.uk/src/utils.ts
@@ -91,6 +91,7 @@ export const exhaustiveCheck = (type: never): never => {
 };
 
 export function formatDelta(delta: number): string {
+  if (delta === 0) return "0";
   const formatted = Math.abs(delta).toLocaleString("en-GB");
-  return delta >= 0 ? `+${formatted}` : `-${formatted}`;
+  return delta > 0 ? `+${formatted}` : `-${formatted}`;
 }


### PR DESCRIPTION
## What does this PR do?

Sets up UI and Storybook file for "PlanX in numbers" widget (I've called it `NumbersWidget` for now, better naming suggestions welcome)
- Adjusts styling of Explore page to match layout and style of Dashboard
- Adds placeholder search button
- Sets up `NumbersWidget` with same loading pattern as `StatsBanner`
- Sets up Storybook file with mock data

**Testing:**
- Toggle feature flag for `explore` - https://7038.planx.pizza/app/explore
- Storybook with mock data - https://storybook.7038.planx.pizza/?path=/docs/editor-components-explore-numberswidget--docs