### PR TITLE
fix: don't delete notes when deleting nodes - so restore still works

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.test.ts
@@ -26,8 +26,8 @@ beforeEach(() => {
 });
 
 describe("repositionNotesForDeletedNodes", () => {
-  it("deletes all attached notes whose node was deleted, regardless of author", async () => {
-    let deleteIds: string[] | undefined;
+  it("leaves attached notes whose node was deleted untouched (orphaned), regardless of author", async () => {
+    let mutationCalled = false;
 
     server.use(
       graphql.query("GetFlowNotePositionsForReposition", () =>
@@ -50,22 +50,17 @@ describe("repositionNotesForDeletedNodes", () => {
           },
         }),
       ),
-      graphql.mutation("DeleteFlowNotePositions", ({ variables }) => {
-        deleteIds = variables.ids;
+      graphql.mutation("ReanchorFlowNotePosition", () => {
+        mutationCalled = true;
         return HttpResponse.json({
-          data: {
-            delete_flow_note_positions: { affected_rows: variables.ids.length },
-          },
+          data: { update_flow_note_positions_by_pk: { id: "unused" } },
         });
       }),
     );
 
     await repositionNotesForDeletedNodes(["deleted-node"], {}, {});
 
-    expect(deleteIds).toEqual(
-      expect.arrayContaining(["note-attached", "note-other-author"]),
-    );
-    expect(deleteIds).toHaveLength(2);
+    expect(mutationCalled).toBe(false);
   });
 
   it("re-anchors a sibling-anchored positioned note to the surviving preceding sibling", async () => {
@@ -168,14 +163,14 @@ describe("repositionNotesForDeletedNodes", () => {
     });
   });
 
-  it("deletes a positioned note when its entire container was also deleted", async () => {
+  it("leaves a positioned note untouched (orphaned) when its entire container was also deleted", async () => {
     const flowBefore = {
       _root: { edges: ["folder"] },
       folder: { edges: ["child"] },
       child: { type: 8 },
     };
     const flowAfter = { _root: {} };
-    let deleteIds: string[] | undefined;
+    let mutationCalled = false;
 
     server.use(
       graphql.query("GetFlowNotePositionsForReposition", () =>
@@ -192,12 +187,10 @@ describe("repositionNotesForDeletedNodes", () => {
           },
         }),
       ),
-      graphql.mutation("DeleteFlowNotePositions", ({ variables }) => {
-        deleteIds = variables.ids;
+      graphql.mutation("ReanchorFlowNotePosition", () => {
+        mutationCalled = true;
         return HttpResponse.json({
-          data: {
-            delete_flow_note_positions: { affected_rows: variables.ids.length },
-          },
+          data: { update_flow_note_positions_by_pk: { id: "unused" } },
         });
       }),
     );
@@ -208,7 +201,7 @@ describe("repositionNotesForDeletedNodes", () => {
       flowAfter,
     );
 
-    expect(deleteIds).toEqual(["note-orphaned"]);
+    expect(mutationCalled).toBe(false);
   });
 
   it("issues no mutations when there is nothing to reposition", async () => {
@@ -218,10 +211,10 @@ describe("repositionNotesForDeletedNodes", () => {
       graphql.query("GetFlowNotePositionsForReposition", () =>
         HttpResponse.json({ data: { flow_note_positions: [] } }),
       ),
-      graphql.mutation("DeleteFlowNotePositions", () => {
+      graphql.mutation("ReanchorFlowNotePosition", () => {
         mutationCalled = true;
         return HttpResponse.json({
-          data: { delete_flow_note_positions: { affected_rows: 0 } },
+          data: { update_flow_note_positions_by_pk: { id: "unused" } },
         });
       }),
     );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.ts
@@ -24,14 +24,6 @@ const GET_FLOW_NOTE_POSITIONS_FOR_REPOSITION = gql`
   }
 `;
 
-const DELETE_FLOW_NOTE_POSITIONS = gql`
-  mutation DeleteFlowNotePositions($ids: [uuid!]!) {
-    delete_flow_note_positions(where: { id: { _in: $ids } }) {
-      affected_rows
-    }
-  }
-`;
-
 const REANCHOR_FLOW_NOTE_POSITION = gql`
   mutation ReanchorFlowNotePosition($id: uuid!, $placement: jsonb!) {
     update_flow_note_positions_by_pk(
@@ -45,6 +37,7 @@ const REANCHOR_FLOW_NOTE_POSITION = gql`
 
 /**
  * Called after a node is removed from the flow, with the flow as it was immediately before and immediately after.
+
  */
 export const repositionNotesForDeletedNodes = async (
   deletedNodeIds: string[],
@@ -65,14 +58,10 @@ export const repositionNotesForDeletedNodes = async (
     fetchPolicy: "network-only",
   });
 
-  const toDelete: string[] = [];
   const toReanchor: Array<{ id: string; placement: NotePlacement }> = [];
 
   for (const note of data.flow_note_positions) {
-    if (note.node_id) {
-      if (deleted.has(note.node_id)) toDelete.push(note.id);
-      continue;
-    }
+    if (note.node_id) continue;
 
     if (!note.placement) continue;
 
@@ -99,28 +88,18 @@ export const repositionNotesForDeletedNodes = async (
       );
       if (repositioned) {
         toReanchor.push({ id: note.id, placement: repositioned });
-      } else {
-        toDelete.push(note.id);
       }
     }
   }
 
-  await Promise.all([
-    ...(toDelete.length > 0
-      ? [
-          client.mutate({
-            mutation: DELETE_FLOW_NOTE_POSITIONS,
-            variables: { ids: toDelete },
-          }),
-        ]
-      : []),
-    ...toReanchor.map(({ id, placement }) =>
+  await Promise.all(
+    toReanchor.map(({ id, placement }) =>
       client.mutate({
         mutation: REANCHOR_FLOW_NOTE_POSITION,
         variables: { id, placement },
       }),
     ),
-  ]);
+  );
 };
 
 /**


### PR DESCRIPTION
The implication of this is that we will end up with dangling notes that have no node, in the case where the node is deleted but not restored. Perhaps we should have a cleanup job to deal with those? Or maybe its fine to leave them.