### PR TITLE
feat(editor): Initial add pattern UI

### DIFF
--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -1,5 +1,9 @@
 // add/edit/remove feature flags in array below
-export const AVAILABLE_FEATURE_FLAGS = ["EXPLORE", "NOTES"] as const;
+export const AVAILABLE_FEATURE_FLAGS = [
+  "EXPLORE",
+  "NOTES",
+  "PATTERN_SELECT",
+] as const;
 
 export type FeatureFlag = (typeof AVAILABLE_FEATURE_FLAGS)[number];
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
@@ -1,22 +1,26 @@
 import Paper from "@mui/material/Paper";
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
 
-import AddComponentModal from ".";
-import { componentListFrameSx, ComponentsTab } from "./ComponentsTab";
+import { componentListFrameSx } from "./ComponentsTab";
+import { ModalTabs } from "./ModalTabs";
 
-const meta: Meta<typeof AddComponentModal> = {
+/**
+ * Stories render the modal's tabbed content rather than the full `AddComponentModal`,
+ * which additionally needs a popover anchor and a router context
+ */
+const meta: Meta<typeof ModalTabs> = {
   title: "Editor Components/Modal/AddComponentModal",
-  component: AddComponentModal,
+  component: ModalTabs,
 };
 
 export default meta;
 
-type Story = StoryObj<typeof AddComponentModal>;
+type Story = StoryObj<typeof ModalTabs>;
 
 export const Default: Story = {
   render: () => (
     <Paper sx={componentListFrameSx}>
-      <ComponentsTab onSelect={() => {}} />
+      <ModalTabs onComponentSelect={() => {}} onPatternSelect={() => {}} />
     </Paper>
   ),
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
@@ -1,8 +1,11 @@
 import Paper from "@mui/material/Paper";
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import React, { useState } from "react";
 
-import { componentListFrameSx } from "./ComponentsTab";
+import { COMPONENT_LIST_WIDTH, componentListFrameSx } from "./ComponentsTab";
+import type { ModalTab } from "./ModalTabs";
 import { ModalTabs } from "./ModalTabs";
+import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
 
 /**
  * Stories render the modal's tabbed content rather than the full `AddComponentModal`,
@@ -17,10 +20,39 @@ export default meta;
 
 type Story = StoryObj<typeof ModalTabs>;
 
-export const Default: Story = {
-  render: () => (
-    <Paper sx={componentListFrameSx}>
-      <ModalTabs onComponentSelect={() => {}} onPatternSelect={() => {}} />
+/**
+ * Stands in for the popover, which owns the tab state and sizes itself to the tab
+ *
+ */
+const ModalTabsWrapper: React.FC<{ initialTab: ModalTab }> = ({
+  initialTab,
+}) => {
+  const [activeTab, setActiveTab] = useState<ModalTab>(initialTab);
+
+  return (
+    <Paper
+      sx={{
+        ...componentListFrameSx,
+        width:
+          activeTab === "patterns"
+            ? COMPONENT_LIST_WIDTH + DETAIL_PANEL_WIDTH
+            : COMPONENT_LIST_WIDTH,
+      }}
+    >
+      <ModalTabs
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        onComponentSelect={() => {}}
+        onInsertPattern={() => {}}
+      />
     </Paper>
-  ),
+  );
+};
+
+export const Default: Story = {
+  render: () => <ModalTabsWrapper initialTab="components" />,
+};
+
+export const Patterns: Story = {
+  render: () => <ModalTabsWrapper initialTab="patterns" />,
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/ComponentRow.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/ComponentRow.tsx
@@ -3,7 +3,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { ICONS } from "@planx/components/shared/icons";
 import React, { useEffect, useState } from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { AiChip } from "ui/editor/AiChip";
 
 import type { ComponentItem } from "./componentData";
@@ -41,6 +41,8 @@ export const ComponentRow: React.FC<Props> = ({
       slotProps={{ tooltip: { sx: { maxWidth: 240 } } }}
     >
       <Box
+        component="button"
+        type="button"
         onClick={onClick}
         data-component-type={item.type}
         sx={{
@@ -49,11 +51,18 @@ export const ComponentRow: React.FC<Props> = ({
           gap: 1,
           px: 1.5,
           py: 0.875,
+          width: "100%",
+          border: 0,
+          backgroundColor: "transparent",
+          font: "inherit",
+          color: "inherit",
+          textAlign: "left",
           cursor: "pointer",
           "&:hover": {
             backgroundColor: "action.hover",
             "& .component-title": { fontWeight: FONT_WEIGHT_SEMI_BOLD },
           },
+          "&:focus-visible": focusStyle,
         }}
       >
         {Icon && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
+import { TabHeader } from "../TabHeader";
 import type { Category, ComponentItem } from "./componentData";
 import { ALL_CATEGORIES, ALL_ITEMS } from "./componentData";
 import { ComponentRow } from "./ComponentRow";
@@ -53,15 +54,7 @@ export const ComponentsTab: React.FC<Props> = ({ onSelect }) => {
 
   return (
     <>
-      <Box
-        sx={{
-          px: 1.5,
-          py: 1.25,
-          borderBottom: 1,
-          borderColor: "divider",
-          backgroundColor: "background.paper",
-        }}
-      >
+      <TabHeader>
         <SearchBox<ComponentItem>
           records={ALL_ITEMS}
           setRecords={setSearchedItems}
@@ -71,7 +64,7 @@ export const ComponentsTab: React.FC<Props> = ({ onSelect }) => {
           fullWidth
           placeholder="Search components"
         />
-      </Box>
+      </TabHeader>
       <Box ref={listRef} sx={{ overflowY: "auto", pb: 2 }}>
         {filteredCategories.length === 0 ? (
           <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
@@ -9,6 +9,9 @@ import { PatternsTab } from "./PatternsTab";
 
 export type ModalTab = "components" | "patterns";
 
+const tabId = (tab: ModalTab) => `add-component-modal-tab-${tab}`;
+const panelId = (tab: ModalTab) => `add-component-modal-panel-${tab}`;
+
 const TabList = styled(Box)(({ theme }) => ({
   position: "relative",
   borderBottom: `1px solid ${theme.palette.divider}`,
@@ -52,15 +55,43 @@ export const ModalTabs: React.FC<Props> = ({
             aria-label="Modal tabs"
             variant="fullWidth"
           >
-            <StyledTab value="components" label="Components" />
-            <StyledTab value="patterns" label="Patterns" />
+            <StyledTab
+              value="components"
+              label="Components"
+              id={tabId("components")}
+              aria-controls={
+                activeTab === "components" ? panelId("components") : undefined
+              }
+            />
+            <StyledTab
+              value="patterns"
+              label="Patterns"
+              id={tabId("patterns")}
+              aria-controls={
+                activeTab === "patterns" ? panelId("patterns") : undefined
+              }
+            />
           </Tabs>
         </Box>
       </TabList>
-      {activeTab === "components" && (
-        <ComponentsTab onSelect={onComponentSelect} />
-      )}
-      {activeTab === "patterns" && <PatternsTab onInsert={onInsertPattern} />}
+      <Box
+        role="tabpanel"
+        id={panelId(activeTab)}
+        aria-labelledby={tabId(activeTab)}
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          minHeight: 0,
+          overflow: "hidden",
+        }}
+      >
+        {activeTab === "components" ? (
+          <ComponentsTab onSelect={onComponentSelect} />
+        ) : (
+          <PatternsTab onInsert={onInsertPattern} />
+        )}
+      </Box>
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
@@ -1,0 +1,64 @@
+import Box from "@mui/material/Box";
+import { styled } from "@mui/material/styles";
+import Tabs, { tabsClasses } from "@mui/material/Tabs";
+import React, { useState } from "react";
+import StyledTab from "ui/editor/StyledTab";
+
+import { COMPONENT_LIST_WIDTH, ComponentsTab } from "./ComponentsTab";
+import { PatternsTab } from "./PatternsTab";
+
+export type ModalTab = "components" | "patterns";
+
+const TabList = styled(Box)(({ theme }) => ({
+  position: "relative",
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  backgroundColor: theme.palette.background.paper,
+  width: "100%",
+  [`& .${tabsClasses.root}`]: {
+    minHeight: 0,
+    padding: theme.spacing(0, 1),
+  },
+  [`& .${tabsClasses.indicator}`]: {
+    display: "none",
+  },
+}));
+
+interface Props {
+  onComponentSelect: (slug: string) => void;
+  onPatternSelect: (patternId: string) => void;
+}
+
+/**
+ * Tabbed content of the AddComponentModal
+ *
+ * Kept free of the Popover and router wiring which live in the parent, so that this
+ * can be rendered standalone (e.g. in Storybook)
+ */
+export const ModalTabs: React.FC<Props> = ({
+  onComponentSelect,
+  onPatternSelect,
+}) => {
+  const [activeTab, setActiveTab] = useState<ModalTab>("components");
+
+  return (
+    <>
+      <TabList>
+        <Box sx={{ maxWidth: COMPONENT_LIST_WIDTH }}>
+          <Tabs
+            value={activeTab}
+            onChange={(_event, value: ModalTab) => setActiveTab(value)}
+            aria-label="Modal tabs"
+            variant="fullWidth"
+          >
+            <StyledTab value="components" label="Components" />
+            <StyledTab value="patterns" label="Patterns" />
+          </Tabs>
+        </Box>
+      </TabList>
+      {activeTab === "components" && (
+        <ComponentsTab onSelect={onComponentSelect} />
+      )}
+      {activeTab === "patterns" && <PatternsTab onSelect={onPatternSelect} />}
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ModalTabs.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
-import React, { useState } from "react";
+import React from "react";
 import StyledTab from "ui/editor/StyledTab";
 
 import { COMPONENT_LIST_WIDTH, ComponentsTab } from "./ComponentsTab";
@@ -24,8 +24,10 @@ const TabList = styled(Box)(({ theme }) => ({
 }));
 
 interface Props {
+  activeTab: ModalTab;
+  onTabChange: (tab: ModalTab) => void;
   onComponentSelect: (slug: string) => void;
-  onPatternSelect: (patternId: string) => void;
+  onInsertPattern: (patternId: string) => void;
 }
 
 /**
@@ -35,18 +37,18 @@ interface Props {
  * can be rendered standalone (e.g. in Storybook)
  */
 export const ModalTabs: React.FC<Props> = ({
+  activeTab,
+  onTabChange,
   onComponentSelect,
-  onPatternSelect,
+  onInsertPattern,
 }) => {
-  const [activeTab, setActiveTab] = useState<ModalTab>("components");
-
   return (
     <>
       <TabList>
         <Box sx={{ maxWidth: COMPONENT_LIST_WIDTH }}>
           <Tabs
             value={activeTab}
-            onChange={(_event, value: ModalTab) => setActiveTab(value)}
+            onChange={(_event, value: ModalTab) => onTabChange(value)}
             aria-label="Modal tabs"
             variant="fullWidth"
           >
@@ -58,7 +60,7 @@ export const ModalTabs: React.FC<Props> = ({
       {activeTab === "components" && (
         <ComponentsTab onSelect={onComponentSelect} />
       )}
-      {activeTab === "patterns" && <PatternsTab onSelect={onPatternSelect} />}
+      {activeTab === "patterns" && <PatternsTab onInsert={onInsertPattern} />}
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
@@ -1,0 +1,71 @@
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+import type { Pattern } from ".";
+
+export const DETAIL_PANEL_WIDTH = 300;
+
+interface Props {
+  pattern: Pattern | null;
+  onInsert: (patternId: string) => void;
+  onClear: () => void;
+}
+
+export const PatternDetailPanel: React.FC<Props> = ({
+  pattern,
+  onInsert,
+  onClear,
+}) => (
+  <Box
+    sx={{
+      width: DETAIL_PANEL_WIDTH,
+      flexShrink: 0,
+      overflowY: "auto",
+      p: 2,
+      display: "flex",
+      flexDirection: "column",
+      gap: 1.5,
+    }}
+  >
+    {pattern ? (
+      <>
+        <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, flexGrow: 1 }}
+          >
+            {pattern.name}
+          </Typography>
+          <IconButton
+            onClick={onClear}
+            aria-label={`Close ${pattern.name} details`}
+            size="small"
+            sx={{ mt: -0.5, mr: -0.5 }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        {pattern.summary && (
+          <Typography variant="body2">{pattern.summary}</Typography>
+        )}
+        <Button
+          variant="contained"
+          size="small"
+          // disabled={!pattern.data}
+          onClick={() => onInsert(pattern.id)}
+        >
+          Insert pattern
+        </Button>
+      </>
+    ) : (
+      <Typography color="textSecondary" variant="body2">
+        Select a pattern to see details.
+      </Typography>
+    )}
+  </Box>
+);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import type { Pattern } from ".";
 
@@ -14,8 +14,11 @@ interface Props {
 export const PatternRow: React.FC<Props> = ({ pattern, selected, onClick }) => {
   return (
     <Box
+      component="button"
+      type="button"
       onClick={onClick}
       data-testid={`pattern-${pattern.id}`}
+      aria-current={selected}
       sx={{
         display: "flex",
         alignItems: "center",
@@ -23,13 +26,19 @@ export const PatternRow: React.FC<Props> = ({ pattern, selected, onClick }) => {
         pl: 1.5,
         pr: 1.5,
         py: 1,
+        width: "100%",
+        font: "inherit",
+        color: "inherit",
+        textAlign: "left",
         cursor: "pointer",
+        border: 0,
         borderLeft: "3px solid",
         borderLeftColor: selected ? "info.main" : "transparent",
         backgroundColor: selected ? "action.selected" : "transparent",
         "&:hover": {
           backgroundColor: selected ? "action.selected" : "action.hover",
         },
+        "&:focus-visible": focusStyle,
       }}
     >
       <Box sx={{ minWidth: 0 }}>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
@@ -1,0 +1,46 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+import type { Pattern } from ".";
+
+interface Props {
+  pattern: Pattern;
+  selected: boolean;
+  onClick: () => void;
+}
+
+export const PatternRow: React.FC<Props> = ({ pattern, selected, onClick }) => {
+  return (
+    <Box
+      onClick={onClick}
+      data-testid={`pattern-${pattern.id}`}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        pl: 1.5,
+        pr: 1.5,
+        py: 1,
+        cursor: "pointer",
+        borderLeft: "3px solid",
+        borderLeftColor: selected ? "info.main" : "transparent",
+        backgroundColor: selected ? "action.selected" : "transparent",
+        "&:hover": {
+          backgroundColor: selected ? "action.selected" : "action.hover",
+        },
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+          noWrap
+        >
+          {pattern.name}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
@@ -1,7 +1,95 @@
-import type React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import React, { useState } from "react";
+import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
-interface Props {
-  onSelect: (patternId: string) => void;
+import { TabHeader } from "../TabHeader";
+import { PatternDetailPanel } from "./PatternDetailPanel";
+import { PatternRow } from "./PatternRow";
+
+export interface Pattern {
+  id: string;
+  slug: string;
+  name: string;
+  summary: string | null;
+  // data: Graph | null;
 }
 
-export const PatternsTab: React.FC<Props> = ({ onSelect }) => "patterns!";
+const summary =
+  "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium voluptatum excepturi at rem enim distinctio officia";
+
+// TODO: Replace mock data with a query
+const MOCK_PATTERNS: Pattern[] = [
+  { id: "1", slug: "pattern-1", name: "Pattern 1", summary },
+  { id: "2", slug: "pattern-2", name: "Pattern 2", summary },
+  { id: "3", slug: "pattern-3", name: "Pattern 3", summary },
+  { id: "4", slug: "pattern-4", name: "Pattern 4", summary },
+  { id: "5", slug: "pattern-5", name: "Pattern 5", summary },
+];
+
+interface Props {
+  onInsert: (patternId: string) => void;
+}
+
+export const PatternsTab: React.FC<Props> = ({ onInsert }) => {
+  const patterns = MOCK_PATTERNS;
+
+  const [searchedPatterns, setSearchedPatterns] = useState<Pattern[] | null>(
+    null,
+  );
+  const visiblePatterns = searchedPatterns ?? patterns;
+
+  const [selectedPatternId, setSelectedPatternId] = useState<string | null>(
+    null,
+  );
+  const selectedPattern =
+    visiblePatterns.find((pattern) => pattern.id === selectedPatternId) ?? null;
+
+  return (
+    <Box sx={{ display: "flex", flex: 1, minHeight: 0 }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          minWidth: 0,
+          borderRight: 1,
+          borderColor: "divider",
+        }}
+      >
+        <TabHeader>
+          <SearchBox<Pattern>
+            records={patterns}
+            setRecords={setSearchedPatterns}
+            searchKey={["name", "summary"]}
+            compact
+            hideLabel
+            fullWidth
+            placeholder="Search patterns"
+          />
+        </TabHeader>
+        <Box sx={{ overflowY: "auto", minHeight: 0, pb: 2 }}>
+          {visiblePatterns.length === 0 ? (
+            <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>
+              No patterns match your search.
+            </Typography>
+          ) : (
+            visiblePatterns.map((pattern) => (
+              <PatternRow
+                key={pattern.id}
+                pattern={pattern}
+                selected={pattern.id === selectedPatternId}
+                onClick={() => setSelectedPatternId(pattern.id)}
+              />
+            ))
+          )}
+        </Box>
+      </Box>
+      <PatternDetailPanel
+        pattern={selectedPattern}
+        onInsert={onInsert}
+        onClear={() => setSelectedPatternId(null)}
+      />
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
@@ -1,0 +1,7 @@
+import type React from "react";
+
+interface Props {
+  onSelect: (patternId: string) => void;
+}
+
+export const PatternsTab: React.FC<Props> = ({ onSelect }) => "patterns!";

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/TabHeader.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/TabHeader.tsx
@@ -1,0 +1,17 @@
+import Box from "@mui/material/Box";
+import type { PropsWithChildren } from "react";
+import React from "react";
+
+export const TabHeader: React.FC<PropsWithChildren> = ({ children }) => (
+  <Box
+    sx={{
+      px: 1.5,
+      py: 1.25,
+      borderBottom: 1,
+      borderColor: "divider",
+      backgroundColor: "background.paper",
+    }}
+  >
+    {children}
+  </Box>
+);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
@@ -1,12 +1,18 @@
 import Popover from "@mui/material/Popover";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
-import React from "react";
+import React, { useState } from "react";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
-import { componentListFrameSx, ComponentsTab } from "./ComponentsTab";
+import {
+  COMPONENT_LIST_WIDTH,
+  componentListFrameSx,
+  ComponentsTab,
+} from "./ComponentsTab";
+import type { ModalTab } from "./ModalTabs";
 import { ModalTabs } from "./ModalTabs";
+import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
 
 interface Props {
   anchorEl: HTMLElement | null;
@@ -26,6 +32,12 @@ const AddComponentModal: React.FC<Props> = ({
   const navigate = useNavigate();
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
 
+  const [activeTab, setActiveTab] = useState<ModalTab>("components");
+  const popoverWidth =
+    showPatterns && activeTab === "patterns"
+      ? COMPONENT_LIST_WIDTH + DETAIL_PANEL_WIDTH
+      : COMPONENT_LIST_WIDTH;
+
   const handleComponentSelect = (slug: string) => {
     onClose();
     navigate({
@@ -40,7 +52,7 @@ const AddComponentModal: React.FC<Props> = ({
     });
   };
 
-  const handlePatternSelect = (patternId: string) =>
+  const handleInsertPattern = (patternId: string) =>
     console.log(`Inserting pattern ${patternId}!`);
 
   // Flip the popover above the hanger when there isn't room below it
@@ -64,7 +76,11 @@ const AddComponentModal: React.FC<Props> = ({
       disableScrollLock
       slotProps={{
         paper: {
-          sx: { ...componentListFrameSx, mt: showBelow ? "4px" : "-4px" },
+          sx: {
+            ...componentListFrameSx,
+            width: popoverWidth,
+            mt: showBelow ? "4px" : "-4px",
+          },
         },
         backdrop: {
           sx: { backgroundColor: "rgba(0, 0, 0, 0.3)" },
@@ -73,8 +89,10 @@ const AddComponentModal: React.FC<Props> = ({
     >
       {showPatterns ? (
         <ModalTabs
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
           onComponentSelect={handleComponentSelect}
-          onPatternSelect={handlePatternSelect}
+          onInsertPattern={handleInsertPattern}
         />
       ) : (
         <ComponentsTab onSelect={handleComponentSelect} />

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
@@ -1,10 +1,12 @@
 import Popover from "@mui/material/Popover";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import React, { useCallback } from "react";
+import { hasFeatureFlag } from "lib/featureFlags";
+import React from "react";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
 import { componentListFrameSx, ComponentsTab } from "./ComponentsTab";
+import { ModalTabs } from "./ModalTabs";
 
 interface Props {
   anchorEl: HTMLElement | null;
@@ -19,25 +21,27 @@ const AddComponentModal: React.FC<Props> = ({
   before,
   onClose,
 }) => {
+  const showPatterns = hasFeatureFlag("PATTERN_SELECT");
+
   const navigate = useNavigate();
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
 
-  const handleSelect = useCallback(
-    (slug: string) => {
-      onClose();
-      navigate({
-        to: getNodeRoute(parent, before),
-        params: {
-          team,
-          flow,
-          ...(parent && { parent }),
-          ...(before && { before }),
-        },
-        search: { type: slug as NodeSearchParams["type"] },
-      });
-    },
-    [navigate, team, flow, parent, before, onClose],
-  );
+  const handleComponentSelect = (slug: string) => {
+    onClose();
+    navigate({
+      to: getNodeRoute(parent, before),
+      params: {
+        team,
+        flow,
+        ...(parent && { parent }),
+        ...(before && { before }),
+      },
+      search: { type: slug as NodeSearchParams["type"] },
+    });
+  };
+
+  const handlePatternSelect = (patternId: string) =>
+    console.log(`Inserting pattern ${patternId}!`);
 
   // Flip the popover above the hanger when there isn't room below it
   const rect = anchorEl?.getBoundingClientRect();
@@ -67,7 +71,14 @@ const AddComponentModal: React.FC<Props> = ({
         },
       }}
     >
-      <ComponentsTab onSelect={handleSelect} />
+      {showPatterns ? (
+        <ModalTabs
+          onComponentSelect={handleComponentSelect}
+          onPatternSelect={handlePatternSelect}
+        />
+      ) : (
+        <ComponentsTab onSelect={handleComponentSelect} />
+      )}
     </Popover>
   );
 };


### PR DESCRIPTION
## What does this PR do?
This PR adds the Patterns tab to the `AddComponentModal`, behind the `PATTERN_SELECT` feature flag. The flag is intended to be very short lived, just covering this feature, but it means we can easily merge discrete PRs onto `main` / `production`.

This PR is strictly UI only. Patterns are static mock data, and clicking "Insert" does nothing yet.

UI is largely pulled from https://github.com/theopensystemslab/planx-new/pull/7000 (thanks @ianjon3s !), but with a few notable exclusions - 
 - No "preview" in sidepanel (see comment on `PatternDetailPanel.tsx`)
 - No component count (see comment on `pattern.data`)

https://github.com/user-attachments/assets/62be0e7f-228c-4f8a-a336-054996cfddc1

## Testing
 - Please try this out on Storybook, link here - https://storybook.7092.planx.pizza/?path=/docs/editor-components-modal-addcomponentmodal--docs

## Next steps...
 - [ ] Create queries to populate real flows https://github.com/theopensystemslab/planx-new/pull/7095
 - [ ] Tests
 - [ ] Insert patterns into flows
 - [ ] Fix search focus across tabs