### PR TITLE
fix(editor): Allow retries on GovUK Pay failures

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Confirm.tsx
@@ -32,6 +32,7 @@ export interface Props extends Omit<Pay, "title" | "fn" | "govPayMetadata"> {
   buttonTitle?: string;
   onConfirm: () => void;
   error?: string;
+  warning?: string;
   hideFeeBanner?: boolean;
 }
 
@@ -94,6 +95,9 @@ const PayBody: React.FC<PayBodyProps> = (props) => {
         }
         openLinksOnNewTab
       />
+      {props.warning && (
+        <ErrorSummary format="warning" heading={props.warning} />
+      )}
       <Button
         variant="contained"
         color="primary"

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.test.tsx
@@ -1,12 +1,14 @@
+import type { GovUKPayment } from "@opensystemslab/planx-core/types";
 import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
-import { act, screen } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { logger } from "airbrake";
 import ErrorFallback from "components/Error/ErrorFallback";
+import { http, HttpResponse } from "msw";
 import type { FullStore, Store } from "pages/FlowEditor/lib/store";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import server from "test/mockServer";
 import { setup } from "test/utils";
 import type { Breadcrumbs } from "types";
 import { ApplicationPath } from "types";
@@ -225,6 +227,221 @@ describe("Pay component when fee is undefined or £0", () => {
     expect(loggerSpy).toHaveBeenCalledWith(
       expect.stringMatching(/Negative fee calculated/),
     );
+  });
+});
+
+describe("Pay component when returning from GOV.UK Pay", () => {
+  const flowWithFee: Store.Flow = {
+    _root: {
+      edges: ["setValue", "pay"],
+    },
+    setValue: {
+      type: TYPES.SetValue,
+      edges: ["pay"],
+      data: {
+        fn: "application.fee.payable",
+        val: "103",
+      },
+    },
+    pay: {
+      type: TYPES.Pay,
+      data: {
+        fn: "application.fee.payable",
+      },
+    },
+  };
+
+  const feeBreadcrumbs: Breadcrumbs = {
+    setValue: {
+      auto: true,
+      data: {
+        "application.fee.payable": ["103"],
+      },
+    },
+  };
+
+  const inFlightPayment: GovUKPayment = {
+    amount: 103,
+    reference: "test-reference",
+    state: {
+      status: PaymentStatus.created,
+      finished: false,
+    },
+    payment_id: "test-payment-id",
+    payment_provider: "sandbox",
+    created_date: "2024-01-01T00:00:00.000Z",
+    _links: {
+      self: {
+        href: "https://gov.uk/pay/self",
+        method: "GET",
+      },
+      next_url: {
+        href: "https://gov.uk/pay/next",
+        method: "GET",
+      },
+      next_url_post: {
+        type: "multipart/form-data",
+        params: { chargeTokenId: "test-charge-token" },
+        href: "https://gov.uk/pay/next",
+        method: "POST",
+      },
+    },
+  };
+
+  const getPaymentUrl = `${import.meta.env.VITE_APP_API_URL}/pay/:teamSlug/:paymentId`;
+
+  const setUpPayComponent = (payment: GovUKPayment) => {
+    act(() =>
+      setState({
+        flow: flowWithFee,
+        breadcrumbs: feeBreadcrumbs,
+        teamSlug: "testTeam",
+        govUkPayment: payment,
+      }),
+    );
+
+    const handleSubmit = vi.fn();
+
+    return { handleSubmit };
+  };
+
+  beforeAll(() => (initialState = getState()));
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    act(() => setState(initialState));
+  });
+
+  const successfulPaymentResponse = {
+    ...inFlightPayment,
+    state: { status: PaymentStatus.success, finished: true },
+  };
+
+  it("offers a status check when the payment status request fails", async () => {
+    server.use(
+      http.get(getPaymentUrl, () =>
+        HttpResponse.json({ error: "Something went wrong" }, { status: 500 }),
+      ),
+    );
+
+    const { handleSubmit } = setUpPayComponent(inFlightPayment);
+
+    await setup(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Pay
+          title="Pay"
+          fn="application.fee.payable"
+          handleSubmit={handleSubmit}
+          govPayMetadata={[]}
+        />
+      </ErrorBoundary>,
+    );
+
+    expect(await screen.findByText("Check payment status")).toBeInTheDocument();
+    expect(
+      screen.getByText(/We could not check the status of your payment/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText("Loading payment information"),
+    ).not.toBeInTheDocument();
+
+    // We do not offer to resume the payment
+    expect(screen.queryByText("Retry payment")).not.toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("recovers when a repeated status check succeeds", async () => {
+    let isFirstRequest = true;
+
+    server.use(
+      http.get(getPaymentUrl, () => {
+        if (isFirstRequest) {
+          isFirstRequest = false;
+          return HttpResponse.json(
+            { error: "Something went wrong" },
+            { status: 500 },
+          );
+        }
+
+        return HttpResponse.json(successfulPaymentResponse);
+      }),
+    );
+
+    const { handleSubmit } = setUpPayComponent(inFlightPayment);
+
+    const { user } = await setup(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Pay
+          title="Pay"
+          fn="application.fee.payable"
+          handleSubmit={handleSubmit}
+          govPayMetadata={[]}
+        />
+      </ErrorBoundary>,
+    );
+
+    await user.click(await screen.findByText("Check payment status"));
+
+    // The second check reads the successful payment user can continue
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
+    expect(getState().govUkPayment?.state?.status).toEqual(
+      PaymentStatus.success,
+    );
+  });
+
+  it("offers a status check when the payment is missing a payment_id", async () => {
+    const loggerSpy = vi.spyOn(logger, "notify");
+
+    const { handleSubmit } = setUpPayComponent({
+      ...inFlightPayment,
+      payment_id: "",
+    });
+
+    await setup(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Pay
+          title="Pay"
+          fn="application.fee.payable"
+          handleSubmit={handleSubmit}
+          govPayMetadata={[]}
+        />
+      </ErrorBoundary>,
+    );
+
+    expect(await screen.findByText("Check payment status")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Loading payment information"),
+    ).not.toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/Missing GOV.UK payment_id/),
+    );
+  });
+
+  it("allows the user to continue when the payment status request succeeds", async () => {
+    server.use(
+      http.get(getPaymentUrl, () =>
+        HttpResponse.json(successfulPaymentResponse),
+      ),
+    );
+
+    const { handleSubmit } = setUpPayComponent(inFlightPayment);
+
+    await setup(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Pay
+          title="Pay"
+          fn="application.fee.payable"
+          handleSubmit={handleSubmit}
+          govPayMetadata={[]}
+        />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
+    expect(screen.queryByText("Check payment status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Retry payment")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.tsx
@@ -10,7 +10,7 @@ import type { APIError } from "lib/api/client";
 import { getPayment, initiatePayment } from "lib/api/pay/requests";
 import { saveSession } from "lib/local.new";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect, useReducer } from "react";
+import { useEffect, useReducer } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 
 import { makeData } from "../../shared/utils";
@@ -23,11 +23,12 @@ export type Props = PublicProps<Pay>;
 
 type ComponentState =
   | { status: "indeterminate"; displayText?: string }
-  | { status: "no_payment_found" } // landed on Pay, has not redirected to Gov Pay to initiate payment
+  | { status: "no_payment_found" }
   | { status: "init" }
   | { status: "redirecting"; displayText?: string }
   | { status: "fetching_payment"; displayText?: string }
   | { status: "retry" }
+  | { status: "status_unknown" }
   | { status: "success"; displayText?: string }
   | { status: "unsupported_team" }
   | { status: "undefined_fee" }
@@ -35,9 +36,12 @@ type ComponentState =
 
 enum Action {
   NoFeeFound,
+  /** Landed on Pay, has not redirected to Gov Pay to initiate payment */
   NoPaymentFound,
   IncompletePaymentFound,
   IncompletePaymentConfirmed,
+  /** We could not read the payment status, so we don't know whether the user has paid */
+  PaymentStatusUnknown,
   StartNewPayment,
   StartNewPaymentError,
   ResumePayment,
@@ -99,6 +103,8 @@ function Component(props: Props) {
         };
       case Action.IncompletePaymentConfirmed:
         return { status: "retry" };
+      case Action.PaymentStatusUnknown:
+        return { status: "status_unknown" };
       case Action.StartNewPayment:
         return {
           status: "redirecting",
@@ -158,7 +164,6 @@ function Component(props: Props) {
     if (govUkPayment.state.status === PaymentStatus.success) {
       handleSuccess();
     } else {
-      dispatch(Action.IncompletePaymentFound);
       refetchPayment();
     }
   }, []);
@@ -194,10 +199,17 @@ function Component(props: Props) {
   };
 
   const refetchPayment = async () => {
-    try {
-      const paymentId = govUkPayment?.payment_id;
-      if (!paymentId) return;
+    dispatch(Action.IncompletePaymentFound);
 
+    const paymentId = govUkPayment?.payment_id;
+
+    if (!govUkPayment || !paymentId) {
+      logger.notify(`Missing GOV.UK payment_id for session ${sessionId}`);
+      dispatch(Action.PaymentStatusUnknown);
+      return;
+    }
+
+    try {
       const { state } = await getPayment({
         teamSlug,
         sessionId,
@@ -206,22 +218,22 @@ function Component(props: Props) {
       });
 
       // Update local state with the refetched payment state
-      if (govUkPayment) {
-        await resolvePaymentResponse({
-          ...govUkPayment,
-          state,
-        });
-        if (state.status === PaymentStatus.success) {
-          handleSuccess();
-          return;
-        }
+      await resolvePaymentResponse({
+        ...govUkPayment,
+        state,
+      });
+
+      if (state.status === PaymentStatus.success) {
+        handleSuccess();
+        return;
       }
+
       dispatch(Action.IncompletePaymentConfirmed);
     } catch (err) {
       // XXX: There's probably been an issue fetching the payment status,
-      //      but there's a chance that the user might've made a successful
-      //      payment. We silently log the error and the service continues.
+      //      allow user to re-run status check instead of silently failing
       logger.notify(err);
+      dispatch(Action.PaymentStatusUnknown);
     }
   };
 
@@ -296,6 +308,18 @@ function Component(props: Props) {
     if (shouldContinueWithoutPaying) continueWithoutPaying();
     if (["no_payment_found", "init"].includes(state.status)) startNewPayment();
     if (state.status === "retry") resumeExistingPayment();
+    if (state.status === "status_unknown") refetchPayment();
+  };
+
+  const getButtonTitle = () => {
+    switch (state.status) {
+      case "retry":
+        return "Retry payment";
+      case "status_unknown":
+        return "Check payment status";
+      default:
+        return "Pay now using GOV.UK Pay";
+    }
   };
 
   return (
@@ -303,6 +327,7 @@ function Component(props: Props) {
       {state.status === "no_payment_found" ||
       state.status === "init" ||
       state.status === "retry" ||
+      state.status === "status_unknown" ||
       state.status === "unsupported_team" ||
       state.status === "undefined_fee" ||
       state.status === "zero_fee" ? (
@@ -310,10 +335,11 @@ function Component(props: Props) {
           {...props}
           fee={fee}
           onConfirm={onConfirm}
-          buttonTitle={
-            state.status === "retry"
-              ? "Retry payment"
-              : "Pay now using GOV.UK Pay"
+          buttonTitle={getButtonTitle()}
+          warning={
+            (state.status === "status_unknown" &&
+              "We could not check the status of your payment. If you have already paid, checking again will confirm your payment.") ||
+            undefined
           }
           error={
             (state.status === "unsupported_team" &&

--- a/e2e/tests/ui-driven/src/pay.spec.ts
+++ b/e2e/tests/ui-driven/src/pay.spec.ts
@@ -91,6 +91,55 @@ test.describe("Gov Pay integration @regression", () => {
     await expect(page.getByText(paymentId!)).toBeVisible();
   });
 
+  // On redirection back from GOV.UK Pay we need to check payment status, in order
+  // to proceed to the Send node. This test checks that a failure in this request
+  // still gives the applicant a way to proceed
+  test("recovering from an error fetching the payment status", async ({
+    page,
+  }) => {
+    await setGovPayReferrer(page);
+
+    const sessionId = await navigateToPayComponent(page, context);
+    context.sessionIds!.push(sessionId);
+
+    // Simulate a failure of the payment status request
+    // This could be an API 5xx, a dropped connection, or a slow GOV.UK Pay response
+    await failNextPaymentStatusFetch(page, context);
+
+    await page.getByText(payButtonText).click();
+    await fillGovUkCardDetails({
+      page,
+      cardNumber: cards.successful_card_number,
+    });
+    await submitCardDetails(page);
+
+    // The applicant has paid, but we could not read the status
+    await expect(
+      page.getByText(/We could not check the status of your payment/),
+    ).toBeVisible();
+    await expect(page.getByTestId("delayed-loading-indicator")).toBeHidden();
+
+    // We do not send them back to GOV.UK Pay
+    await expect(page.getByText("Retry payment")).toBeHidden();
+
+    // Checking again succeeds, and the user proceeds to the Send component
+    await page.getByText("Check payment status").click();
+    await expect(page.getByText("Form sent")).toBeVisible();
+
+    const session = await findSession({ adminGQLClient, sessionId });
+    const paymentId = session?.data?.govUkPayment?.payment_id;
+    expect(paymentId).toBeTruthy();
+
+    await expect(page.getByText(paymentId!)).toBeVisible();
+    expect(
+      await hasPaymentStatus({
+        status: "success",
+        paymentId: paymentId!,
+        adminGQLClient,
+      }),
+    ).toBe(true);
+  });
+
   test("a retry attempt for a failed GOV.UK payment", async ({ page }) => {
     await setGovPayReferrer(page);
 
@@ -524,6 +573,29 @@ async function resumeSessionViaMagicLink({
   await page.goto(`${previewURL}&sessionId=${sessionId}`);
   await page.locator("#email").fill(context.user.email);
   await page.getByTestId("continue-button").click();
+}
+
+/**
+ * Fail the next GET /pay/:team/:paymentId request with a 500
+ *
+ * Only the first status fetch is failed, so that a recovering user can still
+ * complete their payment on a subsequent attempt
+ */
+async function failNextPaymentStatusFetch(page: Page, context: TestContext) {
+  let hasFailed = false;
+
+  await page.route(`**/pay/${context.team!.slug!}/*`, async (route) => {
+    // POST /pay/:team initiates a payment - only the status fetch should fail
+    const isStatusFetch = route.request().method() === "GET";
+    if (hasFailed || !isStatusFetch) return route.continue();
+
+    hasFailed = true;
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Internal server error" }),
+    });
+  });
 }
 
 /**


### PR DESCRIPTION
## What's the problem?
This is spun out from https://github.com/theopensystemslab/planx-new/pull/7121

We've had incidents where payments have been made, without the related submission getting through.

When GOV.UK Pay redirects an applicant back, we fire a single `GET /pay/:team/:paymentId`. This request is the only thing which writes a `success` row to `payment_status` and lets the flow advance to the `Send` node.

`refetchPayment` sets `IncompletePaymentConfirmed` inside the `try/catch` block and the `catch` only logs an error. This means that any issue like an API 5xx, slow GovPay response, or a connection issue can leave the user stuck on `fetching_payment` with a perpetual "Loading payment information" spinner.

If the applicant gives up at this point, the payment is made but the submission is not completed.

We have no _direct_ proof that this is what's happened to users in the past unfortunately, but it's a failure method which we're not accounting for and could lead to this result. See video below from Playwright running the test added here against `main` - the user ends up stuck in a loading state.

[video.webm](https://github.com/user-attachments/assets/24307596-128b-4a23-b10b-23191f1fe570)

## What's the solution?
A new `status_unknown` component state, which both failure paths (the `catch`, and a missing `payment_id`) now dispatch. It shows the user a "Check payment status" button which just re-runs the status request, plus a warning explaining that we couldn't read their payment status.