### PR TITLE
feat: copy notes when a flow is copied

### DIFF
--- a/apps/api.planx.uk/helpers.ts
+++ b/apps/api.planx.uk/helpers.ts
@@ -421,19 +421,34 @@ const getChildren = (
 };
 
 /**
+ * Rename a single node id the same way `makeUniqueFlow` renames the flow it belongs to
+ * (replace last n characters), leaving `_root` and nullish ids untouched.
+ */
+function renameNodeId(nodeId: string, replaceValue: string): string;
+function renameNodeId(
+  nodeId: string | null | undefined,
+  replaceValue: string,
+): string | null | undefined;
+function renameNodeId(
+  nodeId: string | null | undefined,
+  replaceValue: string,
+): string | null | undefined {
+  if (!nodeId || nodeId === "_root") return nodeId;
+  return nodeId.slice(0, -replaceValue.length) + replaceValue;
+}
+
+/**
  * For a given flow, make it unique by renaming its' node ids (replace last n characters) while preserving its' content
  */
 const makeUniqueFlow = (
   flowData: Flow["data"],
   replaceValue: string,
 ): Flow["data"] => {
-  const charactersToReplace = replaceValue.length;
-
   Object.keys(flowData).forEach((node) => {
     // if this node has edges, rename them (includes _root.edges)
     if (flowData[node]["edges"]) {
-      const newEdges = flowData[node]["edges"]?.map(
-        (edge) => edge.slice(0, -charactersToReplace) + replaceValue,
+      const newEdges = flowData[node]["edges"]?.map((edge) =>
+        renameNodeId(edge, replaceValue),
       );
       delete flowData[node]["edges"];
       flowData[node]["edges"] = newEdges;
@@ -441,7 +456,7 @@ const makeUniqueFlow = (
 
     // rename this top-level node if it's not _root
     if (node !== "_root") {
-      const newNodeId = node.slice(0, -charactersToReplace) + replaceValue;
+      const newNodeId = renameNodeId(node, replaceValue);
       flowData[newNodeId] = flowData[node];
       delete flowData[node];
     }
@@ -478,4 +493,5 @@ export {
   getMostRecentPublishedFlowVersion,
   isLiveEnv,
   makeUniqueFlow,
+  renameNodeId,
 };

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -60,6 +60,14 @@ beforeEach(() => {
       },
     },
   });
+
+  queryMock.mockQuery({
+    name: "GetFlowNotesForCopy",
+    matchOnVariables: false,
+    data: {
+      flow_note_positions: [],
+    },
+  });
 });
 
 const auth = authHeader({ role: "teamEditor" });
@@ -193,6 +201,121 @@ it("inserts copied unique flow data", async () => {
     name: "test (copy)",
     slug: "test-copy",
   };
+
+  await supertest(app)
+    .post("/flows/1/copy")
+    .send(body)
+    .set(auth)
+    .expect(200)
+    .then((res) => {
+      expect(res.body).toEqual(mockCopyFlowResponseInserted);
+    });
+});
+
+it("copies a flow's notes, preserving clone relationships between notes but not to the original flow's notes", async () => {
+  const body = {
+    insert: true,
+    replaceValue: "T3ST1",
+    teamId: 1,
+    name: "test (copy)",
+    slug: "test-copy",
+  };
+
+  queryMock.mockQuery({
+    name: "GetFlowNotesForCopy",
+    matchOnVariables: false,
+    data: {
+      flow_note_positions: [
+        {
+          // a standalone note
+          note_id: "note-a",
+          node_id: "Yh7t91FisE",
+          placement: null,
+          note: { text: "Solo note", color: "#fffdb0" },
+        },
+        {
+          // first of a clone pair - shares note_id "note-b" with the row below
+          note_id: "note-b",
+          node_id: null,
+          placement: { parent: "_root", before: "kNX8Rej9rk" },
+          note: { text: "Cloned note", color: "#ffd6a5" },
+        },
+        {
+          // second of the clone pair
+          note_id: "note-b",
+          node_id: "h8DSw40zNr",
+          placement: null,
+          note: { text: "Cloned note", color: "#ffd6a5" },
+        },
+      ],
+    },
+  });
+
+  // One new flow_note_content row created per unique original note, via its first position
+  queryMock.mockQuery({
+    name: "InsertFlowNotePositionWithContentForCopy",
+    variables: {
+      object: {
+        flow_id: 2,
+        node_id: "Yh7t9T3ST1",
+        placement: null,
+        created_by: "123",
+        note: {
+          data: {
+            text: "Solo note",
+            color: "#fffdb0",
+            created_by: "123",
+            updated_by: "123",
+          },
+        },
+      },
+    },
+    data: {
+      insert_flow_note_positions_one: { note_id: "new-note-a" },
+    },
+  });
+
+  queryMock.mockQuery({
+    name: "InsertFlowNotePositionWithContentForCopy",
+    variables: {
+      object: {
+        flow_id: 2,
+        node_id: null,
+        placement: { parent: "_root", before: "kNX8RT3ST1" },
+        created_by: "123",
+        note: {
+          data: {
+            text: "Cloned note",
+            color: "#ffd6a5",
+            created_by: "123",
+            updated_by: "123",
+          },
+        },
+      },
+    },
+    data: {
+      insert_flow_note_positions_one: { note_id: "new-note-b" },
+    },
+  });
+
+  // The clone pair's second position points at the shared new note, not a new content row
+  queryMock.mockQuery({
+    name: "InsertFlowNotePositionsForCopy",
+    variables: {
+      objects: [
+        {
+          flow_id: 2,
+          node_id: "h8DSwT3ST1",
+          placement: null,
+          created_by: "123",
+          note_id: "new-note-b",
+        },
+      ],
+    },
+    data: {
+      insert_flow_note_positions: { affected_rows: 1 },
+    },
+  });
 
   await supertest(app)
     .post("/flows/1/copy")

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlow.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
     name: "GetFlowNotesForCopy",
     matchOnVariables: false,
     data: {
-      flow_note_positions: [],
+      flowNotePositions: [],
     },
   });
 });
@@ -225,25 +225,25 @@ it("copies a flow's notes, preserving clone relationships between notes but not 
     name: "GetFlowNotesForCopy",
     matchOnVariables: false,
     data: {
-      flow_note_positions: [
+      flowNotePositions: [
         {
           // a standalone note
-          note_id: "note-a",
-          node_id: "Yh7t91FisE",
+          noteId: "note-a",
+          nodeId: "Yh7t91FisE",
           placement: null,
           note: { text: "Solo note", color: "#fffdb0" },
         },
         {
-          // first of a clone pair - shares note_id "note-b" with the row below
-          note_id: "note-b",
-          node_id: null,
+          // first of a clone pair - shares noteId "note-b" with the row below
+          noteId: "note-b",
+          nodeId: null,
           placement: { parent: "_root", before: "kNX8Rej9rk" },
           note: { text: "Cloned note", color: "#ffd6a5" },
         },
         {
           // second of the clone pair
-          note_id: "note-b",
-          node_id: "h8DSw40zNr",
+          noteId: "note-b",
+          nodeId: "h8DSw40zNr",
           placement: null,
           note: { text: "Cloned note", color: "#ffd6a5" },
         },
@@ -271,7 +271,7 @@ it("copies a flow's notes, preserving clone relationships between notes but not 
       },
     },
     data: {
-      insert_flow_note_positions_one: { note_id: "new-note-a" },
+      insertedNotePosition: { noteId: "new-note-a" },
     },
   });
 
@@ -294,7 +294,7 @@ it("copies a flow's notes, preserving clone relationships between notes but not 
       },
     },
     data: {
-      insert_flow_note_positions_one: { note_id: "new-note-b" },
+      insertedNotePosition: { noteId: "new-note-b" },
     },
   });
 

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlowNotes.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlowNotes.ts
@@ -1,0 +1,159 @@
+import { gql } from "graphql-request";
+
+import { getClient } from "../../../client/index.js";
+import { renameNodeId } from "../../../helpers.js";
+import type { Flow } from "../../../types.js";
+import { userContext } from "../../auth/middleware.js";
+
+interface NotePlacement {
+  parent: string;
+  container?: string;
+  before?: string;
+  parentIsContainer?: boolean;
+}
+
+interface FlowNotePositionRow {
+  note_id: string;
+  node_id: string | null;
+  placement: NotePlacement | null;
+  note: {
+    text: string;
+    color: string;
+  };
+}
+
+const GET_FLOW_NOTES = gql`
+  query GetFlowNotesForCopy($flowId: uuid!) {
+    flow_note_positions(where: { flow_id: { _eq: $flowId } }) {
+      note_id
+      node_id
+      placement
+      note {
+        text
+        color
+      }
+    }
+  }
+`;
+
+// Creates a new flow_note_content row alongside the first position, mirroring the "createFlowNote" pattern
+const INSERT_FLOW_NOTE_POSITION_WITH_CONTENT = gql`
+  mutation InsertFlowNotePositionWithContentForCopy(
+    $object: flow_note_positions_insert_input!
+  ) {
+    insert_flow_note_positions_one(object: $object) {
+      note_id
+    }
+  }
+`;
+
+// Points additional positions at an already-copied note, mirroring the "pasteFlowNoteClone" pattern
+const INSERT_FLOW_NOTE_POSITIONS = gql`
+  mutation InsertFlowNotePositionsForCopy(
+    $objects: [flow_note_positions_insert_input!]!
+  ) {
+    insert_flow_note_positions(objects: $objects) {
+      affected_rows
+    }
+  }
+`;
+
+const remapPlacement = (
+  placement: NotePlacement,
+  replaceValue: string,
+): NotePlacement => ({
+  ...placement,
+  parent: renameNodeId(placement.parent, replaceValue),
+  container: renameNodeId(placement.container, replaceValue) ?? undefined,
+  before: renameNodeId(placement.before, replaceValue) ?? undefined,
+});
+
+const remapPosition = (
+  { node_id, placement }: Pick<FlowNotePositionRow, "node_id" | "placement">,
+  replaceValue: string,
+) => ({
+  node_id: renameNodeId(node_id, replaceValue),
+  placement: placement ? remapPlacement(placement, replaceValue) : null,
+});
+
+/**
+ * Copy a flow's notes to a newly-copied flow, remapping nodeIds/placements to match the destination flow's renamed nodes.
+ * editing a note in the new flow instance will not affect the original flow's note
+ *
+ * notes that were clones of one another in the source flow are copied as clones of one another in the destination flow too
+ * - they are just no longer clones of the original notes
+ */
+export const copyFlowNotes = async ({
+  sourceFlowId,
+  newFlowId,
+  replaceValue,
+}: {
+  sourceFlowId: Flow["id"];
+  newFlowId: Flow["id"];
+  replaceValue: string;
+}): Promise<void> => {
+  const userId = userContext.getStore()?.user?.sub;
+  if (!userId) return;
+
+  const { client: $client } = getClient();
+
+  const { flow_note_positions } = await $client.request<{
+    flow_note_positions: FlowNotePositionRow[];
+  }>(GET_FLOW_NOTES, { flowId: sourceFlowId });
+
+  if (!flow_note_positions.length) return;
+
+  const groupsByOriginalNoteId = new Map<string, FlowNotePositionRow[]>();
+  for (const row of flow_note_positions) {
+    const group = groupsByOriginalNoteId.get(row.note_id);
+    if (group) group.push(row);
+    else groupsByOriginalNoteId.set(row.note_id, [row]);
+  }
+
+  // One new flow_note_content row per unique original note, created via the first position that used it
+  const newNoteIdByOriginalNoteId = new Map<string, string>();
+  await Promise.all(
+    Array.from(groupsByOriginalNoteId.entries()).map(
+      async ([originalNoteId, [first]]) => {
+        const { insert_flow_note_positions_one } = await $client.request<{
+          insert_flow_note_positions_one: { note_id: string };
+        }>(INSERT_FLOW_NOTE_POSITION_WITH_CONTENT, {
+          object: {
+            flow_id: newFlowId,
+            ...remapPosition(first, replaceValue),
+            created_by: userId,
+            note: {
+              data: {
+                text: first.note.text,
+                color: first.note.color,
+                created_by: userId,
+                updated_by: userId,
+              },
+            },
+          },
+        });
+        newNoteIdByOriginalNoteId.set(
+          originalNoteId,
+          insert_flow_note_positions_one.note_id,
+        );
+      },
+    ),
+  );
+
+  // Remaining positions in each group are clones - point them at the shared new note
+  const cloneObjects = Array.from(groupsByOriginalNoteId.entries()).flatMap(
+    ([originalNoteId, [, ...clones]]) =>
+      clones.map((clone) => ({
+        flow_id: newFlowId,
+        ...remapPosition(clone, replaceValue),
+        created_by: userId,
+        note_id: newNoteIdByOriginalNoteId.get(originalNoteId),
+      })),
+  );
+
+  if (cloneObjects.length > 0) {
+    await $client.request(INSERT_FLOW_NOTE_POSITIONS, {
+      objects: cloneObjects,
+    });
+  }
+};

--- a/apps/api.planx.uk/modules/flows/copyFlow/copyFlowNotes.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/copyFlowNotes.ts
@@ -13,8 +13,8 @@ interface NotePlacement {
 }
 
 interface FlowNotePositionRow {
-  note_id: string;
-  node_id: string | null;
+  noteId: string;
+  nodeId: string | null;
   placement: NotePlacement | null;
   note: {
     text: string;
@@ -24,9 +24,11 @@ interface FlowNotePositionRow {
 
 const GET_FLOW_NOTES = gql`
   query GetFlowNotesForCopy($flowId: uuid!) {
-    flow_note_positions(where: { flow_id: { _eq: $flowId } }) {
-      note_id
-      node_id
+    flowNotePositions: flow_note_positions(
+      where: { flow_id: { _eq: $flowId } }
+    ) {
+      noteId: note_id
+      nodeId: node_id
       placement
       note {
         text
@@ -41,8 +43,8 @@ const INSERT_FLOW_NOTE_POSITION_WITH_CONTENT = gql`
   mutation InsertFlowNotePositionWithContentForCopy(
     $object: flow_note_positions_insert_input!
   ) {
-    insert_flow_note_positions_one(object: $object) {
-      note_id
+    insertedNotePosition: insert_flow_note_positions_one(object: $object) {
+      noteId: note_id
     }
   }
 `;
@@ -69,10 +71,10 @@ const remapPlacement = (
 });
 
 const remapPosition = (
-  { node_id, placement }: Pick<FlowNotePositionRow, "node_id" | "placement">,
+  { nodeId, placement }: Pick<FlowNotePositionRow, "nodeId" | "placement">,
   replaceValue: string,
 ) => ({
-  node_id: renameNodeId(node_id, replaceValue),
+  node_id: renameNodeId(nodeId, replaceValue),
   placement: placement ? remapPlacement(placement, replaceValue) : null,
 });
 
@@ -97,17 +99,17 @@ export const copyFlowNotes = async ({
 
   const { client: $client } = getClient();
 
-  const { flow_note_positions } = await $client.request<{
-    flow_note_positions: FlowNotePositionRow[];
+  const { flowNotePositions } = await $client.request<{
+    flowNotePositions: FlowNotePositionRow[];
   }>(GET_FLOW_NOTES, { flowId: sourceFlowId });
 
-  if (!flow_note_positions.length) return;
+  if (!flowNotePositions.length) return;
 
   const groupsByOriginalNoteId = new Map<string, FlowNotePositionRow[]>();
-  for (const row of flow_note_positions) {
-    const group = groupsByOriginalNoteId.get(row.note_id);
+  for (const row of flowNotePositions) {
+    const group = groupsByOriginalNoteId.get(row.noteId);
     if (group) group.push(row);
-    else groupsByOriginalNoteId.set(row.note_id, [row]);
+    else groupsByOriginalNoteId.set(row.noteId, [row]);
   }
 
   // One new flow_note_content row per unique original note, created via the first position that used it
@@ -115,8 +117,8 @@ export const copyFlowNotes = async ({
   await Promise.all(
     Array.from(groupsByOriginalNoteId.entries()).map(
       async ([originalNoteId, [first]]) => {
-        const { insert_flow_note_positions_one } = await $client.request<{
-          insert_flow_note_positions_one: { note_id: string };
+        const { insertedNotePosition } = await $client.request<{
+          insertedNotePosition: { noteId: string };
         }>(INSERT_FLOW_NOTE_POSITION_WITH_CONTENT, {
           object: {
             flow_id: newFlowId,
@@ -134,7 +136,7 @@ export const copyFlowNotes = async ({
         });
         newNoteIdByOriginalNoteId.set(
           originalNoteId,
-          insert_flow_note_positions_one.note_id,
+          insertedNotePosition.noteId,
         );
       },
     ),

--- a/apps/api.planx.uk/modules/flows/copyFlow/service.ts
+++ b/apps/api.planx.uk/modules/flows/copyFlow/service.ts
@@ -1,5 +1,6 @@
 import { createFlow, getFlowData, makeUniqueFlow } from "../../../helpers.js";
 import type { CopyFlowRequest } from "./controller.js";
+import { copyFlowNotes } from "./copyFlowNotes.js";
 
 const copyFlow = async ({
   flowId,
@@ -18,7 +19,7 @@ const copyFlow = async ({
   // Check if copied flow data should be inserted into `flows` table, or just returned for reference
   if (insert) {
     // Insert the flow and an associated operation
-    await createFlow({
+    const insertedFlow = await createFlow({
       teamId,
       slug,
       name,
@@ -27,6 +28,13 @@ const copyFlow = async ({
       copiedFrom: flowId,
       isService: flow.isService,
       isPattern: flow.isPattern,
+    });
+
+    // Copy this flow's notes too, as new (not cloned) notes pointing at the new nodeIds
+    await copyFlowNotes({
+      sourceFlowId: flowId,
+      newFlowId: insertedFlow.id,
+      replaceValue,
     });
   }
 

--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -59,62 +59,62 @@ export type FlowNote = AttachedNote | PositionedNote;
 
 const GET_FLOW_NOTES = gql`
   subscription GetFlowNotes($flowId: uuid!) {
-    flow_note_positions(
+    flowNotePositions: flow_note_positions(
       where: { flow_id: { _eq: $flowId } }
       order_by: { created_at: asc, id: asc }
     ) {
-      id
-      flow_id
-      node_id
+      positionId: id
+      flowId: flow_id
+      nodeId: node_id
       placement
       note {
-        id
+        contentId: id
         text
         color
-        created_by
-        updated_by
-        created_at
-        updated_at
+        createdBy: created_by
+        updatedBy: updated_by
+        createdAt: created_at
+        updatedAt: updated_at
       }
     }
   }
 `;
 
 interface FlowNotePositionRow {
-  id: string;
-  flow_id: string;
-  node_id: string | null;
+  positionId: string;
+  flowId: string;
+  nodeId: string | null;
   placement: NotePlacement | null;
   note: {
-    id: string;
+    contentId: string;
     text: string;
     color: string;
-    created_by: number;
-    updated_by: number;
-    created_at: string;
-    updated_at: string;
+    createdBy: number;
+    updatedBy: number;
+    createdAt: string;
+    updatedAt: string;
   };
 }
 
 interface QueryResult {
-  flow_note_positions: FlowNotePositionRow[];
+  flowNotePositions: FlowNotePositionRow[];
 }
 
 const toFlowNote = (row: FlowNotePositionRow): FlowNote => {
   const base = {
-    positionId: row.id,
-    contentId: row.note.id,
-    flowId: row.flow_id,
+    positionId: row.positionId,
+    contentId: row.note.contentId,
+    flowId: row.flowId,
     text: row.note.text,
     color: row.note.color,
-    createdBy: row.note.created_by,
-    updatedBy: row.note.updated_by,
-    createdAt: row.note.created_at,
-    updatedAt: row.note.updated_at,
+    createdBy: row.note.createdBy,
+    updatedBy: row.note.updatedBy,
+    createdAt: row.note.createdAt,
+    updatedAt: row.note.updatedAt,
   };
 
-  return row.node_id
-    ? { ...base, nodeId: row.node_id, placement: null }
+  return row.nodeId
+    ? { ...base, nodeId: row.nodeId, placement: null }
     : { ...base, nodeId: null, placement: row.placement as NotePlacement };
 };
 
@@ -135,7 +135,7 @@ export const useFlowNotes = (): UseFlowNotesResult => {
     },
   );
 
-  const notes = (data?.flow_note_positions ?? []).map(toFlowNote);
+  const notes = (data?.flowNotePositions ?? []).map(toFlowNote);
 
   return { notes, loading, error };
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.test.tsx
@@ -75,7 +75,7 @@ describe("positioned-note context menu", () => {
         queriedId = variables.id;
         return HttpResponse.json({
           data: {
-            flow_note_content_by_pk: { text: "hi", color: "#fffdb0" },
+            noteContent: { text: "hi", color: "#fffdb0" },
           },
         });
       }),
@@ -117,7 +117,7 @@ describe("hanger context menu - paste note", () => {
       graphql.mutation("CreateFlowNotePosition", ({ variables }) => {
         capturedObject = variables.object;
         return HttpResponse.json({
-          data: { insert_flow_note_positions_one: { id: "new-position-id" } },
+          data: { insertedNotePosition: { id: "new-position-id" } },
         });
       }),
     );
@@ -141,7 +141,7 @@ describe("hanger context menu - paste note", () => {
       graphql.mutation("CreateFlowNotePosition", ({ variables }) => {
         capturedObject = variables.object;
         return HttpResponse.json({
-          data: { insert_flow_note_positions_one: { id: "new-position-id" } },
+          data: { insertedNotePosition: { id: "new-position-id" } },
         });
       }),
     );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.stories.tsx
@@ -37,7 +37,7 @@ export const Create = {
         graphql.mutation("CreateFlowNotePosition", ({ variables }) => {
           console.log("createFlowNote", variables.object);
           return HttpResponse.json({
-            data: { insert_flow_note_positions_one: { id: "new-note-id" } },
+            data: { insertedNotePosition: { id: "new-note-id" } },
           });
         }),
       ],

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.test.tsx
@@ -52,7 +52,7 @@ beforeEach(() => {
     graphql.mutation("CreateFlowNotePosition", ({ variables }) => {
       createFlowNote(variables.object);
       return HttpResponse.json({
-        data: { insert_flow_note_positions_one: { id: "new-id" } },
+        data: { insertedNotePosition: { id: "new-id" } },
       });
     }),
     graphql.mutation("UpdateFlowNoteContent", ({ variables }) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/mutations.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/mutations.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const CREATE_FLOW_NOTE_POSITION = gql`
   mutation CreateFlowNotePosition($object: flow_note_positions_insert_input!) {
-    insert_flow_note_positions_one(object: $object) {
+    insertedNotePosition: insert_flow_note_positions_one(object: $object) {
       id
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCopyFlowNote.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCopyFlowNote.ts
@@ -4,7 +4,7 @@ import { useSetCopiedFlowNote } from "./useSetCopiedFlowNote";
 
 const GET_FLOW_NOTE_CONTENT = gql`
   query GetFlowNoteContent($id: uuid!) {
-    flow_note_content_by_pk(id: $id) {
+    noteContent: flow_note_content_by_pk(id: $id) {
       text
       color
     }
@@ -12,7 +12,7 @@ const GET_FLOW_NOTE_CONTENT = gql`
 `;
 
 interface GetFlowNoteContentResult {
-  flow_note_content_by_pk: { text: string; color: string } | null;
+  noteContent: { text: string; color: string } | null;
 }
 
 export const useCopyFlowNote = () => {
@@ -24,9 +24,9 @@ export const useCopyFlowNote = () => {
 
   const copyFlowNote = async (noteContentId: string) => {
     const { data } = await fetchContent({ variables: { id: noteContentId } });
-    if (!data?.flow_note_content_by_pk) return;
+    if (!data?.noteContent) return;
 
-    setCopiedFlowNote(data.flow_note_content_by_pk);
+    setCopiedFlowNote(data.noteContent);
   };
 
   return { copyFlowNote, ...queryState };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCreateFlowNote.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCreateFlowNote.ts
@@ -7,7 +7,7 @@ import { CREATE_FLOW_NOTE_POSITION } from "./mutations";
 export type CreateFlowNoteInput = FlowNoteTarget & { text: string };
 
 interface CreateFlowNotePositionResult {
-  insert_flow_note_positions_one: { id: string } | null;
+  insertedNotePosition: { id: string } | null;
 }
 
 export const useCreateFlowNote = () => {
@@ -42,7 +42,7 @@ export const useCreateFlowNote = () => {
       },
     });
 
-    return data?.insert_flow_note_positions_one?.id;
+    return data?.insertedNotePosition?.id;
   };
 
   return { createFlowNote, ...mutationState };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteClone.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteClone.ts
@@ -6,7 +6,7 @@ import { CREATE_FLOW_NOTE_POSITION } from "./mutations";
 import { useClonedFlowNoteId } from "./useClonedFlowNoteId";
 
 interface CreateFlowNotePositionResult {
-  insert_flow_note_positions_one: { id: string } | null;
+  insertedNotePosition: { id: string } | null;
 }
 
 export const usePasteFlowNoteClone = () => {
@@ -33,7 +33,7 @@ export const usePasteFlowNoteClone = () => {
       },
     });
 
-    return data?.insert_flow_note_positions_one?.id;
+    return data?.insertedNotePosition?.id;
   };
 
   return { pasteFlowNoteClone, ...mutationState };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteCopy.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteCopy.ts
@@ -6,7 +6,7 @@ import { CREATE_FLOW_NOTE_POSITION } from "./mutations";
 import { useCopiedFlowNote } from "./useCopiedFlowNote";
 
 interface CreateFlowNotePositionResult {
-  insert_flow_note_positions_one: { id: string } | null;
+  insertedNotePosition: { id: string } | null;
 }
 
 export const usePasteFlowNoteCopy = () => {
@@ -40,7 +40,7 @@ export const usePasteFlowNoteCopy = () => {
       },
     });
 
-    return data?.insert_flow_note_positions_one?.id;
+    return data?.insertedNotePosition?.id;
   };
 
   return { pasteFlowNoteCopy, ...mutationState };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.test.ts
@@ -33,18 +33,18 @@ describe("repositionNotesForDeletedNodes", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({
           data: {
-            flow_note_positions: [
+            flowNotePositions: [
               {
                 id: "note-attached",
-                node_id: "deleted-node",
+                nodeId: "deleted-node",
                 placement: null,
-                created_by: 42,
+                createdBy: 42,
               },
               {
                 id: "note-other-author",
-                node_id: "deleted-node",
+                nodeId: "deleted-node",
                 placement: null,
-                created_by: 999,
+                createdBy: 999,
               },
             ],
           },
@@ -81,12 +81,12 @@ describe("repositionNotesForDeletedNodes", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({
           data: {
-            flow_note_positions: [
+            flowNotePositions: [
               {
                 id: "note-after-deleted",
-                node_id: null,
+                nodeId: null,
                 placement: { parent: "deleted-node" },
-                created_by: 42,
+                createdBy: 42,
               },
             ],
           },
@@ -130,15 +130,15 @@ describe("repositionNotesForDeletedNodes", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({
           data: {
-            flow_note_positions: [
+            flowNotePositions: [
               {
                 id: "note-leading",
-                node_id: null,
+                nodeId: null,
                 placement: {
                   parent: "parent-container",
                   before: "deleted-node",
                 },
-                created_by: 42,
+                createdBy: 42,
               },
             ],
           },
@@ -181,12 +181,12 @@ describe("repositionNotesForDeletedNodes", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({
           data: {
-            flow_note_positions: [
+            flowNotePositions: [
               {
                 id: "note-orphaned",
-                node_id: null,
+                nodeId: null,
                 placement: { parent: "child" },
-                created_by: 42,
+                createdBy: 42,
               },
             ],
           },
@@ -216,7 +216,7 @@ describe("repositionNotesForDeletedNodes", () => {
 
     server.use(
       graphql.query("GetFlowNotePositionsForReposition", () =>
-        HttpResponse.json({ data: { flow_note_positions: [] } }),
+        HttpResponse.json({ data: { flowNotePositions: [] } }),
       ),
       graphql.mutation("DeleteFlowNotePositions", () => {
         mutationCalled = true;
@@ -240,18 +240,18 @@ describe("repositionNotesForMovedNode", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({
           data: {
-            flow_note_positions: [
+            flowNotePositions: [
               {
                 id: "note-before-moved",
-                node_id: null,
+                nodeId: null,
                 placement: { parent: "old-parent", before: "moved-node" },
-                created_by: 42,
+                createdBy: 42,
               },
               {
                 id: "note-elsewhere",
-                node_id: null,
+                nodeId: null,
                 placement: { parent: "old-parent", before: "some-other-node" },
-                created_by: 42,
+                createdBy: 42,
               },
             ],
           },


### PR DESCRIPTION
Adds missing feature behaviour to copy notes for a flow when the flow is copied. Handles the case for cloned notes by creating a single new flow_note_content row and multiple flow_note_position rows.

Copying flows is an api-implemented feature so we had to redeclare types here that had already been declared in the editor. I'm guessing we will be creating more shared types soon now that monorepo is almost ready, so I left this for now.