### PR TITLE
fix: Support for FME submission retries

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButton.tsx
@@ -43,6 +43,8 @@ export const ResubmitButton = (params: RenderCellParams) => {
       "Submit to Uniform": "uniform",
       "Send to email": "email",
       "Upload to AWS S3": "s3",
+      "Upload to AWS S3 (no notification)": "fme",
+      "Submit to Idox Nexus": "idox",
     };
 
     const destination =

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/submissionFilterOptions.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/submissionFilterOptions.ts
@@ -6,6 +6,8 @@ export const submissionEventTypes: Array<Submission["eventType"]> = [
   "Submit to BOPS",
   "Submit to Uniform",
   "Upload to AWS S3",
+  "Upload to AWS S3 (no notification)",
+  "Submit to Idox Nexus",
 ];
 
 export const submissionStatusOptions: Required<Array<Submission["status"]>> = [

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -7,7 +7,9 @@ export interface Submission {
     | "Submit to BOPS"
     | "Submit to Uniform"
     | "Send to email"
-    | "Upload to AWS S3";
+    | "Upload to AWS S3"
+    | "Upload to AWS S3 (no notification)"
+    | "Submit to Idox Nexus";
   status?:
     | "Success"
     | "Failed (500)" // Hasura scheduled event status codes


### PR DESCRIPTION
## What's the problem?
`fme` has been missed a submission type, meaning we're unable to retry submissions directly within the Editor.

Updating types here resolves this. These types are driven by the view `submission_services_log` and aren't used elsewhere. Once we have typegen for Hasura setup these will be generated and imported, no need to manually track and sync.

Frontend types now match the following `event_type` values - 

https://github.com/theopensystemslab/planx-new/blob/5af3d2192fc81525255bbfbeb603347b67e937b8/apps/hasura.planx.uk/migrations/default/1783614492150_update_submission_services_log_address/up.sql#L25-L33

Further context - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1785795651320889