### PR TITLE
fix: Tidy up editor secondary buttons

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Flow/Template/index.tsx
@@ -119,7 +119,6 @@ const Template: React.FC = () => {
                     onClick={handleClose}
                     color="secondary"
                     variant="contained"
-                    sx={{ backgroundColor: "background.default" }}
                   >
                     Cancel
                   </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsUpsertModal.tsx
@@ -128,7 +128,6 @@ export const EmailsUpsertModal = ({
                 onClick={() => setModalState(null)}
                 color="secondary"
                 variant="contained"
-                sx={{ backgroundColor: "background.default" }}
               >
                 Cancel
               </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/AddCommentDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/EditHistory/AddCommentDialog.tsx
@@ -84,7 +84,6 @@ export const AddCommentDialog = ({
             color="secondary"
             variant="contained"
             onClick={() => setDialogOpen(false)}
-            sx={{ backgroundColor: "background.default" }}
           >
             Back
           </Button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Publish/PublishDialog.tsx
@@ -225,10 +225,7 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
           </Box>
         </DialogContent>
         <DialogFooterActions>
-          <Button
-            onClick={handleBack}
-            sx={{ backgroundColor: "background.default" }}
-          >
+          <Button onClick={handleBack} variant="contained" color="secondary">
             Back
           </Button>
           <Button
@@ -341,10 +338,7 @@ export const ChangesDialog = (props: ChangesDialogProps) => {
           )}
         </DialogContent>
         <DialogFooterActions>
-          <Button
-            onClick={handleBack}
-            sx={{ backgroundColor: "background.default" }}
-          >
+          <Button onClick={handleBack} variant="contained" color="secondary">
             Back
           </Button>
           <Button

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal.tsx
@@ -381,7 +381,6 @@ const FormModal: React.FC<FormModalProps> = ({
                   });
                 }}
                 disabled={disabled}
-                sx={{ backgroundColor: "background.default" }}
               >
                 Make unique
               </Button>


### PR DESCRIPTION
## What does this PR do?

Quick one:
- Use correct `contained` / `secondary` button style (subtle border) for back buttons in publish modal
- Remove a few obsolete background colour properties