### PR TITLE
feat: Shared `insertGraph()` function

### DIFF
--- a/apps/editor.planx.uk/src/@planx/graph/__tests__/insert_graph.test.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/__tests__/insert_graph.test.ts
@@ -1,0 +1,207 @@
+import type { Graph } from "..";
+import { insertGraph } from "..";
+
+let count = 0;
+const deterministicId = () => `ID_${count++}`;
+
+beforeEach(() => {
+  count = 0;
+});
+
+/** All graph nodes, minus _root */
+const nodeIds = (graph: Graph) =>
+  Object.keys(graph).filter((id) => id !== "_root");
+
+const emptyFlow = (): Graph => ({ _root: { edges: [] } });
+
+const pattern: Graph = {
+  _root: { edges: ["question", "notice"] },
+  question: { type: 100, data: { text: "Question?" }, edges: ["yes", "no"] },
+  yes: { type: 200, data: { text: "Yes" } },
+  no: { type: 200, data: { text: "No" } },
+  notice: { type: 8, data: { title: "Notice" } },
+};
+
+describe("inserting a graph", () => {
+  describe("basic behaviour", () => {
+    test("adds every node from the source, with fresh ids", () => {
+      const [graph] = insertGraph(pattern, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+
+      expect(graph).toEqual({
+        _root: { edges: ["ID_0", "ID_3"] },
+        ID_0: {
+          type: 100,
+          data: { text: "Question?" },
+          edges: ["ID_1", "ID_2"],
+        },
+        ID_1: { type: 200, data: { text: "Yes" } },
+        ID_2: { type: 200, data: { text: "No" } },
+        ID_3: { type: 8, data: { title: "Notice" } },
+      });
+    });
+
+    test("does not carry over the source's root node", () => {
+      const [graph] = insertGraph(pattern, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+
+      // The only root is the destination's own, holding the new top level nodes
+      expect(Object.keys(graph)).not.toContain("question");
+      expect(graph["_root"]).toEqual({ edges: ["ID_0", "ID_3"] });
+    });
+
+    test("keeps the order of top level nodes", () => {
+      const [graph] = insertGraph(pattern, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+      const [firstId, secondId] = graph["_root"].edges!;
+
+      expect(graph[firstId].data).toEqual({ text: "Question?" });
+      expect(graph[secondId].data).toEqual({ title: "Notice" });
+    });
+
+    test("inserts into a given parent, leaving the rest of the graph alone", () => {
+      const existing: Graph = {
+        _root: { edges: ["folder"] },
+        folder: { type: 300, edges: ["existingChild"] },
+        existingChild: { type: 8 },
+      };
+
+      const [graph] = insertGraph(pattern, {
+        parent: "folder",
+        idFn: deterministicId,
+      })(existing);
+
+      expect(graph["folder"].edges).toEqual(["existingChild", "ID_0", "ID_3"]);
+      expect(graph["_root"]).toEqual({ edges: ["folder"] });
+      expect(graph["existingChild"]).toEqual({ type: 8 });
+    });
+
+    test("inserts before a given sibling, in source order", () => {
+      const existing: Graph = {
+        _root: { edges: ["first", "last"] },
+        first: { type: 8 },
+        last: { type: 8 },
+      };
+
+      const [graph] = insertGraph(pattern, {
+        before: "last",
+        idFn: deterministicId,
+      })(existing);
+
+      expect(graph["_root"].edges).toEqual(["first", "ID_0", "ID_3", "last"]);
+    });
+
+    test("can insert the same source twice, without id collisions", () => {
+      const [once] = insertGraph(pattern, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+      const firstCopy = nodeIds(once);
+
+      const [twice] = insertGraph(pattern, { idFn: deterministicId })(once);
+      const secondCopy = nodeIds(twice).filter((id) => !firstCopy.includes(id));
+
+      // Both copies are present in full, sharing no nodes between them
+      expect(firstCopy).toHaveLength(4);
+      expect(secondCopy).toHaveLength(4);
+      expect(nodeIds(twice)).toHaveLength(8);
+
+      // Inserting again leaves the first copy untouched - edits can't bleed across
+      // No unexpected "clone" behaviour introduced
+      firstCopy.forEach((id) => expect(twice[id]).toEqual(once[id]));
+    });
+  });
+
+  // This means that the entire "insert" can be reversed by a single "undo" in the History panel
+  test("batches the entire insert in a single batch of ops", () => {
+    const [, ops] = insertGraph(pattern, { idFn: deterministicId })(
+      emptyFlow(),
+    );
+
+    const createdNodeIds = ops
+      .filter((op) => "oi" in op && op.p.length === 1)
+      .map((op) => op.p[0]);
+
+    expect(createdNodeIds.sort()).toEqual(
+      ["ID_0", "ID_1", "ID_2", "ID_3"].sort(),
+    );
+  });
+
+  describe("clones", () => {
+    const withClone: Graph = {
+      _root: { edges: ["question"] },
+      question: { type: 100, edges: ["optionA", "optionB"] },
+      optionA: { type: 200, edges: ["clone"] },
+      optionB: { type: 200, edges: ["clone"] },
+      clone: { type: 8, data: { title: "clone!" } },
+    };
+
+    /** Follows both of a question's options, asserting they still meet at one node */
+    const cloneBeneath = (graph: Graph, questionId: string) => {
+      const [optionAId, optionBId] = graph[questionId].edges!;
+      const viaOptionA = graph[optionAId].edges![0];
+      const viaOptionB = graph[optionBId].edges![0];
+
+      expect(viaOptionA).toBe(viaOptionB);
+
+      return viaOptionA;
+    };
+
+    test("are kept as clones within a single insert", () => {
+      const [graph] = insertGraph(withClone, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+
+      const [questionId] = graph["_root"].edges!;
+      const cloneId = cloneBeneath(graph, questionId);
+
+      expect(graph[cloneId].data).toEqual({ title: "clone!" });
+
+      // Clones are not de-duplicated - relationship remains intact
+      expect(nodeIds(graph)).toHaveLength(4);
+    });
+
+    test("are not shared between two inserts of the same pattern", () => {
+      const [once] = insertGraph(withClone, { idFn: deterministicId })(
+        emptyFlow(),
+      );
+      const [twice] = insertGraph(withClone, { idFn: deterministicId })(once);
+
+      const [firstQuestionId, secondQuestionId] = twice["_root"].edges!;
+
+      // Each insert maintains its own clone...
+      const firstCloneId = cloneBeneath(twice, firstQuestionId);
+      const secondCloneId = cloneBeneath(twice, secondQuestionId);
+
+      // ...but the clones never meet
+      // Clones are not shared across repetitions of the same pattern
+      expect(firstCloneId).not.toBe(secondCloneId);
+      expect(nodeIds(twice)).toHaveLength(8);
+    });
+  });
+
+  describe("when there is nothing to insert", () => {
+    test("an empty source results in no-op", () => {
+      const existing: Graph = { _root: { edges: ["keep"] }, keep: {} };
+      const [graph, ops] = insertGraph({}, { idFn: deterministicId })(existing);
+
+      expect(graph).toEqual(existing);
+      expect(ops).toEqual([]);
+    });
+
+    test("a source holding only a root is a no-op", () => {
+      const existing: Graph = { _root: { edges: ["keep"] }, keep: {} };
+      const [graph, ops] = insertGraph(
+        { _root: { edges: [] } },
+        {
+          idFn: deterministicId,
+        },
+      )(existing);
+
+      expect(graph).toEqual(existing);
+      expect(ops).toEqual([]);
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/graph/index.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/index.ts
@@ -863,9 +863,7 @@ export const insertGraph =
         .filter((newId): newId is string => Boolean(newId))
         .map((newId) => buildGraphFromNodes(newId, newNodes));
 
-      /**
-       * 4. Finally, insert each rebuilt node in turn and all its nested children
-       */
+      // 4. Finally, insert each rebuilt node in turn and all its nested children
       topLevelTrees.forEach(({ id, children, ...nodeData }) => {
         _add(draft, { id, ...nodeData }, { children, parent, before });
       });

--- a/apps/editor.planx.uk/src/@planx/graph/index.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/index.ts
@@ -813,3 +813,60 @@ export const buildGraphFromNodes = (
     children: children,
   };
 };
+
+/**
+ * Insert a copy of an entire graph (e.g. a pattern or pasted content) into current graph
+ *
+ * All mutations are collected into a single set of ops (due to wrap()), so an insert
+ * is a single ShareDB transaction (and so a single "undo")
+ */
+export const insertGraph =
+  (
+    source: Graph,
+    {
+      parent = ROOT_NODE_KEY,
+      before = undefined,
+      idFn = uniqueId,
+    }: { parent?: NodeId; before?: NodeId; idFn?: () => string } = {},
+  ) =>
+  (graph: Graph = {}): [Graph, Array<OT.Op>] =>
+    wrap(graph, (draft) => {
+      const topLevelIds = source[ROOT_NODE_KEY]?.edges || [];
+      if (topLevelIds.length === 0) return;
+
+      draft[ROOT_NODE_KEY] = draft[ROOT_NODE_KEY] || {};
+
+      // Keep a map of originalId: newId allowing us to insert unique nodes and maintain our edge relationships
+      const idMap = new Map<string, string>();
+      const newNodes: { [id: string]: Store.Node } = {};
+
+      // 1. First pass: Create new nodes and build the ID map
+      Object.entries(source).forEach(([sourceId, nodeData]) => {
+        if (sourceId === ROOT_NODE_KEY) return;
+        const newId = idFn();
+        idMap.set(sourceId, newId);
+        newNodes[newId] = structuredClone(nodeData);
+      });
+
+      // 2. Second pass: Re-link edges using the ID map
+      Object.values(newNodes).forEach((node) => {
+        if (node.edges && node.edges.length > 0) {
+          node.edges = node.edges
+            .map((edgeId) => idMap.get(edgeId))
+            .filter((edgeId): edgeId is string => Boolean(edgeId));
+        }
+      });
+
+      // 3. Rebuild each top level node's hierarchy from the flat node list, keeping source order
+      const topLevelTrees = topLevelIds
+        .map((sourceId) => idMap.get(sourceId))
+        .filter((newId): newId is string => Boolean(newId))
+        .map((newId) => buildGraphFromNodes(newId, newNodes));
+
+      /**
+       * 4. Finally, insert each rebuilt node in turn and all its nested children
+       */
+      topLevelTrees.forEach(({ id, children, ...nodeData }) => {
+        _add(draft, { id, ...nodeData }, { children, parent, before });
+      });
+    });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.test.tsx
@@ -83,14 +83,14 @@ describe("PatternsTab", () => {
         "Pattern 2",
       );
 
-      await waitFor(() =>
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Pattern 2/ }),
+        ).toBeInTheDocument();
         expect(
           screen.queryByRole("button", { name: /Pattern 1/ }),
-        ).not.toBeInTheDocument(),
-      );
-      expect(
-        screen.getByRole("button", { name: /Pattern 2/ }),
-      ).toBeInTheDocument();
+        ).not.toBeInTheDocument();
+      });
     });
 
     it("shows a distinct message when nothing matches the search", async () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/stripTemplatedNodeProps.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/__tests__/stripTemplatedNodeProps.test.ts
@@ -1,0 +1,62 @@
+import type { Store } from "../store";
+import { stripTemplatedNodeProps } from "../store/editor";
+
+describe("stripTemplatedNodeProps", () => {
+  it("removes every templated-node prop from data", () => {
+    const node: Store.Node = {
+      type: 100,
+      data: {
+        text: "A question",
+        isTemplatedNode: true,
+        templatedNodeInstructions: "Fill this in",
+        areTemplatedNodeInstructionsRequired: true,
+      },
+    };
+
+    expect(stripTemplatedNodeProps(node).data).toEqual({
+      text: "A question",
+    });
+  });
+
+  it("leaves data untouched when there's nothing to strip", () => {
+    const node: Store.Node = { type: 100, data: { text: "A question" } };
+
+    expect(stripTemplatedNodeProps(node).data).toEqual({
+      text: "A question",
+    });
+  });
+
+  it("leaves a node with no data as-is", () => {
+    const node: Store.Node = { type: 100 };
+
+    expect(stripTemplatedNodeProps(node)).toEqual({ type: 100 });
+  });
+
+  it("leaves the rest of the node untouched", () => {
+    const node: Store.Node = {
+      type: 100,
+      edges: ["a", "b"],
+      data: { text: "A question", isTemplatedNode: true },
+    };
+
+    expect(stripTemplatedNodeProps(node)).toEqual({
+      type: 100,
+      edges: ["a", "b"],
+      data: { text: "A question" },
+    });
+  });
+
+  it("does not mutate the node passed in", () => {
+    const node: Store.Node = {
+      type: 100,
+      data: { text: "A question", isTemplatedNode: true },
+    };
+
+    stripTemplatedNodeProps(node);
+
+    expect(node.data).toEqual({
+      text: "A question",
+      isTemplatedNode: true,
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -10,11 +10,11 @@ import {
   ComponentType as TYPES,
   flatFlags,
 } from "@opensystemslab/planx-core/types";
-import type { Relationships } from "@planx/graph";
+import type { Graph, Relationships } from "@planx/graph";
 import {
   add,
-  buildGraphFromNodes,
   clone,
+  insertGraph,
   isClone,
   makeUnique,
   move,
@@ -702,52 +702,27 @@ export const editorStore: StateCreator<
       }: CopiedPayload = JSON.parse(copiedString);
       if (!copiedNodes || copiedNodes.length === 0) return;
 
-      // Keep a map of originalId: newId allowing us to insert unique nodes and maintain our edge relationships
-      const idMap = new Map<string, string>();
-      const newNodes: { [id: string]: Store.Node } = {};
-      let newRootId: string | null = null;
+      // If copied from a source template and now pasting to a non-source template, remove templated node props
+      const { isTemplate: pastingToTemplate } = get();
+      const stripTemplateProps = copiedFromTemplate && !pastingToTemplate;
 
-      // 1. First pass: Create new nodes and build the ID map
+      /**
+       * Generate a full graph with _root
+       * insertGraph() expects a full graph structure, but will strip this out before inserting
+       */
+      const source: Graph = { [ROOT_NODE_KEY]: { edges: [rootId] } };
       copiedNodes.forEach(({ originalId, nodeData }) => {
-        const newId = uniqueId();
-        idMap.set(originalId, newId);
-
-        // If copied from a source template and now pasting to a non-source template, remove templated node props
-        const { isTemplate: pastingToTemplate } = get();
-        if (copiedFromTemplate && !pastingToTemplate) {
-          delete nodeData.data?.["isTemplatedNode"];
-          delete nodeData.data?.["templatedNodeInstructions"];
-          delete nodeData.data?.["areTemplatedNodeInstructionsRequired"];
-        }
-
-        newNodes[newId] = structuredClone(nodeData);
-
-        if (originalId === rootId) {
-          newRootId = newId;
-        }
+        source[originalId] = stripTemplateProps
+          ? stripTemplatedNodeProps(nodeData)
+          : nodeData;
       });
 
-      if (!newRootId) {
+      if (!source[rootId]) {
         throw new Error("Root node for pasting could not be found.");
       }
 
-      // 2. Second pass: Re-link edges using the ID map
-      Object.values(newNodes).forEach((node) => {
-        if (node.edges && node.edges.length > 0) {
-          node.edges = node.edges
-            .map((oldEdgeId) => idMap.get(oldEdgeId))
-            .filter((id): id is string => !!id);
-        }
-      });
-
-      // 3. Rebuild the graph structure from our flat node list
-      const { id, children, ...nodeData } = buildGraphFromNodes(
-        newRootId,
-        newNodes,
-      );
-
-      // 4. Finally, insert the original pasted node, and all its nested children
-      get().addNode({ id, ...nodeData }, { parent, before, children });
+      const [, ops] = insertGraph(source, { parent, before })(get().flow);
+      send(ops);
     } catch (err) {
       alert((err as Error).message);
     }
@@ -884,3 +859,25 @@ export const editorStore: StateCreator<
     return response;
   },
 });
+
+const TEMPLATED_NODE_PROPS = [
+  "isTemplatedNode",
+  "templatedNodeInstructions",
+  "areTemplatedNodeInstructionsRequired",
+] as const;
+
+/**
+ * Strip template-authoring props from a node's data
+ *
+ * Used when pasting a node copied from a source template into a flow that isn't
+ * itself a source template - those props only make sense there, so left behind
+ * they'd falsely mark an ordinary node as templated
+ */
+export const stripTemplatedNodeProps = (node: Store.Node): Store.Node => {
+  if (!node.data) return node;
+
+  const data = { ...node.data };
+  TEMPLATED_NODE_PROPS.forEach((prop) => delete data[prop]);
+
+  return { ...node, data };
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -41,6 +41,7 @@ import { getFlowDoc, subscribeToDoc } from "./../sharedb";
 import { type Store } from ".";
 import type { NavigationStore } from "./navigation";
 import type { SharedStore } from "./shared";
+import { stripTemplatedNodeProps } from "./utils/stripTemplatedNodeProps";
 
 let doc: Doc;
 
@@ -859,25 +860,3 @@ export const editorStore: StateCreator<
     return response;
   },
 });
-
-const TEMPLATED_NODE_PROPS = [
-  "isTemplatedNode",
-  "templatedNodeInstructions",
-  "areTemplatedNodeInstructionsRequired",
-] as const;
-
-/**
- * Strip template-authoring props from a node's data
- *
- * Used when pasting a node copied from a source template into a flow that isn't
- * itself a source template - those props only make sense there, so left behind
- * they'd falsely mark an ordinary node as templated
- */
-export const stripTemplatedNodeProps = (node: Store.Node): Store.Node => {
-  if (!node.data) return node;
-
-  const data = { ...node.data };
-  TEMPLATED_NODE_PROPS.forEach((prop) => delete data[prop]);
-
-  return { ...node, data };
-};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/stripTemplatedNodeProps.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/stripTemplatedNodeProps.test.ts
@@ -1,5 +1,5 @@
-import type { Store } from "../store";
-import { stripTemplatedNodeProps } from "../store/editor";
+import type { Store } from "..";
+import { stripTemplatedNodeProps } from "./stripTemplatedNodeProps";
 
 describe("stripTemplatedNodeProps", () => {
   it("removes every templated-node prop from data", () => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/stripTemplatedNodeProps.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/stripTemplatedNodeProps.ts
@@ -1,0 +1,23 @@
+import type { Store } from "..";
+
+const TEMPLATED_NODE_PROPS = [
+  "isTemplatedNode",
+  "templatedNodeInstructions",
+  "areTemplatedNodeInstructionsRequired",
+] as const;
+
+/**
+ * Strip template-authoring props from a node's data
+ *
+ * Used when pasting a node copied from a source template into a flow that isn't
+ * itself a source template - those props only make sense there, so left behind
+ * they'd falsely mark an ordinary node as templated
+ */
+export const stripTemplatedNodeProps = (node: Store.Node): Store.Node => {
+  if (!node.data) return node;
+
+  const data = { ...node.data };
+  TEMPLATED_NODE_PROPS.forEach((prop) => delete data[prop]);
+
+  return { ...node, data };
+};


### PR DESCRIPTION
## What does this PR do?
- Creates a new `insertGraph()` function. The aim of this is to share business logic across both `pasteNode()` and `insertPattern()` - these should both function consistently under the hood.
- Test coverage for this shared logic
- Implements this directly into `pasteNode()` - I'll prompt the content team to test this on the Pizza