### PR TITLE
chore(iac): Bump ECR repo lifecycle policy

### DIFF
--- a/infrastructure/application/index.ts
+++ b/infrastructure/application/index.ts
@@ -47,8 +47,8 @@ export = async () => {
     lifecyclePolicy: {
       rules: [
         {
-          description: "Keep last 100 images",
-          maximumNumberOfImages: 100,
+          description: "Keep last 1000 images",
+          maximumNumberOfImages: 1000,
           tagStatus: "any",
         },
       ],


### PR DESCRIPTION
Follow up and fix here for the `CannotPullContainerError` AWS ECR repo error we were hitting last week (https://github.com/theopensystemslab/planx-new/pull/7060, https://github.com/theopensystemslab/planx-new/pull/7061, https://github.com/theopensystemslab/planx-new/pull/7062)

By increasing the `maximumNumberOfImages` we make this issue significantly less likely to reoccur. It's not impossible however, just much less likely.

If we find we hit this again / hit this often, then we can look at a setup of a per-docker image `aws.ecr.repository` so that we keep the last X caches, per-docker file.