### PR TITLE
feat: grouped submissions log

### DIFF
--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,8 @@
 // add/edit/remove feature flags in array below
-export const AVAILABLE_FEATURE_FLAGS = ["EXPLORE", "NOTES"] as const;
+export const AVAILABLE_FEATURE_FLAGS = [
+  "EXPLORE",
+  "GROUPED_SUBMISSIONS",
+  "NOTES"] as const;
 
 export type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -49,6 +49,11 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   const submissions = useMemo(() => data?.submissions || [], [data]);
 
   const sessionSummaries = useMemo(() => {
+    type PartialSummary = Omit<
+      SubmissionSummary,
+      "eventCount" | "mostRecentEventType" | "mostRecentStatus" | "status"
+    >;
+
     const grouped = submissions.reduce(
       (acc, submission) => {
         if (!acc[submission.sessionId]) {
@@ -71,17 +76,26 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
 
         return acc;
       },
-      {} as Record<string, SubmissionSummary>,
+      {} as Record<string, PartialSummary>,
     );
 
-    return Object.values(grouped).map((session) => ({
-      ...session,
-      eventCount: session.events.length,
-      // if ANY most recent event failed, session fails
-      sessionStatus: session.events.some((e) => e.status !== "Success")
-        ? "Failed"
-        : "Success",
-    }));
+    return Object.values(grouped).map((session) => {
+      // Find the most recent event
+      const mostRecentEvent = session.events.reduce((latest, event) =>
+        event.createdAt > latest.createdAt ? event : latest,
+      );
+
+      return {
+        ...session,
+        eventCount: session.events.length,
+        mostRecentEventType: mostRecentEvent.eventType,
+        mostRecentStatus: mostRecentEvent.status,
+        // if ANY most recent event failed, session fails
+        status: session.events.some((e) => e.status !== "Success")
+          ? ("Failed" as const)
+          : ("Success" as const),
+      };
+    });
   }, [submissions]);
 
   // filter by flow if flowId prop is passed from route params

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -8,33 +8,26 @@ import { slugify } from "utils";
 
 import { useStore } from "../../lib/store";
 import EventsLogGrouped from "./components/EventsLogGrouped";
-import type { Submission, SubmissionsProps, SubmissionSummary } from "./types";
+import type { SubmissionsProps, SubmissionSummary } from "./types";
 
 const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   const [teamId] = useStore((state) => [state.teamId]);
 
-  // submission_services_log view is already filtered for events >= Jan 1 2024
-  const { data, loading, error } = useQuery<{ submissions: Submission[] }>(
+  const { data, loading, error } = useQuery<{
+    submissions: SubmissionSummary[];
+  }>(
     gql`
       query GetSubmissions($team_id: Int!) {
-        submissions: submission_services_log(
+        submissions: submissions_grouped(
           where: { team_id: { _eq: $team_id } }
-          order_by: [
-            { session_id: asc }
-            { event_type: asc }
-            { created_at: desc }
-          ]
-          distinct_on: [session_id, event_type]
+          order_by: [{ session_id: asc }, { created_at: desc }]
+          distinct_on: session_id
         ) {
           flowId: flow_id
-          sessionId: session_id
-          eventId: event_id
-          eventType: event_type
+          id: session_id
           status: status
-          retry: retry
-          response: response
           address: address
-          createdAt: created_at
+          eventCreatedAt: created_at
           flowName: flow_name
         }
       }
@@ -47,59 +40,8 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   );
 
   const submissions = useMemo(() => data?.submissions || [], [data]);
-
-  const sessionSummaries = useMemo(() => {
-    type PartialSummary = Omit<
-      SubmissionSummary,
-      "eventCount" | "mostRecentEventType" | "mostRecentStatus" | "status"
-    >;
-
-    const grouped = submissions.reduce(
-      (acc, submission) => {
-        if (!acc[submission.sessionId]) {
-          acc[submission.sessionId] = {
-            id: submission.sessionId,
-            flowId: submission.flowId,
-            flowName: submission.flowName,
-            address: submission.address,
-            events: [],
-            mostRecentDate: submission.createdAt,
-          };
-        }
-
-        acc[submission.sessionId].events.push(submission);
-
-        // most recent date (eg for events after created date)
-        if (submission.createdAt > acc[submission.sessionId].mostRecentDate) {
-          acc[submission.sessionId].mostRecentDate = submission.createdAt;
-        }
-
-        return acc;
-      },
-      {} as Record<string, PartialSummary>,
-    );
-
-    return Object.values(grouped).map((session) => {
-      // Find the most recent event
-      const mostRecentEvent = session.events.reduce((latest, event) =>
-        event.createdAt > latest.createdAt ? event : latest,
-      );
-
-      return {
-        ...session,
-        eventCount: session.events.length,
-        mostRecentEventType: mostRecentEvent.eventType,
-        mostRecentStatus: mostRecentEvent.status,
-        // if ANY most recent event failed, session fails
-        status: session.events.some((e) => e.status !== "Success")
-          ? ("Failed" as const)
-          : ("Success" as const),
-      };
-    });
-  }, [submissions]);
-
   // filter by flow if flowId prop is passed from route params
-  const filteredSubmissions = sessionSummaries.filter(
+  const filteredSubmissions = submissions.filter(
     (submission) => !flowSlug || slugify(submission.flowName) === flowSlug,
   );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -1,0 +1,118 @@
+import { gql, useQuery } from "@apollo/client";
+import Typography from "@mui/material/Typography";
+import { BREADCRUMBS_HEIGHT } from "components/Breadcrumbs";
+import React, { useMemo } from "react";
+import FixedHeightDashboardContainer from "ui/editor/FixedHeightDashboardContainer";
+import SettingsSection from "ui/editor/SettingsSection";
+import { slugify } from "utils";
+
+import { useStore } from "../../lib/store";
+import EventsLogGrouped from "./components/EventsLogGrouped";
+import type { Submission, SubmissionsProps, SubmissionSummary } from "./types";
+
+const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
+  const [teamId] = useStore((state) => [state.teamId]);
+
+  // submission_services_log view is already filtered for events >= Jan 1 2024
+  const { data, loading, error } = useQuery<{ submissions: Submission[] }>(
+    gql`
+      query GetSubmissions($team_id: Int!) {
+        submissions: submission_services_log(
+          where: { team_id: { _eq: $team_id } }
+          order_by: [
+            { session_id: asc }
+            { event_type: asc }
+            { created_at: desc }
+          ]
+          distinct_on: [session_id, event_type]
+        ) {
+          flowId: flow_id
+          sessionId: session_id
+          eventId: event_id
+          eventType: event_type
+          status: status
+          retry: retry
+          response: response
+          address: address
+          createdAt: created_at
+          flowName: flow_name
+        }
+      }
+    `,
+    {
+      variables: { team_id: teamId },
+      skip: !teamId,
+      pollInterval: 10_000,
+    },
+  );
+
+  const submissions = useMemo(() => data?.submissions || [], [data]);
+
+  const sessionSummaries = useMemo(() => {
+    const grouped = submissions.reduce(
+      (acc, submission) => {
+        if (!acc[submission.sessionId]) {
+          acc[submission.sessionId] = {
+            id: submission.sessionId,
+            flowId: submission.flowId,
+            flowName: submission.flowName,
+            address: submission.address,
+            events: [],
+            mostRecentDate: submission.createdAt,
+          };
+        }
+
+        acc[submission.sessionId].events.push(submission);
+
+        // most recent date (eg for events after created date)
+        if (submission.createdAt > acc[submission.sessionId].mostRecentDate) {
+          acc[submission.sessionId].mostRecentDate = submission.createdAt;
+        }
+
+        return acc;
+      },
+      {} as Record<string, SubmissionSummary>,
+    );
+
+    return Object.values(grouped).map((session) => ({
+      ...session,
+      eventCount: session.events.length,
+      // if ANY most recent event failed, session fails
+      sessionStatus: session.events.some((e) => e.status !== "Success")
+        ? "Failed"
+        : "Success",
+    }));
+  }, [submissions]);
+
+  // filter by flow if flowId prop is passed from route params
+  const filteredSubmissions = sessionSummaries.filter(
+    (submission) => !flowSlug || slugify(submission.flowName) === flowSlug,
+  );
+
+  return (
+    <FixedHeightDashboardContainer
+      bgColor="background.paper"
+      topOffset={flowSlug ? BREADCRUMBS_HEIGHT : 0}
+    >
+      <SettingsSection>
+        <Typography variant="h2" component="h3" gutterBottom>
+          Submissions
+        </Typography>
+        <Typography variant="body1" sx={{ maxWidth: "contentWrap" }}>
+          Payment and send events for{" "}
+          {flowSlug ? "this service" : "all services in this team"}. Successful
+          submissions received within the last 28 days are available to
+          download. This table includes events since 1st January 2024.
+        </Typography>
+      </SettingsSection>
+      <EventsLogGrouped
+        submissions={filteredSubmissions}
+        loading={loading}
+        error={error}
+        filterByFlow={Boolean(flowSlug)}
+      />
+    </FixedHeightDashboardContainer>
+  );
+};
+
+export default Submissions;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -76,7 +76,7 @@ const EventsLog: React.FC<EventsLogGroupedProps> = ({
       },
     },
     {
-      field: "mostRecentDate",
+      field: "eventCreatedAt",
       headerName: "Date",
       width: 125,
       columnOptions: {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -3,7 +3,6 @@ import type { GridFilterItem } from "@mui/x-data-grid";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { EmptyState } from "ui/editor/EmptyState";
@@ -12,26 +11,21 @@ import type { ColumnConfig } from "ui/shared/DataTable/types";
 import { ColumnFilterType } from "ui/shared/DataTable/types";
 import { dateFormatter } from "ui/shared/DataTable/utils";
 
-import {
-  submissionEventTypes,
-  submissionStatusOptions,
-} from "../submissionFilterOptions";
-import type { EventsLogProps, Submission, SubmissionSummary } from "../types";
-import { ResubmitButton } from "./ResubmitButton";
+import { submissionStatusOptions } from "../submissionFilterOptions";
+import type {
+  EventsLogGroupedProps,
+  Submission,
+  SubmissionSummary,
+} from "../types";
 import { StatusChip } from "./StatusChip";
 import SubmissionDetailModal from "./SubmissionDetailModal";
-import { SubmissionEvent } from "./SubmissionEvent";
 
-const EventsLog: React.FC<EventsLogProps> = ({
+const EventsLog: React.FC<EventsLogGroupedProps> = ({
   submissions,
   loading,
   error,
   filterByFlow,
 }) => {
-  const isPlatformAdmin = useStore((state) =>
-    Boolean(state.user?.isPlatformAdmin),
-  );
-
   const [selectedSubmission, setSelectedSubmission] =
     useState<Submission | null>(null);
 
@@ -90,7 +84,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       },
       type: ColumnFilterType.DATE,
     },
-    { field: "sessionId", headerName: "Session ID", width: 400 },
+    { field: "id", headerName: "Session ID", width: 400 },
   ];
 
   return (
@@ -102,7 +96,7 @@ const EventsLog: React.FC<EventsLogProps> = ({
       />
       <SubmissionDetailModal
         open={!!selectedSubmission}
-        submission={selectedSubmission}
+        sessionId={selectedSubmission?.sessionId}
         handleClose={() => setSelectedSubmission(null)}
       />
     </ErrorBoundary>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -1,0 +1,112 @@
+import BarChartIcon from "@mui/icons-material/BarChart";
+import type { GridFilterItem } from "@mui/x-data-grid";
+import { useNavigate } from "@tanstack/react-router";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import ErrorFallback from "components/Error/ErrorFallback";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { EmptyState } from "ui/editor/EmptyState";
+import { DataTable } from "ui/shared/DataTable/DataTable";
+import type { ColumnConfig } from "ui/shared/DataTable/types";
+import { ColumnFilterType } from "ui/shared/DataTable/types";
+import { dateFormatter } from "ui/shared/DataTable/utils";
+
+import {
+  submissionEventTypes,
+  submissionStatusOptions,
+} from "../submissionFilterOptions";
+import type { EventsLogProps, Submission, SubmissionSummary } from "../types";
+import { ResubmitButton } from "./ResubmitButton";
+import { StatusChip } from "./StatusChip";
+import SubmissionDetailModal from "./SubmissionDetailModal";
+import { SubmissionEvent } from "./SubmissionEvent";
+
+const EventsLog: React.FC<EventsLogProps> = ({
+  submissions,
+  loading,
+  error,
+  filterByFlow,
+}) => {
+  const isPlatformAdmin = useStore((state) =>
+    Boolean(state.user?.isPlatformAdmin),
+  );
+
+  const [selectedSubmission, setSelectedSubmission] =
+    useState<Submission | null>(null);
+
+  if (loading)
+    return (
+      <DelayedLoadingIndicator
+        msDelayBeforeVisible={0}
+        text="Fetching events..."
+      />
+    );
+
+  if (error) throw error;
+
+  if (submissions.length === 0)
+    return (
+      <EmptyState
+        title={`No payment or send events found for this ${filterByFlow ? "service" : "team"}`}
+        description="If you're looking for events before 1st January 2024, please contact a PlanX developer"
+        icon={<BarChartIcon />}
+      />
+    );
+
+  const columns: ColumnConfig<SubmissionSummary>[] = [
+    {
+      field: "flowName",
+      headerName: "Service",
+      width: 250,
+      type: ColumnFilterType.SINGLE_SELECT,
+      customComponent: (params) => <strong>{`${params.value}`}</strong>,
+      columnOptions: {
+        // Allow filtering by unique flow names
+        valueOptions: [...new Set(submissions.map(({ flowName }) => flowName))],
+      },
+    },
+    {
+      field: "address",
+      headerName: "Address",
+      width: 250,
+    },
+    {
+      field: "status",
+      headerName: "Status",
+      width: 125,
+      type: ColumnFilterType.SINGLE_SELECT,
+      customComponent: StatusChip,
+      columnOptions: {
+        valueOptions: submissionStatusOptions,
+      },
+    },
+    {
+      field: "mostRecentDate",
+      headerName: "Date",
+      width: 125,
+      columnOptions: {
+        valueFormatter: dateFormatter,
+      },
+      type: ColumnFilterType.DATE,
+    },
+    { field: "sessionId", headerName: "Session ID", width: 400 },
+  ];
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <DataTable
+        columns={columns}
+        rows={submissions}
+        onRowClick={(params) => setSelectedSubmission(params.row)}
+      />
+      <SubmissionDetailModal
+        open={!!selectedSubmission}
+        submission={selectedSubmission}
+        handleClose={() => setSelectedSubmission(null)}
+      />
+    </ErrorBoundary>
+  );
+};
+
+export default EventsLog;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,0 +1,49 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import React from "react";
+
+import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
+import { OpenResponseButton } from "./OpenResponseButton";
+import { ViewSubmissionButton } from "./ViewSubmissionButton";
+
+interface RowModalProps {
+  sessionId: string;
+  open: boolean;
+  handleClose: () => void;
+}
+
+const SubmissionDetailModal: React.FC<RowModalProps> = ({
+  sessionId,
+  open,
+  handleClose,
+}) => {
+  // hook to get session ID submission and pay history
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle variant="h3" component="h1">
+        Submission details
+      </DialogTitle>
+      <Box sx={{ display: "flex", flexDirection: "row" }}>
+        <DialogContent>Details</DialogContent>
+        <DialogContent>History</DialogContent>
+      </Box>
+      <DialogActions>
+        <Button
+          onClick={handleClose}
+          color="secondary"
+          variant="contained"
+          sx={{ backgroundColor: "background.default" }}
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SubmissionDetailModal;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -11,7 +11,7 @@ import { OpenResponseButton } from "./OpenResponseButton";
 import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
 interface RowModalProps {
-  sessionId: string;
+  sessionId?: string;
   open: boolean;
   handleClose: () => void;
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/hooks.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/hooks.ts
@@ -1,0 +1,1 @@
+// useGetSubmissionHistory

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -35,16 +35,9 @@ export interface SubmissionSummary {
   flowId: string;
   flowName: string;
   address: string | null;
-
-  // aggregated/computed fields
-  eventCount: number;
-  mostRecentDate: string;
+  eventCreatedAt: string;
   mostRecentEventType: Submission["eventType"];
-  mostRecentStatus: Submission["status"];
-  status: "Success" | "Failed";
-
-  // accumulate underlying events for modal
-  events: Submission[];
+  status: Submission["status"];
 }
 
 export interface EventsLogProps {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -29,8 +29,26 @@ export interface Submission {
   flowName: string;
   address: string | null;
 }
+
+export interface SubmissionSummary {
+  sessionId: string;
+  flowId: string;
+  flowName: string;
+  address: string | null;
+
+  // aggregated/computed fields
+  eventCount: number;
+  mostRecentDate: string;
+  mostRecentEventType: Submission["eventType"];
+  mostRecentStatus: Submission["status"];
+  status: "Success" | "Failed";
+
+  // accumulate underlying events for modal
+  events: Submission[];
+}
+
 export interface EventsLogProps {
-  submissions: Submission[];
+  submissions: SubmissionSummary[];
   loading: boolean;
   error: Error | undefined;
   filterByFlow?: boolean;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -31,7 +31,7 @@ export interface Submission {
 }
 
 export interface SubmissionSummary {
-  sessionId: string;
+  id: string;
   flowId: string;
   flowName: string;
   address: string | null;
@@ -48,11 +48,19 @@ export interface SubmissionSummary {
 }
 
 export interface EventsLogProps {
+  submissions: Submission[]; // TODO: remove extra type after removing GROUPED_SUBMISSIONS feature flag
+  loading: boolean;
+  error: Error | undefined;
+  filterByFlow?: boolean;
+}
+
+export interface EventsLogGroupedProps {
   submissions: SubmissionSummary[];
   loading: boolean;
   error: Error | undefined;
   filterByFlow?: boolean;
 }
+
 export interface SubmissionsProps {
   flowSlug?: string;
 }

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/submissions.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/submissions.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { hasFeatureFlag } from "lib/featureFlags";
 import Submissions from "pages/FlowEditor/components/Submissions/Submissions";
+import SubmissionsGrouped from "pages/FlowEditor/components/Submissions/SubmissionsGrouped";
 import React from "react";
 
 export const Route = createFileRoute(
@@ -16,5 +18,9 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const data = Route.useLoaderData();
-  return <Submissions flowSlug={data.flow} />;
+  if (hasFeatureFlag("GROUPED_SUBMISSIONS")) {
+    return <SubmissionsGrouped flowSlug={data.flow} />;
+  } else {
+    return <Submissions flowSlug={data.flow} />;
+  }
 }

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions.tsx
@@ -1,6 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { hasFeatureFlag } from "lib/featureFlags";
 import Submissions from "pages/FlowEditor/components/Submissions/Submissions";
+import SubmissionsGrouped from "pages/FlowEditor/components/Submissions/SubmissionsGrouped";
 
 export const Route = createFileRoute("/_authenticated/app/$team/submissions")({
-  component: Submissions,
+  pendingComponent: DelayedLoadingIndicator,
+  component: hasFeatureFlag("GROUPED_SUBMISSIONS")
+    ? SubmissionsGrouped
+    : Submissions,
 });

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/DataTable.tsx
@@ -58,6 +58,7 @@ export const DataTable = <T,>({
   onProcessRowUpdate,
   checkboxSelection,
   customTools,
+  onRowClick,
 }: DataGridProps<T>) => {
   const renderCellComponentByType = (
     params: RenderCellParams,
@@ -131,11 +132,22 @@ export const DataTable = <T,>({
         <DataGrid
           rows={rows}
           columns={dataColumns}
+          onRowClick={onRowClick}
           onFilterModelChange={handleFilterChange}
           getRowHeight={() => "auto"}
           getRowClassName={(params) =>
             params.indexRelativeToCurrentPage % 2 === 0 ? "even" : "odd"
           }
+          sx={{
+            ...(onRowClick && {
+              "& .MuiDataGrid-row": {
+                cursor: "pointer",
+              },
+              "& .MuiDataGrid-row:hover": {
+                backgroundColor: "action.hover",
+              },
+            }),
+          }}
           slots={{
             toolbar: CustomToolbar,
           }}

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/types.ts
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/types.ts
@@ -1,6 +1,7 @@
 import type {
   GridColDef,
   GridRenderCellParams,
+  GridRowParams,
   GridSingleSelectColDef,
   GridTreeNodeWithRender,
 } from "@mui/x-data-grid";
@@ -52,4 +53,5 @@ export interface DataGridProps<T> {
   onProcessRowUpdate?: (updatedRow: T) => void;
   checkboxSelection?: boolean;
   customTools?: React.FC[];
+  onRowClick?: (params: GridRowParams) => void;
 }

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_submissions_grouped.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_submissions_grouped.yaml
@@ -1,0 +1,47 @@
+table:
+  name: submissions_grouped
+  schema: public
+object_relationships:
+  - name: team
+    using:
+      manual_configuration:
+        column_mapping:
+          team_id: id
+        insertion_order: null
+        remote_table:
+          name: teams
+          schema: public
+select_permissions:
+  - role: platformAdmin
+    permission:
+      columns:
+        - team_id
+        - address
+        - event_type
+        - flow_name
+        - status
+        - created_at
+        - flow_id
+        - session_id
+      filter: {}
+    comment: ""
+  - role: teamEditor
+    permission:
+      columns:
+        - team_id
+        - address
+        - event_type
+        - flow_name
+        - status
+        - created_at
+        - flow_id
+        - session_id
+      filter:
+        team:
+          members:
+            _and:
+              - user_id:
+                  _eq: x-hasura-user-id
+              - role:
+                  _eq: teamEditor
+    comment: ""

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/tables.yaml
@@ -54,6 +54,7 @@
 - "!include public_submission_emails.yaml"
 - "!include public_submission_services_log.yaml"
 - "!include public_submission_services_summary.yaml"
+- "!include public_submissions_grouped.yaml"
 - "!include public_team_dashboard_stats.yaml"
 - "!include public_team_integrations.yaml"
 - "!include public_team_members.yaml"

--- a/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW submissions_grouped;

--- a/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/up.sql
@@ -1,0 +1,149 @@
+CREATE OR REPLACE VIEW "public"."submissions_grouped" AS WITH payments AS (
+  SELECT
+    ps.session_id,
+    'Pay' :: text AS event_type,
+    initcap(ps.status) AS status,
+    ps.created_at
+  FROM
+    (
+      payment_status ps
+      LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status))
+    )
+  WHERE
+    (
+      (ps.status <> 'created' :: text)
+      AND (
+        ps.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+    )
+),
+submissions AS (
+  SELECT
+    (
+      (
+        (
+          (seil.request -> 'payload' :: text) -> 'payload' :: text
+        ) ->> 'sessionId' :: text
+      )
+    ) :: uuid AS session_id,
+    CASE
+      WHEN ((se.webhook_conf) :: text ~~ '%bops%' :: text) THEN 'Submit to BOPS' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%uniform%' :: text) THEN 'Submit to Uniform' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+      ) THEN 'Send to email' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+      ) THEN 'Upload to AWS S3 (no notification)' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+      ) THEN 'Upload to AWS S3' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%idox%' :: text) THEN 'Submit to Idox Nexus' :: text
+      ELSE (se.webhook_conf) :: text
+    END AS event_type,
+    CASE
+      WHEN (seil.status = 200) THEN 'Success' :: text
+      ELSE format('Failed (%s)' :: text, seil.status)
+    END AS status,
+    seil.created_at
+  FROM
+    (
+      hdb_catalog.hdb_scheduled_events se
+      LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id))
+    )
+  WHERE
+    (
+      (
+        seil.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (
+        ((se.webhook_conf) :: text ~~ '%bops%' :: text)
+        OR ((se.webhook_conf) :: text ~~ '%uniform%' :: text)
+        OR (
+          (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+        )
+        OR ((se.webhook_conf) :: text ~~ '%idox%' :: text)
+      )
+    )
+),
+all_events AS (
+  SELECT
+    payments.session_id,
+    payments.event_type,
+    payments.status,
+    payments.created_at
+  FROM
+    payments
+  UNION ALL
+  SELECT
+    submissions.session_id,
+    submissions.event_type,
+    submissions.status,
+    submissions.created_at
+  FROM
+    submissions
+),
+latest_per_event_type AS (
+  SELECT DISTINCT ON (session_id, event_type)
+    session_id,
+    event_type,
+    status,
+    created_at
+  FROM
+    all_events
+  ORDER BY
+    session_id,
+    event_type,
+    created_at DESC
+),
+representative_event AS (
+  SELECT DISTINCT ON (session_id)
+    session_id,
+    event_type,
+    status,
+    created_at
+  FROM
+    latest_per_event_type
+  ORDER BY
+    session_id,
+    (status ~~ 'Failed%' :: text) DESC,
+    created_at DESC
+)
+SELECT
+  f.id AS flow_id,
+  re.session_id,
+  re.event_type,
+  re.status,
+  re.created_at,
+  f.team_id,
+  f.name AS flow_name,
+  COALESCE(
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'single_line_address' :: text
+    ),
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'title' :: text
+    )
+  ) AS address
+FROM
+  (
+    (
+      representative_event re
+      LEFT JOIN lowcal_sessions ls ON ((ls.id = re.session_id))
+    )
+    LEFT JOIN flows f ON ((f.id = ls.flow_id))
+  )
+WHERE
+  (ls.flow_id IS NOT NULL)
+ORDER BY
+  re.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1784812787512_created_submissions_grouped_view/up.sql
@@ -17,6 +17,18 @@ CREATE OR REPLACE VIEW "public"."submissions_grouped" AS WITH payments AS (
       )
     )
 ),
+invitations_to_pay AS (
+  SELECT
+    pr.session_id,
+    'Invite to pay' :: text AS event_type,
+    CASE
+      WHEN pr.paid_at IS NULL THEN 'Invited to pay' :: text
+      ELSE 'Paid' :: text
+    END AS status,
+    pr.created_at
+  FROM
+    payment_requests pr
+),
 submissions AS (
   SELECT
     (
@@ -80,6 +92,14 @@ all_events AS (
     payments.created_at
   FROM
     payments
+  UNION ALL
+  SELECT
+    invitations_to_pay.session_id,
+    invitations_to_pay.event_type,
+    invitations_to_pay.status,
+    invitations_to_pay.created_at
+  FROM
+    invitations_to_pay
   UNION ALL
   SELECT
     submissions.session_id,


### PR DESCRIPTION
This PR starts the grouped submissions log feature:

**db changes**
- Creates a `submissions_grouped` view that is similar to the `submission_services_log` view _but only has one row per session_ and does not include columns such as `response`
    - This replicates a lot of the logic from `submission_services_log` but I figured it was better to avoid complicated dependencies _and_ would be better for performance to not be querying a non-materialized view
    - The aggregation logic happens here--if the most recent event for _any_ event fails, then we will show a failure; if there are no failures, show the status of the most recent event
    - We might still use `submission_services_log` for the detailed view of events (and there is a `daily_failed_submissions` dependency to keep in mind, as Jess flagged!)

**Frontend changes**
- Creates `GROUPED_SUBMISSIONS` feature flag and duplicates certain components (eg `EventsLog` and `Submissions` -> `EventsLogGrouped` and `SubmissionsGrouped`)
    -  At dev call we decided that route-level feature flagging with replicated code was probably the simplest way of feature flagging this work
- Removes 'View submission', 'Download', 'Response' and 'Resubmit' columns from submissions log (info to go into detail modal)
- Makes rows clickable
- Creates placeholder submission detail modal

Before:
<img width="600" alt="Screenshot 2026-07-22 114331" src="https://github.com/user-attachments/assets/2c192283-b89d-4820-915b-cb8101ab0389" />

After:
<img width="600" alt="Screenshot 2026-07-22 114312" src="https://github.com/user-attachments/assets/e2e9bafd-9b19-4511-ac7c-3c01da824c98" />

with modal placeholder:
<img width="450" alt="Screenshot 2026-07-22 114317" src="https://github.com/user-attachments/assets/8a02301f-8d8c-4b0e-a0b0-b39d973897eb" />
