### PR TITLE
fix: Clone appearance when cloning or releasing

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -26,7 +26,6 @@ const Node: React.FC<any> = (props) => {
 
   const allProps = {
     ...props,
-    ...node,
     wasVisited,
     tags: node.data?.tags,
     isTemplatedNode: node.data?.isTemplatedNode,
@@ -160,7 +159,13 @@ const Node: React.FC<any> = (props) => {
     case TYPES.ResponsiveQuestion:
     case TYPES.Checklist:
     case TYPES.ResponsiveChecklist:
-      return <Checklist {...allProps} text={node?.data?.text ?? "[Empty]"} />;
+      return (
+        <Checklist
+          {...allProps}
+          {...node}
+          text={node?.data?.text ?? "[Empty]"}
+        />
+      );
     case TYPES.AddressInput:
       return <Question {...allProps} text={node?.data?.title ?? "Address"} />;
     case TYPES.ContactInput:

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -26,6 +26,7 @@ const Node: React.FC<any> = (props) => {
 
   const allProps = {
     ...props,
+    ...node,
     wasVisited,
     tags: node.data?.tags,
     isTemplatedNode: node.data?.isTemplatedNode,
@@ -159,13 +160,7 @@ const Node: React.FC<any> = (props) => {
     case TYPES.ResponsiveQuestion:
     case TYPES.Checklist:
     case TYPES.ResponsiveChecklist:
-      return (
-        <Checklist
-          {...allProps}
-          {...node}
-          text={node?.data?.text ?? "[Empty]"}
-        />
-      );
+      return <Checklist {...allProps} text={node?.data?.text ?? "[Empty]"} />;
     case TYPES.AddressInput:
       return <Question {...allProps} text={node?.data?.title ?? "Address"} />;
     case TYPES.ContactInput:

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -29,12 +29,14 @@ type Props = {
 };
 
 const Question: React.FC<Props> = React.memo((props) => {
-  const [isClone, childNodes, showHelpText, showTags] = useStore((state) => [
-    state.isClone,
-    state.childNodesOf(props.id),
-    state.showHelpText,
-    state.showTags,
-  ]);
+  const [isCloneValue, childNodes, showHelpText, showTags] = useStore(
+    (state) => [
+      state.isClone(props.id),
+      state.childNodesOf(props.id),
+      state.showHelpText,
+      state.showTags,
+    ],
+  );
 
   const { team, flow } = useParams({ from: "/_authenticated/app/$team/$flow" });
 
@@ -80,7 +82,7 @@ const Question: React.FC<Props> = React.memo((props) => {
           "type-" + TYPES[props.type as TYPES],
           {
             isDragging,
-            isClone: isClone(props.id),
+            isClone: isCloneValue,
             wasVisited: props.wasVisited,
             hasFailed: props.hasFailed,
           },

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -225,10 +225,7 @@ const FormModal: React.FC<FormModalProps> = ({
 
   const showDeleteButton = id && !isDisabledTemplatedNode;
 
-  const showMakeUniqueButton = useMemo(
-    () => id && isClone(id) && !isDisabledTemplatedNode,
-    [isClone, id, isDisabledTemplatedNode],
-  );
+  const showMakeUniqueButton = id && isClone(id) && !isDisabledTemplatedNode;
 
   const disabled = isTemplatedFrom
     ? !canUserEditTemplatedNode


### PR DESCRIPTION
## Issue

Reported in Slack here:
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1783676184671859

- When cloning a node, the original/source of the clone did not immediately receive clone bordered styling (browser refresh corrected this)
- Similarly when releasing a clone (make unique or delete on one of a pair of clones, the other/remaining node didn't not immediately lose clone styling

**Testing:**
https://editor.planx.dev/app/testing/clones

## Solution

Several things happening here:
- `isClone(props.id)` is being cached in `Question.tsx`, preventing the border from updating from first render
- Moving `isClone(props.id)` inside the Zustand selector solves the above
- Also refresh node data uniformly in `Node.tsx` and un-memoizing the `Make unique` button in `FormModal.tsx`, both of which had smaller instances of the same staleness problem

**Testing:**
https://7097.planx.pizza/app/testing/clones