### PR TITLE
chore: grant metabase select permissions to `analytics_planning_data_teams` view

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1786442842479_grant_metabase_permissions_to_analytics_planning_data_view/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1786442842479_grant_metabase_permissions_to_analytics_planning_data_view/down.sql
@@ -1,0 +1,1 @@
+REVOKE SELECT ON "public"."analytics_planning_data_teams" TO metabase_read_only;

--- a/apps/hasura.planx.uk/migrations/default/1786442842479_grant_metabase_permissions_to_analytics_planning_data_view/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1786442842479_grant_metabase_permissions_to_analytics_planning_data_view/up.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON "public"."analytics_planning_data_teams" TO metabase_read_only;


### PR DESCRIPTION
Nit missed in #7145, CRM automation [still uses this view](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1786442260013049?thread_ts=1786437573.273189&cid=C01E3AC0C03)