### PR TITLE
[infra] enable multi-az failover for RDS instance

### DIFF
--- a/infrastructure/data/index.ts
+++ b/infrastructure/data/index.ts
@@ -65,6 +65,8 @@ const db = new aws.rds.Instance("app", {
   finalSnapshotIdentifier: "final-before-deletion",
   publiclyAccessible: true,
   storageEncrypted: true,
+  // enable synchronous standby in a second AZ, with automatic failover (~60-120s) on primary failure
+  multiAz: true,
   backupRetentionPeriod: env === "production" ? 35 : 1,
   applyImmediately: true,
   parameterGroupName: parameterGroup.name,


### PR DESCRIPTION
As per title, motivated by filling in Bristol questionnaire ([Slack](https://opensystemslab.slack.com/archives/C0ARCE260LF/p1783521504085579)) - specifically, wanting to shore up our answer on the following point:

> The solution is deployed on cloud-based infrastructure, uses separate containers to mitigate the effects of disaster, and enables dynamic scaling and elastic load balancing.

See AWS docs [here](https://aws.amazon.com/rds/features/multi-az/). What we're expecting to happen when we deploy this is as follows:

<img width="777" height="371" alt="Screenshot From 2026-07-23 11-58-47" src="https://github.com/user-attachments/assets/446ec730-5747-40ff-84d8-c3616285216b" />

This is all `data` layer so requires manual deploy via command line. Suggest we do this on staging as soon as this is approved and assuming no issue, deploy to prod at end of day.

Looks like this will cost us an extra $75 or so /month on prod, but it probably is something we want at this point. Worthwhile imo.

<img width="916" height="128" alt="image" src="https://github.com/user-attachments/assets/69f7bed4-ebc1-4144-9272-26cf571003b7" />
