### PR TITLE
feat(editor): Dummy payments UI pages

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Layout.tsx
@@ -1,9 +1,11 @@
+import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
 import AlternateEmailIcon from "@mui/icons-material/AlternateEmail";
 import ExtensionIcon from "@mui/icons-material/Extension";
 import LockIcon from "@mui/icons-material/Lock";
 import MapIcon from "@mui/icons-material/Map";
 import PaletteIcon from "@mui/icons-material/Palette";
 import { useParams } from "@tanstack/react-router";
+import { hasFeatureFlag } from "lib/featureFlags";
 import { useStore } from "pages/FlowEditor/lib/store";
 import type { PropsWithChildren } from "react";
 import React from "react";
@@ -41,6 +43,9 @@ const TeamSettingsLayout: React.FC<PropsWithChildren> = ({ children }) => {
 
   const settingsLinks = [
     ...baseSettingsLinks,
+    ...(hasFeatureFlag("STRIPE_MIGRATION")
+      ? [{ label: "Payment", path: "/payment", icon: AccountBalanceIcon }]
+      : []),
     ...(isPlatformAdmin
       ? [{ label: "Advanced", path: "/advanced", icon: LockIcon }]
       : []),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Layout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Layout.tsx
@@ -18,34 +18,30 @@ const TeamSettingsLayout: React.FC<PropsWithChildren> = ({ children }) => {
   const { team } = useParams({ from: "/_authenticated/app/$team" });
 
   // TODO: Make links type-safe
-  const baseSettingsLinks: SettingsLink[] = [
+  const settingsLinks: SettingsLink[] = [
     {
       label: "Contact information",
       path: "/contact",
       icon: AlternateEmailIcon,
     },
     {
-      label: "Integrations",
-      path: "/integrations",
-      icon: ExtensionIcon,
-    },
-    {
       label: "GIS data",
       path: "/gis-data",
       icon: MapIcon,
+    },
+    ...(hasFeatureFlag("STRIPE_MIGRATION")
+      ? [{ label: "Payments", path: "/payments", icon: AccountBalanceIcon }]
+      : []),
+    {
+      label: "Integrations",
+      path: "/integrations",
+      icon: ExtensionIcon,
     },
     {
       label: "Design",
       path: "/design",
       icon: PaletteIcon,
     },
-  ];
-
-  const settingsLinks = [
-    ...baseSettingsLinks,
-    ...(hasFeatureFlag("STRIPE_MIGRATION")
-      ? [{ label: "Payment", path: "/payment", icon: AccountBalanceIcon }]
-      : []),
     ...(isPlatformAdmin
       ? [{ label: "Advanced", path: "/advanced", icon: LockIcon }]
       : []),

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Onboarding/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Onboarding/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+
+export const Onboarding: React.FC = () => (
+  <FeaturePlaceholder title="Onboarding" />
+);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
@@ -1,6 +1,218 @@
-import React from "react";
-import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import InputLegend from "ui/editor/InputLegend";
+import NewSettingsSection from "ui/editor/NewSettingsSection";
+import SettingsDescription from "ui/editor/SettingsDescription";
 
-export const Provider: React.FC = () => (
-  <FeaturePlaceholder title="Payment provider" />
-);
+type PaymentProvider = "govpay" | "stripe";
+
+type DialogState =
+  | { type: "closed" }
+  | { type: "checking" }
+  | { type: "blocked"; sessionCount: number }
+  | { type: "confirm" };
+
+const PROVIDER_LABELS: Record<PaymentProvider, string> = {
+  govpay: "GOV.UK Pay",
+  stripe: "Stripe",
+};
+
+/**
+ * Placeholder - randomly returns a success or failure option
+ * @todo Query DB, return real results
+ */
+const checkActiveSessions = async (
+  teamId: number,
+): Promise<{ count: number; canMigrate: boolean }> => {
+  console.log(
+    `[Provider] Checking active payment sessions for team ${teamId}...`,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  const count = Math.random() > 0.5 ? 3 : 0;
+  console.log(`[Provider] Found ${count} active session(s)`);
+  return { count, canMigrate: count === 0 };
+};
+
+export const Provider: React.FC = () => {
+  const teamId = useStore((state) => state.teamId);
+  const [provider, setProvider] = useState<PaymentProvider>("govpay");
+  const [dialogState, setDialogState] = useState<DialogState>({
+    type: "closed",
+  });
+
+  const handleMigrateClick = async () => {
+    setDialogState({ type: "checking" });
+    const result = await checkActiveSessions(teamId);
+    if (result.canMigrate) {
+      setDialogState({ type: "confirm" });
+    } else {
+      setDialogState({ type: "blocked", sessionCount: result.count });
+    }
+  };
+
+  /**
+   * Placeholder - updates local state only, no DB tables updated
+   * @todo Write to Hasura
+   */
+  const handleConfirmMigration = () => {
+    console.log(
+      `[Provider] Migrating team ${teamId} from ${PROVIDER_LABELS[provider]} to Stripe`,
+    );
+    setProvider("stripe");
+    setDialogState({ type: "closed" });
+    console.log("[Provider] Migration complete");
+  };
+
+  const handleClose = () => setDialogState({ type: "closed" });
+
+  const isStripe = provider === "stripe";
+
+  return (
+    <NewSettingsSection>
+      <Grid container spacing={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
+          <InputLegend gutterBottom>Payment provider</InputLegend>
+          <SettingsDescription>
+            <p>
+              Manage your team's payment provider for processing application
+              fees.
+            </p>
+            <p>
+              PlanX is migrating from GOV.UK Pay to Stripe. Once migrated, all
+              new payment sessions will be processed through Stripe.
+            </p>
+            <p>
+              Migration requires that there are no active payment sessions in
+              progress. If sessions are found, please wait for them to complete
+              before trying again.
+            </p>
+          </SettingsDescription>
+        </Grid>
+        <Grid size={{ xs: 12, md: 8 }}>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              paddingTop: 0.25,
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <Typography variant="body1">Current provider:</Typography>
+              <Chip
+                label={PROVIDER_LABELS[provider]}
+                color={isStripe ? "success" : "primary"}
+                size="small"
+              />
+            </Box>
+            {isStripe ? (
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                This team has been migrated to Stripe. No further action is
+                needed.
+              </Typography>
+            ) : (
+              <Box>
+                <Button
+                  onClick={handleMigrateClick}
+                  variant="contained"
+                  disabled={dialogState.type === "checking"}
+                >
+                  Migrate to Stripe
+                </Button>
+              </Box>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+
+      <Dialog
+        open={dialogState.type !== "closed"}
+        onClose={dialogState.type === "checking" ? undefined : handleClose}
+      >
+        {dialogState.type === "checking" && (
+          <>
+            <DialogTitle component="h1" variant="h3">
+              Checking active sessions
+            </DialogTitle>
+            <DialogContent
+              sx={{
+                display: "flex",
+                justifyContent: "center",
+                py: 4,
+              }}
+            >
+              <CircularProgress />
+            </DialogContent>
+          </>
+        )}
+
+        {dialogState.type === "blocked" && (
+          <>
+            <DialogTitle component="h1" variant="h3">
+              Active payment sessions found
+            </DialogTitle>
+            <DialogContent dividers>
+              <DialogContentText>
+                Unable to migrate payment provider to Stripe. Your team
+                currently has {dialogState.sessionCount} open payment
+                session(s). Please wait for these to complete and try again.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={handleClose}
+                color="secondary"
+                variant="contained"
+              >
+                Close
+              </Button>
+            </DialogActions>
+          </>
+        )}
+
+        {dialogState.type === "confirm" && (
+          <>
+            <DialogTitle component="h1" variant="h3">
+              Confirm migration to Stripe
+            </DialogTitle>
+            <DialogContent dividers>
+              <DialogContentText>
+                No active payment sessions found. You can proceed with migrating
+                this team's payment provider from GOV.UK Pay to Stripe.
+              </DialogContentText>
+              <DialogContentText sx={{ mt: 1 }}>
+                This action cannot be undone. All future payment sessions will
+                be processed through Stripe.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={handleClose}
+                color="secondary"
+                variant="contained"
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmMigration} variant="contained">
+                Migrate to Stripe
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </NewSettingsSection>
+  );
+};
+
+export default Provider;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
@@ -9,6 +9,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import { useToast } from "hooks/useToast";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import InputLegend from "ui/editor/InputLegend";
@@ -45,6 +46,7 @@ const checkActiveSessions = async (
 };
 
 export const Provider: React.FC = () => {
+  const toast = useToast();
   const teamId = useStore((state) => state.teamId);
   const [provider, setProvider] = useState<PaymentProvider>("govpay");
   const [dialogState, setDialogState] = useState<DialogState>({
@@ -71,6 +73,7 @@ export const Provider: React.FC = () => {
     );
     setProvider("stripe");
     setDialogState({ type: "closed" });
+    toast.success("Migration to Stripe successful");
     console.log("[Provider] Migration complete");
   };
 
@@ -112,7 +115,7 @@ export const Provider: React.FC = () => {
               <Typography variant="body1">Current provider:</Typography>
               <Chip
                 label={PROVIDER_LABELS[provider]}
-                color={isStripe ? "success" : "primary"}
+                color="info"
                 size="small"
               />
             </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Provider/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+
+export const Provider: React.FC = () => (
+  <FeaturePlaceholder title="Payment provider" />
+);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Status/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/Status/index.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import { FeaturePlaceholder } from "ui/editor/FeaturePlaceholder";
+
+export const Status: React.FC = () => <FeaturePlaceholder title="Status" />;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Payment/index.tsx
@@ -1,0 +1,15 @@
+import Stack from "@mui/material/Stack";
+
+import { Onboarding } from "./Onboarding";
+import { Provider } from "./Provider";
+import { Status } from "./Status";
+
+const PaymentSettings = () => (
+  <Stack spacing={2}>
+    <Onboarding />
+    <Status />
+    <Provider />
+  </Stack>
+);
+
+export default PaymentSettings;

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -55,7 +55,7 @@ import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './route
 import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
 import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
 import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
-import { Route as AuthenticatedAppTeamSettingsPaymentRouteImport } from './routes/_authenticated/app/$team/settings/payment'
+import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
 import { Route as AuthenticatedAppTeamSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/submission.$sessionId'
 import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
 import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
@@ -372,10 +372,10 @@ const AuthenticatedAppTeamSettingsIntegrationsRoute =
     path: '/integrations',
     getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsPaymentRoute =
-  AuthenticatedAppTeamSettingsPaymentRouteImport.update({
-    id: '/payment',
-    path: '/payment',
+const AuthenticatedAppTeamSettingsPaymentsRoute =
+  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
+    id: '/payments',
+    path: '/payments',
     getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
   } as any)
 const AuthenticatedAppTeamSubmissionSessionIdRoute =
@@ -737,7 +737,7 @@ export interface FileRoutesByFullPath {
   '/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
-  '/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
+  '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -822,7 +822,7 @@ export interface FileRoutesByTo {
   '/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
-  '/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
+  '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -922,7 +922,7 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/_authenticated/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/_authenticated/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
-  '/_authenticated/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
+  '/_authenticated/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/_authenticated/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/_public/_customDomain/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/_public/_customDomain/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -1021,7 +1021,7 @@ export interface FileRouteTypes {
     | '/app/$team/settings/design'
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
-    | '/app/$team/settings/payment'
+    | '/app/$team/settings/payments'
     | '/app/$team/submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
@@ -1106,7 +1106,7 @@ export interface FileRouteTypes {
     | '/app/$team/settings/design'
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
-    | '/app/$team/settings/payment'
+    | '/app/$team/settings/payments'
     | '/app/$team/submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
@@ -1205,7 +1205,7 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/settings/design'
     | '/_authenticated/app/$team/settings/gis-data'
     | '/_authenticated/app/$team/settings/integrations'
-    | '/_authenticated/app/$team/settings/payment'
+    | '/_authenticated/app/$team/settings/payments'
     | '/_authenticated/app/$team/submission/$sessionId'
     | '/_public/_customDomain/$flow/pages/$page'
     | '/_public/_customDomain/$flow/pay/not-found'
@@ -1591,11 +1591,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
       parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
     }
-    '/_authenticated/app/$team/settings/payment': {
-      id: '/_authenticated/app/$team/settings/payment'
-      path: '/payment'
-      fullPath: '/app/$team/settings/payment'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentRouteImport
+    '/_authenticated/app/$team/settings/payments': {
+      id: '/_authenticated/app/$team/settings/payments'
+      path: '/payments'
+      fullPath: '/app/$team/settings/payments'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
       parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
     }
     '/_authenticated/app/$team/submission/$sessionId': {
@@ -2125,7 +2125,7 @@ interface AuthenticatedAppTeamSettingsRouteRouteChildren {
   AuthenticatedAppTeamSettingsDesignRoute: typeof AuthenticatedAppTeamSettingsDesignRoute
   AuthenticatedAppTeamSettingsGisDataRoute: typeof AuthenticatedAppTeamSettingsGisDataRoute
   AuthenticatedAppTeamSettingsIntegrationsRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRoute
-  AuthenticatedAppTeamSettingsPaymentRoute: typeof AuthenticatedAppTeamSettingsPaymentRoute
+  AuthenticatedAppTeamSettingsPaymentsRoute: typeof AuthenticatedAppTeamSettingsPaymentsRoute
   AuthenticatedAppTeamSettingsIndexRoute: typeof AuthenticatedAppTeamSettingsIndexRoute
 }
 
@@ -2141,8 +2141,8 @@ const AuthenticatedAppTeamSettingsRouteRouteChildren: AuthenticatedAppTeamSettin
       AuthenticatedAppTeamSettingsGisDataRoute,
     AuthenticatedAppTeamSettingsIntegrationsRoute:
       AuthenticatedAppTeamSettingsIntegrationsRoute,
-    AuthenticatedAppTeamSettingsPaymentRoute:
-      AuthenticatedAppTeamSettingsPaymentRoute,
+    AuthenticatedAppTeamSettingsPaymentsRoute:
+      AuthenticatedAppTeamSettingsPaymentsRoute,
     AuthenticatedAppTeamSettingsIndexRoute:
       AuthenticatedAppTeamSettingsIndexRoute,
   }

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './route
 import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
 import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
 import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
+import { Route as AuthenticatedAppTeamSettingsPaymentRouteImport } from './routes/_authenticated/app/$team/settings/payment'
 import { Route as AuthenticatedAppTeamSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/submission.$sessionId'
 import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
 import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
@@ -369,6 +370,12 @@ const AuthenticatedAppTeamSettingsIntegrationsRoute =
   AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
     id: '/integrations',
     path: '/integrations',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsPaymentRoute =
+  AuthenticatedAppTeamSettingsPaymentRouteImport.update({
+    id: '/payment',
+    path: '/payment',
     getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
   } as any)
 const AuthenticatedAppTeamSubmissionSessionIdRoute =
@@ -730,6 +737,7 @@ export interface FileRoutesByFullPath {
   '/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
+  '/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -814,6 +822,7 @@ export interface FileRoutesByTo {
   '/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
+  '/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -913,6 +922,7 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/settings/design': typeof AuthenticatedAppTeamSettingsDesignRoute
   '/_authenticated/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/_authenticated/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
+  '/_authenticated/app/$team/settings/payment': typeof AuthenticatedAppTeamSettingsPaymentRoute
   '/_authenticated/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/_public/_customDomain/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/_public/_customDomain/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
@@ -1011,6 +1021,7 @@ export interface FileRouteTypes {
     | '/app/$team/settings/design'
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
+    | '/app/$team/settings/payment'
     | '/app/$team/submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
@@ -1095,6 +1106,7 @@ export interface FileRouteTypes {
     | '/app/$team/settings/design'
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
+    | '/app/$team/settings/payment'
     | '/app/$team/submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
@@ -1193,6 +1205,7 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/settings/design'
     | '/_authenticated/app/$team/settings/gis-data'
     | '/_authenticated/app/$team/settings/integrations'
+    | '/_authenticated/app/$team/settings/payment'
     | '/_authenticated/app/$team/submission/$sessionId'
     | '/_public/_customDomain/$flow/pages/$page'
     | '/_public/_customDomain/$flow/pay/not-found'
@@ -1576,6 +1589,13 @@ declare module '@tanstack/react-router' {
       path: '/integrations'
       fullPath: '/app/$team/settings/integrations'
       preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/payment': {
+      id: '/_authenticated/app/$team/settings/payment'
+      path: '/payment'
+      fullPath: '/app/$team/settings/payment'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentRouteImport
       parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
     }
     '/_authenticated/app/$team/submission/$sessionId': {
@@ -2105,6 +2125,7 @@ interface AuthenticatedAppTeamSettingsRouteRouteChildren {
   AuthenticatedAppTeamSettingsDesignRoute: typeof AuthenticatedAppTeamSettingsDesignRoute
   AuthenticatedAppTeamSettingsGisDataRoute: typeof AuthenticatedAppTeamSettingsGisDataRoute
   AuthenticatedAppTeamSettingsIntegrationsRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRoute
+  AuthenticatedAppTeamSettingsPaymentRoute: typeof AuthenticatedAppTeamSettingsPaymentRoute
   AuthenticatedAppTeamSettingsIndexRoute: typeof AuthenticatedAppTeamSettingsIndexRoute
 }
 
@@ -2120,6 +2141,8 @@ const AuthenticatedAppTeamSettingsRouteRouteChildren: AuthenticatedAppTeamSettin
       AuthenticatedAppTeamSettingsGisDataRoute,
     AuthenticatedAppTeamSettingsIntegrationsRoute:
       AuthenticatedAppTeamSettingsIntegrationsRoute,
+    AuthenticatedAppTeamSettingsPaymentRoute:
+      AuthenticatedAppTeamSettingsPaymentRoute,
     AuthenticatedAppTeamSettingsIndexRoute:
       AuthenticatedAppTeamSettingsIndexRoute,
   }

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/settings/payment.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/settings/payment.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { hasFeatureFlag } from "lib/featureFlags";
+import PaymentSettings from "pages/FlowEditor/components/Settings/Team/Payment";
+
+export const Route = createFileRoute(
+  "/_authenticated/app/$team/settings/payment",
+)({
+  beforeLoad: ({ params }) => {
+    if (!hasFeatureFlag("STRIPE_MIGRATION")) {
+      throw redirect({
+        to: "/app/$team/settings",
+        params: { team: params.team },
+        replace: true,
+      });
+    }
+  },
+  component: PaymentSettings,
+});

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/settings/payments.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/settings/payments.tsx
@@ -3,7 +3,7 @@ import { hasFeatureFlag } from "lib/featureFlags";
 import PaymentSettings from "pages/FlowEditor/components/Settings/Team/Payment";
 
 export const Route = createFileRoute(
-  "/_authenticated/app/$team/settings/payment",
+  "/_authenticated/app/$team/settings/payments",
 )({
   beforeLoad: ({ params }) => {
     if (!hasFeatureFlag("STRIPE_MIGRATION")) {


### PR DESCRIPTION
## What does this PR do?
 - Adds `/:team/settings/payments` route
 - Populates with three sections
   - Onboarding, left as placeholder
   - ~~Status, left as placeholder~~ Removed in https://github.com/theopensystemslab/planx-new/pull/7138
   - Migrate to Stripe - dummy UI
   
All behind the `STRIPE_MIGRATION` feature flag. This is purely frontend only, there's no real queries or data persistence here at all. This can all get wired up later.

Project board ticket - https://github.com/orgs/theopensystemslab/projects/11/views/1?pane=issue&itemId=223929582

https://github.com/user-attachments/assets/0f5d05da-ad51-4dc7-bef4-5b653d765ffd

