### PR TITLE
fix: make useFormikWithRef hook consistent across components

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -1,6 +1,6 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { EditorProps } from "@planx/components/shared/types";
-import { useFormik } from "formik";
+import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import InputGroup from "ui/editor/InputGroup";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -21,17 +21,20 @@ export type Props = EditorProps<TYPES.FindProperty, FindProperty>;
 export default FindPropertyComponent;
 
 function FindPropertyComponent(props: Props) {
-  const formik = useFormik<FindProperty>({
-    initialValues: parseFindProperty(props.node?.data),
-    onSubmit: (newValues) => {
-      if (props.handleSubmit) {
-        props.handleSubmit({ type: TYPES.FindProperty, data: newValues });
-      }
+  const formik = useFormikWithRef<FindProperty>(
+    {
+      initialValues: parseFindProperty(props.node?.data),
+      onSubmit: (newValues) => {
+        if (props.handleSubmit) {
+          props.handleSubmit({ type: TYPES.FindProperty, data: newValues });
+        }
+      },
+      validationSchema,
+      validateOnBlur: false,
+      validateOnChange: false,
     },
-    validationSchema,
-    validateOnBlur: false,
-    validateOnChange: false,
-  });
+    props.formikRef,
+  );
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <TemplatedNodeInstructions

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -1,7 +1,7 @@
 import Typography from "@mui/material/Typography";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import type { EditorProps } from "@planx/components/shared/types";
-import { useFormik } from "formik";
+import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import React from "react";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
@@ -20,18 +20,21 @@ type Props = EditorProps<TYPES.PropertyInformation, PropertyInformation>;
 export default PropertyInformationComponent;
 
 function PropertyInformationComponent(props: Props) {
-  const formik = useFormik({
-    initialValues: parseContent(props.node?.data),
-    onSubmit: (newValues) => {
-      props.handleSubmit?.({
-        type: TYPES.PropertyInformation,
-        data: newValues,
-      });
+  const formik = useFormikWithRef<PropertyInformation>(
+    {
+      initialValues: parseContent(props.node?.data),
+      onSubmit: (newValues) => {
+        props.handleSubmit?.({
+          type: TYPES.PropertyInformation,
+          data: newValues,
+        });
+      },
+      validationSchema: validationSchema,
+      validateOnChange: false,
+      validateOnBlur: false,
     },
-    validationSchema: validationSchema,
-    validateOnChange: false,
-    validateOnBlur: false,
-  });
+    props.formikRef,
+  );
 
   return (
     <form onSubmit={formik.handleSubmit} id="modal">

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -4,7 +4,8 @@ import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import type { SendIntegration } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { Formik, getIn, useFormikContext } from "formik";
+import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
+import { FormikProvider, getIn } from "formik";
 import type { SubmissionEmailInput } from "pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/types";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useCallback } from "react";
@@ -29,186 +30,13 @@ import { parseSend, validateSchema } from "./model";
 
 export type Props = EditorProps<TYPES.Send, Send>;
 
-interface SendFormProps {
-  disabled?: boolean;
-}
-
-const SendForm: React.FC<SendFormProps> = ({ disabled }) => {
-  const [teamSlug, teamId, flowSlug] = useStore((state) => [
+const SendComponent: React.FC<Props> = (props) => {
+  const [teamSlug, teamId, flowSlug, id] = useStore((state) => [
     state.teamSlug,
     state.teamId,
     state.flowSlug,
+    state.id,
   ]);
-
-  const formik = useFormikContext<Send>();
-
-  const toggleSwitch = useCallback(
-    (value: SendIntegration) => {
-      let newCheckedValues: SendIntegration[];
-
-      if (formik.values.destinations.includes(value)) {
-        newCheckedValues = formik.values.destinations.filter(
-          (x) => x !== value,
-        );
-      } else {
-        newCheckedValues = [...formik.values.destinations, value];
-      }
-
-      formik.setFieldValue("destinations", newCheckedValues.sort());
-    },
-    [formik],
-  );
-
-  return (
-    <form onSubmit={formik.handleSubmit} id="modal">
-      <TemplatedNodeInstructions
-        isTemplatedNode={formik.values.isTemplatedNode}
-        templatedNodeInstructions={formik.values.templatedNodeInstructions}
-        areTemplatedNodeInstructionsRequired={
-          formik.values.areTemplatedNodeInstructionsRequired
-        }
-      />
-      <ModalSection>
-        <ModalSectionContent>
-          <InputRow>
-            <Input
-              format="large"
-              name="title"
-              value={formik.values.title}
-              placeholder="Editor title"
-              onChange={formik.handleChange}
-              disabled={disabled}
-              errorMessage={formik.errors.title}
-            />
-          </InputRow>
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalSection>
-        <ErrorWrapper error={getIn(formik.errors, "destinations")}>
-          <>
-            <ModalSectionContent title={"Back Office Planning System"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("bops")}
-                  onChange={() => toggleSwitch("bops")}
-                  label={`Send to BOPS ${
-                    import.meta.env.VITE_APP_ENV === "production"
-                      ? "production"
-                      : "staging"
-                  }`}
-                  disabled={disabled}
-                />
-              </InputRow>
-            </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"Email"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("email")}
-                  onChange={() => toggleSwitch("email")}
-                  label={`Send to email`}
-                  disabled={disabled}
-                />
-              </InputRow>
-              {formik.values.destinations.includes("email") ? (
-                <EmailSection teamId={teamId} teamSlug={teamSlug} />
-              ) : (
-                <></>
-              )}
-            </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"Microsoft SharePoint"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("s3")}
-                  onChange={() => toggleSwitch("s3")}
-                  label="Send to Microsoft SharePoint"
-                  disabled={disabled}
-                />
-              </InputRow>
-              <Typography variant="body2">
-                Receive submissions in MS SharePoint via a Power Automate
-                workflow. This option requires you to host a Power Automate
-                webhook that can receive notifications of new submissions in
-                real-time. Learn more about this option in our{" "}
-                <Link
-                  href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  resources
-                </Link>
-                .
-              </Typography>
-            </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"FME Workbench"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("fme")}
-                  onChange={() => toggleSwitch("fme")}
-                  label="Retrieve using FME Workbench"
-                  disabled={disabled}
-                />
-              </InputRow>
-              <Typography variant="body2">
-                Retrieve submissions using FME Workbench to download to your
-                local network. This option requires you to setup a workflow
-                which polls for new submissions on a schedule of your choice.
-              </Typography>
-            </ModalSectionContent>
-            <Divider />
-            <ModalSectionContent title={"Uniform"}>
-              <InputRow>
-                <Switch
-                  checked={formik.values.destinations.includes("uniform")}
-                  onChange={() => toggleSwitch("uniform")}
-                  label={`Send to Uniform ${
-                    import.meta.env.VITE_APP_ENV === "production"
-                      ? "production"
-                      : "staging"
-                  }`}
-                  disabled={
-                    disabled ||
-                    !["buckinghamshire", "lambeth", "southwark"].includes(
-                      teamSlug,
-                    )
-                  }
-                />
-              </InputRow>
-              <Typography variant="body2">
-                This is a legacy integration with limited support. It is only
-                available for specific councils and suitable for use with Lawful
-                Development Certificate applications (existing and proposed).
-              </Typography>
-            </ModalSectionContent>
-          </>
-        </ErrorWrapper>
-        <ModalSectionContent>
-          <WarningContainer>
-            <FactCheckIcon />
-            <Typography variant="body2" sx={{ ml: 2 }}>
-              Records of submissions can be viewed in the{" "}
-              <Link
-                href={`/${teamSlug}/${flowSlug}/submissions`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Submissions
-              </Link>{" "}
-              log in the left-hand menu. Editors can download successful
-              submissions within 28 days from receipt.
-            </Typography>
-          </WarningContainer>
-        </ModalSectionContent>
-      </ModalSection>
-      <ModalFooter formik={formik} showMoreInformation={false} />
-    </form>
-  );
-};
-
-const SendComponent: React.FC<Props> = (props) => {
-  const [teamId, id] = useStore((state) => [state.teamId, state.id]);
 
   const { data: flowData } = useFlowEmailId(id);
   const existingEmailId = flowData?.flowsByPK?.submissionEmailId;
@@ -263,22 +91,22 @@ const SendComponent: React.FC<Props> = (props) => {
     }
   };
 
-  return (
-    <Formik<Send>
-      initialValues={parseSend(props.node?.data)}
-      onSubmit={async (newValues, formikHelpers) => {
+  const formik = useFormikWithRef<Send>(
+    {
+      initialValues: parseSend(props.node?.data),
+      onSubmit: async (newValues, formikHelpers) => {
         try {
+          const updatedEmailId = await handleInsertOrUpdate(
+            newValues,
+            existingEmailId,
+            insertNewDefaultEmail,
+          );
+
+          if (updatedEmailId) {
+            newValues.submissionEmailId = updatedEmailId;
+          }
+
           if (props.handleSubmit) {
-            const updatedEmailId = await handleInsertOrUpdate(
-              newValues,
-              existingEmailId,
-              insertNewDefaultEmail,
-            );
-
-            if (updatedEmailId) {
-              newValues.submissionEmailId = updatedEmailId;
-            }
-
             props.handleSubmit({ type: TYPES.Send, data: newValues });
           }
         } catch (error) {
@@ -287,13 +115,179 @@ const SendComponent: React.FC<Props> = (props) => {
             (error as Error).message,
           );
         }
-      }}
-      validationSchema={validateSchema(
+      },
+      validationSchema: validateSchema(
         emailOptions.map((email: SubmissionEmailInput) => email.address),
-      )}
-    >
-      <SendForm />
-    </Formik>
+      ),
+    },
+    props.formikRef,
+  );
+
+  const toggleSwitch = useCallback(
+    (value: SendIntegration) => {
+      let newCheckedValues: SendIntegration[];
+
+      if (formik.values.destinations.includes(value)) {
+        newCheckedValues = formik.values.destinations.filter(
+          (x) => x !== value,
+        );
+      } else {
+        newCheckedValues = [...formik.values.destinations, value];
+      }
+
+      formik.setFieldValue("destinations", newCheckedValues.sort());
+    },
+    [formik],
+  );
+
+  return (
+    <FormikProvider value={formik}>
+      <form onSubmit={formik.handleSubmit} id="modal">
+        <TemplatedNodeInstructions
+          isTemplatedNode={formik.values.isTemplatedNode}
+          templatedNodeInstructions={formik.values.templatedNodeInstructions}
+          areTemplatedNodeInstructionsRequired={
+            formik.values.areTemplatedNodeInstructionsRequired
+          }
+        />
+        <ModalSection>
+          <ModalSectionContent>
+            <InputRow>
+              <Input
+                format="large"
+                name="title"
+                value={formik.values.title}
+                placeholder="Editor title"
+                onChange={formik.handleChange}
+                disabled={props.disabled}
+                errorMessage={formik.errors.title}
+              />
+            </InputRow>
+          </ModalSectionContent>
+        </ModalSection>
+        <ModalSection>
+          <ErrorWrapper error={getIn(formik.errors, "destinations")}>
+            <>
+              <ModalSectionContent title={"Back Office Planning System"}>
+                <InputRow>
+                  <Switch
+                    checked={formik.values.destinations.includes("bops")}
+                    onChange={() => toggleSwitch("bops")}
+                    label={`Send to BOPS ${
+                      import.meta.env.VITE_APP_ENV === "production"
+                        ? "production"
+                        : "staging"
+                    }`}
+                    disabled={props.disabled}
+                  />
+                </InputRow>
+              </ModalSectionContent>
+              <Divider />
+              <ModalSectionContent title={"Email"}>
+                <InputRow>
+                  <Switch
+                    checked={formik.values.destinations.includes("email")}
+                    onChange={() => toggleSwitch("email")}
+                    label={`Send to email`}
+                    disabled={props.disabled}
+                  />
+                </InputRow>
+                {formik.values.destinations.includes("email") ? (
+                  <EmailSection teamId={teamId} teamSlug={teamSlug} />
+                ) : (
+                  <></>
+                )}
+              </ModalSectionContent>
+              <Divider />
+              <ModalSectionContent title={"Microsoft SharePoint"}>
+                <InputRow>
+                  <Switch
+                    checked={formik.values.destinations.includes("s3")}
+                    onChange={() => toggleSwitch("s3")}
+                    label="Send to Microsoft SharePoint"
+                    disabled={props.disabled}
+                  />
+                </InputRow>
+                <Typography variant="body2">
+                  Receive submissions in MS SharePoint via a Power Automate
+                  workflow. This option requires you to host a Power Automate
+                  webhook that can receive notifications of new submissions in
+                  real-time. Learn more about this option in our{" "}
+                  <Link
+                    href="https://opensystemslab.notion.site/How-you-can-receive-process-PlanX-applications-using-Microsoft-365-tools-like-Power-Automate-13197a4bbd24421eaf7b5021ddd07741?pvs=74"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    resources
+                  </Link>
+                  .
+                </Typography>
+              </ModalSectionContent>
+              <Divider />
+              <ModalSectionContent title={"FME Workbench"}>
+                <InputRow>
+                  <Switch
+                    checked={formik.values.destinations.includes("fme")}
+                    onChange={() => toggleSwitch("fme")}
+                    label="Retrieve using FME Workbench"
+                    disabled={props.disabled}
+                  />
+                </InputRow>
+                <Typography variant="body2">
+                  Retrieve submissions using FME Workbench to download to your
+                  local network. This option requires you to setup a workflow
+                  which polls for new submissions on a schedule of your choice.
+                </Typography>
+              </ModalSectionContent>
+              <Divider />
+              <ModalSectionContent title={"Uniform"}>
+                <InputRow>
+                  <Switch
+                    checked={formik.values.destinations.includes("uniform")}
+                    onChange={() => toggleSwitch("uniform")}
+                    label={`Send to Uniform ${
+                      import.meta.env.VITE_APP_ENV === "production"
+                        ? "production"
+                        : "staging"
+                    }`}
+                    disabled={
+                      props.disabled ||
+                      !["buckinghamshire", "lambeth", "southwark"].includes(
+                        teamSlug,
+                      )
+                    }
+                  />
+                </InputRow>
+                <Typography variant="body2">
+                  This is a legacy integration with limited support. It is only
+                  available for specific councils and suitable for use with
+                  Lawful Development Certificate applications (existing and
+                  proposed).
+                </Typography>
+              </ModalSectionContent>
+            </>
+          </ErrorWrapper>
+          <ModalSectionContent>
+            <WarningContainer>
+              <FactCheckIcon />
+              <Typography variant="body2" sx={{ ml: 2 }}>
+                Records of submissions can be viewed in the{" "}
+                <Link
+                  href={`/${teamSlug}/${flowSlug}/submissions`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Submissions
+                </Link>{" "}
+                log in the left-hand menu. Editors can download successful
+                submissions within 28 days from receipt.
+              </Typography>
+            </WarningContainer>
+          </ModalSectionContent>
+        </ModalSection>
+        <ModalFooter formik={formik} showMoreInformation={false} />
+      </form>
+    </FormikProvider>
   );
 };
 


### PR DESCRIPTION
Bug as flagged by [August](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1784904959081099). I didn't check every single component type in #6938, and when going through the "Accessibility testing 2026" flow trying to I replicated the issue in FindProperty and PropertyInformation, in addition to Send. 

The issues were that these components used `useFormik` and not the `useFormikWithRef` hook.