### PR TITLE
fix: ensure `articleFour.{teamSlug}.caz` values are consistently camelCased

### DIFF
--- a/apps/api.planx.uk/modules/gis/service/digitalLand.ts
+++ b/apps/api.planx.uk/modules/gis/service/digitalLand.ts
@@ -252,7 +252,7 @@ async function go(
     }
 
     // rename `articleFour.caz` to reflect localAuthority if applicable, ensuring `councilName` segment matches other A4 values (not always same as team-slug)
-    const localCaz = `articleFour.${localAuthority.includes("-") ? camelCase(localAuthority) : localAuthority}.caz`;
+    const localCaz = `articleFour.${camelCase(localAuthority)}.caz`;
 
     if (formattedResult["articleFour.caz"]) {
       formattedResult[localCaz] = formattedResult["articleFour.caz"];

--- a/apps/api.planx.uk/modules/gis/service/helpers.ts
+++ b/apps/api.planx.uk/modules/gis/service/helpers.ts
@@ -1,3 +1,5 @@
+import camelCase from "lodash/camelCase.js";
+
 import * as adurWorthing from "./local_authorities/metadata/adurWorthing.js";
 import * as barkingAndDagenham from "./local_authorities/metadata/barkingAndDagenham.js";
 import * as barnet from "./local_authorities/metadata/barnet.js";
@@ -111,7 +113,7 @@ export const getLocalAuthorityArticleFourSchema = (
         "articleFour"
       ]["records"],
     ),
-    ...[`articleFour.${localAuthority}.caz`],
+    ...[`articleFour.${camelCase(localAuthority)}.caz`],
   ];
 
   return granularValues.sort();


### PR DESCRIPTION
Spotted while testing team migrations: https://opensystemslab.slack.com/archives/C01E3AC0C03/p1785758646510029?thread_ts=1785705766.751399&cid=C01E3AC0C03

Planning constraints schema endpoint was returning an inconsistent value ! 
- Before: https://api.editor.planx.dev/planning-constraints-schema?localAuthority=stoke-on-trent (includes `articleFour.stoke-on-trent.caz`)
- After: (pizza api coming soon) http://localhost:7002/planning-constraints-schema?localAuthority=stoke-on-trent (includes `articleFour.stokeOnTrent.caz`)