### PR TITLE
fix(a11y): Description list and button context labels for list component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -3,22 +3,18 @@ import EditIcon from "@mui/icons-material/Edit";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { styled } from "@mui/material/styles";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import { formatTitle } from "@planx/components/shared/Schema/InputFields";
 import { isMapFieldResponse } from "@planx/components/shared/Schema/model";
 import { SchemaFields } from "@planx/components/shared/Schema/SchemaFields";
 import type { PublicProps } from "@planx/components/shared/types";
 import React, { useEffect, useRef } from "react";
-import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FullWidthWrapper from "ui/public/FullWidthWrapper";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
 
 import Card from "../../shared/Preview/Card";
 import { CardHeader } from "../../shared/Preview/CardHeader/CardHeader";
+import { SummaryListTable } from "../../shared/Preview/SummaryList";
 import type { List } from "../model";
 import { formatSchemaDisplayValue } from "../utils";
 import { ListProvider, useListContext } from "./Context";
@@ -33,7 +29,7 @@ const ListCard = styled(Box)(({ theme }) => ({
   flexDirection: "column",
   gap: theme.spacing(3),
   marginBottom: theme.spacing(2),
-  "& label, & table": {
+  "& label, & dl": {
     maxWidth: theme.breakpoints.values.formWrap,
   },
 }));
@@ -84,13 +80,15 @@ const ActiveListCard: React.FC<{
   const isInitialCard =
     activeIndex === 0 && formik.values?.schemaData?.length === 1;
 
+  const itemLabel = `${schema.type} ${i + 1}`;
+
   return (
     <ErrorWrapper
       error={errors.unsavedItem ? "Please save in order to continue" : ""}
     >
       <ListCard data-testid={`list-card-${i}`} ref={ref}>
         <Typography component="h2" variant="h3">
-          {`${schema.type} ${i + 1}`}
+          {itemLabel}
         </Typography>
         <SchemaFields
           sx={(theme) => ({
@@ -108,6 +106,7 @@ const ActiveListCard: React.FC<{
             color="prompt"
             data-testid="save-item-button"
             onClick={async () => await saveItem()}
+            aria-label={`Save ${itemLabel}`}
           >
             Save
           </Button>
@@ -115,6 +114,8 @@ const ActiveListCard: React.FC<{
             <CardButton
               data-testid="cancel-edit-item-button"
               onClick={cancelEditItem}
+              variant="contained"
+              color="secondary"
             >
               Cancel
             </CardButton>
@@ -142,47 +143,52 @@ const InactiveListCard: React.FC<{
       : null;
   })();
 
+  const itemLabel = `${schema.type} ${i + 1}`;
+
   return (
     <ListCard data-testid={`list-card-${i}`}>
       <Typography component="h2" variant="h3">
-        {`${schema.type} ${i + 1}`}
+        {itemLabel}
       </Typography>
       <InactiveListCardLayout>
         {formattedMapResponse && (
-          <Box sx={{ flexBasis: "50%" }}>{formattedMapResponse}</Box>
+          <Box sx={{ flexBasis: "40%", flexGrow: 0, flexShrink: 0 }}>
+            {formattedMapResponse}
+          </Box>
         )}
-        <Table>
-          <TableBody>
-            {schema.fields.map(
-              (field, j) =>
-                field.type !== "map" && (
-                  <TableRow key={`tableRow-${j}`} sx={{ verticalAlign: "top" }}>
-                    <TableCell
-                      sx={{
-                        fontWeight: FONT_WEIGHT_SEMI_BOLD,
-                        maxWidth: "160px",
-                      }}
-                    >
-                      {formatTitle(field)}
-                    </TableCell>
-                    <TableCell>
-                      {formatSchemaDisplayValue(
-                        formik.values.schemaData[i][field.data.fn],
-                        schema.fields[j],
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ),
-            )}
-          </TableBody>
-        </Table>
+        <SummaryListTable sx={{ margin: 0 }}>
+          {schema.fields.map(
+            (field, j) =>
+              field.type !== "map" && (
+                <React.Fragment key={`field-${j}`}>
+                  <Box component="dt">{formatTitle(field)}</Box>
+                  <Box component="dd">
+                    {formatSchemaDisplayValue(
+                      formik.values.schemaData[i][field.data.fn],
+                      schema.fields[j],
+                    )}
+                  </Box>
+                </React.Fragment>
+              ),
+          )}
+        </SummaryListTable>
       </InactiveListCardLayout>
       <Box sx={{ display: "flex", gap: 2 }}>
-        <CardButton onClick={() => removeItem(i)}>
+        <CardButton
+          onClick={() => removeItem(i)}
+          aria-label={`Remove ${itemLabel}`}
+          variant="contained"
+          color="secondary"
+        >
           <DeleteIcon color="warning" fontSize="medium" />
           Remove
         </CardButton>
-        <CardButton onClick={() => editItem(i)}>
+        <CardButton
+          onClick={() => editItem(i)}
+          aria-label={`Edit ${itemLabel}`}
+          variant="contained"
+          color="secondary"
+        >
           <EditIcon fontSize="medium" />
           Edit
         </CardButton>

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/tests/index.test.tsx
@@ -127,43 +127,43 @@ test(
     await fillInResponse(user);
 
     // Text input
-    expect(getByText("What's their name?", { selector: "td" })).toBeVisible();
-    expect(getByText("Richard Parker", { selector: "td" })).toBeVisible();
+    expect(getByText("What's their name?", { selector: "dt" })).toBeVisible();
+    expect(getByText("Richard Parker", { selector: "dd" })).toBeVisible();
 
     // Email input
     expect(
-      getByText("What's their email address?", { selector: "td" }),
+      getByText("What's their email address?", { selector: "dt" }),
     ).toBeVisible();
     expect(
-      getByText("richard.parker@pi.com", { selector: "td" }),
+      getByText("richard.parker@pi.com", { selector: "dd" }),
     ).toBeVisible();
 
     // Number input
-    expect(getByText("How old are they?", { selector: "td" })).toBeVisible();
-    expect(getByText("10 years old", { selector: "td" })).toBeVisible();
+    expect(getByText("How old are they?", { selector: "dt" })).toBeVisible();
+    expect(getByText("10 years old", { selector: "dd" })).toBeVisible();
 
     // Question input - select
-    expect(getByText("What size are they?", { selector: "td" })).toBeVisible();
-    expect(getByText("Medium", { selector: "td" })).toBeVisible();
+    expect(getByText("What size are they?", { selector: "dt" })).toBeVisible();
+    expect(getByText("Medium", { selector: "dd" })).toBeVisible();
 
     // Question input - radio
-    expect(getByText("How cute are they?", { selector: "td" })).toBeVisible();
-    expect(getByText("Very", { selector: "td" })).toBeVisible();
+    expect(getByText("How cute are they?", { selector: "dt" })).toBeVisible();
+    expect(getByText("Very", { selector: "dd" })).toBeVisible();
 
     // Checklist input
-    expect(getByText("What do they eat?", { selector: "td" })).toBeVisible();
+    expect(getByText("What do they eat?", { selector: "dt" })).toBeVisible();
     expect(getByText("Meat", { selector: "li" })).toBeVisible();
     expect(getByText("Leaves", { selector: "li" })).toBeVisible();
     expect(getByText("Bamboo", { selector: "li" })).toBeVisible();
 
     // Address input
     expect(
-      getByText("What's their address?", { selector: "td" }),
+      getByText("What's their address?", { selector: "dt" }),
     ).toBeVisible();
     expect(
       getByText(
         "134 Corstorphine Rd, Corstorphine, Edinburgh, Midlothian, EH12 6TS, Scotland",
-        { selector: "td" },
+        { selector: "dd" },
       ),
     ).toBeVisible();
   },


### PR DESCRIPTION
## Issue

Relates to:
p.18 - DAC_Tables_01 - https://trello.com/c/ldp0P4nz/3714-a-tables-01
p.28 - DAC_Headings_and_Labels_01 - https://trello.com/c/W6TKb4IU/3719-aa-headings-and-labels-01

List component:
- Tables are not marked up with descriptive headers and values
- Buttons do not give context of list item they relate to

## Solution

- Change table to description list (`dl`, `dt`, `dd`), as used in property information and review component tables
  - Update tests to reflect new structure
- Add `aria-label` to buttons describing list item

### Testing

https://7132.planx.pizza/testing/list/preview