### PR TITLE
feat: add drag-n-drop support for notes

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Hanger.tsx
@@ -13,6 +13,7 @@ import { useDragLayer, useDrop } from "react-dnd";
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
 import { useFlowNotesContext } from "../notes/FlowNotesContext";
+import { useMoveFlowNotePosition } from "../notes/hooks/useMoveFlowNotePosition";
 import { placementKey } from "../notes/lib/partitionNotes";
 import { PositionedNoteCard } from "../notes/PositionedNoteCard";
 
@@ -28,7 +29,12 @@ interface Item {
   text: string;
 }
 
-const DROPPABLE_TYPES = ["DECISION", "PORTAL", "PAGE"];
+interface NoteItem {
+  positionId: string;
+  text: string;
+}
+
+const DROPPABLE_TYPES = ["DECISION", "PORTAL", "PAGE", "NOTE"];
 
 const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
   parent = getParentId(parent);
@@ -45,6 +51,7 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
       state.showNotes,
     ],
   );
+  const { moveFlowNotePosition } = useMoveFlowNotePosition();
 
   const { positioned, clonedContentIds } = useFlowNotesContext();
   const notes = [...(positioned.get(placementKey(parent, before)) ?? [])].sort(
@@ -71,8 +78,13 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
 
   const [{ isOver, canDrop, item }, drop] = useDrop({
     accept: DROPPABLE_TYPES,
-    drop: (item: Item) => {
-      moveNode(item.id, item.parent, before, parent);
+    drop: (item: Item | NoteItem, monitor) => {
+      if (monitor.getItemType() === "NOTE") {
+        moveFlowNotePosition((item as NoteItem).positionId, parent, before);
+      } else {
+        const nodeItem = item as Item;
+        moveNode(nodeItem.id, nodeItem.parent, before, parent);
+      }
     },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
@@ -81,7 +93,7 @@ const Hanger: React.FC<HangerProps> = ({ before, parent, hidden = false }) => {
     }),
   });
 
-  // Highlight every valid hanger as a drop target while a node is being dragged on the canvas
+  // Highlight every valid hanger as a drop target while a node or note is being dragged on the canvas
   const isDropTargetVisible = useDragLayer(
     (monitor) =>
       monitor.isDragging() &&

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.stories.tsx
@@ -11,6 +11,8 @@ import {
 } from "@tanstack/react-router";
 import type { FlowNote } from "hooks/data/useFlowNotes";
 import React from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { PositionedNoteCard } from "./PositionedNoteCard";
 
@@ -113,7 +115,11 @@ const PositionedNoteCardDemo: React.FC<{
     }),
   });
 
-  return <RouterProvider router={router} />;
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <RouterProvider router={router} />
+    </DndProvider>
+  );
 };
 
 export const Default = {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/PositionedNoteCard.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import type { FlowNote } from "hooks/data/useFlowNotes";
 import { useContextMenu } from "hooks/useContextMenu";
 import React from "react";
+import { useDrag } from "react-dnd";
 
 interface Props {
   note: FlowNote;
@@ -17,13 +18,24 @@ export const PositionedNoteCard: React.FC<Props> = ({
   const navigate = useNavigate();
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
 
+  const [{ isDragging }, drag] = useDrag({
+    item: {
+      positionId: note.positionId,
+      text: note.text,
+    },
+    type: "NOTE",
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
   const handleContextMenu = useContextMenu({
     source: "positioned-note",
     relationships: { self: note.positionId, contentId: note.contentId },
   });
 
   return (
-    <li className={classNames("note-card", { isClone })}>
+    <li className={classNames("note-card", { isClone, isDragging })}>
       <button
         type="button"
         onContextMenu={handleContextMenu}
@@ -33,6 +45,9 @@ export const PositionedNoteCard: React.FC<Props> = ({
             params: { team, flow, id: note.positionId },
           })
         }
+        ref={(el) => {
+          drag(el);
+        }}
       >
         <span className="note-text">{note.text || "Untitled note"}</span>
       </button>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useMoveFlowNotePosition.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useMoveFlowNotePosition.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from "@testing-library/react";
+import { graphql, HttpResponse } from "msw";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import server from "test/mockServer";
+import { setup } from "test/utils";
+import { describe, expect, it } from "vitest";
+
+import { useMoveFlowNotePosition } from "./useMoveFlowNotePosition";
+
+const MoveFlowNotePositionTestHarness: React.FC<{
+  positionId: string;
+  container: string;
+  before?: string;
+}> = ({ positionId, container, before }) => {
+  const { moveFlowNotePosition } = useMoveFlowNotePosition();
+
+  return (
+    <button
+      type="button"
+      onClick={() => moveFlowNotePosition(positionId, container, before)}
+    >
+      Move
+    </button>
+  );
+};
+
+describe("useMoveFlowNotePosition", () => {
+  it("re-anchors a dragged note to the dropped hanger's coordinate", async () => {
+    useStore.setState({
+      flow: {
+        _root: { edges: ["node-a", "node-b"] },
+        "node-a": { type: 200 },
+        "node-b": { type: 200 },
+      } as any,
+    });
+
+    let reanchored: any;
+    server.use(
+      graphql.mutation("ReanchorFlowNotePosition", ({ variables }) => {
+        reanchored = variables;
+        return HttpResponse.json({
+          data: { update_flow_note_positions_by_pk: { id: variables.id } },
+        });
+      }),
+    );
+
+    const { user } = await setup(
+      <MoveFlowNotePositionTestHarness
+        positionId="dragged-note"
+        container="_root"
+        before="node-b"
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(reanchored).toEqual({
+      id: "dragged-note",
+      placement: { parent: "node-a", container: "_root" },
+    });
+  });
+
+  it("re-anchors to a container's leading slot when dropped with no preceding sibling", async () => {
+    useStore.setState({
+      flow: {
+        _root: { edges: ["node-a"] },
+        "node-a": { type: 200 },
+      } as any,
+    });
+
+    let reanchored: any;
+    server.use(
+      graphql.mutation("ReanchorFlowNotePosition", ({ variables }) => {
+        reanchored = variables;
+        return HttpResponse.json({
+          data: { update_flow_note_positions_by_pk: { id: variables.id } },
+        });
+      }),
+    );
+
+    const { user } = await setup(
+      <MoveFlowNotePositionTestHarness
+        positionId="dragged-note"
+        container="_root"
+        before="node-a"
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(reanchored).toEqual({
+      id: "dragged-note",
+      placement: { parent: "_root", before: "node-a", parentIsContainer: true },
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useMoveFlowNotePosition.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useMoveFlowNotePosition.ts
@@ -1,0 +1,22 @@
+import { useMutation } from "@apollo/client";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+import { resolveNotePlacement } from "../lib/notePlacement";
+import { REANCHOR_FLOW_NOTE_POSITION } from "./mutations";
+
+export const useMoveFlowNotePosition = () => {
+  const [mutate, mutationState] = useMutation(REANCHOR_FLOW_NOTE_POSITION);
+
+  const moveFlowNotePosition = async (
+    positionId: string,
+    container: string,
+    before?: string,
+  ) => {
+    const flow = useStore.getState().flow;
+    const placement = resolveNotePlacement(flow, container, before);
+
+    await mutate({ variables: { id: positionId, placement } });
+  };
+
+  return { moveFlowNotePosition, ...mutationState };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -640,6 +640,13 @@ $fontMonospace: "Source Code Pro", monospace;
     @include cloneStyle;
   }
 
+  &.isDragging {
+    opacity: 0.5;
+    > button {
+      border-style: dashed;
+    }
+  }
+
   > button {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
Fairly straightforward change, hooking into the existing drag and drop implementation but enabling this behaviour for positioned notes, and handling this case in the Hanger. Attached notes do not need this support, as they are moved by default along with the node they are attached to.