### PR TITLE
chore: disable `Internal notes` input ahead of migration

### DIFF
--- a/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -31,7 +31,8 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             multiline
             placeholder="Internal notes"
             rows={3}
-            disabled={disabled}
+            // disabled while migrating, to be deprecated soon !
+            disabled={true}
           />
         </InputRow>
       </ModalSectionContent>


### PR DESCRIPTION
We're preparing to migrate the existing internal notes _property_ to new `flow_notes` structure.

In order to not have a moving target while migrating, I'm proposing we disable the input but still ensure it's visible to read in the interim. We'll move forward with full deprecation once migrated.

Please note this does not prevent nodes or flows with internal notes from being copied, templated, nested in the meantime. It's imperfect ! 

Will open a similar follow-up for disabling Questions without options soon.