### PR TITLE
fix(a11y): Make dropzone input interactable

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -73,7 +73,7 @@ const Root = styled(Box, {
       }),
     ],
   },
-  "&:focus": {
+  "&:focus-within": {
     ...borderedFocusStyle,
     boxShadow: "none",
     borderStyle: "solid",
@@ -175,9 +175,18 @@ export function Dropzone<T extends FileUploadSlot>({
     onDropRejected: handleRejectedUpload,
   });
 
+  // Keep focus/click/keyboard handling on the input
+  const {
+    role: _role,
+    tabIndex: _tabIndex,
+    onClick: _onClick,
+    onKeyDown: _onKeyDown,
+    ...dragProps
+  } = getRootProps();
+
   return (
     <Root
-      {...getRootProps()}
+      {...dragProps}
       isDragActive={isDragActive}
       isWithinListCard={isWithinListCard}
     >
@@ -185,6 +194,15 @@ export function Dropzone<T extends FileUploadSlot>({
         data-testid="upload-input"
         {...getInputProps()}
         aria-labelledby="dropzone-label"
+        tabIndex={0}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          opacity: 0,
+          cursor: "pointer",
+        }}
       />
       <Box sx={{ pl: 2, pr: 3, color: "text.secondary" }}>
         <CloudUpload />


### PR DESCRIPTION
## Issue

Relates to:
p.26 - DAC_Name_Role_Value_02 - https://trello.com/c/1OfFaojT/3718-a-name-role-value-02

Dropzone input can not be actioned via voice activation users:

> The file input has been removed from the tab order, while the surrounding container is
focusable but has a role="presentation". As a result, voice activation users cannot activate
the control by name or role, and had to rely on alternative pointer-based commands such as
Mouse Grid.

## Solution

- Ensure that the input can be interacted with to upload files, rather than relying on the container for interaction

### Testing

https://7140.planx.pizza/testing/dropzone-test/preview