### PR TITLE
fix(a11y, lps): Link context for application card buttons

### DIFF
--- a/apps/localplanning.services/src/components/applications/ApplicationCard.tsx
+++ b/apps/localplanning.services/src/components/applications/ApplicationCard.tsx
@@ -59,7 +59,12 @@ const ActionText: React.FC<Application> = (application) => {
   return <span className="text-body-md mb-0">{actionText}</span>;
 };
 
-const DeleteButton: React.FC<Application> = ({ id }) => {
+const DeleteButton: React.FC<Application> = ({
+  id,
+  address,
+  createdAt,
+  service,
+}) => {
   const deleteApplication = useDeleteApplication();
 
   const handleDelete = () => {
@@ -71,6 +76,9 @@ const DeleteButton: React.FC<Application> = ({ id }) => {
   return (
     <button
       onClick={handleDelete}
+      aria-label={`Delete application to ${service.name} at ${
+        address || "an undeclared address"
+      }, started ${formatDate(createdAt)}`}
       className="button button--small button-focus-style button--secondary"
     >
       Delete
@@ -85,6 +93,9 @@ const ViewApplicationButton: React.FC<Application> = (application) => {
   return (
     <a
       href={url}
+      aria-label={`View application to ${application.service.name} at ${
+        application.address || "an undeclared address"
+      }, started ${formatDate(application.createdAt)}`}
       className="button button--primary button--small button-focus-style paragraph-link--external"
       onClick={handleClick}
     >
@@ -103,6 +114,9 @@ const ActionButtons: React.FC<Application> = (application) => {
             <a
               href={application.serviceUrl}
               target="_blank"
+              aria-label={`Resume application to ${application.service.name} at ${
+                application.address || "an undeclared address"
+              }, started ${formatDate(application.createdAt)}`}
               className="button button--primary button--small button-focus-style paragraph-link--external"
             >
               Resume
@@ -116,6 +130,9 @@ const ActionButtons: React.FC<Application> = (application) => {
             <a
               href={application.paymentUrl}
               target="_blank"
+              aria-label={`Go to payment URL for application to ${application.service.name} at ${
+                application.address || "an undeclared address"
+              }, started ${formatDate(application.createdAt)}`}
               className="button button--primary button--small button-focus-style paragraph-link--external"
             >
               Go to payment URL


### PR DESCRIPTION
## Issue

Relates to:
p.30 - DAC_Headings_and_Labels_02 - https://trello.com/c/VtxMWK72/3720-aa-headings-and-labels-02

On the application dashboard, card action buttons do not give adequate context to non-sighted users:

> Multiple Delete buttons were provided with identical accessible names. As the buttons did
not identify which application they related to, screen reader users could not determine
which item would be deleted when navigating directly between interactive elements such as
buttons or links. Screen reader users frequently navigate by lists of controls rather than
reading surrounding content, meaning generic labels can become ambiguous and increase
the risk of deleting the wrong application.

## Solution

Add full context to all buttons, so that they read (for example):

`Delete application to Report a planning breach at 7, AMERSHAM ROAD, BEACONSFIELD, BUCKINGHAMSHIRE, HP9 2HA, started 7 August 2026`

For applications with "address not yet declared" they will read (for example):

`Resume application to Report a planning breach at an undeclared address, started 7 August 2026`

### Side note

The interface still uniformly refers to "applications", rather than forms. Wider update to be carried out to update this, I've added a card to new requests: https://trello.com/c/WBsgpSSC/3740-update-language-for-lps-dashboard-to-refer-to-forms-rather-than-applications