### PR TITLE
chore: run `reconcile payments` CRON every 3 hours, not every 30 minutes

### DIFF
--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -18,7 +18,7 @@
   comment: 'Checks for any failed submissions and logs them to #planx-notifications-internal to investigate further'
 - name: reconcile_payments
   webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/reconcile-payments'
-  schedule: '*/3 * * * *'
+  schedule: 0 */3 * * *
   include_in_metadata: true
   payload: {}
   headers:

--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -18,7 +18,7 @@
   comment: 'Checks for any failed submissions and logs them to #planx-notifications-internal to investigate further'
 - name: reconcile_payments
   webhook: '{{HASURA_PLANX_API_URL}}/webhooks/hasura/reconcile-payments'
-  schedule: '*/30 * * * *'
+  schedule: '*/3 * * * *'
   include_in_metadata: true
   payload: {}
   headers:


### PR DESCRIPTION
This felt quite noisy yesterday ! Every 3 hours should let us ID proactively - see https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1786318900791539

Skipping pizza as this only runs on prod anyways! 