### PR TITLE
chore(ci): Make change to Hasura dockerfile to ensure fresh Pulumi build

### DIFF
--- a/apps/hasura.planx.uk/Dockerfile
+++ b/apps/hasura.planx.uk/Dockerfile
@@ -1,3 +1,4 @@
+# Temp comment to cache-bust this image
 FROM hasura/graphql-engine:v2.48.1.cli-migrations-v3
 WORKDIR /
 COPY metadata hasura-metadata


### PR DESCRIPTION
Hasura build on staging is failing with the following error - 

```bash
service was unable to place a task. Reason: CannotPullContainerError: pull image manifest has been retried 7 time(s): failed to resolve ref 781751952389.dkr.ecr.eu-west-2.amazonaws.com/repo-c37914e@sha256:87910b457a45fcff315ff4652a3d45e2b3a0d022f1077eea9ae9e180707e2135: 781751952389.dkr.ecr.eu-west-2.amazonaws.com/repo-c37914e@sha256:87910b457a45fcff315ff4652a3d45e2b3a0d022f1077eea9ae9e180707e2135: not found.
```

It looks like we're trying to pull an old image here (now evicted from the cache of images) which no longer exists. If this is correct, a change to the dockerfile should trigger a rebuild and new image - not a request for an old image.

I think the sequence of events went like this...
 - https://github.com/theopensystemslab/planx-new/pull/7045 constitutes a change to the Hasura build, creates a new cached image
 - Old Hasura image evicted from cache
 - https://github.com/theopensystemslab/planx-new/pull/7045 fails to deploy - cause not yet narrowed down
 - Rollbacks to previous state expect to pick up _old_ Hasura image
 - No longer in cache, rollbacks fail ❌ 

If correct, this failure method is not directly linked to the `up.sql` causing issues in any way - it's just that we didn't keep the old version around for rollbacks. This PR _should_ make a new image, so we won't look in the cache for one.

If this does pass and a build to `main` passes post-merge, I'll come back with a PR to improve how we retain and cache these images.

