### PR TITLE
fix(editor): Only display flow rename warning for services

### DIFF
--- a/apps/editor.planx.uk/src/pages/Flows/components/ActiveFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/ActiveFlowMenu.tsx
@@ -96,6 +96,7 @@ const ActiveFlowMenu: React.FC<FlowMenuProps> = ({
             name: flow.name,
             slug: flow.slug,
             id: flow.id,
+            isService: flow.isService,
           }}
           teamId={teamId}
         />

--- a/apps/editor.planx.uk/src/pages/Flows/components/ArchivedFlowMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/ArchivedFlowMenu.tsx
@@ -105,6 +105,7 @@ const ArchivedFlowMenu: React.FC<FlowMenuProps> = ({
             name: flow.name,
             slug: flow.slug,
             id: flow.id,
+            isService: flow.isService,
           }}
           teamId={teamId}
         />

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.test.tsx
@@ -10,6 +10,7 @@ const flow = {
   id: "flow-123",
   name: "Apply for a lawful development certificate",
   slug: "apply-for-a-lawful-development-certificate",
+  isService: true,
 };
 
 const renameFlowSpy = vi.fn();
@@ -86,6 +87,34 @@ describe("RenameDialog confirmation step", () => {
     await user.click(screen.getByRole("button", { name: "Rename flow" }));
 
     await screen.findByText("Renaming will break existing links");
+    await user.click(screen.getByRole("button", { name: "Rename flow" }));
+
+    await waitFor(() => expect(renameFlowSpy).toHaveBeenCalledTimes(1));
+    expect(renameFlowSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: flow.id,
+        newName: "A brand new name",
+        newSlug: "a-brand-new-name",
+      }),
+    );
+    await waitFor(() => expect(handleClose).toHaveBeenCalled());
+  });
+
+  it("does not display the warning if a flow is not a service", async () => {
+    const handleClose = vi.fn();
+    const { user } = await setup(
+      <RenameDialog
+        mode="rename"
+        isDialogOpen
+        handleClose={handleClose}
+        flow={{ ...flow, isService: false }}
+        teamId={1}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText("Flow name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "A brand new name");
     await user.click(screen.getByRole("button", { name: "Rename flow" }));
 
     await waitFor(() => expect(renameFlowSpy).toHaveBeenCalledTimes(1));

--- a/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/RenameDialog.tsx
@@ -37,6 +37,7 @@ interface Props {
     name: string;
     slug: string;
     id: string;
+    isService: boolean;
   };
   teamId: number;
 }
@@ -50,32 +51,28 @@ const RenameWarning: React.FC = () => (
   <ErrorSummary format="warning" heading="Renaming will break existing links">
     <Typography variant="body2" sx={{ mt: 2 }}>
       If applicable:
-      <List>
-        <ListItem>
-          <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 1 }} />
-          Any nested flow references will update automatically
-        </ListItem>
-        <ListItem>
-          <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 1 }} />
-          Local Planning Services (LPS) listing will update automatically
-        </ListItem>
-        <ListItem>
-          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
-          Any links to this service on your council website will need to be
-          updated by your IT team
-        </ListItem>
-        <ListItem>
-          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
-          Any Next Steps components pointing to this service will need to be
-          updated and published
-        </ListItem>
-        <ListItem>
-          <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
-          Any users with active magic links or bookmarks will get an error if
-          this is a public-facing service and need to be manually redirected.
-        </ListItem>
-      </List>
     </Typography>
+    <List>
+      <ListItem>
+        <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 1 }} />
+        Local Planning Services (LPS) listing will update automatically
+      </ListItem>
+      <ListItem>
+        <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+        Any links to this service on your council website will need to be
+        updated by your IT team
+      </ListItem>
+      <ListItem>
+        <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+        Any Next Steps components pointing to this service will need to be
+        updated and published
+      </ListItem>
+      <ListItem>
+        <WarningAmber color="warning" fontSize="small" sx={{ mr: 1 }} />
+        Any users with active magic links or bookmarks will get an error if this
+        is a public-facing service and need to be manually redirected.
+      </ListItem>
+    </List>
   </ErrorSummary>
 );
 
@@ -102,7 +99,7 @@ export const RenameDialog: React.FC<Props> = ({
     { setFieldError, setSubmitting },
   ) => {
     const slugWillChange = mode === "rename" && flowSlug !== flow.slug;
-    if (slugWillChange && !isConfirming) {
+    if (slugWillChange && !isConfirming && flow.isService) {
       setIsConfirming(true);
       setSubmitting(false);
       return;


### PR DESCRIPTION
Please see feedback here (OSL Slack) - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1785492555188379