### PR TITLE
fix(iac): Bust cache with label, not plain comment

### DIFF
--- a/apps/hasura.planx.uk/Dockerfile
+++ b/apps/hasura.planx.uk/Dockerfile
@@ -1,5 +1,5 @@
-# Temp comment to cache-bust this image
 FROM hasura/graphql-engine:v2.48.1.cli-migrations-v3
+LABEL test="abc123"
 WORKDIR /
 COPY metadata hasura-metadata
 COPY migrations hasura-migrations


### PR DESCRIPTION
Follow up to #7060 

>_Comment lines are removed before the Dockerfile instructions are executed_

Source: https://docs.docker.com/reference/dockerfile/#format

Using a temp `LABEL` ([docs](https://docs.docker.com/reference/dockerfile/#label)) here should allow me to force a rebuild here 🤞 