### PR TITLE
feat: Add tooltip with exact time to history items

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -11,7 +11,6 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import type { OT } from "@planx/graph/types";
-import { format, parseISO } from "date-fns";
 import type {
   CommentHistoryItem,
   HistoryItem,
@@ -19,10 +18,10 @@ import type {
   PublishHistoryItem,
 } from "lib/api/publishFlow/types";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { formatLastEditDate } from "pages/FlowEditor/utils";
-import React, { useState } from "react";
+import { useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import Permission from "ui/editor/Permission";
+import { RelativeTime } from "ui/shared/RelativeTime";
 
 import {
   CommentTimelineItem,
@@ -163,32 +162,27 @@ export const EditHistoryTimeline = ({
                       : `Created flow`
                   }`}
                 </Typography>
-                <Tooltip
-                  placement="right"
-                  title={format(parseISO(op.createdAt), "MMM d, yyyy, HH:mm O")}
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "small",
+                    pt: 0.25,
+                    pb: 0.75,
+                    color:
+                      inUndoScope(i) && isUndoType(op.type)
+                        ? "GrayText"
+                        : "text.secondary",
+                  }}
                 >
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontSize: "small",
-                      pt: 0.25,
-                      pb: 0.75,
-                      color:
-                        inUndoScope(i) && isUndoType(op.type)
-                          ? "GrayText"
-                          : "text.secondary",
-                    }}
-                  >
-                    <strong>{`${
-                      {
-                        publish: "Published",
-                        comment: "Commented",
-                        operation: "Edited",
-                      }[op.type]
-                    }`}</strong>{" "}
-                    {formatLastEditDate(op.createdAt)}
-                  </Typography>
-                </Tooltip>
+                  <strong>{`${
+                    {
+                      publish: "Published",
+                      comment: "Commented",
+                      operation: "Edited",
+                    }[op.type]
+                  }`}</strong>{" "}
+                  <RelativeTime date={op.createdAt} placement="right" />
+                </Typography>
               </Box>
               {showUndoButton(op, i) && (
                 <Permission.CanEdit>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/Timeline.tsx
@@ -11,6 +11,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ROOT_NODE_KEY } from "@planx/graph";
 import type { OT } from "@planx/graph/types";
+import { format, parseISO } from "date-fns";
 import type {
   CommentHistoryItem,
   HistoryItem,
@@ -162,27 +163,32 @@ export const EditHistoryTimeline = ({
                       : `Created flow`
                   }`}
                 </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontSize: "small",
-                    pt: 0.25,
-                    pb: 0.75,
-                    color:
-                      inUndoScope(i) && isUndoType(op.type)
-                        ? "GrayText"
-                        : "text.secondary",
-                  }}
+                <Tooltip
+                  placement="right"
+                  title={format(parseISO(op.createdAt), "MMM d, yyyy, HH:mm O")}
                 >
-                  <strong>{`${
-                    {
-                      publish: "Published",
-                      comment: "Commented",
-                      operation: "Edited",
-                    }[op.type]
-                  }`}</strong>{" "}
-                  {`${formatLastEditDate(op.createdAt)}`}
-                </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontSize: "small",
+                      pt: 0.25,
+                      pb: 0.75,
+                      color:
+                        inUndoScope(i) && isUndoType(op.type)
+                          ? "GrayText"
+                          : "text.secondary",
+                    }}
+                  >
+                    <strong>{`${
+                      {
+                        publish: "Published",
+                        comment: "Commented",
+                        operation: "Edited",
+                      }[op.type]
+                    }`}</strong>{" "}
+                    {formatLastEditDate(op.createdAt)}
+                  </Typography>
+                </Tooltip>
               </Box>
               {showUndoButton(op, i) && (
                 <Permission.CanEdit>

--- a/apps/editor.planx.uk/src/ui/shared/RelativeTime.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/RelativeTime.tsx
@@ -1,0 +1,30 @@
+import Box from "@mui/material/Box";
+import type { TooltipProps } from "@mui/material/Tooltip";
+import Tooltip from "@mui/material/Tooltip";
+import { format, formatDistanceToNow, parseISO } from "date-fns";
+import type React from "react";
+
+type Props = { date: string } & Partial<Exclude<TooltipProps, "title">>;
+
+export const RelativeTime: React.FC<Props> = ({ date, ...tooltipProps }) => {
+  const relativeTime = formatDistanceToNow(new Date(date), {
+    includeSeconds: true,
+    addSuffix: true,
+  });
+  const absoluteTime = format(parseISO(date), "MMM d, yyyy, HH:mm");
+
+  return (
+    <Tooltip
+      {...tooltipProps}
+      title={absoluteTime}
+      slotProps={{
+        ...tooltipProps.slotProps,
+        tooltip: {
+          sx: { fontSize: "0.75rem" },
+        },
+      }}
+    >
+      <Box component="span">{relativeTime}</Box>
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
When debugging an issue with Lambeth's pre-app I noticed that there's no way in the Editor to get an exact date - just a relative date.

This PR adds a tooltip to display this - idea and formatting taken from GitHub. Comments most welcome, [cross-posted to `#planx-design` also](https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1785251673196849)

<img width="489" height="152" alt="image" src="https://github.com/user-attachments/assets/c17cd724-c93b-49ba-b16d-e7bc1c21ec6b" />

<img width="301" height="86" alt="image" src="https://github.com/user-attachments/assets/a5bc1ead-cffe-4853-aa55-338221cf8213" />

