### PR TITLE
chore: Rotate GovNotify API keys across all envs

### DIFF
--- a/infrastructure/application/Pulumi.production.yaml
+++ b/infrastructure/application/Pulumi.production.yaml
@@ -45,7 +45,7 @@ config:
   application:google-client-secret:
     secure: AAABAN5E+De3A3HtpLVaSNTDwk9Uz4r2d5g8SIRVbNOd2fj3eU+lGJXjVbEAnxezr14hwabbfwW2ptjcFzqkhG7OmQ==
   application:govuk-notify-api-key:
-    secure: AAABADo05EPv/HWj7Rkf19nBeTcPJd4pEcRi2/uhyB3agraFODpLvNMx2bXfISf5pZ4HA41GYCE4f7OLcJN6hIV6ZMWUlEriPzvkoUAixbLlz1LIERiyk73R8E4F2bV65/9aFqi4l7caLS5c8iDJrE+JAvu2i7oS
+    secure: AAABAGnNAydaUYfiP0CZg1hctj1cHvR000SMEwNhycjohmbeWC+KCRc37ns9FkcbfWlnCvabr9MvtRT9YSTtUb4W/b8lDsMtsFQ2cgq4ewVpIiyFFC3ICrc0vA5WpbIIeCDs4mRiHIlKr0AAWAGF4KuECMYmWRuO3uVE7w==
   application:hasura-admin-secret:
     secure: AAABAI+T8RFROAmmTg7ahXUuUX/85OcJ47pVKetKKoVjQklpXjvKE6mUc/wDcjIbA330+XoWufw=
   application:hasura-cpu: "2048"

--- a/infrastructure/application/Pulumi.staging.yaml
+++ b/infrastructure/application/Pulumi.staging.yaml
@@ -44,7 +44,7 @@ config:
   application:google-client-secret:
     secure: AAABAGQuqQDU4S+vR+cQaFoa6xAeWU9clVaNonQ/dq0R8Dke+o0y7ALOmYMy4fOX4Pa6HiZl85npU/cbwy8HdMYaiA==
   application:govuk-notify-api-key:
-    secure: AAABACgwjEmlLmE19ofRO8e/JpD8sHDV2lcDmSXbU/Mw8ZRh5gTgll8DZ3BVjpDWfQfIecBAIf2TFgeo9CsBSLjfaRJ7eJyKDSWm7i8LlMC2JN/PN+Ig8oeI0H0oLkqJIziNKKjx+e97zDiXO9LZ1CVzrywR
+    secure: AAABAPOfN++CwJ/4V159VyiWLqsF/54nxTghcUitG0yHU9vSxtTQU1SSQuZUBT1JLuX6+lfFtGVV20nuZ64QwnRwY/Af7kzxOYjQq0ZWU8F7YOe9WADJhayx0eTPI2AyPsHkib1SwjI+JVjg/p2+s4WT3GNAUQ75zQ==
   application:hasura-admin-secret:
     secure: AAABAESVIf00jdpXgPOOIynUMvRTRc932FX7/U9mN6hGc0Xk9dpH91/Ier+RzoSF55ucZSeKpH0=
   application:hasura-cpu: "1024"


### PR DESCRIPTION
## What does this PR do?
 - Rotates API keys for staging and prod environments
 - New keys pushed to AWS S3 `.env` and `.env.test` files
 - Lightweight follow up to https://github.com/theopensystemslab/planx-new/pull/6492 - lets get this across the line, and revisit the above ADR when capacity allows

Once this has reached production and been tested, I'll remove old API keys from the GovNotify dashboard - currently both old and new are live to support the migration.