### PR TITLE
fix(a11y): Make notice identify as distinct region

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Notice/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Notice/Public.tsx
@@ -79,6 +79,7 @@ const Title = styled(Typography)(({ theme }) => ({
 
 const NoticeComponent: React.FC<Props> = (props) => {
   const theme = useTheme();
+  const titleId = React.useId();
   const textColor = getContrastTextColor(
     props.color,
     theme.palette.text.primary,
@@ -110,11 +111,15 @@ const NoticeComponent: React.FC<Props> = (props) => {
   return (
     <Card handleSubmit={handleSubmit} isValid>
       <>
-        <Container customColor={props.color}>
+        <Container
+          customColor={props.color}
+          component="section"
+          aria-labelledby={titleId}
+        >
           <Content>
             <TitleWrap>
               <ErrorOutline sx={{ width: 34, height: 34 }} />
-              <Title variant="h3" component="h1">
+              <Title variant="h3" component="h1" id={titleId}>
                 {props.title}
               </Title>
             </TitleWrap>


### PR DESCRIPTION
## Issue

Relates to:
p.20 - DAC_Information_and_Relationships_01 - https://trello.com/c/tYIMWTFq/3715-a-information-and-relationships-01

Notice component in public interface does not identify as a region:

> The informational banner was not programmatically identified as a distinct region. The
information icon is hidden from screen reading software and there is no alternative.
**Solution:**
Ensure the informational banner is programmatically identified as a distinct region or other
appropriate semantic structure.
For example, mark-up the banner using an appropriate landmark or container with an
accessible name, and ensure the close button is contained within that region so its
relationship to the banner is conveyed programmatically.

(close button comments can be disregarded)

## Solution

- Make the container a `<section>` with `aria-labelledby` referencing the notice title

### Testing
https://7133.planx.pizza/testing/notice/preview