### PR TITLE
fix(a11y): Save button text on upload + label

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/SelectMultipleFileTypes.tsx
@@ -184,9 +184,9 @@ export const SelectMultipleFileTypes = (props: ChecklistProps) => {
           onClick={onSave}
           data-testid={`save-${uploadedFile.file.name}`}
         >
-          Save
+          Save{" "}
           <Box sx={visuallyHidden} component="span">
-            {` labels for ${uploadedFile.file.name}`}
+            {`labels for ${uploadedFile.file.name}`}
           </Box>
         </Button>
       )}


### PR DESCRIPTION
## Issue

Relates to:
p.32 - DAC_Headings_and_Labels_03 - https://trello.com/c/PTmdo9nd/3721-aa-headings-and-labels-03

Upload & label - the text read out on the save button is being truncated:

> Passing over the button to save, the audible response fed back with ‘savelables’. This
description was not only inaccurate but also audibly confusing. My expectation would have
been for an audibly accurate description of the displayed text, with the inclusion of an
extended border outline to aid ease of visual identification when moving down the page.

## Solution

Add a space as a JSX space, rather than leading space inside the hidden span, which appears to be stripped by some assistive technologies.

<img width="799" height="472" alt="image" src="https://github.com/user-attachments/assets/8dd9ae36-c5f5-44cb-bf40-910f13fd0116" />
