### PR TITLE
feat: submission detail modal and route

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -3,6 +3,7 @@ import type { GridFilterItem } from "@mui/x-data-grid";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { EmptyState } from "ui/editor/EmptyState";
@@ -12,13 +13,8 @@ import { ColumnFilterType } from "ui/shared/DataTable/types";
 import { dateFormatter } from "ui/shared/DataTable/utils";
 
 import { submissionStatusOptions } from "../submissionFilterOptions";
-import type {
-  EventsLogGroupedProps,
-  Submission,
-  SubmissionSummary,
-} from "../types";
+import type { EventsLogGroupedProps, SubmissionSummary } from "../types";
 import { StatusChip } from "./StatusChip";
-import SubmissionDetailModal from "./SubmissionDetailModal";
 
 const EventsLog: React.FC<EventsLogGroupedProps> = ({
   submissions,
@@ -26,8 +22,8 @@ const EventsLog: React.FC<EventsLogGroupedProps> = ({
   error,
   filterByFlow,
 }) => {
-  const [selectedSubmission, setSelectedSubmission] =
-    useState<Submission | null>(null);
+  const navigate = useNavigate();
+  const teamSlug = useStore((state) => state.teamSlug);
 
   if (loading)
     return (
@@ -86,18 +82,20 @@ const EventsLog: React.FC<EventsLogGroupedProps> = ({
     },
     { field: "id", headerName: "Session ID", width: 400 },
   ];
-
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <DataTable
         columns={columns}
         rows={submissions}
-        onRowClick={(params) => setSelectedSubmission(params.row)}
-      />
-      <SubmissionDetailModal
-        open={!!selectedSubmission}
-        sessionId={selectedSubmission?.sessionId}
-        handleClose={() => setSelectedSubmission(null)}
+        onRowClick={(params) => {
+          navigate({
+            to: "/app/$team/submissions/$sessionId",
+            params: {
+              team: teamSlug,
+              sessionId: params.row.id,
+            },
+          });
+        }}
       />
     </ErrorBoundary>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -70,6 +71,19 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
 
         <Box>
           <Typography variant="h4">Event History</Typography>
+          {events.map((event, index) => (
+            <ListItem key={`${event.eventId}-${index}`}>
+              <Box>
+                <Typography>
+                  {event.eventType} {event.retry && "[Retry]"}
+                </Typography>
+                <Typography>
+                  Status: {event.status},{" "}
+                  {new Date(event.createdAt).toLocaleString()}
+                </Typography>
+              </Box>
+            </ListItem>
+          ))}
         </Box>
       </Box>
       <DialogActions>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,45 +1,89 @@
+import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
-import DialogTitle from "@mui/material/DialogTitle";
-import React from "react";
+import Typography from "@mui/material/Typography";
+import { useNavigate } from "@tanstack/react-router";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { useStore } from "pages/FlowEditor/lib/store";
 
-import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
-import { OpenResponseButton } from "./OpenResponseButton";
-import { ViewSubmissionButton } from "./ViewSubmissionButton";
+import type { Submission } from "../types";
 
-interface RowModalProps {
-  sessionId?: string;
-  open: boolean;
-  handleClose: () => void;
+const GET_SUBMISSION_EVENTS = gql`
+  query GetSubmissionEvents($sessionId: uuid!) {
+    submissions: submission_services_log(
+      where: { session_id: { _eq: $sessionId } }
+      order_by: { created_at: desc }
+    ) {
+      flowId: flow_id
+      sessionId: session_id
+      eventId: event_id
+      eventType: event_type
+      status: status
+      retry: retry
+      response: response
+      address: address
+      createdAt: created_at
+      flowName: flow_name
+    }
+  }
+`;
+
+interface SubmissionDetailModalProps {
+  sessionId: string;
 }
 
-const SubmissionDetailModal: React.FC<RowModalProps> = ({
+const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   sessionId,
-  open,
-  handleClose,
 }) => {
-  // hook to get session ID submission and pay history
+  const navigate = useNavigate();
+  const [teamSlug] = useStore((state) => [state.teamSlug]);
 
+  const { data, loading, error } = useQuery<{ submissions: Submission[] }>(
+    GET_SUBMISSION_EVENTS,
+    {
+      variables: { sessionId },
+      skip: !sessionId,
+    },
+  );
+
+  const events = data?.submissions || [];
+  const latestEvent = events[0];
+
+  if (loading) return <DelayedLoadingIndicator />;
+  if (error) throw error;
   return (
-    <Dialog open={open} onClose={handleClose}>
-      <DialogTitle variant="h3" component="h1">
-        Submission details
-      </DialogTitle>
-      <Box sx={{ display: "flex", flexDirection: "row" }}>
-        <DialogContent>Details</DialogContent>
-        <DialogContent>History</DialogContent>
+    <Dialog open>
+      <Typography variant="h2" component="h1" gutterBottom>
+        Submission Details
+      </Typography>
+
+      <Box sx={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: 3 }}>
+        <Box>
+          <Typography variant="h4">Details</Typography>
+          <Typography>Address: {latestEvent?.address}</Typography>
+          <Typography>Service: {latestEvent?.flowName}</Typography>
+          <Typography>Session ID: {sessionId}</Typography>
+        </Box>
+
+        <Box>
+          <Typography variant="h4">Event History</Typography>
+        </Box>
       </Box>
       <DialogActions>
         <Button
-          onClick={handleClose}
-          color="secondary"
-          variant="contained"
-          sx={{ backgroundColor: "background.default" }}
+          onClick={() =>
+            navigate({
+              to: "/app/$team/submissions",
+              params: {
+                team: teamSlug,
+              },
+            })
+          }
         >
-          Cancel
+          Back
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -9,110 +9,107 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
-import { Route as authLoginRouteImport } from './routes/(auth)/login'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as authLogoutRouteImport } from './routes/(auth)/logout'
-import { Route as AuthenticatedAppRouteRouteImport } from './routes/_authenticated/app/route'
+import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as PublicCustomDomainRouteRouteImport } from './routes/_public/_customDomain/route'
+import { Route as AuthenticatedAppRouteRouteImport } from './routes/_authenticated/app/route'
 import { Route as AuthenticatedAppIndexRouteImport } from './routes/_authenticated/app/index'
-import { Route as AuthenticatedAppTeamRouteRouteImport } from './routes/_authenticated/app/$team/route'
-import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
-import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
 import { Route as AuthenticatedAppUsersRouteImport } from './routes/_authenticated/app/users'
+import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
 import { Route as PublicCustomDomainFlowRouteRouteImport } from './routes/_public/_customDomain/$flow/route'
-import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
-import { Route as AuthenticatedAppTeamFlowRouteRouteImport } from './routes/_authenticated/app/$team/$flow/route'
-import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
-import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
-import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
-import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
-import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
-import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
-import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
-import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
-import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
-import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
-import { Route as AuthenticatedAppTeamSubmissionsRouteImport } from './routes/_authenticated/app/$team/submissions'
-import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
-import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
-import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
-import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
-import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
-import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
-import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
-import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
+import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
+import { Route as AuthenticatedAppTeamRouteRouteImport } from './routes/_authenticated/app/$team/route'
 import { Route as PublicPlanXDomainDownloadSubmissionIndexRouteImport } from './routes/_public/_planXDomain/download-submission/index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/route'
-import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
-import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
-import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
-import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
-import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
-import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
-import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
-import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
-import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
-import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
-import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
-import { Route as AuthenticatedAppTeamSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/submission.$sessionId'
-import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
-import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
-import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
-import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
+import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
+import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
+import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
+import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
+import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
+import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
+import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
+import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
+import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
+import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
+import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
+import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
+import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
+import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
+import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
+import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
+import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
+import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
+import { Route as AuthenticatedAppTeamSubmissionsRouteRouteImport } from './routes/_authenticated/app/$team/submissions/route'
+import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
+import { Route as AuthenticatedAppTeamFlowRouteRouteImport } from './routes/_authenticated/app/$team/$flow/route'
 import { Route as PublicPlanXDomainTeamFlowIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/index'
-import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
-import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
-import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
+import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
+import { Route as AuthenticatedAppTeamSubmissionsIndexRouteImport } from './routes/_authenticated/app/$team/submissions/index'
+import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
+import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
+import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
+import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
+import { Route as AuthenticatedAppTeamSubmissionsSessionIdRouteImport } from './routes/_authenticated/app/$team/submissions/$sessionId'
+import { Route as AuthenticatedAppTeamSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/submission.$sessionId'
+import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
+import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
+import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
+import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
+import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
+import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
+import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
+import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
+import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
 import { Route as PublicPlanXDomainTeamFlowPublishedRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/route'
-import { Route as AuthenticatedAppTeamFlowFlowEditorIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
-import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
-import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
-import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
-import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
-import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
-import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
-import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
-import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
-import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
-import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
-import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
-import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
-import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
-import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
+import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
+import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
+import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
+import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
+import { Route as AuthenticatedAppTeamFlowFlowEditorRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/route'
 import { Route as PublicPlanXDomainTeamFlowPublishedIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/index'
+import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
+import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
+import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
+import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
+import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
+import { Route as AuthenticatedAppTeamFlowFlowEditorIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/index'
 import { Route as PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/view-application'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/add'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
-import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
+import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
+import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
+import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
+import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
+import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
+import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
+import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
+import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
+import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
 import { Route as PublicPlanXDomainTeamFlowPayInviteIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/index'
-import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
-import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
 import { Route as PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/pages.$page'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit'
+import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
+import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
+import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/add'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
 import { Route as PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/pages.$page'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit.$before'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.index'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit.$before'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
@@ -122,9 +119,9 @@ const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
-const authLoginRoute = authLoginRouteImport.update({
-  id: '/(auth)/login',
-  path: '/login',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authLogoutRoute = authLogoutRouteImport.update({
@@ -132,31 +129,41 @@ const authLogoutRoute = authLogoutRouteImport.update({
   path: '/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AuthenticatedAppRouteRoute = AuthenticatedAppRouteRouteImport.update({
-  id: '/app',
-  path: '/app',
-  getParentRoute: () => AuthenticatedRouteRoute,
+const authLoginRoute = authLoginRouteImport.update({
+  id: '/(auth)/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PublicCustomDomainRouteRoute = PublicCustomDomainRouteRouteImport.update({
   id: '/_public/_customDomain',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthenticatedAppRouteRoute = AuthenticatedAppRouteRouteImport.update({
+  id: '/app',
+  path: '/app',
+  getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
 const AuthenticatedAppIndexRoute = AuthenticatedAppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthenticatedAppRouteRoute,
 } as any)
-const AuthenticatedAppTeamRouteRoute =
-  AuthenticatedAppTeamRouteRouteImport.update({
-    id: '/$team',
-    path: '/$team',
-    getParentRoute: () => AuthenticatedAppRouteRoute,
-  } as any)
+const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AuthenticatedAppRouteRoute,
+} as any)
 const AuthenticatedAppAdminPanelRoute =
   AuthenticatedAppAdminPanelRouteImport.update({
     id: '/admin-panel',
     path: '/admin-panel',
     getParentRoute: () => AuthenticatedAppRouteRoute,
+  } as any)
+const PublicCustomDomainFlowRouteRoute =
+  PublicCustomDomainFlowRouteRouteImport.update({
+    id: '/$flow',
+    path: '/$flow',
+    getParentRoute: () => PublicCustomDomainRouteRoute,
   } as any)
 const AuthenticatedAppGlobalSettingsRouteRoute =
   AuthenticatedAppGlobalSettingsRouteRouteImport.update({
@@ -164,16 +171,29 @@ const AuthenticatedAppGlobalSettingsRouteRoute =
     path: '/global-settings',
     getParentRoute: () => AuthenticatedAppRouteRoute,
   } as any)
-const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => AuthenticatedAppRouteRoute,
-} as any)
-const PublicCustomDomainFlowRouteRoute =
-  PublicCustomDomainFlowRouteRouteImport.update({
-    id: '/$flow',
-    path: '/$flow',
-    getParentRoute: () => PublicCustomDomainRouteRoute,
+const AuthenticatedAppTeamRouteRoute =
+  AuthenticatedAppTeamRouteRouteImport.update({
+    id: '/$team',
+    path: '/$team',
+    getParentRoute: () => AuthenticatedAppRouteRoute,
+  } as any)
+const PublicPlanXDomainDownloadSubmissionIndexRoute =
+  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
+    id: '/_public/_planXDomain/download-submission/',
+    path: '/download-submission/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const PublicCustomDomainFlowIndexRoute =
+  PublicCustomDomainFlowIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const AuthenticatedAppGlobalSettingsIndexRoute =
+  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
   } as any)
 const AuthenticatedAppTeamIndexRoute =
   AuthenticatedAppTeamIndexRouteImport.update({
@@ -181,76 +201,22 @@ const AuthenticatedAppTeamIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowRouteRoute =
-  AuthenticatedAppTeamFlowRouteRouteImport.update({
-    id: '/$flow',
-    path: '/$flow',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+const PublicCustomDomainFlowViewApplicationRoute =
+  PublicCustomDomainFlowViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamDashboardRoute =
-  AuthenticatedAppTeamDashboardRouteImport.update({
-    id: '/dashboard',
-    path: '/dashboard',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+const AuthenticatedAppGlobalSettingsFooterRoute =
+  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
+    id: '/footer',
+    path: '/footer',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamDesignRoute =
-  AuthenticatedAppTeamDesignRouteImport.update({
-    id: '/design',
-    path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamExploreRoute =
-  AuthenticatedAppTeamExploreRouteImport.update({
-    id: '/explore',
-    path: '/explore',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFeedbackRoute =
-  AuthenticatedAppTeamFeedbackRouteImport.update({
-    id: '/feedback',
-    path: '/feedback',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowsRoute =
-  AuthenticatedAppTeamFlowsRouteImport.update({
-    id: '/flows',
-    path: '/flows',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamMembersRoute =
-  AuthenticatedAppTeamMembersRouteImport.update({
-    id: '/members',
-    path: '/members',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamNotificationsRoute =
-  AuthenticatedAppTeamNotificationsRouteImport.update({
-    id: '/notifications',
-    path: '/notifications',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamOnboardingRoute =
-  AuthenticatedAppTeamOnboardingRouteImport.update({
-    id: '/onboarding',
-    path: '/onboarding',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamResourcesRoute =
-  AuthenticatedAppTeamResourcesRouteImport.update({
-    id: '/resources',
-    path: '/resources',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsRouteRoute =
-  AuthenticatedAppTeamSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionsRoute =
-  AuthenticatedAppTeamSubmissionsRouteImport.update({
-    id: '/submissions',
-    path: '/submissions',
+const AuthenticatedAppTeamTutorialsRoute =
+  AuthenticatedAppTeamTutorialsRouteImport.update({
+    id: '/tutorials',
+    path: '/tutorials',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
 const AuthenticatedAppTeamSubscriptionRoute =
@@ -259,41 +225,59 @@ const AuthenticatedAppTeamSubscriptionRoute =
     path: '/subscription',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamTutorialsRoute =
-  AuthenticatedAppTeamTutorialsRouteImport.update({
-    id: '/tutorials',
-    path: '/tutorials',
+const AuthenticatedAppTeamResourcesRoute =
+  AuthenticatedAppTeamResourcesRouteImport.update({
+    id: '/resources',
+    path: '/resources',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppGlobalSettingsIndexRoute =
-  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+const AuthenticatedAppTeamOnboardingRoute =
+  AuthenticatedAppTeamOnboardingRouteImport.update({
+    id: '/onboarding',
+    path: '/onboarding',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppGlobalSettingsFooterRoute =
-  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
-    id: '/footer',
-    path: '/footer',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+const AuthenticatedAppTeamNotificationsRoute =
+  AuthenticatedAppTeamNotificationsRouteImport.update({
+    id: '/notifications',
+    path: '/notifications',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowIndexRoute =
-  PublicCustomDomainFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamMembersRoute =
+  AuthenticatedAppTeamMembersRouteImport.update({
+    id: '/members',
+    path: '/members',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowPayRouteRoute =
-  PublicCustomDomainFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamFlowsRoute =
+  AuthenticatedAppTeamFlowsRouteImport.update({
+    id: '/flows',
+    path: '/flows',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowViewApplicationRoute =
-  PublicCustomDomainFlowViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamFeedbackRoute =
+  AuthenticatedAppTeamFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamExploreRoute =
+  AuthenticatedAppTeamExploreRouteImport.update({
+    id: '/explore',
+    path: '/explore',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamDesignRoute =
+  AuthenticatedAppTeamDesignRouteImport.update({
+    id: '/design',
+    path: '/design',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamDashboardRoute =
+  AuthenticatedAppTeamDashboardRouteImport.update({
+    id: '/dashboard',
+    path: '/dashboard',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowRouteRoute =
   PublicPlanXDomainTeamFlowRouteRouteImport.update({
@@ -301,40 +285,47 @@ const PublicPlanXDomainTeamFlowRouteRoute =
     path: '/$team/$flow',
     getParentRoute: () => rootRouteImport,
   } as any)
-const PublicPlanXDomainDownloadSubmissionIndexRoute =
-  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
-    id: '/_public/_planXDomain/download-submission/',
-    path: '/download-submission/',
-    getParentRoute: () => rootRouteImport,
+const PublicCustomDomainFlowPayRouteRoute =
+  PublicCustomDomainFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
-    id: '/_flowEditor',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowAboutRoute =
-  AuthenticatedAppTeamFlowAboutRouteImport.update({
-    id: '/about',
-    path: '/about',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFeedbackRoute =
-  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
-    id: '/feedback',
-    path: '/feedback',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsRouteRoute =
-  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSubmissionsRoute =
-  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
+const AuthenticatedAppTeamSubmissionsRouteRoute =
+  AuthenticatedAppTeamSubmissionsRouteRouteImport.update({
     id: '/submissions',
     path: '/submissions',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsRouteRoute =
+  AuthenticatedAppTeamSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowRouteRoute =
+  AuthenticatedAppTeamFlowRouteRouteImport.update({
+    id: '/$flow',
+    path: '/$flow',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowIndexRoute =
+  PublicPlanXDomainTeamFlowIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayIndexRoute =
+  PublicCustomDomainFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSubmissionsIndexRoute =
+  AuthenticatedAppTeamSubmissionsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
   } as any)
 const AuthenticatedAppTeamSettingsIndexRoute =
   AuthenticatedAppTeamSettingsIndexRouteImport.update({
@@ -342,58 +333,10 @@ const AuthenticatedAppTeamSettingsIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsAdvancedRoute =
-  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
-    id: '/advanced',
-    path: '/advanced',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsContactRoute =
-  AuthenticatedAppTeamSettingsContactRouteImport.update({
-    id: '/contact',
-    path: '/contact',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsDesignRoute =
-  AuthenticatedAppTeamSettingsDesignRouteImport.update({
-    id: '/design',
-    path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsGisDataRoute =
-  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
-    id: '/gis-data',
-    path: '/gis-data',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsIntegrationsRoute =
-  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
-    id: '/integrations',
-    path: '/integrations',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsPaymentsRoute =
-  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
-    id: '/payments',
-    path: '/payments',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionSessionIdRoute =
-  AuthenticatedAppTeamSubmissionSessionIdRouteImport.update({
-    id: '/submission/$sessionId',
-    path: '/submission/$sessionId',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPagesPageRoute =
-  PublicCustomDomainFlowPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayIndexRoute =
-  PublicCustomDomainFlowPayIndexRouteImport.update({
-    id: '/',
-    path: '/',
+const PublicCustomDomainFlowPayViewApplicationRoute =
+  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
     getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
 const PublicCustomDomainFlowPayNotFoundRoute =
@@ -402,28 +345,82 @@ const PublicCustomDomainFlowPayNotFoundRoute =
     path: '/not-found',
     getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicCustomDomainFlowPayViewApplicationRoute =
-  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+const PublicCustomDomainFlowPagesPageRoute =
+  PublicCustomDomainFlowPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowIndexRoute =
-  PublicPlanXDomainTeamFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamSubmissionsSessionIdRoute =
+  AuthenticatedAppTeamSubmissionsSessionIdRouteImport.update({
+    id: '/$sessionId',
+    path: '/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowDraftRouteRoute =
-  PublicPlanXDomainTeamFlowDraftRouteRouteImport.update({
-    id: '/draft',
-    path: '/draft',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamSubmissionSessionIdRoute =
+  AuthenticatedAppTeamSubmissionSessionIdRouteImport.update({
+    id: '/submission/$sessionId',
+    path: '/submission/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayRouteRoute =
-  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
+const AuthenticatedAppTeamSettingsPaymentsRoute =
+  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
+    id: '/payments',
+    path: '/payments',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsIntegrationsRoute =
+  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
+    id: '/integrations',
+    path: '/integrations',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsGisDataRoute =
+  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
+    id: '/gis-data',
+    path: '/gis-data',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsDesignRoute =
+  AuthenticatedAppTeamSettingsDesignRouteImport.update({
+    id: '/design',
+    path: '/design',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsContactRoute =
+  AuthenticatedAppTeamSettingsContactRouteImport.update({
+    id: '/contact',
+    path: '/contact',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsAdvancedRoute =
+  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
+    id: '/advanced',
+    path: '/advanced',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSubmissionsRoute =
+  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
+    id: '/submissions',
+    path: '/submissions',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFeedbackRoute =
+  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowAboutRoute =
+  AuthenticatedAppTeamFlowAboutRouteImport.update({
+    id: '/about',
+    path: '/about',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedRouteRoute =
+  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
+    id: '/published',
+    path: '/published',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPreviewRouteRoute =
@@ -432,83 +429,46 @@ const PublicPlanXDomainTeamFlowPreviewRouteRoute =
     path: '/preview',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedRouteRoute =
-  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
-    id: '/published',
-    path: '/published',
+const PublicPlanXDomainTeamFlowPayRouteRoute =
+  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorIndexRoute =
-  AuthenticatedAppTeamFlowFlowEditorIndexRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftRouteRoute =
+  PublicPlanXDomainTeamFlowDraftRouteRouteImport.update({
+    id: '/draft',
+    path: '/draft',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsRouteRoute =
+  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
+    id: '/_flowEditor',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedIndexRoute =
+  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport.update({
-    id: '/nodes',
-    path: '/nodes',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
-    id: '/note',
-    path: '/note',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsIndexRoute =
-  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
+const PublicPlanXDomainTeamFlowPreviewIndexRoute =
+  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowSettingsAboutRoute =
-  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
-    id: '/about',
-    path: '/about',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsEmailsRoute =
-  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
-    id: '/emails',
-    path: '/emails',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
-  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
-    id: '/legal-disclaimer',
-    path: '/legal-disclaimer',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
-  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
-    id: '/templates',
-    path: '/templates',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
-  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
-    id: '/visibility',
-    path: '/visibility',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteIndexRoute =
-  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
-    id: '/invite/',
-    path: '/invite/',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteFailedRoute =
-  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
-    id: '/invite/failed',
-    path: '/invite/failed',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayPagesPageRoute =
-  PublicCustomDomainFlowPayPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+const PublicPlanXDomainTeamFlowPayIndexRoute =
+  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowDraftIndexRoute =
   PublicPlanXDomainTeamFlowDraftIndexRouteImport.update({
@@ -516,16 +476,40 @@ const PublicPlanXDomainTeamFlowDraftIndexRoute =
     path: '/',
     getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
-  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+const PublicCustomDomainFlowPayInviteIndexRoute =
+  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
+    id: '/invite/',
+    path: '/invite/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayIndexRoute =
-  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
+const AuthenticatedAppTeamFlowSettingsIndexRoute =
+  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorIndexRoute =
+  AuthenticatedAppTeamFlowFlowEditorIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayNotFoundRoute =
@@ -534,70 +518,88 @@ const PublicPlanXDomainTeamFlowPayNotFoundRoute =
     path: '/not-found',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
+  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
     id: '/view-application',
     path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPreviewIndexRoute =
-  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedIndexRoute =
-  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
-    id: '/add',
-    path: '/add',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
-  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
-    id: '/pages/help',
-    path: '/pages/help',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
-  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
-    id: '/pages/privacy',
-    path: '/pages/privacy',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInvitePagesPageRoute =
-  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
-  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
+const PublicCustomDomainFlowPayPagesPageRoute =
+  PublicCustomDomainFlowPayPagesPageRouteImport.update({
     id: '/pages/$page',
     path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayInviteFailedRoute =
+  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
+    id: '/invite/failed',
+    path: '/invite/failed',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
+  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
+    id: '/visibility',
+    path: '/visibility',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
+  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
+    id: '/templates',
+    path: '/templates',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
+  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
+    id: '/legal-disclaimer',
+    path: '/legal-disclaimer',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsEmailsRoute =
+  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
+    id: '/emails',
+    path: '/emails',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsAboutRoute =
+  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
+    id: '/about',
+    path: '/about',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
+    id: '/note',
+    path: '/note',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport.update({
+    id: '/nodes',
+    path: '/nodes',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayInviteIndexRoute =
   PublicPlanXDomainTeamFlowPayInviteIndexRouteImport.update({
     id: '/invite/',
     path: '/invite/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
+  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
+  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayPagesPageRoute =
+  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
@@ -606,29 +608,35 @@ const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
     path: '/invite/failed',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayPagesPageRoute =
-  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
+  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
     id: '/pages/$page',
     path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
-  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+const PublicCustomDomainFlowPayInvitePagesPageRoute =
+  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
-  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
+  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
+    id: '/pages/privacy',
+    path: '/pages/privacy',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport.update({
-    id: '/$id/edit',
-    path: '/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
+  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
+    id: '/pages/help',
+    path: '/pages/help',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
+    id: '/add',
+    path: '/add',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport.update({
@@ -636,11 +644,11 @@ const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
     path: '/new/',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
-    id: '/new/$before',
-    path: '/new/$before',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
+  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
   AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport.update({
@@ -648,23 +656,23 @@ const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
     path: '/$id/edit',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
-  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
+    id: '/new/$before',
+    path: '/new/$before',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport.update({
+    id: '/$id/edit',
+    path: '/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport.update({
     id: '/$before',
     path: '/$before',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
-    id: '/$parent/nodes/$id/edit',
-    path: '/$parent/nodes/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport.update({
@@ -680,6 +688,12 @@ const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRoute =
       getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
     } as any,
   )
+const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
+    id: '/$parent/nodes/$id/edit',
+    path: '/$parent/nodes/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport.update(
     {
@@ -702,8 +716,9 @@ export interface FileRoutesByFullPath {
   '/app/admin-panel': typeof AuthenticatedAppAdminPanelRoute
   '/app/users': typeof AuthenticatedAppUsersRoute
   '/app/': typeof AuthenticatedAppIndexRoute
-  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowRouteRouteWithChildren
+  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteWithChildren
   '/app/$team/settings': typeof AuthenticatedAppTeamSettingsRouteRouteWithChildren
+  '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRouteRouteWithChildren
   '/$flow/pay': typeof PublicCustomDomainFlowPayRouteRouteWithChildren
   '/$team/$flow': typeof PublicPlanXDomainTeamFlowRouteRouteWithChildren
   '/app/$team/dashboard': typeof AuthenticatedAppTeamDashboardRoute
@@ -715,7 +730,6 @@ export interface FileRoutesByFullPath {
   '/app/$team/notifications': typeof AuthenticatedAppTeamNotificationsRoute
   '/app/$team/onboarding': typeof AuthenticatedAppTeamOnboardingRoute
   '/app/$team/resources': typeof AuthenticatedAppTeamResourcesRoute
-  '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
   '/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
@@ -739,10 +753,12 @@ export interface FileRoutesByFullPath {
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
+  '/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
   '/app/$team/settings/': typeof AuthenticatedAppTeamSettingsIndexRoute
+  '/app/$team/submissions/': typeof AuthenticatedAppTeamSubmissionsIndexRoute
   '/$flow/pay/': typeof PublicCustomDomainFlowPayIndexRoute
   '/$team/$flow/': typeof PublicPlanXDomainTeamFlowIndexRoute
   '/app/$team/$flow/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
@@ -805,7 +821,6 @@ export interface FileRoutesByTo {
   '/app/$team/notifications': typeof AuthenticatedAppTeamNotificationsRoute
   '/app/$team/onboarding': typeof AuthenticatedAppTeamOnboardingRoute
   '/app/$team/resources': typeof AuthenticatedAppTeamResourcesRoute
-  '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
   '/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
@@ -824,10 +839,12 @@ export interface FileRoutesByTo {
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
+  '/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
   '/app/$team/settings': typeof AuthenticatedAppTeamSettingsIndexRoute
+  '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsIndexRoute
   '/$flow/pay': typeof PublicCustomDomainFlowPayIndexRoute
   '/$team/$flow': typeof PublicPlanXDomainTeamFlowIndexRoute
   '/app/$team/$flow/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
@@ -888,6 +905,7 @@ export interface FileRoutesById {
   '/_authenticated/app/': typeof AuthenticatedAppIndexRoute
   '/_authenticated/app/$team/$flow': typeof AuthenticatedAppTeamFlowRouteRouteWithChildren
   '/_authenticated/app/$team/settings': typeof AuthenticatedAppTeamSettingsRouteRouteWithChildren
+  '/_authenticated/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRouteRouteWithChildren
   '/_public/_customDomain/$flow/pay': typeof PublicCustomDomainFlowPayRouteRouteWithChildren
   '/_public/_planXDomain/$team/$flow': typeof PublicPlanXDomainTeamFlowRouteRouteWithChildren
   '/_authenticated/app/$team/dashboard': typeof AuthenticatedAppTeamDashboardRoute
@@ -899,7 +917,6 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/notifications': typeof AuthenticatedAppTeamNotificationsRoute
   '/_authenticated/app/$team/onboarding': typeof AuthenticatedAppTeamOnboardingRoute
   '/_authenticated/app/$team/resources': typeof AuthenticatedAppTeamResourcesRoute
-  '/_authenticated/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRoute
   '/_authenticated/app/$team/subscription': typeof AuthenticatedAppTeamSubscriptionRoute
   '/_authenticated/app/$team/tutorials': typeof AuthenticatedAppTeamTutorialsRoute
   '/_authenticated/app/global-settings/footer': typeof AuthenticatedAppGlobalSettingsFooterRoute
@@ -924,10 +941,12 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/_authenticated/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
   '/_authenticated/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
+  '/_authenticated/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
   '/_public/_customDomain/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/_public/_customDomain/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/_public/_customDomain/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
   '/_authenticated/app/$team/settings/': typeof AuthenticatedAppTeamSettingsIndexRoute
+  '/_authenticated/app/$team/submissions/': typeof AuthenticatedAppTeamSubmissionsIndexRoute
   '/_public/_customDomain/$flow/pay/': typeof PublicCustomDomainFlowPayIndexRoute
   '/_public/_planXDomain/$team/$flow/': typeof PublicPlanXDomainTeamFlowIndexRoute
   '/_authenticated/app/$team/$flow/_flowEditor/nodes': typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteWithChildren
@@ -988,6 +1007,7 @@ export interface FileRouteTypes {
     | '/app/'
     | '/app/$team/$flow'
     | '/app/$team/settings'
+    | '/app/$team/submissions'
     | '/$flow/pay'
     | '/$team/$flow'
     | '/app/$team/dashboard'
@@ -999,7 +1019,6 @@ export interface FileRouteTypes {
     | '/app/$team/notifications'
     | '/app/$team/onboarding'
     | '/app/$team/resources'
-    | '/app/$team/submissions'
     | '/app/$team/subscription'
     | '/app/$team/tutorials'
     | '/app/global-settings/footer'
@@ -1023,10 +1042,12 @@ export interface FileRouteTypes {
     | '/app/$team/settings/integrations'
     | '/app/$team/settings/payments'
     | '/app/$team/submission/$sessionId'
+    | '/app/$team/submissions/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
     | '/$flow/pay/view-application'
     | '/app/$team/settings/'
+    | '/app/$team/submissions/'
     | '/$flow/pay/'
     | '/$team/$flow/'
     | '/app/$team/$flow/nodes'
@@ -1089,7 +1110,6 @@ export interface FileRouteTypes {
     | '/app/$team/notifications'
     | '/app/$team/onboarding'
     | '/app/$team/resources'
-    | '/app/$team/submissions'
     | '/app/$team/subscription'
     | '/app/$team/tutorials'
     | '/app/global-settings/footer'
@@ -1108,10 +1128,12 @@ export interface FileRouteTypes {
     | '/app/$team/settings/integrations'
     | '/app/$team/settings/payments'
     | '/app/$team/submission/$sessionId'
+    | '/app/$team/submissions/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
     | '/$flow/pay/view-application'
     | '/app/$team/settings'
+    | '/app/$team/submissions'
     | '/$flow/pay'
     | '/$team/$flow'
     | '/app/$team/$flow/nodes'
@@ -1171,6 +1193,7 @@ export interface FileRouteTypes {
     | '/_authenticated/app/'
     | '/_authenticated/app/$team/$flow'
     | '/_authenticated/app/$team/settings'
+    | '/_authenticated/app/$team/submissions'
     | '/_public/_customDomain/$flow/pay'
     | '/_public/_planXDomain/$team/$flow'
     | '/_authenticated/app/$team/dashboard'
@@ -1182,7 +1205,6 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/notifications'
     | '/_authenticated/app/$team/onboarding'
     | '/_authenticated/app/$team/resources'
-    | '/_authenticated/app/$team/submissions'
     | '/_authenticated/app/$team/subscription'
     | '/_authenticated/app/$team/tutorials'
     | '/_authenticated/app/global-settings/footer'
@@ -1207,10 +1229,12 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/settings/integrations'
     | '/_authenticated/app/$team/settings/payments'
     | '/_authenticated/app/$team/submission/$sessionId'
+    | '/_authenticated/app/$team/submissions/$sessionId'
     | '/_public/_customDomain/$flow/pages/$page'
     | '/_public/_customDomain/$flow/pay/not-found'
     | '/_public/_customDomain/$flow/pay/view-application'
     | '/_authenticated/app/$team/settings/'
+    | '/_authenticated/app/$team/submissions/'
     | '/_public/_customDomain/$flow/pay/'
     | '/_public/_planXDomain/$team/$flow/'
     | '/_authenticated/app/$team/$flow/_flowEditor/nodes'
@@ -1269,13 +1293,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/$': {
       id: '/$'
       path: '/$'
@@ -1290,11 +1307,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(auth)/login': {
-      id: '/(auth)/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof authLoginRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(auth)/logout': {
@@ -1304,12 +1321,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authLogoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/app': {
-      id: '/_authenticated/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
+    '/(auth)/login': {
+      id: '/(auth)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof authLoginRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_public/_customDomain': {
       id: '/_public/_customDomain'
@@ -1318,32 +1335,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicCustomDomainRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/app': {
+      id: '/_authenticated/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/app/': {
       id: '/_authenticated/app/'
       path: '/'
       fullPath: '/app/'
       preLoaderRoute: typeof AuthenticatedAppIndexRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/$team': {
-      id: '/_authenticated/app/$team'
-      path: '/$team'
-      fullPath: '/app/$team'
-      preLoaderRoute: typeof AuthenticatedAppTeamRouteRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/admin-panel': {
-      id: '/_authenticated/app/admin-panel'
-      path: '/admin-panel'
-      fullPath: '/app/admin-panel'
-      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/global-settings': {
-      id: '/_authenticated/app/global-settings'
-      path: '/global-settings'
-      fullPath: '/app/global-settings'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
     '/_authenticated/app/users': {
@@ -1353,12 +1356,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppUsersRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
+    '/_authenticated/app/admin-panel': {
+      id: '/_authenticated/app/admin-panel'
+      path: '/admin-panel'
+      fullPath: '/app/admin-panel'
+      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
     '/_public/_customDomain/$flow': {
       id: '/_public/_customDomain/$flow'
       path: '/$flow'
       fullPath: '/$flow'
       preLoaderRoute: typeof PublicCustomDomainFlowRouteRouteImport
       parentRoute: typeof PublicCustomDomainRouteRoute
+    }
+    '/_authenticated/app/global-settings': {
+      id: '/_authenticated/app/global-settings'
+      path: '/global-settings'
+      fullPath: '/app/global-settings'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
+    '/_authenticated/app/$team': {
+      id: '/_authenticated/app/$team'
+      path: '/$team'
+      fullPath: '/app/$team'
+      preLoaderRoute: typeof AuthenticatedAppTeamRouteRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
+    '/_public/_planXDomain/download-submission/': {
+      id: '/_public/_planXDomain/download-submission/'
+      path: '/download-submission'
+      fullPath: '/download-submission/'
+      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_public/_customDomain/$flow/': {
+      id: '/_public/_customDomain/$flow/'
+      path: '/'
+      fullPath: '/$flow/'
+      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_authenticated/app/global-settings/': {
+      id: '/_authenticated/app/global-settings/'
+      path: '/'
+      fullPath: '/app/global-settings/'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
     }
     '/_authenticated/app/$team/': {
       id: '/_authenticated/app/$team/'
@@ -1367,88 +1412,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/$flow': {
-      id: '/_authenticated/app/$team/$flow'
-      path: '/$flow'
-      fullPath: '/app/$team/$flow'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    '/_public/_customDomain/$flow/view-application': {
+      id: '/_public/_customDomain/$flow/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_authenticated/app/$team/dashboard': {
-      id: '/_authenticated/app/$team/dashboard'
-      path: '/dashboard'
-      fullPath: '/app/$team/dashboard'
-      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    '/_authenticated/app/global-settings/footer': {
+      id: '/_authenticated/app/global-settings/footer'
+      path: '/footer'
+      fullPath: '/app/global-settings/footer'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
     }
-    '/_authenticated/app/$team/design': {
-      id: '/_authenticated/app/$team/design'
-      path: '/design'
-      fullPath: '/app/$team/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/explore': {
-      id: '/_authenticated/app/$team/explore'
-      path: '/explore'
-      fullPath: '/app/$team/explore'
-      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/feedback': {
-      id: '/_authenticated/app/$team/feedback'
-      path: '/feedback'
-      fullPath: '/app/$team/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/flows': {
-      id: '/_authenticated/app/$team/flows'
-      path: '/flows'
-      fullPath: '/app/$team/flows'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/members': {
-      id: '/_authenticated/app/$team/members'
-      path: '/members'
-      fullPath: '/app/$team/members'
-      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/notifications': {
-      id: '/_authenticated/app/$team/notifications'
-      path: '/notifications'
-      fullPath: '/app/$team/notifications'
-      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/onboarding': {
-      id: '/_authenticated/app/$team/onboarding'
-      path: '/onboarding'
-      fullPath: '/app/$team/onboarding'
-      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/resources': {
-      id: '/_authenticated/app/$team/resources'
-      path: '/resources'
-      fullPath: '/app/$team/resources'
-      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/settings': {
-      id: '/_authenticated/app/$team/settings'
-      path: '/settings'
-      fullPath: '/app/$team/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/submissions': {
-      id: '/_authenticated/app/$team/submissions'
-      path: '/submissions'
-      fullPath: '/app/$team/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteImport
+    '/_authenticated/app/$team/tutorials': {
+      id: '/_authenticated/app/$team/tutorials'
+      path: '/tutorials'
+      fullPath: '/app/$team/tutorials'
+      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
     '/_authenticated/app/$team/subscription': {
@@ -1458,47 +1440,68 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamSubscriptionRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/tutorials': {
-      id: '/_authenticated/app/$team/tutorials'
-      path: '/tutorials'
-      fullPath: '/app/$team/tutorials'
-      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
+    '/_authenticated/app/$team/resources': {
+      id: '/_authenticated/app/$team/resources'
+      path: '/resources'
+      fullPath: '/app/$team/resources'
+      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/global-settings/': {
-      id: '/_authenticated/app/global-settings/'
-      path: '/'
-      fullPath: '/app/global-settings/'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    '/_authenticated/app/$team/onboarding': {
+      id: '/_authenticated/app/$team/onboarding'
+      path: '/onboarding'
+      fullPath: '/app/$team/onboarding'
+      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/global-settings/footer': {
-      id: '/_authenticated/app/global-settings/footer'
-      path: '/footer'
-      fullPath: '/app/global-settings/footer'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    '/_authenticated/app/$team/notifications': {
+      id: '/_authenticated/app/$team/notifications'
+      path: '/notifications'
+      fullPath: '/app/$team/notifications'
+      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/': {
-      id: '/_public/_customDomain/$flow/'
-      path: '/'
-      fullPath: '/$flow/'
-      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/members': {
+      id: '/_authenticated/app/$team/members'
+      path: '/members'
+      fullPath: '/app/$team/members'
+      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/pay': {
-      id: '/_public/_customDomain/$flow/pay'
-      path: '/pay'
-      fullPath: '/$flow/pay'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/flows': {
+      id: '/_authenticated/app/$team/flows'
+      path: '/flows'
+      fullPath: '/app/$team/flows'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/view-application': {
-      id: '/_public/_customDomain/$flow/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/feedback': {
+      id: '/_authenticated/app/$team/feedback'
+      path: '/feedback'
+      fullPath: '/app/$team/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/explore': {
+      id: '/_authenticated/app/$team/explore'
+      path: '/explore'
+      fullPath: '/app/$team/explore'
+      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/design': {
+      id: '/_authenticated/app/$team/design'
+      path: '/design'
+      fullPath: '/app/$team/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/dashboard': {
+      id: '/_authenticated/app/$team/dashboard'
+      path: '/dashboard'
+      fullPath: '/app/$team/dashboard'
+      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
     '/_public/_planXDomain/$team/$flow': {
       id: '/_public/_planXDomain/$team/$flow'
@@ -1507,47 +1510,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_public/_planXDomain/download-submission/': {
-      id: '/_public/_planXDomain/download-submission/'
-      path: '/download-submission'
-      fullPath: '/download-submission/'
-      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_public/_customDomain/$flow/pay': {
+      id: '/_public/_customDomain/$flow/pay'
+      path: '/pay'
+      fullPath: '/$flow/pay'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor'
-      path: ''
-      fullPath: '/app/$team/$flow'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/about': {
-      id: '/_authenticated/app/$team/$flow/about'
-      path: '/about'
-      fullPath: '/app/$team/$flow/about'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowAboutRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/feedback': {
-      id: '/_authenticated/app/$team/$flow/feedback'
-      path: '/feedback'
-      fullPath: '/app/$team/$flow/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings': {
-      id: '/_authenticated/app/$team/$flow/settings'
-      path: '/settings'
-      fullPath: '/app/$team/$flow/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/submissions': {
-      id: '/_authenticated/app/$team/$flow/submissions'
+    '/_authenticated/app/$team/submissions': {
+      id: '/_authenticated/app/$team/submissions'
       path: '/submissions'
-      fullPath: '/app/$team/$flow/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+      fullPath: '/app/$team/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/settings': {
+      id: '/_authenticated/app/$team/settings'
+      path: '/settings'
+      fullPath: '/app/$team/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/$flow': {
+      id: '/_authenticated/app/$team/$flow'
+      path: '/$flow'
+      fullPath: '/app/$team/$flow'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/': {
+      id: '/_public/_planXDomain/$team/$flow/'
+      path: '/'
+      fullPath: '/$team/$flow/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/': {
+      id: '/_public/_customDomain/$flow/pay/'
+      path: '/'
+      fullPath: '/$flow/pay/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_authenticated/app/$team/submissions/': {
+      id: '/_authenticated/app/$team/submissions/'
+      path: '/'
+      fullPath: '/app/$team/submissions/'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
     }
     '/_authenticated/app/$team/settings/': {
       id: '/_authenticated/app/$team/settings/'
@@ -1556,67 +1566,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamSettingsIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
     }
-    '/_authenticated/app/$team/settings/advanced': {
-      id: '/_authenticated/app/$team/settings/advanced'
-      path: '/advanced'
-      fullPath: '/app/$team/settings/advanced'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/contact': {
-      id: '/_authenticated/app/$team/settings/contact'
-      path: '/contact'
-      fullPath: '/app/$team/settings/contact'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/design': {
-      id: '/_authenticated/app/$team/settings/design'
-      path: '/design'
-      fullPath: '/app/$team/settings/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/gis-data': {
-      id: '/_authenticated/app/$team/settings/gis-data'
-      path: '/gis-data'
-      fullPath: '/app/$team/settings/gis-data'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/integrations': {
-      id: '/_authenticated/app/$team/settings/integrations'
-      path: '/integrations'
-      fullPath: '/app/$team/settings/integrations'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/payments': {
-      id: '/_authenticated/app/$team/settings/payments'
-      path: '/payments'
-      fullPath: '/app/$team/settings/payments'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/submission/$sessionId': {
-      id: '/_authenticated/app/$team/submission/$sessionId'
-      path: '/submission/$sessionId'
-      fullPath: '/app/$team/submission/$sessionId'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionSessionIdRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_public/_customDomain/$flow/pages/$page': {
-      id: '/_public/_customDomain/$flow/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/': {
-      id: '/_public/_customDomain/$flow/pay/'
-      path: '/'
-      fullPath: '/$flow/pay/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
+    '/_public/_customDomain/$flow/pay/view-application': {
+      id: '/_public/_customDomain/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
     '/_public/_customDomain/$flow/pay/not-found': {
@@ -1626,32 +1580,95 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicCustomDomainFlowPayNotFoundRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_customDomain/$flow/pay/view-application': {
-      id: '/_public/_customDomain/$flow/pay/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    '/_public/_customDomain/$flow/pages/$page': {
+      id: '/_public/_customDomain/$flow/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/': {
-      id: '/_public/_planXDomain/$team/$flow/'
-      path: '/'
-      fullPath: '/$team/$flow/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/submissions/$sessionId': {
+      id: '/_authenticated/app/$team/submissions/$sessionId'
+      path: '/$sessionId'
+      fullPath: '/app/$team/submissions/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft': {
-      id: '/_public/_planXDomain/$team/$flow/draft'
-      path: '/draft'
-      fullPath: '/$team/$flow/draft'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/submission/$sessionId': {
+      id: '/_authenticated/app/$team/submission/$sessionId'
+      path: '/submission/$sessionId'
+      fullPath: '/app/$team/submission/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay': {
-      id: '/_public/_planXDomain/$team/$flow/pay'
-      path: '/pay'
-      fullPath: '/$team/$flow/pay'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
+    '/_authenticated/app/$team/settings/payments': {
+      id: '/_authenticated/app/$team/settings/payments'
+      path: '/payments'
+      fullPath: '/app/$team/settings/payments'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/integrations': {
+      id: '/_authenticated/app/$team/settings/integrations'
+      path: '/integrations'
+      fullPath: '/app/$team/settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/gis-data': {
+      id: '/_authenticated/app/$team/settings/gis-data'
+      path: '/gis-data'
+      fullPath: '/app/$team/settings/gis-data'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/design': {
+      id: '/_authenticated/app/$team/settings/design'
+      path: '/design'
+      fullPath: '/app/$team/settings/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/contact': {
+      id: '/_authenticated/app/$team/settings/contact'
+      path: '/contact'
+      fullPath: '/app/$team/settings/contact'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/advanced': {
+      id: '/_authenticated/app/$team/settings/advanced'
+      path: '/advanced'
+      fullPath: '/app/$team/settings/advanced'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/submissions': {
+      id: '/_authenticated/app/$team/$flow/submissions'
+      path: '/submissions'
+      fullPath: '/app/$team/$flow/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/feedback': {
+      id: '/_authenticated/app/$team/$flow/feedback'
+      path: '/feedback'
+      fullPath: '/app/$team/$flow/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/about': {
+      id: '/_authenticated/app/$team/$flow/about'
+      path: '/about'
+      fullPath: '/app/$team/$flow/about'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowAboutRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published': {
+      id: '/_public/_planXDomain/$team/$flow/published'
+      path: '/published'
+      fullPath: '/$team/$flow/published'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/preview': {
@@ -1661,96 +1678,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published': {
-      id: '/_public/_planXDomain/$team/$flow/published'
-      path: '/published'
-      fullPath: '/$team/$flow/published'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
+    '/_public/_planXDomain/$team/$flow/pay': {
+      id: '/_public/_planXDomain/$team/$flow/pay'
+      path: '/pay'
+      fullPath: '/$team/$flow/pay'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/'
+    '/_public/_planXDomain/$team/$flow/draft': {
+      id: '/_public/_planXDomain/$team/$flow/draft'
+      path: '/draft'
+      fullPath: '/$team/$flow/draft'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings': {
+      id: '/_authenticated/app/$team/$flow/settings'
+      path: '/settings'
+      fullPath: '/app/$team/$flow/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor'
+      path: ''
+      fullPath: '/app/$team/$flow'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/': {
+      id: '/_public/_planXDomain/$team/$flow/published/'
       path: '/'
-      fullPath: '/app/$team/$flow/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+      fullPath: '/$team/$flow/published/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes'
-      path: '/nodes'
-      fullPath: '/app/$team/$flow/nodes'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
-      path: '/note'
-      fullPath: '/app/$team/$flow/note'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/': {
-      id: '/_authenticated/app/$team/$flow/settings/'
+    '/_public/_planXDomain/$team/$flow/preview/': {
+      id: '/_public/_planXDomain/$team/$flow/preview/'
       path: '/'
-      fullPath: '/app/$team/$flow/settings/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+      fullPath: '/$team/$flow/preview/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
     }
-    '/_authenticated/app/$team/$flow/settings/about': {
-      id: '/_authenticated/app/$team/$flow/settings/about'
-      path: '/about'
-      fullPath: '/app/$team/$flow/settings/about'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/emails': {
-      id: '/_authenticated/app/$team/$flow/settings/emails'
-      path: '/emails'
-      fullPath: '/app/$team/$flow/settings/emails'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
-      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-      path: '/legal-disclaimer'
-      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/templates': {
-      id: '/_authenticated/app/$team/$flow/settings/templates'
-      path: '/templates'
-      fullPath: '/app/$team/$flow/settings/templates'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/visibility': {
-      id: '/_authenticated/app/$team/$flow/settings/visibility'
-      path: '/visibility'
-      fullPath: '/app/$team/$flow/settings/visibility'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/': {
-      id: '/_public/_customDomain/$flow/pay/invite/'
-      path: '/invite'
-      fullPath: '/$flow/pay/invite/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/failed': {
-      id: '/_public/_customDomain/$flow/pay/invite/failed'
-      path: '/invite/failed'
-      fullPath: '/$flow/pay/invite/failed'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    '/_public/_planXDomain/$team/$flow/pay/': {
+      id: '/_public/_planXDomain/$team/$flow/pay/'
+      path: '/'
+      fullPath: '/$team/$flow/pay/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/draft/': {
       id: '/_public/_planXDomain/$team/$flow/draft/'
@@ -1759,18 +1734,46 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftIndexRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/draft/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/': {
+      id: '/_public/_customDomain/$flow/pay/invite/'
+      path: '/invite'
+      fullPath: '/$flow/pay/invite/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/': {
-      id: '/_public/_planXDomain/$team/$flow/pay/'
+    '/_authenticated/app/$team/$flow/settings/': {
+      id: '/_authenticated/app/$team/$flow/settings/'
       path: '/'
-      fullPath: '/$team/$flow/pay/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
+      fullPath: '/app/$team/$flow/settings/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/'
+      path: '/'
+      fullPath: '/app/$team/$flow/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/published/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/published/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/preview/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/not-found': {
@@ -1780,81 +1783,102 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayNotFoundRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
+    '/_public/_planXDomain/$team/$flow/draft/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
       path: '/view-application'
-      fullPath: '/$team/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+      fullPath: '/$team/$flow/draft/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/preview/': {
-      id: '/_public/_planXDomain/$team/$flow/preview/'
-      path: '/'
-      fullPath: '/$team/$flow/preview/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/preview/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/preview/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/': {
-      id: '/_public/_planXDomain/$team/$flow/published/'
-      path: '/'
-      fullPath: '/$team/$flow/published/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/published/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/published/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
-      path: '/add'
-      fullPath: '/app/$team/$flow/note/add'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/help': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/help'
-      path: '/pages/help'
-      fullPath: '/app/$team/$flow/settings/pages/help'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
-      path: '/pages/privacy'
-      fullPath: '/app/$team/$flow/settings/pages/privacy'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
+    '/_public/_customDomain/$flow/pay/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/draft/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/failed': {
+      id: '/_public/_customDomain/$flow/pay/invite/failed'
+      path: '/invite/failed'
+      fullPath: '/$flow/pay/invite/failed'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/visibility': {
+      id: '/_authenticated/app/$team/$flow/settings/visibility'
+      path: '/visibility'
+      fullPath: '/app/$team/$flow/settings/visibility'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/templates': {
+      id: '/_authenticated/app/$team/$flow/settings/templates'
+      path: '/templates'
+      fullPath: '/app/$team/$flow/settings/templates'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
+      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+      path: '/legal-disclaimer'
+      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/emails': {
+      id: '/_authenticated/app/$team/$flow/settings/emails'
+      path: '/emails'
+      fullPath: '/app/$team/$flow/settings/emails'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/about': {
+      id: '/_authenticated/app/$team/$flow/settings/about'
+      path: '/about'
+      fullPath: '/app/$team/$flow/settings/about'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
+      path: '/note'
+      fullPath: '/app/$team/$flow/note'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes'
+      path: '/nodes'
+      fullPath: '/app/$team/$flow/nodes'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/invite/': {
       id: '/_public/_planXDomain/$team/$flow/pay/invite/'
       path: '/invite'
       fullPath: '/$team/$flow/pay/invite/'
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/published/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/preview/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/invite/failed': {
@@ -1864,33 +1888,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteFailedRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
+    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
       path: '/pages/$page'
-      fullPath: '/$team/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+      fullPath: '/$team/$flow/draft/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/preview/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/published/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
+      path: '/pages/privacy'
+      fullPath: '/app/$team/$flow/settings/pages/privacy'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit'
-      path: '/$id/edit'
-      fullPath: '/app/$team/$flow/nodes/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    '/_authenticated/app/$team/$flow/settings/pages/help': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/help'
+      path: '/pages/help'
+      fullPath: '/app/$team/$flow/settings/pages/help'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
+      path: '/add'
+      fullPath: '/app/$team/$flow/note/add'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/'
@@ -1899,12 +1930,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
-      path: '/new/$before'
-      fullPath: '/app/$team/$flow/nodes/new/$before'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$team/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit'
@@ -1913,12 +1944,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$team/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
+      path: '/new/$before'
+      fullPath: '/app/$team/$flow/nodes/new/$before'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit'
+      path: '/$id/edit'
+      fullPath: '/app/$team/$flow/nodes/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before'
@@ -1926,13 +1964,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/app/$team/$flow/nodes/$id/edit/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
-      path: '/$parent/nodes/$id/edit'
-      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/'
@@ -1946,6 +1977,13 @@ declare module '@tanstack/react-router' {
       path: '/$parent/nodes/new/$before'
       fullPath: '/app/$team/$flow/nodes/$parent/nodes/new/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
+      path: '/$parent/nodes/$id/edit'
+      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit/$before': {
@@ -2152,9 +2190,28 @@ const AuthenticatedAppTeamSettingsRouteRouteWithChildren =
     AuthenticatedAppTeamSettingsRouteRouteChildren,
   )
 
+interface AuthenticatedAppTeamSubmissionsRouteRouteChildren {
+  AuthenticatedAppTeamSubmissionsSessionIdRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
+  AuthenticatedAppTeamSubmissionsIndexRoute: typeof AuthenticatedAppTeamSubmissionsIndexRoute
+}
+
+const AuthenticatedAppTeamSubmissionsRouteRouteChildren: AuthenticatedAppTeamSubmissionsRouteRouteChildren =
+  {
+    AuthenticatedAppTeamSubmissionsSessionIdRoute:
+      AuthenticatedAppTeamSubmissionsSessionIdRoute,
+    AuthenticatedAppTeamSubmissionsIndexRoute:
+      AuthenticatedAppTeamSubmissionsIndexRoute,
+  }
+
+const AuthenticatedAppTeamSubmissionsRouteRouteWithChildren =
+  AuthenticatedAppTeamSubmissionsRouteRoute._addFileChildren(
+    AuthenticatedAppTeamSubmissionsRouteRouteChildren,
+  )
+
 interface AuthenticatedAppTeamRouteRouteChildren {
   AuthenticatedAppTeamFlowRouteRoute: typeof AuthenticatedAppTeamFlowRouteRouteWithChildren
   AuthenticatedAppTeamSettingsRouteRoute: typeof AuthenticatedAppTeamSettingsRouteRouteWithChildren
+  AuthenticatedAppTeamSubmissionsRouteRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteWithChildren
   AuthenticatedAppTeamDashboardRoute: typeof AuthenticatedAppTeamDashboardRoute
   AuthenticatedAppTeamDesignRoute: typeof AuthenticatedAppTeamDesignRoute
   AuthenticatedAppTeamExploreRoute: typeof AuthenticatedAppTeamExploreRoute
@@ -2164,7 +2221,6 @@ interface AuthenticatedAppTeamRouteRouteChildren {
   AuthenticatedAppTeamNotificationsRoute: typeof AuthenticatedAppTeamNotificationsRoute
   AuthenticatedAppTeamOnboardingRoute: typeof AuthenticatedAppTeamOnboardingRoute
   AuthenticatedAppTeamResourcesRoute: typeof AuthenticatedAppTeamResourcesRoute
-  AuthenticatedAppTeamSubmissionsRoute: typeof AuthenticatedAppTeamSubmissionsRoute
   AuthenticatedAppTeamSubscriptionRoute: typeof AuthenticatedAppTeamSubscriptionRoute
   AuthenticatedAppTeamTutorialsRoute: typeof AuthenticatedAppTeamTutorialsRoute
   AuthenticatedAppTeamIndexRoute: typeof AuthenticatedAppTeamIndexRoute
@@ -2177,6 +2233,8 @@ const AuthenticatedAppTeamRouteRouteChildren: AuthenticatedAppTeamRouteRouteChil
       AuthenticatedAppTeamFlowRouteRouteWithChildren,
     AuthenticatedAppTeamSettingsRouteRoute:
       AuthenticatedAppTeamSettingsRouteRouteWithChildren,
+    AuthenticatedAppTeamSubmissionsRouteRoute:
+      AuthenticatedAppTeamSubmissionsRouteRouteWithChildren,
     AuthenticatedAppTeamDashboardRoute: AuthenticatedAppTeamDashboardRoute,
     AuthenticatedAppTeamDesignRoute: AuthenticatedAppTeamDesignRoute,
     AuthenticatedAppTeamExploreRoute: AuthenticatedAppTeamExploreRoute,
@@ -2187,7 +2245,6 @@ const AuthenticatedAppTeamRouteRouteChildren: AuthenticatedAppTeamRouteRouteChil
       AuthenticatedAppTeamNotificationsRoute,
     AuthenticatedAppTeamOnboardingRoute: AuthenticatedAppTeamOnboardingRoute,
     AuthenticatedAppTeamResourcesRoute: AuthenticatedAppTeamResourcesRoute,
-    AuthenticatedAppTeamSubmissionsRoute: AuthenticatedAppTeamSubmissionsRoute,
     AuthenticatedAppTeamSubscriptionRoute:
       AuthenticatedAppTeamSubscriptionRoute,
     AuthenticatedAppTeamTutorialsRoute: AuthenticatedAppTeamTutorialsRoute,

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/$sessionId.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/$sessionId.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import SubmissionDetailModal from "pages/FlowEditor/components/Submissions/components/SubmissionDetailModal";
+
+export const Route = createFileRoute(
+  "/_authenticated/app/$team/submissions/$sessionId",
+)({
+  loader: async ({ params }) => ({
+    sessionId: params.sessionId,
+  }),
+  pendingComponent: DelayedLoadingIndicator,
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { sessionId } = Route.useLoaderData();
+  return <SubmissionDetailModal sessionId={sessionId} />;
+}

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/index.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/app/$team/submissions/")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return null;
+}

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/submissions/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { hasFeatureFlag } from "lib/featureFlags";
 import Submissions from "pages/FlowEditor/components/Submissions/Submissions";
@@ -6,7 +6,18 @@ import SubmissionsGrouped from "pages/FlowEditor/components/Submissions/Submissi
 
 export const Route = createFileRoute("/_authenticated/app/$team/submissions")({
   pendingComponent: DelayedLoadingIndicator,
-  component: hasFeatureFlag("GROUPED_SUBMISSIONS")
-    ? SubmissionsGrouped
-    : Submissions,
+  component: SubmissionsGroupedLayout,
 });
+
+function SubmissionsGroupedLayout() {
+  const SubmissionsWrapper = hasFeatureFlag("GROUPED_SUBMISSIONS")
+    ? SubmissionsGrouped
+    : Submissions;
+
+  return (
+    <>
+      <SubmissionsWrapper />
+      <Outlet />
+    </>
+  );
+}


### PR DESCRIPTION
PR shows many lines changed but most are in `routeTree.gen.ts`!

- Creates a new route for the submission detail modal, using established pattern to load child route & navigating back to submissions log when modal closes
- Gets events log per session ID in `SubmissionDetailModal`
- Rough rendering of detail view

<img width="600" alt="Screenshot 2026-08-11 155306" src="https://github.com/user-attachments/assets/e83d210a-5cb3-4603-9a90-26bbc2813840" />
