### PR TITLE
fix: URL preview when creating new flows

### DIFF
--- a/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/BaseFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/BaseFormSection.tsx
@@ -66,7 +66,7 @@ export const BaseFormSection: React.FC = () => {
           disabled
           id="flow.slug"
           type="text"
-          startAdornment={<URLPrefix />}
+          startAdornment={<URLPrefix mode="flow" />}
         />
       </InputLabel>
       {values.mode === "new" && (

--- a/apps/editor.planx.uk/src/pages/Flows/components/CopyDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/CopyDialog.tsx
@@ -122,7 +122,7 @@ export const CopyDialog: React.FC<Props> = ({
                     disabled
                     id="flow.slug"
                     type="text"
-                    startAdornment={<URLPrefix />}
+                    startAdornment={<URLPrefix mode="flow" />}
                   />
                 </InputLabel>
               </DialogContent>

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
@@ -162,7 +162,7 @@ export const RenameDialog: React.FC<Props> = ({
                     disabled
                     id="flowSlug"
                     type="text"
-                    startAdornment={<URLPrefix />}
+                    startAdornment={<URLPrefix mode="flow" />}
                   />
                 </InputLabel>
               </DialogContent>

--- a/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
+++ b/apps/editor.planx.uk/src/pages/Teams/AddTeamButton.tsx
@@ -124,7 +124,7 @@ export const AddTeamButton: React.FC = () => {
                       {...getFieldProps("slug")}
                       disabled
                       type="text"
-                      startAdornment={<URLPrefix />}
+                      startAdornment={<URLPrefix mode="team" />}
                     />
                   </InputLabel>
                   <Switch

--- a/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
@@ -1,9 +1,19 @@
 import InputAdornment from "@mui/material/InputAdornment";
 import { typographyClasses } from "@mui/material/Typography";
+import { useParams } from "@tanstack/react-router";
 import React, { useState } from "react";
 
 type Props = {
   mode: "team" | "flow";
+};
+
+const getPath = (mode: Props["mode"], team?: string) => {
+  switch (mode) {
+    case "team":
+      return "/app";
+    case "flow":
+      return `/app/${team}`;
+  }
 };
 
 /**
@@ -11,10 +21,11 @@ type Props = {
  * Used to display URLs when creating teams and flows
  */
 export const URLPrefix: React.FC<Props> = ({ mode }) => {
+  const { team } = useParams({ strict: false });
+
   // Store in component state so this does not update when user submits form
   const [urlPrefix] = useState(() => {
-    const { origin, pathname } = window.location;
-    const path = mode === "team" ? pathname : pathname.replace("/flows", ""); // if creating a new flow, the route of the flow itself should not be a child of `/flows`
+    const path = getPath(mode, team);
     return `${origin}${path}/`;
   });
 

--- a/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
@@ -2,15 +2,19 @@ import InputAdornment from "@mui/material/InputAdornment";
 import { typographyClasses } from "@mui/material/Typography";
 import React, { useState } from "react";
 
+type Props = {
+  mode: "team" | "flow";
+};
+
 /**
  * InputAdornment for text inputs displaying the current URL
  * Used to display URLs when creating teams and flows
  */
-export const URLPrefix: React.FC = () => {
+export const URLPrefix: React.FC<Props> = ({ mode }) => {
   // Store in component state so this does not update when user submits form
   const [urlPrefix] = useState(() => {
     const { origin, pathname } = window.location;
-    const path = pathname !== "/" ? pathname.replace("/flows", "") : "";
+    const path = mode === "team" ? pathname : pathname.replace("/flows", ""); // if creating a new flow, the route of the flow itself should not be a child of `/flows`
     return `${origin}${path}/`;
   });
 

--- a/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/URLPrefix.tsx
@@ -10,7 +10,7 @@ export const URLPrefix: React.FC = () => {
   // Store in component state so this does not update when user submits form
   const [urlPrefix] = useState(() => {
     const { origin, pathname } = window.location;
-    const path = pathname !== "/" ? pathname : "";
+    const path = pathname !== "/" ? pathname.replace("/flows", "") : "";
     return `${origin}${path}/`;
   });
 


### PR DESCRIPTION
As flagged by @ianjon3s in dev call, I missed this in #6950

Tested for:
- all methods of new flow creation
- flow rename
- new team creation

(basically everywhere `URLPrefix` is used)

I figured it was fine to use a `.replace` in `URLPrefix` but let me know if that's too brittle somehow?