### PR TITLE
chore: set up South Staffordshire custom domain

### DIFF
--- a/apps/editor.planx.uk/src/airbrake.ts
+++ b/apps/editor.planx.uk/src/airbrake.ts
@@ -28,6 +28,7 @@ function getEnvForAllowedHosts(host: string) {
     case "planningservices.northumberland.gov.uk":
     case "planningservices.southglos.gov.uk":
     case "planningservices.southwark.gov.uk":
+    case "planningservices.sstaffs.gov.uk":
     case "planningservices.stalbans.gov.uk":
     case "planningservices.stockport.gov.uk":
     case "planningservices.tewkesbury.gov.uk":

--- a/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
+++ b/apps/editor.planx.uk/src/utils/routeUtils/utils.ts
@@ -54,6 +54,7 @@ const PREVIEW_ONLY_DOMAINS = [
   "planningservices.northumberland.gov.uk",
   "planningservices.southglos.gov.uk",
   "planningservices.southwark.gov.uk",
+  "planningservices.sstaffs.gov.uk",
   "planningservices.stalbans.gov.uk",
   "planningservices.stockport.gov.uk",
   "planningservices.tewkesbury.gov.uk",

--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -126,7 +126,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "south-staffordshire",
           domain: "planningservices.sstaffs.gov.uk",
-          cloudFrontState: "validation-only",
+          cloudFrontState: "shared-final",
         },
         {
           name: "kingston",


### PR DESCRIPTION
Advances `cloudFrontState` to `shared-final` (step 5) and adds application-level config (step 8) [in the docs](https://github.com/theopensystemslab/planx-new/blob/main/doc/how-to/how-to-setup-custom-domains.md). Hasura prod updated in parallel! 

Validation record was verified with `dig` command in step 4 + AWS ACM check. Shared cert also verified with `aws acm describe-certificate` (showed `Status: ISSUED` and new domain in `SANs`. ✅ 