### PR TITLE
fix(a11y): New tab warning for next steps

### DIFF
--- a/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
+++ b/apps/editor.planx.uk/src/ui/public/NextStepsList.tsx
@@ -120,6 +120,12 @@ const Step = ({ title, description, url }: ListItemProps) => (
         }}
       >
         {description}
+        {url && (
+          <>
+            {description && <br />}
+            {`(opens in new tab)`}
+          </>
+        )}
       </Typography>
     </Box>
     <ArrowButton className="arrowButton">


### PR DESCRIPTION
## Issue

Relates to:
p.36 - DAC_Change_on_Request_02 - https://trello.com/c/TN77ckE8/3723-aaa-change-on-request-02

External links in Next Steps open in a new tab without warning the user.

> Components open a new tab or window when activated without making users aware that
this is the case prior to activation. Users may not be aware that they have been navigated to
a new tab and may not be aware of why they cannot navigate back to the previous page
using the ‘back’ button.

## Solution

Add `(opens in a new tab)` warning to all external links

### Testing

https://7166.planx.pizza/testing/next-steps-links/preview