### PR TITLE
feat: Mop-up cronjob for GovPay

### DIFF
--- a/apps/api.planx.uk/.env.test.example
+++ b/apps/api.planx.uk/.env.test.example
@@ -31,6 +31,9 @@ FILE_API_KEY_NEXUS=👻
 FILE_API_KEY_SOUTHWARK=👻
 FILE_API_KEY_TEWKESBURY=👻
 
+# API
+API_URL_EXT=https://api.example.com
+
 # Editor
 EDITOR_URL_EXT=https://www.example.com
 

--- a/apps/api.planx.uk/modules/webhooks/controller.ts
+++ b/apps/api.planx.uk/modules/webhooks/controller.ts
@@ -22,6 +22,8 @@ import {
   createPaymentReminderEvents,
 } from "./service/paymentRequestEvents/index.js";
 import type { CreatePaymentEventController } from "./service/paymentRequestEvents/schema.js";
+import { reconcilePayments } from "./service/reconcilePayments/index.js";
+import type { ReconcilePaymentsController } from "./service/reconcilePayments/types.js";
 import { sanitiseApplicationData } from "./service/sanitiseApplicationData/index.js";
 import type { SanitiseApplicationData } from "./service/sanitiseApplicationData/types.js";
 import { sendSlackNotification } from "./service/sendNotification/index.js";
@@ -320,6 +322,24 @@ export const failedSubmissionsController: FailedSubmissionController = async (
     return next(
       new ServerError({
         message: `Failed to log submission failures today`,
+        cause: error,
+      }),
+    );
+  }
+};
+
+export const reconcilePaymentsController: ReconcilePaymentsController = async (
+  _req,
+  res,
+  next,
+) => {
+  try {
+    const response = await reconcilePayments();
+    return res.status(200).send(response);
+  } catch (error) {
+    return next(
+      new ServerError({
+        message: `Failed to reconcile payments`,
         cause: error,
       }),
     );

--- a/apps/api.planx.uk/modules/webhooks/routes.ts
+++ b/apps/api.planx.uk/modules/webhooks/routes.ts
@@ -14,6 +14,7 @@ import {
   deleteSessionController,
   failedSubmissionsController,
   isCleanJSONBController,
+  reconcilePaymentsController,
   sanitiseApplicationDataController,
   sendSlackMessageController,
   sendSlackNotificationController,
@@ -94,6 +95,7 @@ router.post(
   updateTemplatedFlowEditsController,
 );
 router.post("/webhooks/hasura/failed-submissions", failedSubmissionsController);
+router.post("/webhooks/hasura/reconcile-payments", reconcilePaymentsController);
 
 // TODO: Convert to the new API module structure
 router.post(

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
@@ -1,0 +1,233 @@
+import nock from "nock";
+import supertest from "supertest";
+
+import app from "../../../../server.js";
+import { queryMock } from "../../../../tests/graphqlQueryMock.js";
+
+const mockSend = vi.fn();
+const mockSlackNotify = vi.fn().mockImplementation(() => ({ send: mockSend }));
+vi.mock("slack-notify", () => ({
+  default: (webhookURL: string) => mockSlackNotify(webhookURL),
+}));
+
+const { post } = supertest(app);
+
+const ENDPOINT = "/webhooks/hasura/reconcile-payments";
+const API_URL = "https://api.example.com";
+const AUTH = { Authorization: process.env.HASURA_PLANX_API_KEY! };
+
+const buildSession = ({
+  sessionId,
+  paymentId,
+  status,
+}: {
+  sessionId: string;
+  paymentId: string;
+  status: string;
+}) => ({
+  sessionId,
+  flowId: "7cd1c4b4-4229-424f-8d04-c9fdc958ef4e",
+  flow: {
+    name: "Apply for a lawful development certificate",
+    team: { slug: "southwark", name: "Southwark" },
+  },
+  paymentStatus: [{ paymentId, status, amount: 25700 }],
+});
+
+const mockSessions = (sessions: ReturnType<typeof buildSession>[]) =>
+  queryMock.mockQuery({
+    name: "GetUnreconciledSessions",
+    matchOnVariables: false,
+    data: { sessions },
+  });
+
+describe("Payment reconciliation webhook", () => {
+  beforeEach(() => {
+    vi.stubEnv("APP_ENVIRONMENT", "production");
+    mockSend.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    nock.cleanAll();
+  });
+
+  it("returns a 401 without correct authentication", async () => {
+    await post(ENDPOINT)
+      .expect(401)
+      .then((response) =>
+        expect(response.body).toEqual({ error: "Unauthorised" }),
+      );
+  });
+
+  it("flags a session which GOV.UK Pay reports as paid", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "created",
+      }),
+    ]);
+
+    const govPay = nock(API_URL)
+      .get("/pay/southwark/pay_abc")
+      .query(true)
+      .reply(200, { state: { status: "success" } });
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toMatchObject({
+          checked: 1,
+          unsubmitted: 1,
+          errors: [],
+        });
+      });
+
+    expect(govPay.isDone()).toBe(true);
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "#planx-notifications-internal",
+        text: expect.stringMatching(/abc-123.*£257\.00.*Southwark/),
+      }),
+    );
+  });
+
+  it("ignores a session which GOV.UK Pay reports as unpaid", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "started",
+      }),
+    ]);
+
+    nock(API_URL)
+      .get("/pay/southwark/pay_abc")
+      .query(true)
+      .reply(200, { state: { status: "failed" } });
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) =>
+        expect(response.body).toMatchObject({ checked: 1, unsubmitted: 0 }),
+      );
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("flags a session already recorded as paid without re-querying GOV.UK Pay", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "success",
+      }),
+    ]);
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) =>
+        // `checked` is 0 - we already knew this was paid, so no GOV.UK Pay call was made
+        expect(response.body).toMatchObject({ checked: 0, unsubmitted: 1 }),
+      );
+
+    expect(mockSend).toHaveBeenCalled();
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
+  it("skips sessions where no money was taken", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "cancelled",
+      }),
+    ]);
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) =>
+        expect(response.body).toMatchObject({ checked: 0, unsubmitted: 0 }),
+      );
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("continues reconciling after a failed lookup", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "broken-session",
+        paymentId: "pay_broken",
+        status: "created",
+      }),
+      buildSession({
+        sessionId: "paid-session",
+        paymentId: "pay_ok",
+        status: "created",
+      }),
+    ]);
+
+    nock(API_URL).get("/pay/southwark/pay_broken").query(true).reply(500);
+    nock(API_URL)
+      .get("/pay/southwark/pay_ok")
+      .query(true)
+      .reply(200, { state: { status: "success" } });
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toMatchObject({ checked: 2, unsubmitted: 1 });
+        expect(response.body.errors).toHaveLength(1);
+        expect(response.body.errors[0]).toMatch(/broken-session/);
+      });
+
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("paid-session"),
+      }),
+    );
+  });
+
+  it("does not notify Slack outside of production", async () => {
+    vi.stubEnv("APP_ENVIRONMENT", "staging");
+
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "success",
+      }),
+    ]);
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) =>
+        expect(response.body).toMatchObject({ unsubmitted: 1 }),
+      );
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("returns a 500 if the session query fails", async () => {
+    queryMock.mockQuery({
+      name: "GetUnreconciledSessions",
+      matchOnVariables: false,
+      data: {},
+      graphqlErrors: [{ message: "Something went wrong" }],
+    });
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(500)
+      .then((response) =>
+        expect(response.body.error).toMatch(/Failed to reconcile payments/),
+      );
+  });
+});

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
@@ -218,6 +218,27 @@ describe("Payment reconciliation webhook", () => {
     );
   });
 
+  it("still reports success if the reconciliation worked but Slack notification failed", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "abc-123",
+        paymentId: "pay_abc",
+        status: "success",
+      }),
+    ]);
+    mockSend.mockRejectedValueOnce(new Error("Slack is down"));
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) => {
+        expect(response.body).toMatchObject({ checked: 0, unsubmitted: 1 });
+        expect(response.body.errors).toEqual([
+          "Slack notification failed: Slack is down",
+        ]);
+      });
+  });
+
   it("does not notify Slack outside of production", async () => {
     vi.stubEnv("APP_ENVIRONMENT", "staging");
 

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.test.ts
@@ -1,8 +1,10 @@
+import { subHours } from "date-fns";
 import nock from "nock";
 import supertest from "supertest";
 
 import app from "../../../../server.js";
 import { queryMock } from "../../../../tests/graphqlQueryMock.js";
+import { GRACE_PERIOD_HOURS } from "./index.js";
 
 const mockSend = vi.fn();
 const mockSlackNotify = vi.fn().mockImplementation(() => ({ send: mockSend }));
@@ -20,10 +22,12 @@ const buildSession = ({
   sessionId,
   paymentId,
   status,
+  createdAt = subHours(new Date(), GRACE_PERIOD_HOURS + 1).toISOString(),
 }: {
   sessionId: string;
   paymentId: string;
   status: string;
+  createdAt?: string;
 }) => ({
   sessionId,
   flowId: "7cd1c4b4-4229-424f-8d04-c9fdc958ef4e",
@@ -31,7 +35,7 @@ const buildSession = ({
     name: "Apply for a lawful development certificate",
     team: { slug: "southwark", name: "Southwark" },
   },
-  paymentStatus: [{ paymentId, status, amount: 25700 }],
+  paymentStatus: [{ paymentId, status, amount: 25700, createdAt }],
 });
 
 const mockSessions = (sessions: ReturnType<typeof buildSession>[]) =>
@@ -92,6 +96,26 @@ describe("Payment reconciliation webhook", () => {
         text: expect.stringMatching(/abc-123.*£257\.00.*Southwark/),
       }),
     );
+  });
+
+  it("ignores a session still within the grace period, even if already recorded as paid", async () => {
+    mockSessions([
+      buildSession({
+        sessionId: "just-paid",
+        paymentId: "pay_abc",
+        status: "success",
+        createdAt: subHours(new Date(), GRACE_PERIOD_HOURS - 1).toISOString(),
+      }),
+    ]);
+
+    await post(ENDPOINT)
+      .set(AUTH)
+      .expect(200)
+      .then((response) =>
+        expect(response.body).toMatchObject({ checked: 0, unsubmitted: 0 }),
+      );
+
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it("ignores a session which GOV.UK Pay reports as unpaid", async () => {

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
@@ -1,0 +1,181 @@
+import axios from "axios";
+import { subHours } from "date-fns";
+import { gql } from "graphql-request";
+
+import { $api } from "../../../../client/index.js";
+import { getFormattedEnvironment } from "../../../../helpers.js";
+import { sendSlackMessage } from "../../../slack/utils.js";
+import type { PaymentCandidate, ReconcilePaymentsResponse } from "./types.js";
+
+/**
+ * How far back to look for payments which never resolved
+ * Payments older than this are assumed to have already been investigated
+ *
+ * Same pattern as daily_failed_submissions - stops repeated alerts for previous failures
+ */
+export const LOOKBACK_HOURS = 24;
+
+/**
+ * Statuses where GOV.UK Pay took no money, so there is nothing to mop up
+ * Docs: https://docs.payments.service.gov.uk/api_reference/#payment-status-meanings
+ */
+const FAILED_STATUSES = ["failed", "cancelled", "error"];
+
+interface GetUnreconciledSessions {
+  sessions: {
+    sessionId: string;
+    flowId: string;
+    flow: {
+      name: string;
+      team: { slug: string; name: string };
+    };
+    paymentStatus: {
+      paymentId: string;
+      status: string;
+      amount: number;
+    }[];
+  }[];
+}
+
+/**
+ * Sessions which began a payment but have never been submitted
+ */
+const getCandidates = async (): Promise<PaymentCandidate[]> => {
+  const since = subHours(new Date(), LOOKBACK_HOURS).toISOString();
+
+  const { sessions } = await $api.client.request<GetUnreconciledSessions>(
+    gql`
+      query GetUnreconciledSessions($since: timestamptz!) {
+        sessions: lowcal_sessions(
+          where: {
+            submitted_at: { _is_null: true }
+            deleted_at: { _is_null: true }
+            payment_status: { created_at: { _gt: $since } }
+          }
+        ) {
+          sessionId: id
+          flowId: flow_id
+          flow {
+            name
+            team {
+              slug
+              name
+            }
+          }
+          paymentStatus: payment_status(
+            order_by: { created_at: desc }
+            limit: 1
+          ) {
+            paymentId: payment_id
+            status
+            amount
+          }
+        }
+      }
+    `,
+    { since },
+  );
+
+  return sessions.map(({ sessionId, flowId, flow, paymentStatus }) => {
+    const latest = paymentStatus[0]!;
+
+    return {
+      sessionId,
+      flowId,
+      flowName: flow.name,
+      teamSlug: flow.team.slug,
+      teamName: flow.team.name,
+      paymentId: latest.paymentId,
+      status: latest.status,
+      amount: latest.amount,
+    };
+  });
+};
+
+/**
+ * Ask GOV.UK Pay for the current status of a payment, via our own proxy route
+ *
+ * Reusing `GET /pay/:localAuthority/:paymentId` means the team's GovPay token is
+ * resolved and the true status is written to `payment_status` as a side effect
+ */
+const refetchPaymentStatus = async ({
+  teamSlug,
+  paymentId,
+  sessionId,
+  flowId,
+}: PaymentCandidate): Promise<string> => {
+  const { data } = await axios.get<{ state?: { status?: string } }>(
+    `${process.env.API_URL_EXT}/pay/${teamSlug}/${paymentId}`,
+    { params: { sessionId, flowId } },
+  );
+
+  return data?.state?.status || "unknown";
+};
+
+const formatSlackMessage = (unsubmitted: PaymentCandidate[]): string => {
+  const lines = unsubmitted.map(
+    ({ sessionId, teamName, flowName, amount }) =>
+      `- *${sessionId}* £${(amount / 100).toFixed(2)} [${teamName}] ${flowName}`,
+  );
+
+  return `Payment taken with no submission, please investigate:\n${lines.join("\n")}`;
+};
+
+/**
+ * Called by Hasura cron job `reconcile_payments`
+ *
+ * A "mop-up job" as recommended by GOV.UK Pay, covering the case where an applicant
+ * pays but never makes it back to PlanX - leaving us with money taken and no submission
+ *
+ * Docs: https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#use-an-automatic-mop-up-job-recommended
+ */
+export const reconcilePayments =
+  async (): Promise<ReconcilePaymentsResponse> => {
+    const candidates = await getCandidates();
+    const unsubmitted: PaymentCandidate[] = [];
+    const errors: string[] = [];
+    let checked = 0;
+
+    for (const candidate of candidates) {
+      // No money was taken, so there is nothing to mop up
+      if (FAILED_STATUSES.includes(candidate.status)) continue;
+
+      // We already know this was paid - the submission, not the payment, is what failed
+      if (candidate.status === "success") {
+        unsubmitted.push(candidate);
+        continue;
+      }
+
+      try {
+        checked++;
+        const paymentStatus = await refetchPaymentStatus(candidate);
+        if (paymentStatus === "success") unsubmitted.push(candidate);
+      } catch (error) {
+        errors.push(
+          `${candidate.sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (unsubmitted.length) await postToSlack(formatSlackMessage(unsubmitted));
+
+    return {
+      message: `Checked ${checked} payment(s), found ${unsubmitted.length} paid but unsubmitted session(s)`,
+      checked,
+      unsubmitted: unsubmitted.length,
+      errors,
+    };
+  };
+
+export const postToSlack = async (text: string): Promise<void> => {
+  if (process.env.APP_ENVIRONMENT !== "production") {
+    console.log(`Skipping Slack notification on non-production:\n${text}`);
+    return;
+  }
+
+  await sendSlackMessage({
+    channel: "#planx-notifications-internal",
+    text,
+    username: `Payment Reconciliation Cron Job (${getFormattedEnvironment()})`,
+  });
+};

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
@@ -10,10 +10,14 @@ import type { PaymentCandidate, ReconcilePaymentsResponse } from "./types.js";
 /**
  * How far back to look for payments which never resolved
  * Payments older than this are assumed to have already been investigated
- *
- * Same pattern as daily_failed_submissions - stops repeated alerts for previous failures
  */
 export const LOOKBACK_HOURS = 24;
+
+/**
+ * Payments more recent than this are ignored, so we don't interfere with one
+ * still being processed by the frontend (as per GovPay recommendations)
+ */
+export const GRACE_PERIOD_HOURS = 3;
 
 /**
  * Statuses where GOV.UK Pay took no money, so there is nothing to mop up
@@ -33,15 +37,18 @@ interface GetUnreconciledSessions {
       paymentId: string;
       status: string;
       amount: number;
+      createdAt: string;
     }[];
   }[];
 }
 
 /**
- * Sessions which began a payment but have never been submitted
+ * Sessions which began a payment but have never been submitted, excluding any
+ * whose most recent payment activity is still within the grace period
  */
 const getCandidates = async (): Promise<PaymentCandidate[]> => {
   const since = subHours(new Date(), LOOKBACK_HOURS).toISOString();
+  const gracePeriodStart = subHours(new Date(), GRACE_PERIOD_HOURS);
 
   const { sessions } = await $api.client.request<GetUnreconciledSessions>(
     gql`
@@ -69,6 +76,7 @@ const getCandidates = async (): Promise<PaymentCandidate[]> => {
             paymentId: payment_id
             status
             amount
+            createdAt: created_at
           }
         }
       }
@@ -76,19 +84,23 @@ const getCandidates = async (): Promise<PaymentCandidate[]> => {
     { since },
   );
 
-  return sessions.map(({ sessionId, flowId, flow, paymentStatus }) => {
+  return sessions.flatMap(({ sessionId, flowId, flow, paymentStatus }) => {
     const latest = paymentStatus[0]!;
 
-    return {
-      sessionId,
-      flowId,
-      flowName: flow.name,
-      teamSlug: flow.team.slug,
-      teamName: flow.team.name,
-      paymentId: latest.paymentId,
-      status: latest.status,
-      amount: latest.amount,
-    };
+    if (new Date(latest.createdAt) > gracePeriodStart) return [];
+
+    return [
+      {
+        sessionId,
+        flowId,
+        flowName: flow.name,
+        teamSlug: flow.team.slug,
+        teamName: flow.team.name,
+        paymentId: latest.paymentId,
+        status: latest.status,
+        amount: latest.amount,
+      },
+    ];
   });
 };
 

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/index.ts
@@ -169,7 +169,15 @@ export const reconcilePayments =
       }
     }
 
-    if (unsubmitted.length) await postToSlack(formatSlackMessage(unsubmitted));
+    if (unsubmitted.length) {
+      try {
+        await postToSlack(formatSlackMessage(unsubmitted));
+      } catch (error) {
+        errors.push(
+          `Slack notification failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
 
     return {
       message: `Checked ${checked} payment(s), found ${unsubmitted.length} paid but unsubmitted session(s)`,

--- a/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/types.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/reconcilePayments/types.ts
@@ -1,0 +1,29 @@
+import type { z } from "zod";
+
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+
+export interface ReconcilePaymentsResponse {
+  message: string;
+  checked: number;
+  unsubmitted: number;
+  errors: string[];
+}
+
+export type ReconcilePaymentsController = ValidatedRequestHandler<
+  z.ZodUndefined,
+  ReconcilePaymentsResponse
+>;
+
+/** A session which began a payment but has never been submitted */
+export interface PaymentCandidate {
+  sessionId: string;
+  flowId: string;
+  flowName: string;
+  teamSlug: string;
+  teamName: string;
+  paymentId: string;
+  /** The most recent status we have recorded locally, which may be out of date */
+  status: string;
+  /** In pence */
+  amount: number;
+}

--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -16,6 +16,15 @@
     - name: authorization
       value_from_env: HASURA_PLANX_API_KEY
   comment: 'Checks for any failed submissions and logs them to #planx-notifications-internal to investigate further'
+- name: reconcile_payments
+  webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/reconcile-payments'
+  schedule: '*/30 * * * *'
+  include_in_metadata: true
+  payload: {}
+  headers:
+    - name: authorization
+      value_from_env: HASURA_PLANX_API_KEY
+  comment: 'Re-checks GOV.UK Pay for sessions which began a payment but were never submitted, and logs any paid-but-unsubmitted sessions to #planx-notifications-internal'
 - name: sanitise_application_data
   webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/sanitise-application-data'
   schedule: 0 2 * * *


### PR DESCRIPTION
## What does this PR do?
This PR adds the "mop-up job" GOV.UK Pay docs recommend here - https://docs.payments.service.gov.uk/integrate_with_govuk_pay/#use-an-automatic-mop-up-job-recommended

This is a Hasura cron that re-checks GOV.UK Pay for any session that began a payment but was never submitted, corrects `payment_status` with the true result, and alerts `#planx-notifications-internal` for anything paid with no submission.

Trello ticket - https://trello.com/c/gzmBq67h/3609-implement-mop-up-job-for-govuk-payments

## Design
I've aimed to keep this lightweight as we're aiming to migrate away relatively soon. If this is lacking in any area we can always build on it in future.
- No new tables or migrations - we don't write failures to the db, just log to Slack
- Re-uses reuse the existing `GET /pay/:team/:paymentId` route rather than a new GOV.UK Pay request. This already resolves the team's token, calls GOV.UK Pay, and writes the result to `payment_status` as a side effect.
- No auto-resubmission on failure - just notify us via Slack.

```mermaid
sequenceDiagram
    participant Cron as Hasura Cron
    participant API as API (reconcile-payments)
    participant DB as Hasura (payment_status / lowcal_sessions)
    participant GovPay as GOV.UK Pay
    participant Slack

    Cron->>API: POST /reconcile-payments (every 30 min)
    API->>DB: query unsubmitted sessions with recent payment activity
    DB-->>API: candidate sessions

    loop each candidate outside the 3h grace period
        alt already failed / cancelled / error
            Note over API: skip - no money taken
        else already known success
            Note over API: flag as unsubmitted
        else needs re-check
            API->>GovPay: GET /pay/:team/:paymentId (self-call)
            GovPay-->>API: current payment state
            API->>DB: write true status to payment_status
            alt status = success
                Note over API: flag as unsubmitted
            else
                Note over API: discard
            end
        end
    end

    opt unsubmitted sessions found
        API->>Slack: post alert to planx-notifications-internal
        Slack-->>API: (failure is logged, retried next run)
    end

    API-->>Cron: 200 { checked, unsubmitted, errors }
```