### PR TITLE
feat(editor): Query pattern list and data

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
@@ -1,10 +1,12 @@
 import Paper from "@mui/material/Paper";
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import { graphql, HttpResponse } from "msw";
 import React, { useState } from "react";
 
 import { COMPONENT_LIST_WIDTH, componentListFrameSx } from "./ComponentsTab";
 import type { ModalTab } from "./ModalTabs";
 import { ModalTabs } from "./ModalTabs";
+import { mockPatternData, mockPatterns } from "./PatternsTab/mocks";
 import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
 
 /**
@@ -14,6 +16,22 @@ import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
 const meta: Meta<typeof ModalTabs> = {
   title: "Editor Components/Modal/AddComponentModal",
   component: ModalTabs,
+  parameters: {
+    msw: {
+      handlers: [
+        graphql.query("GetPatterns", () =>
+          HttpResponse.json({ data: { patterns: mockPatterns } }),
+        ),
+        graphql.query("GetPatternData", ({ variables }) =>
+          HttpResponse.json({
+            data: {
+              pattern: { id: variables.id, data: mockPatternData },
+            },
+          }),
+        ),
+      ],
+    },
+  },
 };
 
 export default meta;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
@@ -6,7 +6,8 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-import type { Pattern } from ".";
+import type { Pattern } from "./queries";
+import { usePatternData } from "./usePatterns";
 
 export const DETAIL_PANEL_WIDTH = 300;
 
@@ -20,52 +21,71 @@ export const PatternDetailPanel: React.FC<Props> = ({
   pattern,
   onInsert,
   onClear,
-}) => (
-  <Box
-    sx={{
-      width: DETAIL_PANEL_WIDTH,
-      flexShrink: 0,
-      overflowY: "auto",
-      p: 2,
-      display: "flex",
-      flexDirection: "column",
-      gap: 1.5,
-    }}
-  >
-    {pattern ? (
-      <>
-        <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
-          <Typography
-            variant="body1"
-            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, flexGrow: 1 }}
-          >
-            {pattern.name}
-          </Typography>
-          <IconButton
-            onClick={onClear}
-            aria-label={`Close ${pattern.name} details`}
-            size="small"
-            sx={{ mt: -0.5, mr: -0.5 }}
-          >
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </Box>
-        {pattern.summary && (
-          <Typography variant="body2">{pattern.summary}</Typography>
-        )}
-        <Button
-          variant="contained"
-          size="small"
-          // disabled={!pattern.data}
-          onClick={() => onInsert(pattern.id)}
+}) => {
+  const { data, loading, error } = usePatternData(pattern?.id ?? null);
+  const graph = data?.pattern?.data;
+
+  const componentCount = Math.max(Object.keys(graph || {}).length - 1, 0);
+
+  if (!pattern) {
+    return (
+      <Box sx={{ width: DETAIL_PANEL_WIDTH, flexShrink: 0, p: 2 }}>
+        <Typography color="textSecondary" variant="body2">
+          Select a pattern to see details.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        width: DETAIL_PANEL_WIDTH,
+        flexShrink: 0,
+        overflowY: "auto",
+        p: 2,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
+        <Typography
+          variant="body1"
+          sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, flexGrow: 1 }}
         >
-          Insert pattern
-        </Button>
-      </>
-    ) : (
-      <Typography color="textSecondary" variant="body2">
-        Select a pattern to see details.
-      </Typography>
-    )}
-  </Box>
-);
+          {pattern.name}
+        </Typography>
+        <IconButton
+          onClick={onClear}
+          aria-label={`Close ${pattern.name} details`}
+          size="small"
+          sx={{ mt: -0.5, mr: -0.5 }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+      {pattern.summary && (
+        <Typography variant="body2">{pattern.summary}</Typography>
+      )}
+      {componentCount && (
+        <Typography variant="body3" sx={{ color: "text.secondary" }}>
+          {componentCount} components
+        </Typography>
+      )}
+      {error && (
+        <Typography color="error" variant="body2">
+          Couldn't load this pattern.
+        </Typography>
+      )}
+      <Button
+        variant="contained"
+        size="small"
+        disabled={loading || Boolean(error) || !graph}
+        onClick={() => onInsert(pattern.id)}
+      >
+        {loading ? "Loading…" : "Insert pattern"}
+      </Button>
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
@@ -34,7 +34,7 @@ export const PatternDetailPanel: React.FC<Props> = ({
       : null;
 
   // A pattern needs at least one component to be insertable
-  // We should aim to catch this when a pattern is "shared" (turned online)
+  // We should aim to catch this when a pattern is made copyable
   const isEmpty = componentCount !== null && componentCount < 1;
   const canInsert = Boolean(graph) && !isEmpty && !error;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
@@ -2,6 +2,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import Skeleton from "@mui/material/Skeleton";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -25,7 +26,17 @@ export const PatternDetailPanel: React.FC<Props> = ({
   const { data, loading, error } = usePatternData(pattern?.id ?? null);
   const graph = data?.pattern?.data;
 
-  const componentCount = Math.max(Object.keys(graph || {}).length - 1, 0);
+  // Both null while there's no graph data (loading, error, or not yet selected)
+  const componentCount = graph ? Object.keys(graph).length - 1 : null;
+  const componentCountLabel =
+    componentCount !== null && componentCount >= 1
+      ? `${componentCount} component${componentCount === 1 ? "" : "s"}`
+      : null;
+
+  // A pattern needs at least one component to be insertable
+  // We should aim to catch this when a pattern is "shared" (turned online)
+  const isEmpty = componentCount !== null && componentCount < 1;
+  const canInsert = Boolean(graph) && !isEmpty && !error;
 
   if (!pattern) {
     return (
@@ -68,23 +79,30 @@ export const PatternDetailPanel: React.FC<Props> = ({
       {pattern.summary && (
         <Typography variant="body2">{pattern.summary}</Typography>
       )}
-      {componentCount && (
-        <Typography variant="body3" sx={{ color: "text.secondary" }}>
-          {componentCount} components
-        </Typography>
-      )}
+      <Typography
+        variant="body3"
+        sx={{ color: "text.secondary", minHeight: "1.5em" }}
+      >
+        {loading ? <Skeleton width={80} /> : componentCountLabel}
+      </Typography>
       {error && (
         <Typography color="error" variant="body2">
           Couldn't load this pattern.
         </Typography>
       )}
+      {isEmpty && (
+        <Typography color="textSecondary" variant="body2">
+          This pattern has no components to insert.
+        </Typography>
+      )}
       <Button
         variant="contained"
         size="small"
-        disabled={loading || Boolean(error) || !graph}
+        fullWidth
+        disabled={loading || !canInsert}
         onClick={() => onInsert(pattern.id)}
       >
-        {loading ? "Loading…" : "Insert pattern"}
+        Insert pattern
       </Button>
     </Box>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternRow.tsx
@@ -3,7 +3,7 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
 
-import type { Pattern } from ".";
+import type { Pattern } from "./queries";
 
 interface Props {
   pattern: Pattern;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
@@ -1,38 +1,22 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import React, { useState } from "react";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
 import { TabHeader } from "../TabHeader";
 import { PatternDetailPanel } from "./PatternDetailPanel";
 import { PatternRow } from "./PatternRow";
-
-export interface Pattern {
-  id: string;
-  slug: string;
-  name: string;
-  summary: string | null;
-  // data: Graph | null;
-}
-
-const summary =
-  "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium voluptatum excepturi at rem enim distinctio officia";
-
-// TODO: Replace mock data with a query
-const MOCK_PATTERNS: Pattern[] = [
-  { id: "1", slug: "pattern-1", name: "Pattern 1", summary },
-  { id: "2", slug: "pattern-2", name: "Pattern 2", summary },
-  { id: "3", slug: "pattern-3", name: "Pattern 3", summary },
-  { id: "4", slug: "pattern-4", name: "Pattern 4", summary },
-  { id: "5", slug: "pattern-5", name: "Pattern 5", summary },
-];
+import type { Pattern } from "./queries";
+import { usePatterns } from "./usePatterns";
 
 interface Props {
   onInsert: (patternId: string) => void;
 }
 
 export const PatternsTab: React.FC<Props> = ({ onInsert }) => {
-  const patterns = MOCK_PATTERNS;
+  const { data, loading, error } = usePatterns();
+  const patterns = data?.patterns ?? [];
 
   const [searchedPatterns, setSearchedPatterns] = useState<Pattern[] | null>(
     null,
@@ -69,11 +53,23 @@ export const PatternsTab: React.FC<Props> = ({ onInsert }) => {
           />
         </TabHeader>
         <Box sx={{ overflowY: "auto", minHeight: 0, pb: 2 }}>
-          {visiblePatterns.length === 0 ? (
-            <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>
-              No patterns match your search.
+          {loading && (
+            <DelayedLoadingIndicator inline text="Loading patterns" />
+          )}
+          {!loading && error && (
+            <Typography color="error" variant="body2" sx={{ p: 2 }}>
+              Couldn't load patterns.
             </Typography>
-          ) : (
+          )}
+          {!loading && !error && visiblePatterns.length === 0 && (
+            <Typography color="textSecondary" variant="body2" sx={{ p: 2 }}>
+              {patterns.length === 0
+                ? "No patterns available yet."
+                : "No patterns match your search."}
+            </Typography>
+          )}
+          {!loading &&
+            !error &&
             visiblePatterns.map((pattern) => (
               <PatternRow
                 key={pattern.id}
@@ -81,8 +77,7 @@ export const PatternsTab: React.FC<Props> = ({ onInsert }) => {
                 selected={pattern.id === selectedPatternId}
                 onClick={() => setSelectedPatternId(pattern.id)}
               />
-            ))
-          )}
+            ))}
         </Box>
       </Box>
       <PatternDetailPanel

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/mocks.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/mocks.ts
@@ -1,0 +1,21 @@
+import type { Graph } from "@planx/graph";
+
+import type { Pattern } from "./queries";
+
+const summary =
+  "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium voluptatum excepturi at rem enim distinctio officia";
+
+export const mockPatterns: Pattern[] = [
+  { id: "1", slug: "pattern-1", name: "Pattern 1", summary },
+  { id: "2", slug: "pattern-2", name: "Pattern 2", summary },
+  { id: "3", slug: "pattern-3", name: "Pattern 3", summary },
+  { id: "4", slug: "pattern-4", name: "Pattern 4", summary },
+  { id: "5", slug: "pattern-5", name: "Pattern 5", summary },
+];
+
+export const mockPatternData = {
+  _root: { edges: ["question", "notice"] },
+  question: { type: 100, data: { text: "A question" }, edges: ["answer"] },
+  answer: { type: 200, data: { text: "An answer" } },
+  notice: { type: 8, data: { title: "A notice" } },
+} as unknown as Graph;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/queries.ts
@@ -7,7 +7,7 @@ export const GET_PATTERNS = gql`
       where: {
         is_pattern: { _eq: true }
         archived_at: { _is_null: true }
-        status: { _eq: online }
+        can_create_from_copy: { _eq: true }
       }
       order_by: { name: asc }
     ) {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/queries.ts
@@ -1,0 +1,51 @@
+import { gql } from "@apollo/client";
+import type { Graph } from "@planx/graph";
+
+export const GET_PATTERNS = gql`
+  query GetPatterns {
+    patterns: flows(
+      where: {
+        is_pattern: { _eq: true }
+        archived_at: { _is_null: true }
+        status: { _eq: online }
+      }
+      order_by: { name: asc }
+    ) {
+      id
+      name
+      slug
+      summary
+    }
+  }
+`;
+
+export interface Pattern {
+  id: string;
+  name: string;
+  slug: string;
+  summary: string | null;
+}
+
+export type GetPatternsQuery = {
+  patterns: Pattern[];
+};
+
+export const GET_PATTERN_DATA = gql`
+  query GetPatternData($id: uuid!) {
+    pattern: flows_by_pk(id: $id) {
+      id
+      data
+    }
+  }
+`;
+
+export type GetPatternDataQuery = {
+  pattern: {
+    id: string;
+    data: Graph;
+  } | null;
+};
+
+export type GetPatternDataVars = {
+  id: string;
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/usePatterns.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/usePatterns.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@apollo/client";
+
+import type {
+  GetPatternDataQuery,
+  GetPatternDataVars,
+  GetPatternsQuery,
+} from "./queries";
+import { GET_PATTERN_DATA, GET_PATTERNS } from "./queries";
+
+export const usePatterns = () => useQuery<GetPatternsQuery>(GET_PATTERNS);
+
+export const usePatternData = (id: string | null) =>
+  useQuery<GetPatternDataQuery, GetPatternDataVars>(GET_PATTERN_DATA, {
+    variables: { id: id! },
+    skip: !id,
+  });


### PR DESCRIPTION
## What does this PR do?
- Replaces static mock data, with live queries to get actual pattern data here
- Handles error and loading states
- Addresses [this question](https://github.com/theopensystemslab/planx-new/pull/7092#discussion_r3689129514) by deferring `flow.data` loading until we open the panel