### PR TITLE
[chore] bump images on which API, sharedb and hasura containers are built

### DIFF
--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -1,5 +1,5 @@
 ## BASE ##
-FROM node:24.14.0-alpine AS base
+FROM node:24.14.1-alpine AS base
 
 # Git required for planx-core github dependency
 RUN apk add --no-cache git
@@ -20,7 +20,7 @@ RUN pnpm --filter api.planx.uk build
 RUN npm_config_inject_workspace_packages=true pnpm --filter api.planx.uk deploy --prod --prefer-offline /deploy/api
 
 ## PRODUCTION ##
-FROM node:24.14.0-alpine AS production
+FROM node:24.14.1-alpine AS production
 WORKDIR /api
 
 ENV NODE_ENV=production

--- a/apps/hasura.planx.uk/Dockerfile
+++ b/apps/hasura.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.48.1.cli-migrations-v3
+FROM hasura/graphql-engine:v2.48.16.cli-migrations-v3
 LABEL test="abc123"
 WORKDIR /
 COPY metadata hasura-metadata

--- a/apps/sharedb.planx.uk/Dockerfile
+++ b/apps/sharedb.planx.uk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.0-alpine AS base
+FROM node:24.14.1-alpine AS base
 
 # Git required for planx-core github dependency
 RUN apk add --no-cache git
@@ -18,7 +18,7 @@ RUN pnpm install --frozen-lockfile --prefer-offline
 RUN npm_config_inject_workspace_packages=true pnpm --filter sharedb.planx.uk deploy --prod --prefer-offline /deploy/sharedb
 
 ## PRODUCTION ##
-FROM node:24.14.0-alpine AS production
+FROM node:24.14.1-alpine AS production
 WORKDIR /sharedb
 ENV NODE_ENV=production
 COPY --from=base /deploy/sharedb ./


### PR DESCRIPTION
Addresses a few vulnerabilities in the [node image](https://hub.docker.com/layers/library/node/24.14.0-alpine/images/sha256-e9445c64ace1a9b5cdc60fc98dd82d1e5142985d902f41c2407e8fffe49d46a3) we build the API and sharedb images off, and also bumps the minor version on the hasura image for good measure.

Note that [node:24.14.1-alpine](https://hub.docker.com/layers/library/node/24.14.1-alpine/images/sha256-6222c83590744c8e778520946b72d1cc4309293886610dc59a4ce3fdfe6f9b40) nevertheless has an outstanding critical CVE from 1wk ago which is the same as dependabot is catching [here](https://github.com/theopensystemslab/planx-new/security/dependabot/1093). So there may be a fix for that sooner rather than later :)

(the other critical would require us bumping to [24.18](https://hub.docker.com/layers/library/node/24.18-alpine/images/sha256-4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc), which is on a more recent Alpine build, but I'm not sure if we'd then need to bump node repo-wide also?)