### PR TITLE
feat: copy notes along with node copies

### DIFF
--- a/apps/editor.planx.uk/src/@planx/graph/__tests__/insert_graph.test.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/__tests__/insert_graph.test.ts
@@ -121,7 +121,7 @@ describe("inserting a graph", () => {
       insertGraph(pattern, { idFn: deterministicId, onInsert })(emptyFlow());
 
       // question then notice, matching pattern._root.edges - not their new ids' sort order
-      expect(onInsert).toHaveBeenCalledWith(["ID_0", "ID_3"]);
+      expect(onInsert).toHaveBeenCalledWith(["ID_0", "ID_3"], expect.any(Map));
     });
 
     test("is not called when there is nothing to insert", () => {

--- a/apps/editor.planx.uk/src/@planx/graph/index.ts
+++ b/apps/editor.planx.uk/src/@planx/graph/index.ts
@@ -837,7 +837,8 @@ export const insertGraph =
       parent?: NodeId;
       before?: NodeId;
       idFn?: () => string;
-      onInsert?: (topLevelIds: string[]) => void;
+      /** Called with the new top-level ids, and a map of every original id (including nested descendants) to its newly generated id */
+      onInsert?: (topLevelIds: string[], idMap: Map<string, string>) => void;
     } = {},
   ) =>
   (graph: Graph = {}): [Graph, Array<OT.Op>] =>
@@ -875,7 +876,10 @@ export const insertGraph =
         .map((newId) => buildGraphFromNodes(newId, newNodes));
 
       // 4. Fire optional callback function
-      onInsert?.(topLevelTrees.map(({ id }) => id));
+      onInsert?.(
+        topLevelTrees.map(({ id }) => id),
+        idMap,
+      );
 
       // 5. Finally, insert each rebuilt node in turn and all its nested children
       topLevelTrees.forEach(({ id, children, ...nodeData }) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/ContextMenu.tsx
@@ -272,7 +272,7 @@ export const ContextMenu: React.FC = () => {
           ? [
               {
                 id: "attach-note",
-                label: "Add note",
+                label: "Attach note",
                 icon: <StickyNote2Icon fontSize="small" />,
                 disabled: false,
                 onClick: handleAttachNote,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes.ts
@@ -1,0 +1,96 @@
+import { gql } from "@apollo/client";
+import { client } from "lib/graphql";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+import { CREATE_FLOW_NOTE_POSITION } from "../hooks/mutations";
+
+export interface CopiedAttachedNote {
+  nodeId: string;
+  text: string;
+  color: string;
+}
+
+interface AttachedFlowNoteRow {
+  node_id: string;
+  note: {
+    text: string;
+    color: string;
+  };
+}
+
+const GET_ATTACHED_FLOW_NOTES_FOR_NODES = gql`
+  query GetAttachedFlowNotesForNodes($flowId: uuid!, $nodeIds: [String!]!) {
+    flow_note_positions(
+      where: { flow_id: { _eq: $flowId }, node_id: { _in: $nodeIds } }
+    ) {
+      node_id
+      note {
+        text
+        color
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch the notes attached to any of the given node ids, so they can be stashed on the clipboard alongside a copied node
+ */
+export const fetchAttachedFlowNotesForNodes = async (
+  flowId: string,
+  nodeIds: string[],
+): Promise<CopiedAttachedNote[]> => {
+  if (!flowId || nodeIds.length === 0) return [];
+
+  const { data } = await client.query<{
+    flow_note_positions: AttachedFlowNoteRow[];
+  }>({
+    query: GET_ATTACHED_FLOW_NOTES_FOR_NODES,
+    variables: { flowId, nodeIds },
+    fetchPolicy: "network-only",
+  });
+
+  return data.flow_note_positions.map((row) => ({
+    nodeId: row.node_id,
+    text: row.note.text,
+    color: row.note.color,
+  }));
+};
+
+/**
+ * Re-attach copied notes to the newly pasted nodes they were originally attached to as an independent copy
+ * editing the pasted note doesn't affect the original
+ */
+export const pasteAttachedFlowNotes = async (
+  notes: CopiedAttachedNote[],
+  idMap: Map<string, string>,
+  flowId: string,
+): Promise<void> => {
+  const userId = useStore.getState().user?.id;
+  if (!flowId || !userId || notes.length === 0) return;
+
+  await Promise.all(
+    notes.map(({ nodeId, text, color }) => {
+      const newNodeId = idMap.get(nodeId);
+      if (!newNodeId) return undefined;
+
+      return client.mutate({
+        mutation: CREATE_FLOW_NOTE_POSITION,
+        variables: {
+          object: {
+            flow_id: flowId,
+            node_id: newNodeId,
+            created_by: userId,
+            note: {
+              data: {
+                text,
+                color,
+                created_by: userId,
+                updated_by: userId,
+              },
+            },
+          },
+        },
+      });
+    }),
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/editor.ts
@@ -32,6 +32,11 @@ import type {
   ContextMenuPosition,
   ContextMenuSource,
 } from "pages/FlowEditor/components/Flow/components/ContextMenu";
+import type { CopiedAttachedNote } from "pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes";
+import {
+  fetchAttachedFlowNotesForNodes,
+  pasteAttachedFlowNotes,
+} from "pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes";
 import {
   repositionNotesForDeletedNodes,
   repositionNotesForMovedNode,
@@ -269,6 +274,7 @@ interface CopiedPayload {
   rootId: string;
   nodes: { originalId: string; nodeData: Store.Node }[];
   isTemplate: boolean;
+  notes: CopiedAttachedNote[];
 }
 
 interface CutPayload {
@@ -298,7 +304,7 @@ export interface EditorStore extends Store.Store {
   disconnectFromFlow: () => void;
   cloneNode: (id: NodeId) => void;
   getClonedNodeId: () => string | null;
-  copyNode: (id: NodeId) => void;
+  copyNode: (id: NodeId) => Promise<void>;
   getCopiedNode: () => { node: Store.Node; children: Store.Node[] };
   copyHelpText: (id: NodeId) => void;
   getCopiedHelpText: () => {
@@ -448,7 +454,7 @@ export const editorStore: StateCreator<
 
   getClonedNodeId: () => localStorage.getItem("clonedNodeId"),
 
-  copyNode(id: string) {
+  async copyNode(id: string) {
     const { flow, isTemplate } = get();
     const rootNode = flow[id];
     if (!rootNode) return;
@@ -473,10 +479,17 @@ export const editorStore: StateCreator<
 
     getDescendants(id);
 
+    const flowId = get().id;
+    const notes = await fetchAttachedFlowNotesForNodes(
+      flowId,
+      nodesToCopy.map(({ originalId }) => originalId),
+    );
+
     const payload: CopiedPayload = {
       rootId: id,
       nodes: nodesToCopy,
       isTemplate: isTemplate,
+      notes,
     };
 
     try {
@@ -726,6 +739,7 @@ export const editorStore: StateCreator<
         rootId,
         nodes: copiedNodes,
         isTemplate: copiedFromTemplate,
+        notes: copiedNotes,
       }: CopiedPayload = JSON.parse(copiedString);
       if (!copiedNodes || copiedNodes.length === 0) return;
 
@@ -747,13 +761,21 @@ export const editorStore: StateCreator<
       }
 
       let insertedIds: string[] = [];
+      let insertedIdMap: Map<string, string> = new Map();
       const [, ops] = insertGraph(source, {
         parent,
         before,
-        onInsert: (ids) => (insertedIds = ids),
+        onInsert: (ids, idMap) => {
+          insertedIds = ids;
+          insertedIdMap = idMap;
+        },
       })(get().flow);
       send(ops);
       set({ lastAddedNodeIds: insertedIds });
+
+      if (copiedNotes?.length) {
+        pasteAttachedFlowNotes(copiedNotes, insertedIdMap, get().id);
+      }
     } catch (err) {
       alert((err as Error).message);
     }


### PR DESCRIPTION
Creates new attached notes for the new node when a node is pasted. Also changed the 'Add note' -> 'Attach Note' wording as @ianjon3s suggested.