### PR TITLE
feat(editor): Download service charge CSV

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -25,7 +25,7 @@
     "cookie-session": "^2.1.1",
     "copyfiles": "^2.4.1",
     "cors": "^2.8.6",
-    "csv-stringify": "^6.8.0",
+    "csv-stringify": "catalog:",
     "date-fns": "^4.4.0",
     "dompurify": "catalog:",
     "express": "^4.22.2",

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -44,6 +44,7 @@
     "camelcase-keys": "^10.0.2",
     "classnames": "^2.5.1",
     "core-js": "^3.48.0",
+    "csv-stringify": "catalog:",
     "date-fns": "^2.30.0",
     "dompurify": "catalog:",
     "formik": "^2.4.9",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+
+import type { ServiceCharge } from "../types";
+import { ServiceCharges } from "./ServiceCharges";
+
+const serviceCharges: ServiceCharge[] = [
+  {
+    flowName: "Apply for a lawful development certificate",
+    sessionId: "session-1",
+    paymentId: "payment-1",
+    amount: 100,
+    paidAt: "2025-04-15T12:00:00.000Z",
+    month: 4,
+    monthText: "April",
+    quarter: 1,
+    fiscalYear: 2025,
+  },
+  {
+    flowName: "Report a planning breach",
+    sessionId: "session-2",
+    paymentId: "payment-2",
+    amount: 120,
+    paidAt: "2025-08-15T12:00:00.000Z",
+    month: 8,
+    monthText: "August",
+    quarter: 2,
+    fiscalYear: 2025,
+  },
+  {
+    flowName: "Apply for prior approval",
+    sessionId: "session-3",
+    paymentId: "payment-3",
+    amount: 150,
+    paidAt: "2025-11-15T12:00:00.000Z",
+    month: 11,
+    monthText: "November",
+    quarter: 3,
+    fiscalYear: 2025,
+  },
+  {
+    flowName: "Apply for a lawful development certificate",
+    sessionId: "session-4",
+    paymentId: "payment-4",
+    amount: 90,
+    paidAt: "2026-01-15T12:00:00.000Z",
+    month: 1,
+    monthText: "January",
+    quarter: 4,
+    fiscalYear: 2025,
+  },
+  {
+    flowName: "Apply for prior approval",
+    sessionId: "session-5",
+    paymentId: "payment-5",
+    amount: 110,
+    paidAt: "2024-05-15T12:00:00.000Z",
+    month: 5,
+    monthText: "May",
+    quarter: 1,
+    fiscalYear: 2024,
+  },
+  {
+    flowName: "Report a planning breach",
+    sessionId: "session-6",
+    paymentId: "payment-6",
+    amount: 130,
+    paidAt: "2024-09-15T12:00:00.000Z",
+    month: 9,
+    monthText: "September",
+    quarter: 2,
+    fiscalYear: 2024,
+  },
+  {
+    flowName: "Apply for a lawful development certificate",
+    sessionId: "session-7",
+    paymentId: "payment-7",
+    amount: 140,
+    paidAt: "2025-02-15T12:00:00.000Z",
+    month: 2,
+    monthText: "February",
+    quarter: 4,
+    fiscalYear: 2024,
+  },
+  {
+    flowName: "Apply for prior approval",
+    sessionId: "session-8",
+    paymentId: "payment-8",
+    amount: 95,
+    paidAt: "2023-06-15T12:00:00.000Z",
+    month: 6,
+    monthText: "June",
+    quarter: 1,
+    fiscalYear: 2023,
+  },
+  {
+    flowName: "Report a planning breach",
+    sessionId: "session-9",
+    paymentId: "payment-9",
+    amount: 125,
+    paidAt: "2023-10-15T12:00:00.000Z",
+    month: 10,
+    monthText: "October",
+    quarter: 3,
+    fiscalYear: 2023,
+  },
+];
+
+const meta = {
+  title: "Editor Components/Subscription/ServiceCharges",
+  component: ServiceCharges,
+} satisfies Meta<typeof ServiceCharges>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SingleYear: Story = {
+  args: {
+    serviceCharges: serviceCharges.filter((sc) => sc.fiscalYear === 2025),
+  },
+};
+
+export const MultipleYears: Story = {
+  args: {
+    serviceCharges,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    serviceCharges: [],
+  },
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
@@ -22,6 +22,7 @@ import Caret from "ui/icons/Caret";
 
 import type { SubscriptionProps } from "../types";
 import {
+  downloadServiceChargesCsv,
   formatUKFiscalYear,
   getUKFiscalYear,
   getUKFiscalYearQuarter,
@@ -96,7 +97,15 @@ const ActiveServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
         />
       </Box>
       <Box sx={{ mt: 2, textAlign: "right" }}>
-        <Link component="button" onClick={() => console.log("todo")}>
+        <Link
+          component="button"
+          onClick={() =>
+            downloadServiceChargesCsv(
+              serviceChargesInActiveYear,
+              `planx-service-charges-${activeYear}.csv`,
+            )
+          }
+        >
           <Typography variant="body2">
             {"Download service charge payment records (.csv)"}
           </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/components/ServiceCharges.tsx
@@ -2,10 +2,10 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import CardContent from "@mui/material/CardContent";
-import Link from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import Table from "@mui/material/Table";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
@@ -97,8 +97,9 @@ const ActiveServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
         />
       </Box>
       <Box sx={{ mt: 2, textAlign: "right" }}>
-        <Link
-          component="button"
+        <Button
+          variant="contained"
+          color="primary"
           onClick={() =>
             downloadServiceChargesCsv(
               serviceChargesInActiveYear,
@@ -109,7 +110,7 @@ const ActiveServiceCharges = ({ serviceCharges }: SubscriptionProps) => {
           <Typography variant="body2">
             {"Download service charge payment records (.csv)"}
           </Typography>
-        </Link>
+        </Button>
       </Box>
     </>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.test.ts
@@ -1,0 +1,44 @@
+import type { ServiceCharge } from "./types";
+import { generateServiceChargesCsv } from "./utils";
+
+const buildServiceCharge = (
+  overrides: Partial<ServiceCharge> = {},
+): ServiceCharge => ({
+  flowName: "Apply for a lawful development certificate",
+  sessionId: "session-1",
+  paymentId: "payment-1",
+  amount: 100,
+  paidAt: "2025-05-01T12:00:00.000Z",
+  month: 5,
+  monthText: "May",
+  quarter: 1,
+  fiscalYear: 2025,
+  ...overrides,
+});
+
+describe("generateServiceChargesCsv", () => {
+  it("returns a header row only when there are no charges", () => {
+    expect(generateServiceChargesCsv([]).trimEnd()).toEqual(
+      "Flow name,Session ID,Payment ID,Amount (excl VAT),Paid at",
+    );
+  });
+
+  it("formats a charge into a row of the expected columns", () => {
+    const csv = generateServiceChargesCsv([buildServiceCharge()]);
+    const [, dataRow] = csv.split("\n");
+
+    expect(dataRow).toEqual(
+      "Apply for a lawful development certificate,session-1,payment-1,100,2025-05-01T12:00:00.000Z",
+    );
+  });
+
+  it("produces one row per charge", () => {
+    const csv = generateServiceChargesCsv([
+      buildServiceCharge({ sessionId: "a" }),
+      buildServiceCharge({ sessionId: "b" }),
+      buildServiceCharge({ sessionId: "c" }),
+    ]);
+
+    expect(csv.trimEnd().split("\n")).toHaveLength(4);
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.test.ts
@@ -41,4 +41,51 @@ describe("generateServiceChargesCsv", () => {
 
     expect(csv.trimEnd().split("\n")).toHaveLength(4);
   });
+
+  describe("escapes characters", () => {
+    const HEADER = "Flow name,Session ID,Payment ID,Amount (excl VAT),Paid at";
+    const REST = "session-1,payment-1,100,2025-05-01T12:00:00.000Z";
+
+    it.each([
+      {
+        scenario: "a comma",
+        flowName: "Householder, minor works",
+        expectedCell: '"Householder, minor works"',
+      },
+      {
+        scenario: "a double quote",
+        flowName: 'The "fast track" service',
+        expectedCell: '"The ""fast track"" service"',
+      },
+      {
+        scenario: "a line break",
+        flowName: "Line one\nLine two",
+        expectedCell: '"Line one\nLine two"',
+      },
+      {
+        scenario: "a carriage return",
+        flowName: "Line one\r\nLine two",
+        expectedCell: '"Line one\r\nLine two"',
+      },
+      {
+        scenario: "commas and quotes together",
+        flowName: 'Apply, review, and "sign"',
+        expectedCell: '"Apply, review, and ""sign"""',
+      },
+      {
+        scenario: "an empty string",
+        flowName: "",
+        expectedCell: "",
+      },
+      {
+        scenario: "non-ASCII characters",
+        flowName: "Café planning – 🏠",
+        expectedCell: "Café planning – 🏠",
+      },
+    ])("handles $scenario", ({ flowName, expectedCell }) => {
+      const csv = generateServiceChargesCsv([buildServiceCharge({ flowName })]);
+
+      expect(csv).toEqual(`${HEADER}\n${expectedCell},${REST}\n`);
+    });
+  });
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Subscription/utils.ts
@@ -1,4 +1,5 @@
 import { formattedPriceWithCurrencySymbol } from "@planx/components/Pay/model";
+import { stringify } from "csv-stringify/sync";
 import sumBy from "lodash/sumBy";
 
 import type { ServiceCharge } from "./types";
@@ -34,4 +35,32 @@ export const getUKFiscalYear = (fyQuarter: number, calendarYear: number) => {
 export const formatUKFiscalYear = (fiscalYear: number): string => {
   const abbreviatedYear = Number(fiscalYear.toString().slice(-2));
   return `FY ${fiscalYear}/${abbreviatedYear + 1}`;
+};
+
+export const generateServiceChargesCsv = (
+  serviceCharges: ServiceCharge[],
+): string =>
+  stringify(serviceCharges, {
+    header: true,
+    columns: [
+      { key: "flowName", header: "Flow name" },
+      { key: "sessionId", header: "Session ID" },
+      { key: "paymentId", header: "Payment ID" },
+      { key: "amount", header: "Amount (excl VAT)" },
+      { key: "paidAt", header: "Paid at" },
+    ],
+  });
+
+export const downloadServiceChargesCsv = (
+  serviceCharges: ServiceCharge[],
+  filename: string,
+): void => {
+  const csv = generateServiceChargesCsv(serviceCharges);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     axios:
       specifier: ^1.18.1
       version: 1.18.1
+    csv-stringify:
+      specifier: ^6.8.0
+      version: 6.8.0
     dompurify:
       specifier: ^3.4.11
       version: 3.4.11
@@ -186,7 +189,7 @@ importers:
         specifier: ^2.8.6
         version: 2.8.6
       csv-stringify:
-        specifier: ^6.8.0
+        specifier: 'catalog:'
         version: 6.8.0
       date-fns:
         specifier: ^4.4.0
@@ -531,6 +534,9 @@ importers:
       core-js:
         specifier: ^3.48.0
         version: 3.49.0
+      csv-stringify:
+        specifier: 'catalog:'
+        version: 6.8.0
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ catalog:
   '@types/node': ~24.10.15
   '@vitest/eslint-plugin': ^1.6.20
   axios: ^1.18.1
+  csv-stringify: ^6.8.0
   dompurify: ^3.4.11
   dotenv: ^17.4.2
   eslint: ^9.39.4


### PR DESCRIPTION
## What does this PR do?
 - Wires up `.csv` download from service charges page
 - Adds Storybook coverage

Storybook demo here - https://storybook.7086.planx.pizza/?path=/docs/editor-components-subscription-servicecharges--docs

Trello ticket - https://trello.com/c/FJjck1KD/3680-fix-download-service-charge-payment-records-csv-link-in-editor