### PR TITLE
fix(ci): Bust cache for Hasura proxy image

### DIFF
--- a/apps/hasura.planx.uk/proxy/Dockerfile
+++ b/apps/hasura.planx.uk/proxy/Dockerfile
@@ -1,2 +1,3 @@
 FROM caddy:2.11-alpine
+LABEL test="abc123"
 COPY Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
Follow up to #7061 & #7060 

Reading the AWS logs properly, the ARN in question here which we're failing to fetch is Hasura proxy, not the main Hasura image.

Again, if this resolves the issue there will be a proper fix incoming as a follow up 👍 