### PR TITLE
fix: Option opening read-only in customisible template folder

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -186,6 +186,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
                   {children.map((child) => (
                     <Node
                       parent={props.id}
+                      containerFolderId={parent}
                       key={child.id}
                       {...child}
                       showTemplatedNodeStatus={props.showTemplatedNodeStatus}
@@ -200,6 +201,7 @@ const Checklist: React.FC<Props> = React.memo((props) => {
             {childNodes.map((child) => (
               <Node
                 parent={props.id}
+                containerFolderId={parent}
                 key={child.id}
                 {...child}
                 showTemplatedNodeStatus={props.showTemplatedNodeStatus}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -6,6 +6,7 @@ import classNames from "classnames";
 import React from "react";
 
 import { useStore } from "../../../lib/store";
+import { getParentId } from "../lib/utils";
 import { AttachedNotes } from "../notes/AttachedNotes";
 import { DataField } from "./DataField";
 import { FlagBand, NoFlagBand } from "./FlagBand";
@@ -16,6 +17,9 @@ import { Thumbnail } from "./Thumbnail";
 const Option: React.FC<any> = (props) => {
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
   const childNodes = useStore((state) => state.childNodesOf(props.id));
+
+  // The folder containing the Question/Checklist this Option belongs to -
+  const containerFolderId = getParentId(props.containerFolderId);
 
   let flags: Flag[] | undefined;
 
@@ -42,11 +46,16 @@ const Option: React.FC<any> = (props) => {
       onContextMenu={(e) => e.preventDefault()}
     >
       <Link
-        to="/app/$team/$flow/nodes/$id/edit"
+        to={
+          containerFolderId
+            ? "/app/$team/$flow/nodes/$parent/nodes/$id/edit"
+            : "/app/$team/$flow/nodes/$id/edit"
+        }
         params={{
           team,
           flow,
           id: props.parent,
+          ...(containerFolderId && { parent: containerFolderId }),
         }}
         hash={props.id}
         preload={false}


### PR DESCRIPTION
## Issue

Trello card: https://trello.com/c/GsoCxT2d/3665-when-copying-pasting-content-in-customisable-folders-ensure-editable-styles-persist-on-paste

Reported here in Slack (originally flagged as caused by copying, but this seems to be resolved, however option clicks still cause bug): https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1775728748087909

- When editing a customisable folder within a template, clicking any option opens the component as read-only

Click any option to see:
https://editor.planx.dev/app/testing/article-4-template-bug%2CHUF6h0hpiR

## Solution

- Pass a folder ID into the option, so when clicking an option `FormModal` doesn't incorrectly compute the whole form as read-only

Click any option to see:
https://7094.planx.pizza/app/testing/article-4-template-bug%2CHUF6h0hpiR