### PR TITLE
feat: make notes searchable

### DIFF
--- a/apps/editor.planx.uk/src/hooks/useSearch.ts
+++ b/apps/editor.planx.uk/src/hooks/useSearch.ts
@@ -19,6 +19,8 @@ export interface SearchResult<T extends object> {
   matchValue: string;
   /** Index within flattened array of item[key] */
   refIndex: number;
+  /** Fuse relevance score - 0-1, lower is better. */
+  score: number;
 }
 
 export type SearchResults<T extends object> = SearchResult<T>[];
@@ -35,6 +37,7 @@ export const useSearch = <T extends object>({
     () => ({
       useExtendedSearch: true,
       includeMatches: true,
+      includeScore: true,
       minMatchCharLength: 3,
       ignoreLocation: true,
       keys,
@@ -66,6 +69,7 @@ export const useSearch = <T extends object>({
           matchIndices: result.matches[0].indices as [number, number][],
           matchValue: result.matches[0].value!,
           refIndex: result.matches[0]?.refIndex || 0,
+          score: result.score ?? 0,
         };
       }),
     );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/NoteResultCard.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/NoteResultCard.tsx
@@ -1,0 +1,57 @@
+import StickyNote2Icon from "@mui/icons-material/StickyNote2";
+import Box from "@mui/material/Box";
+import ListItemButton from "@mui/material/ListItemButton";
+import { styled } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import type { SearchResult } from "hooks/useSearch";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+import { Headline } from "../Headline";
+
+const Root = styled(ListItemButton)(({ theme }) => ({
+  border: `1px solid ${theme.palette.text.primary}`,
+  display: "block",
+  maxWidth: "100%",
+  padding: 0,
+  borderWidth: 2,
+}));
+
+export const NoteResultCard: React.FC<{ result: SearchResult<FlowNote> }> = ({
+  result,
+}) => {
+  const navigate = useNavigate();
+  const { team, flow } = useParams({
+    from: "/_authenticated/app/$team/$flow",
+  });
+
+  const handleClick = () =>
+    navigate({
+      to: "/app/$team/$flow/note/$id/edit",
+      params: { team, flow, id: result.item.positionId },
+    });
+
+  return (
+    <Root onClick={handleClick} disableRipple>
+      <Box sx={{ p: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <StickyNote2Icon sx={{ fontSize: 18 }} />
+          <Typography
+            variant="body2"
+            sx={{ ml: 1, fontSize: 14, fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+          >
+            Note
+          </Typography>
+        </Box>
+        <Box sx={{ mt: 1 }}>
+          <Headline
+            text={result.item.text}
+            matchIndices={result.matchIndices!}
+          />
+        </Box>
+      </Box>
+    </Root>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/index.tsx
@@ -1,16 +1,19 @@
 import Typography from "@mui/material/Typography";
-import type { IndexedNode } from "@opensystemslab/planx-core/types";
-import type { SearchResult } from "hooks/useSearch";
 import React from "react";
 import { NodeCard } from "ui/editor/NodeCard";
 
 import { DATA_FACETS } from "../facets";
 import { Headline } from "../Headline";
+import type { SearchableResult } from "../types";
+import { isNoteResult } from "../types";
 import { getDisplayDetailsForResult } from "./getDisplayDetailsForResult";
+import { NoteResultCard } from "./NoteResultCard";
 
 export const SearchResultCard: React.FC<{
-  result: SearchResult<IndexedNode>;
+  result: SearchableResult;
 }> = ({ result }) => {
+  if (isNoteResult(result)) return <NoteResultCard result={result} />;
+
   const { key, headline } = getDisplayDetailsForResult(result);
 
   const isDataKey = DATA_FACETS.includes(result.key);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -1,6 +1,7 @@
 import type { IndexedNode } from "@opensystemslab/planx-core/types";
 import { flatFlags } from "@opensystemslab/planx-core/types";
 import type { FuseOptionKey, FuseOptionKeyObject } from "fuse.js";
+import type { FlowNote } from "hooks/data/useFlowNotes";
 import { get } from "lodash";
 
 export type SearchFacets = Array<FuseOptionKey<IndexedNode>>;
@@ -172,3 +173,6 @@ export const ALL_FACETS: SearchFacets = [
   ...feedback,
   ...DATA_FACETS,
 ];
+
+/** Notes aren't flow nodes - they're a separate `FlowNote` shape with a single searchable field */
+export const NOTE_FACETS: Array<FuseOptionKey<FlowNote>> = ["text"];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.test.tsx
@@ -1,5 +1,7 @@
 import * as planxCore from "@opensystemslab/planx-core";
 import { waitFor, within } from "@testing-library/react";
+import type { AttachedNote } from "hooks/data/useFlowNotes";
+import { FlowNotesContext } from "pages/FlowEditor/components/Flow/notes/FlowNotesContext";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { setup } from "test/utils";
@@ -7,18 +9,34 @@ import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
 const mockNavigate = vi.fn();
+const mockUseParams = vi.fn(() => ({ team: "test-team", flow: "test-flow" }));
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual("@tanstack/react-router");
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useParams: () => mockUseParams(),
   };
 });
 
 import Search from ".";
 import { flow } from "./mocks/simple";
 import { VirtuosoWrapper } from "./testUtils";
+
+const mockNote: AttachedNote = {
+  positionId: "note-1",
+  contentId: "note-content-1",
+  flowId: "test-flow-id",
+  nodeId: "Ej0xpn4l8u",
+  placement: null,
+  text: "Sample note text",
+  color: "yellow",
+  createdBy: 1,
+  updatedBy: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
 
 const { setState, getState } = useStore;
 
@@ -170,5 +188,79 @@ describe("rich text fields", () => {
     expect(queryByText(/</)).not.toBeInTheDocument();
     expect(queryByText(/>/)).not.toBeInTheDocument();
     expect(queryByText(/\//)).not.toBeInTheDocument();
+  });
+});
+
+describe("notes", () => {
+  const withNote = (children: React.ReactNode) => (
+    <FlowNotesContext.Provider
+      value={{
+        attached: new Map([[mockNote.nodeId, [mockNote]]]),
+        positioned: new Map(),
+        loading: false,
+        clonedContentIds: new Set(),
+      }}
+    >
+      {children}
+    </FlowNotesContext.Provider>
+  );
+
+  test("a matching note is included alongside node results", async () => {
+    const { user, getAllByRole, getByLabelText } = await setup(
+      withNote(
+        <VirtuosoWrapper>
+          <Search />
+        </VirtuosoWrapper>,
+      ),
+    );
+
+    const searchInput = getByLabelText("Search this flow");
+    user.type(searchInput, "text");
+
+    await waitFor(() => expect(getAllByRole("listitem")).toHaveLength(2));
+  });
+
+  test("clicking a note result navigates to the note edit route", async () => {
+    const { user, getAllByRole, getByLabelText } = await setup(
+      withNote(
+        <VirtuosoWrapper>
+          <Search />
+        </VirtuosoWrapper>,
+      ),
+    );
+
+    const searchInput = getByLabelText("Search this flow");
+    user.type(searchInput, "Sample note text");
+
+    await waitFor(() => expect(getAllByRole("listitem")).toHaveLength(1));
+
+    const [noteItem] = getAllByRole("listitem");
+    await user.click(within(noteItem).getByRole("button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/app/$team/$flow/note/$id/edit",
+        params: expect.objectContaining({ id: mockNote.positionId }),
+      }),
+    );
+  });
+
+  test("notes are excluded when 'Search only data fields' is checked", async () => {
+    const { user, getAllByRole, getByRole, getByLabelText } = await setup(
+      withNote(
+        <VirtuosoWrapper>
+          <Search />
+        </VirtuosoWrapper>,
+      ),
+    );
+
+    const checkbox = getByLabelText("Search only data fields");
+    await user.click(checkbox);
+
+    const searchInput = getByLabelText("Search this flow");
+    user.type(searchInput, "Independent");
+
+    await waitFor(() => expect(getByRole("list")).toBeEmptyDOMElement());
+    expect(() => getAllByRole("listitem")).toThrow();
   });
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -99,8 +99,9 @@ const Search: React.FC = () => {
     keys: NOTE_FACETS,
   });
 
+  // Interleave notes and nodes search results by relevance
   const results = useMemo<SearchableResult[]>(
-    () => [...nodeResults, ...noteResults],
+    () => [...nodeResults, ...noteResults].sort((a, b) => a.score - b.score),
     [nodeResults, noteResults],
   );
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/index.tsx
@@ -1,14 +1,10 @@
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import { useTheme } from "@mui/material/styles";
-import type { IndexedNode } from "@opensystemslab/planx-core/types";
 import { useFormik } from "formik";
-import {
-  type SearchResult,
-  type SearchResults,
-  useSearch,
-} from "hooks/useSearch";
+import { useSearch } from "hooks/useSearch";
 import { debounce } from "lodash";
+import { useFlowNotesContext } from "pages/FlowEditor/components/Flow/notes/FlowNotesContext";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useEffect, useMemo, useState } from "react";
 import type { Components } from "react-virtuoso";
@@ -17,9 +13,10 @@ import { SEARCH_DEBOUNCE_MS } from "ui/shared/constants";
 
 import { ExternalPortalList } from "./ExternalPortalList/ExternalPortalList";
 import type { SearchFacets } from "./facets";
-import { ALL_FACETS } from "./facets";
+import { ALL_FACETS, NOTE_FACETS } from "./facets";
 import { SearchHeader } from "./SearchHeader";
 import { SearchResultCard } from "./SearchResultCard";
+import type { SearchableResult } from "./types";
 
 interface SearchNodes {
   pattern: string;
@@ -27,9 +24,9 @@ interface SearchNodes {
 }
 
 // Types for Virtuoso
-export type Data = SearchResult<IndexedNode>;
+export type Data = SearchableResult;
 export type Context = {
-  results: SearchResults<IndexedNode>;
+  results: SearchableResult[];
   formik: ReturnType<typeof useFormik<SearchNodes>>;
   isSearching: boolean;
   lastPattern: string;
@@ -78,20 +75,45 @@ const Search: React.FC = () => {
   const [lastPattern, setLastPattern] = useState("");
 
   // Call custom hook to control searching
-  const { results, search } = useSearch({
+  const { results: nodeResults, search: searchNodes } = useSearch({
     list: orderedFlow || [],
     keys: formik.values.facets,
   });
+
+  // Notes aren't part of the flow graph, so they're searched separately and merged into `results`
+  const { attached, positioned } = useFlowNotesContext();
+  const notes = useMemo(
+    () => [...attached.values(), ...positioned.values()].flat(),
+    [attached, positioned],
+  );
+
+  const isDataOnlySearch = !formik.values.facets.includes("data.title");
+
+  const noteSearchList = useMemo(
+    () => (isDataOnlySearch ? [] : notes),
+    [isDataOnlySearch, notes],
+  );
+
+  const { results: noteResults, search: searchNotes } = useSearch({
+    list: noteSearchList,
+    keys: NOTE_FACETS,
+  });
+
+  const results = useMemo<SearchableResult[]>(
+    () => [...nodeResults, ...noteResults],
+    [nodeResults, noteResults],
+  );
 
   const debouncedSearch = useMemo(
     () =>
       debounce((pattern: string) => {
         console.debug("Search term: ", pattern);
-        search(pattern);
+        searchNodes(pattern);
+        searchNotes(pattern);
         setLastPattern(pattern);
         setIsSearching(false);
       }, SEARCH_DEBOUNCE_MS),
-    [search],
+    [searchNodes, searchNotes],
   );
 
   const theme = useTheme();

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
@@ -306,6 +306,7 @@ export const mockQuestionResult: SearchResult<IndexedNode> = {
   key: "data.text",
   matchIndices: [[0, 7]],
   refIndex: 0,
+  score: 0,
   matchValue: "Seahorse",
 };
 
@@ -352,6 +353,7 @@ export const mockPayResult: SearchResult<IndexedNode> = {
   key: "data.title",
   matchIndices: [[0, 5]],
   refIndex: 3,
+  score: 0,
   matchValue: "Jaguar",
 };
 
@@ -376,6 +378,7 @@ export const mockChecklistResult: SearchResult<IndexedNode> = {
   key: "data.categories.title",
   matchIndices: [[0, 4]],
   refIndex: 0,
+  score: 0,
   matchValue: "Koala",
 };
 
@@ -392,6 +395,7 @@ export const mockChecklistOptionResult: SearchResult<IndexedNode> = {
   key: "data.text",
   matchIndices: [[0, 3]],
   refIndex: 0,
+  score: 0,
   matchValue: "Duck",
 };
 
@@ -415,6 +419,7 @@ export const mockNextStepsOptionResult: SearchResult<IndexedNode> = {
   key: "data.steps.title",
   matchIndices: [[0, 6]],
   refIndex: 0,
+  score: 0,
   matchValue: "Hamster",
 };
 
@@ -445,6 +450,7 @@ export const mockFileUploadAndLabelResult: SearchResult<IndexedNode> = {
   key: "data.fileTypes.name",
   matchIndices: [[0, 6]],
   refIndex: 0,
+  score: 0,
   matchValue: "Penguin",
 };
 
@@ -461,6 +467,7 @@ export const mockNumberInputResult: SearchResult<IndexedNode> = {
   key: "data.units",
   matchIndices: [[0, 8]],
   refIndex: 0,
+  score: 0,
   matchValue: "Wolverine",
 };
 
@@ -515,6 +522,7 @@ export const mockSchemaResult: SearchResult<IndexedNode> = {
   key: "data.schemaName",
   matchIndices: [[0, 7]],
   refIndex: 0,
+  score: 0,
   matchValue: "Hedgehog",
 };
 
@@ -537,6 +545,7 @@ export const mockTaskListResult: SearchResult<IndexedNode> = {
   key: "data.tasks.title",
   matchIndices: [[0, 6]],
   refIndex: 0,
+  score: 0,
   matchValue: "Ostrich",
 };
 
@@ -552,6 +561,7 @@ export const mockContentResult: SearchResult<IndexedNode> = {
   key: "data.content",
   matchIndices: [[3, 7]],
   refIndex: 0,
+  score: 0,
   matchValue: "Sheep",
 };
 
@@ -579,6 +589,7 @@ export const mockConfirmationResult: SearchResult<IndexedNode> = {
   key: "data.heading",
   matchIndices: [[0, 4]],
   refIndex: 0,
+  score: 0,
   matchValue: "Snake",
 };
 
@@ -598,6 +609,7 @@ export const mockFindPropertyResult: SearchResult<IndexedNode> = {
   key: "data.newAddressTitle",
   matchIndices: [[0, 4]],
   refIndex: 0,
+  score: 0,
   matchValue: "Mouse",
 };
 
@@ -618,6 +630,7 @@ export const mockDrawBoundaryResult: SearchResult<IndexedNode> = {
   key: "data.titleForUploading",
   matchIndices: [[0, 7]],
   refIndex: 0,
+  score: 0,
   matchValue: "Elephant",
 };
 
@@ -636,6 +649,7 @@ export const mockPlanningConstraintsResult: SearchResult<IndexedNode> = {
   key: "data.disclaimer",
   matchIndices: [[3, 11]],
   refIndex: 0,
+  score: 0,
   matchValue: "Barracuda",
 };
 
@@ -657,6 +671,7 @@ export const mockResultResult: SearchResult<IndexedNode> = {
   key: "data.overrides.flag.pp.immune.heading",
   matchIndices: [[0, 4]],
   refIndex: 0,
+  score: 0,
   matchValue: "Squid",
 };
 
@@ -678,4 +693,5 @@ export const mockFeedbackResult: SearchResult<IndexedNode> = {
   matchIndices: [[0, 7]],
   matchValue: "Bullfrog",
   refIndex: 0,
+  score: 0,
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/dataFacetFlow.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/dataFacetFlow.ts
@@ -208,6 +208,7 @@ export const mockQuestionResult: SearchResult<IndexedNode> = {
   key: "data.fn",
   matchIndices: [[0, 3]],
   refIndex: 0,
+  score: 0,
   matchValue: "colour",
 };
 
@@ -224,6 +225,7 @@ export const mockAnswerResult: SearchResult<IndexedNode> = {
   key: "data.val",
   matchIndices: [[0, 2]],
   refIndex: 0,
+  score: 0,
   matchValue: "red",
 };
 
@@ -276,6 +278,7 @@ export const mockListRootResult: SearchResult<IndexedNode> = {
   key: "data.fn",
   matchIndices: [[0, 7]],
   refIndex: 0,
+  score: 0,
   matchValue: "listRoot",
 };
 
@@ -418,6 +421,7 @@ export const mockListDataResult: SearchResult<IndexedNode> = {
   key: "data.schema.fields.data.fn",
   matchIndices: [[0, 5]],
   refIndex: 1,
+  score: 0,
   matchValue: "tenure",
 };
 
@@ -560,6 +564,7 @@ export const mockListAnswerResult: SearchResult<IndexedNode> = {
   key: "data.schema.fields.data.options.data.val",
   matchIndices: [[0, 14]],
   refIndex: 10,
+  score: 0,
   matchValue: "selfCustomBuild",
 };
 
@@ -583,6 +588,7 @@ export const mockCalculateRootResult: SearchResult<IndexedNode> = {
   key: "data.fn",
   matchIndices: [[0, 14]],
   refIndex: 0,
+  score: 0,
   matchValue: "calculateOutput",
 };
 
@@ -606,6 +612,7 @@ export const mockCalculateFormulaResult: SearchResult<IndexedNode> = {
   key: "formula",
   matchIndices: [[0, 6]],
   refIndex: 1,
+  score: 0,
   matchValue: "formulaTwo",
 };
 
@@ -631,5 +638,6 @@ export const mockFileUploadAndLabelResult: SearchResult<IndexedNode> = {
   key: "data.fileTypes.fn",
   matchIndices: [[0, 8]],
   refIndex: 0,
+  score: 0,
   matchValue: "floorplan",
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/simple.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/simple.ts
@@ -52,6 +52,7 @@ export const results: SearchResults<IndexedNode> = [
     key: "data.val",
     matchIndices: [[0, 2]],
     refIndex: 0,
+    score: 0,
     matchValue: "india",
   },
   {
@@ -67,6 +68,7 @@ export const results: SearchResults<IndexedNode> = [
     key: "data.val",
     matchIndices: [[0, 2]],
     refIndex: 0,
+    score: 0,
     matchValue: "indonesia",
   },
 ];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/types.ts
@@ -1,0 +1,11 @@
+import type { IndexedNode } from "@opensystemslab/planx-core/types";
+import type { FlowNote } from "hooks/data/useFlowNotes";
+import type { SearchResult } from "hooks/useSearch";
+
+export type SearchableResult =
+  SearchResult<IndexedNode> | SearchResult<FlowNote>;
+
+// `positionId` is unique to FlowNote and identifies a note result
+export const isNoteResult = (
+  result: SearchableResult,
+): result is SearchResult<FlowNote> => "positionId" in result.item;


### PR DESCRIPTION
Adds notes as a separate result list for search tab, using just the text for the search facet. Also tests.