### PR TITLE
feat(editor): Additional warning step on rename flow action

### DIFF
--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
@@ -1,0 +1,102 @@
+import { screen, waitFor } from "@testing-library/react";
+import { graphql, HttpResponse } from "msw";
+import server from "test/mockServer";
+import { setup } from "test/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RenameDialog } from "./RenameDialog";
+
+const flow = {
+  id: "flow-123",
+  name: "Apply for a lawful development certificate",
+  slug: "apply-for-a-lawful-development-certificate",
+};
+
+const renameFlowSpy = vi.fn();
+
+const handlers = [
+  graphql.query("GetFlows", () => HttpResponse.json({ data: { flows: [] } })),
+  graphql.mutation("RenameFlow", ({ variables }) => {
+    renameFlowSpy(variables);
+    return HttpResponse.json({
+      data: {
+        flow: { id: flow.id, name: variables.newName, slug: variables.newSlug },
+      },
+    });
+  }),
+];
+
+const renderDialog = (handleClose = vi.fn()) =>
+  setup(
+    <RenameDialog
+      mode="rename"
+      isDialogOpen
+      handleClose={handleClose}
+      flow={flow}
+      teamId={1}
+    />,
+  );
+
+describe("RenameDialog confirmation step", () => {
+  beforeEach(() => {
+    renameFlowSpy.mockClear();
+    server.use(...handlers);
+  });
+
+  it("shows a warning step instead of renaming immediately when the slug changes", async () => {
+    const { user } = await renderDialog();
+
+    const nameInput = screen.getByLabelText("Flow name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "A brand new name");
+    await user.click(screen.getByRole("button", { name: "Rename flow" }));
+
+    // Warning is shown, mutation has not fired yet
+    expect(
+      await screen.findByText("Renaming will break existing links"),
+    ).toBeVisible();
+    expect(screen.getByText(/a-brand-new-name/)).toBeVisible();
+    expect(renameFlowSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns to the edit form when 'Back' is clicked on the warning step", async () => {
+    const { user } = await renderDialog();
+
+    const nameInput = screen.getByLabelText("Flow name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "A brand new name");
+    await user.click(screen.getByRole("button", { name: "Rename flow" }));
+
+    await screen.findByText("Renaming will break existing links");
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByLabelText("Flow name")).toHaveValue("A brand new name");
+    expect(
+      screen.queryByText("Renaming will break existing links"),
+    ).not.toBeInTheDocument();
+    expect(renameFlowSpy).not.toHaveBeenCalled();
+  });
+
+  it("renames only after the warning is confirmed", async () => {
+    const handleClose = vi.fn();
+    const { user } = await renderDialog(handleClose);
+
+    const nameInput = screen.getByLabelText("Flow name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "A brand new name");
+    await user.click(screen.getByRole("button", { name: "Rename flow" }));
+
+    await screen.findByText("Renaming will break existing links");
+    await user.click(screen.getByRole("button", { name: "Rename flow" }));
+
+    await waitFor(() => expect(renameFlowSpy).toHaveBeenCalledTimes(1));
+    expect(renameFlowSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: flow.id,
+        newName: "A brand new name",
+        newSlug: "a-brand-new-name",
+      }),
+    );
+    await waitFor(() => expect(handleClose).toHaveBeenCalled());
+  });
+});

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
@@ -55,7 +55,6 @@ describe("RenameDialog confirmation step", () => {
     expect(
       await screen.findByText("Renaming will break existing links"),
     ).toBeVisible();
-    expect(screen.getByText(/a-brand-new-name/)).toBeVisible();
     expect(renameFlowSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
@@ -46,6 +46,39 @@ const validationSchema = object().shape({
   flowSlug: string().trim().required("Slug is required"),
 });
 
+const RenameWarning: React.FC = () => (
+  <ErrorSummary format="warning" heading="Renaming will break existing links">
+    <Typography variant="body2" sx={{ mt: 2 }}>
+      If applicable:
+      <List>
+        <ListItem>
+          <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 1 }} />
+          Any nested flow references will update automatically
+        </ListItem>
+        <ListItem>
+          <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 1 }} />
+          Local Planning Services (LPS) listing will update automatically
+        </ListItem>
+        <ListItem>
+          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+          Any links to this service on your council website will need to be
+          updated by your IT team
+        </ListItem>
+        <ListItem>
+          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+          Any Next Steps components pointing to this service will need to be
+          updated and published
+        </ListItem>
+        <ListItem>
+          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+          Any users with active magic links or bookmarks will get an error if
+          this is a public-facing service and need to be manually redirected.
+        </ListItem>
+      </List>
+    </Typography>
+  </ErrorSummary>
+);
+
 export const RenameDialog: React.FC<Props> = ({
   mode,
   isDialogOpen,
@@ -159,53 +192,7 @@ export const RenameDialog: React.FC<Props> = ({
                   <DialogContent
                     sx={{ gap: 2, display: "flex", flexDirection: "column" }}
                   >
-                    <ErrorSummary
-                      format="warning"
-                      heading="Renaming will break existing links"
-                    >
-                      <Typography variant="body2" sx={{ mt: 2 }}>
-                        If applicable:
-                        <List>
-                          <ListItem>
-                            <CheckCircleIcon
-                              color="success"
-                              fontSize="small"
-                              sx={{ mr: 1 }}
-                            />
-                            Any nested flow references will update automatically
-                          </ListItem>
-                          <ListItem>
-                            <CheckCircleIcon
-                              color="success"
-                              fontSize="small"
-                              sx={{ mr: 1 }}
-                            />
-                            Local Planning Services (LPS) listing will update
-                            automatically
-                          </ListItem>
-                          <ListItem>
-                            <WarningAmber
-                              color="warning"
-                              fontSize="small"
-                              sx={{ mr: 1 }}
-                            />
-                            Any Next Steps components pointing to this service
-                            will need to be updated and published
-                          </ListItem>
-                          <ListItem>
-                            <WarningAmber
-                              color="warning"
-                              fontSize="small"
-                              sx={{ mr: 1 }}
-                            />
-                            Any users with active magic links or bookmarks will
-                            get an error If this is a public-facing service,
-                            please coordinate with your IT team to update links
-                            on your website before continuing.
-                          </ListItem>
-                        </List>
-                      </Typography>
-                    </ErrorSummary>
+                    <RenameWarning />
                   </DialogContent>
                   <DialogActions>
                     <Button

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
@@ -9,9 +9,10 @@ import Typography from "@mui/material/Typography";
 import type { FormikConfig } from "formik";
 import { Form, Formik } from "formik";
 import { useToast } from "hooks/useToast";
-import React from "react";
+import React, { useState } from "react";
 import { URLPrefix } from "ui/editor/URLPrefix";
 import InputLabel from "ui/public/InputLabel";
+import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 import Input from "ui/shared/Input/Input";
 import { slugify } from "utils";
 import { object, string } from "yup";
@@ -52,10 +53,24 @@ export const RenameDialog: React.FC<Props> = ({
   const [renameFlow] = useRenameFlow(teamId);
   const [renameAndUnarchiveFlow] = useRenameAndUnarchiveFlow(teamId);
 
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const onClose = () => {
+    setIsConfirming(false);
+    handleClose();
+  };
+
   const onSubmit: FormikConfig<RenameFlow>["onSubmit"] = async (
     { flowName, flowSlug },
     { setFieldError, setSubmitting },
   ) => {
+    const slugWillChange = mode === "rename" && flowSlug !== flow.slug;
+    if (slugWillChange && !isConfirming) {
+      setIsConfirming(true);
+      setSubmitting(false);
+      return;
+    }
+
     const variables = {
       flowId: flow.id,
       newName: flowName.trim(),
@@ -74,7 +89,7 @@ export const RenameDialog: React.FC<Props> = ({
         });
         toast.success(`Renamed and unarchived flow "${flowName}"`);
       }
-      handleClose();
+      onClose();
     } catch (error) {
       const isUniqueSlugError =
         error instanceof Error &&
@@ -82,6 +97,7 @@ export const RenameDialog: React.FC<Props> = ({
         error.message.includes("Uniqueness violation");
 
       if (isUniqueSlugError) {
+        setIsConfirming(false);
         setFieldError("flowName", "Flow name must be unique");
       } else {
         toast.error("Failed to rename flow. Please try again.");
@@ -118,7 +134,7 @@ export const RenameDialog: React.FC<Props> = ({
         <Dialog
           open={isDialogOpen}
           onClose={() => {
-            handleClose();
+            onClose();
             resetForm();
           }}
           aria-labelledby="alert-dialog-title"
@@ -134,58 +150,92 @@ export const RenameDialog: React.FC<Props> = ({
           </DialogTitle>
           <Box>
             <Form>
-              <DialogContent
-                sx={{ gap: 2, display: "flex", flexDirection: "column" }}
-              >
-                {mode === "renameAndUnarchive" && (
-                  <Typography>
-                    An active flow called "{flow.name}" already exists. To
-                    unarchive this one, please give it a unique name first.
-                  </Typography>
-                )}
-                <InputLabel label="Flow name" htmlFor="flowName">
-                  <Input
-                    {...getFieldProps("flowName")}
-                    id="flowName"
-                    type="text"
-                    onChange={(e) => {
-                      setFieldValue("flowName", e.target.value);
-                      setFieldValue("flowSlug", slugify(e.target.value));
-                    }}
-                    errorMessage={errors.flowName}
-                    value={values.flowName}
-                  />
-                </InputLabel>
-                <InputLabel label="Editor URL" htmlFor="flowSlug">
-                  <Input
-                    {...getFieldProps("flowSlug")}
-                    disabled
-                    id="flowSlug"
-                    type="text"
-                    startAdornment={<URLPrefix mode="flow" />}
-                  />
-                </InputLabel>
-              </DialogContent>
-              <DialogActions>
-                <Button
-                  disableRipple
-                  onClick={handleClose}
-                  disabled={isSubmitting}
-                >
-                  Back
-                </Button>
-                <Button
-                  type="submit"
-                  color="primary"
-                  variant="contained"
-                  disableRipple
-                  disabled={isSubmitting}
-                >
-                  {mode === "rename"
-                    ? "Rename flow"
-                    : "Rename and unarchive flow"}
-                </Button>
-              </DialogActions>
+              {isConfirming ? (
+                <>
+                  <DialogContent
+                    sx={{ gap: 2, display: "flex", flexDirection: "column" }}
+                  >
+                    <ErrorSummary
+                      format="warning"
+                      heading="Renaming will break existing links"
+                      message={`This will change the service's URL. Anyone using a link or bookmark to the old URL will get an error. Coordinate with your web team to update links before continuing.`}
+                    />
+                  </DialogContent>
+                  <DialogActions>
+                    <Button
+                      disableRipple
+                      onClick={() => setIsConfirming(false)}
+                      disabled={isSubmitting}
+                    >
+                      Back
+                    </Button>
+                    <Button
+                      type="submit"
+                      color="warning"
+                      variant="contained"
+                      disableRipple
+                      disabled={isSubmitting}
+                    >
+                      Rename flow
+                    </Button>
+                  </DialogActions>
+                </>
+              ) : (
+                <>
+                  <DialogContent
+                    sx={{ gap: 2, display: "flex", flexDirection: "column" }}
+                  >
+                    {mode === "renameAndUnarchive" && (
+                      <Typography>
+                        An active flow called "{flow.name}" already exists. To
+                        unarchive this one, please give it a unique name first.
+                      </Typography>
+                    )}
+                    <InputLabel label="Flow name" htmlFor="flowName">
+                      <Input
+                        {...getFieldProps("flowName")}
+                        id="flowName"
+                        type="text"
+                        onChange={(e) => {
+                          setFieldValue("flowName", e.target.value);
+                          setFieldValue("flowSlug", slugify(e.target.value));
+                        }}
+                        errorMessage={errors.flowName}
+                        value={values.flowName}
+                      />
+                    </InputLabel>
+                    <InputLabel label="Editor URL" htmlFor="flowSlug">
+                      <Input
+                        {...getFieldProps("flowSlug")}
+                        disabled
+                        id="flowSlug"
+                        type="text"
+                        startAdornment={<URLPrefix mode="flow" />}
+                      />
+                    </InputLabel>
+                  </DialogContent>
+                  <DialogActions>
+                    <Button
+                      disableRipple
+                      onClick={onClose}
+                      disabled={isSubmitting}
+                    >
+                      Back
+                    </Button>
+                    <Button
+                      type="submit"
+                      color="primary"
+                      variant="contained"
+                      disableRipple
+                      disabled={isSubmitting}
+                    >
+                      {mode === "rename"
+                        ? "Rename flow"
+                        : "Rename and unarchive flow"}
+                    </Button>
+                  </DialogActions>
+                </>
+              )}
             </Form>
           </Box>
         </Dialog>

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
@@ -1,16 +1,20 @@
 import { isApolloError } from "@apollo/client";
+import WarningAmber from "@mui/icons-material/WarningAmber";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import type { FormikConfig } from "formik";
 import { Form, Formik } from "formik";
 import { useToast } from "hooks/useToast";
 import React, { useState } from "react";
 import { URLPrefix } from "ui/editor/URLPrefix";
+import CheckCircleIcon from "ui/icons/CheckCircle";
 import InputLabel from "ui/public/InputLabel";
 import ErrorSummary from "ui/shared/ErrorSummary/ErrorSummary";
 import Input from "ui/shared/Input/Input";
@@ -158,8 +162,50 @@ export const RenameDialog: React.FC<Props> = ({
                     <ErrorSummary
                       format="warning"
                       heading="Renaming will break existing links"
-                      message={`This will change the service's URL. Anyone using a link or bookmark to the old URL will get an error. Coordinate with your web team to update links before continuing.`}
-                    />
+                    >
+                      <Typography variant="body2" sx={{ mt: 2 }}>
+                        If applicable:
+                        <List>
+                          <ListItem>
+                            <CheckCircleIcon
+                              color="success"
+                              fontSize="small"
+                              sx={{ mr: 1 }}
+                            />
+                            Any nested flow references will update automatically
+                          </ListItem>
+                          <ListItem>
+                            <CheckCircleIcon
+                              color="success"
+                              fontSize="small"
+                              sx={{ mr: 1 }}
+                            />
+                            Local Planning Services (LPS) listing will update
+                            automatically
+                          </ListItem>
+                          <ListItem>
+                            <WarningAmber
+                              color="warning"
+                              fontSize="small"
+                              sx={{ mr: 1 }}
+                            />
+                            Any Next Steps components pointing to this service
+                            will need to be updated and published
+                          </ListItem>
+                          <ListItem>
+                            <WarningAmber
+                              color="warning"
+                              fontSize="small"
+                              sx={{ mr: 1 }}
+                            />
+                            Any users with active magic links or bookmarks will
+                            get an error If this is a public-facing service,
+                            please coordinate with your IT team to update links
+                            on your website before continuing.
+                          </ListItem>
+                        </List>
+                      </Typography>
+                    </ErrorSummary>
                   </DialogContent>
                   <DialogActions>
                     <Button

--- a/apps/editor.planx.uk/src/ui/shared/ErrorSummary/ErrorSummary.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ErrorSummary/ErrorSummary.tsx
@@ -1,9 +1,9 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import type { PropsWithChildren } from "react";
 
-interface Props {
+interface Props extends PropsWithChildren {
   heading?: string;
   message?: string;
   format?: "error" | "warning" | "info";
@@ -29,7 +29,10 @@ function ErrorSummary(props: Props) {
       <Typography variant="h4" gutterBottom>
         {props.heading}
       </Typography>
-      <Typography variant="body2">{props.message}</Typography>
+      {props.message && (
+        <Typography variant="body2">{props.message}</Typography>
+      )}
+      {props.children && props.children}
     </Root>
   );
 }


### PR DESCRIPTION
## What does this PR do?
Adds an additional warning step when updating a flow slug. Suggestions on copy most welcome..!

Trello ticket - https://trello.com/c/iGugBHpq/3690-add-additional-warning-verification-step-on-flow-name-change

https://github.com/user-attachments/assets/29c6b705-9245-4b6e-beaf-0c0743425191
