### PR TITLE
fix(a11y, lps): Link context for option cards

### DIFF
--- a/apps/localplanning.services/src/components/OptionCard.astro
+++ b/apps/localplanning.services/src/components/OptionCard.astro
@@ -24,6 +24,6 @@ const { title, description } = actions[action];
     variant="primary"
     class="m-0 mt-auto self-start"
   >
-    Find local planning services
+    Find local planning services <span class="sr-only">to {title.toLowerCase()}</span>
   </Button>
 </div>


### PR DESCRIPTION
## Issue

Relates to:
p.16 - DAC_Link_Purpose_01 - https://trello.com/c/4lWto0yi/3713-a-aaa-link-order-01

Card links on LPS do not give adequate context to non-sighted users, three instances of identical `Find local planning services`.

> To identify the purpose of the multiple ‘Find local planning services’ links, details within the
surrounding page are required, but these are not part of the programmatically determined
link context. Users should be able to identify the purpose of the link without moving focus
from the link, for example by putting the description of the link in the same sentence,
paragraph, list item, or table cell as the link, or in the table header cell for a link in a data
table, because these are directly associated with the link itself.

## Solution

Append the card title to the link for screenreaders only, so that the full links read out will be:
- Find local planning services to start a planning application
- Find local planning services to notify your authority
- Find local planning services to get planning guidance

### Testing

https://localplanning.7141.planx.pizza/