### PR TITLE
fix(a11y): Add accessible titles to tables

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Public.tsx
@@ -19,10 +19,12 @@ export type Props = PublicProps<Confirmation>;
 export default function ConfirmationComponent(props: Props) {
   const isFinalCard = useStore().isFinalCard();
   const theme = useTheme();
+  const headingId = "confirmation-heading";
   return (
     <Box sx={{ width: "100%" }}>
       <Banner
         heading={props.heading || ""}
+        headingId={headingId}
         color={{
           background: theme.palette.success.light,
           text: theme.palette.text.primary,
@@ -37,7 +39,7 @@ export default function ConfirmationComponent(props: Props) {
         )}
       </Banner>
       <Card handleSubmit={isFinalCard ? undefined : props.handleSubmit}>
-        <ApplicationSummary />
+        <ApplicationSummary titleId={headingId} />
         <ViewApplicationLink />
         {props.nextSteps && Boolean(props.nextSteps?.length) && (
           <Box sx={{ pt: 3 }}>

--- a/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Public/index.tsx
@@ -144,10 +144,11 @@ const InactiveListCard: React.FC<{
   })();
 
   const itemLabel = `${schema.type} ${i + 1}`;
+  const itemLabelId = `list-card-heading-${i}`;
 
   return (
     <ListCard data-testid={`list-card-${i}`}>
-      <Typography component="h2" variant="h3">
+      <Typography component="h2" variant="h3" id={itemLabelId}>
         {itemLabel}
       </Typography>
       <InactiveListCardLayout>
@@ -156,7 +157,7 @@ const InactiveListCard: React.FC<{
             {formattedMapResponse}
           </Box>
         )}
-        <SummaryListTable sx={{ margin: 0 }}>
+        <SummaryListTable sx={{ margin: 0 }} aria-labelledby={itemLabelId}>
           {schema.fields.map(
             (field, j) =>
               field.type !== "map" && (

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/FeeBreakdown/FeeBreakdown.tsx
@@ -6,6 +6,7 @@ import TableCell, { tableCellClasses } from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import { visuallyHidden } from "@mui/utils";
 import type { FeeBreakdown as IFeeBreakdown } from "@opensystemslab/planx-core/types";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
@@ -329,6 +330,9 @@ export const FeeBreakdown: React.FC<{
   return (
     <TableContainer sx={{ mt: 3 }}>
       <StyledTable data-testid="fee-breakdown-table">
+        <Box component="caption" style={visuallyHidden}>
+          Fee breakdown
+        </Box>
         <Header {...breakdown} />
         <TableBody>
           <ApplicationFee {...breakdown} />

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.tsx
@@ -115,6 +115,8 @@ export function Presentational(props: PresentationalProps) {
     }
   }, []);
 
+  const titleId = "property-information-title";
+
   const propertyDetails: PropertyDetail[] = [
     {
       heading: "Address",
@@ -155,6 +157,7 @@ export function Presentational(props: PresentationalProps) {
         policyRef={policyRef}
         howMeasured={howMeasured}
         definitionImg={definitionImg}
+        titleId={titleId}
       />
       <MapContainer environment={environment}>
         <p style={visuallyHidden}>
@@ -192,6 +195,7 @@ export function Presentational(props: PresentationalProps) {
           data={propertyDetails}
           showPropertyTypeOverride={showPropertyTypeOverride}
           overrideAnswer={overrideAnswer}
+          titleId={titleId}
         />
       )}
     </Card>
@@ -209,10 +213,11 @@ interface PropertyDetailsProps {
   showPropertyTypeOverride?: boolean;
   showChangeButton?: boolean;
   overrideAnswer: (fn: string) => void;
+  titleId?: string;
 }
 
 function PropertyDetails(props: PropertyDetailsProps) {
-  const { data, showPropertyTypeOverride, overrideAnswer } = props;
+  const { data, showPropertyTypeOverride, overrideAnswer, titleId } = props;
   const filteredData = data.filter((d) => Boolean(d.detail));
 
   const { trackEvent } = useAnalyticsTracking();
@@ -227,7 +232,7 @@ function PropertyDetails(props: PropertyDetailsProps) {
   };
 
   return (
-    <SummaryListTable showChangeButton={true}>
+    <SummaryListTable showChangeButton={true} aria-labelledby={titleId}>
       {filteredData.map(({ heading, detail, fn }: PropertyDetail) => (
         <React.Fragment key={heading}>
           <Box component="dt">{heading}</Box>

--- a/apps/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Review/Public/Presentational.tsx
@@ -27,9 +27,15 @@ function Component(props: Props) {
     props.breadcrumbs,
   );
 
+  const titleId = "review-title";
+
   return (
     <Card isValid handleSubmit={props.handleSubmit}>
-      <CardHeader title={props.title} description={props.description} />
+      <CardHeader
+        title={props.title}
+        description={props.description}
+        titleId={titleId}
+      />
       <SummaryLists
         breadcrumbs={sortedBreadcrumbs}
         flow={props.flow}
@@ -38,6 +44,7 @@ function Component(props: Props) {
         showChangeButton={props.showChangeButton}
         sectionComponent="h2"
         disclaimer={props.disclaimer}
+        titleId={titleId}
       />
       <PrintButton />
     </Card>

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -147,6 +147,7 @@ interface SummaryListBaseProps {
   passport: Store.Passport;
   changeAnswer: (id: NodeId) => void;
   showChangeButton: boolean;
+  titleId?: string;
 }
 
 interface SummaryListsBySectionsProps extends SummaryListBaseProps {
@@ -237,8 +238,9 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
 
     return (
       <>
-        {sectionsWithFilteredBreadcrumbs.map(
-          (filteredBreadcrumbs, i) =>
+        {sectionsWithFilteredBreadcrumbs.map((filteredBreadcrumbs, i) => {
+          const sectionTitleId = `summary-list-section-heading-${i}`;
+          return (
             Boolean(filteredBreadcrumbs.length) && (
               <React.Fragment key={i}>
                 <Box
@@ -251,6 +253,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                   <Typography
                     component={props.sectionComponent || "h2"}
                     variant="h3"
+                    id={sectionTitleId}
                   >
                     {props.flow[`${Object.keys(sections[i])[0]}`]?.data?.title}
                   </Typography>
@@ -262,10 +265,12 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
                   changeAnswer={props.changeAnswer}
                   showChangeButton={props.showChangeButton}
                   disclaimer={props.disclaimer}
+                  titleId={sectionTitleId}
                 />
               </React.Fragment>
-            ),
-        )}
+            )
+          );
+        })}
       </>
     );
   } else {
@@ -280,6 +285,7 @@ function SummaryListsBySections(props: SummaryListsBySectionsProps) {
         changeAnswer={props.changeAnswer}
         showChangeButton={props.showChangeButton}
         disclaimer={props.disclaimer}
+        titleId={props.titleId}
       />
     );
   }
@@ -314,7 +320,10 @@ function SummaryList(props: SummaryListProps) {
 
   return (
     <>
-      <SummaryListTable showChangeButton={props.showChangeButton}>
+      <SummaryListTable
+        showChangeButton={props.showChangeButton}
+        aria-labelledby={props.titleId}
+      >
         {!props.summaryBreadcrumbs.length && (
           <Typography variant="body2">No responses to display</Typography>
         )}

--- a/apps/editor.planx.uk/src/pages/Preview/ApplicationViewer.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ApplicationViewer.tsx
@@ -34,11 +34,18 @@ const ApplicationViewer: React.FC = () => {
   const noBreadcrumbs = Object.keys(breadcrumbs).length === 0;
   if (noBreadcrumbs) return <NoContentPage />;
 
+  const overviewHeadingId = "overview-heading";
+  const responsesHeadingId = "your-responses-heading";
+
   return (
     <StatusPage bannerHeading="Review your responses">
-      <Typography variant="h2">Overview</Typography>
-      <ApplicationSummary />
-      <Typography variant="h2">Your responses</Typography>
+      <Typography variant="h2" id={overviewHeadingId}>
+        Overview
+      </Typography>
+      <ApplicationSummary titleId={overviewHeadingId} />
+      <Typography variant="h2" id={responsesHeadingId}>
+        Your responses
+      </Typography>
       <SummaryListsBySections
         changeAnswer={() => null}
         showChangeButton={false}
@@ -46,6 +53,7 @@ const ApplicationViewer: React.FC = () => {
         passport={passport}
         breadcrumbs={breadcrumbs}
         sectionComponent="h2"
+        titleId={responsesHeadingId}
       />
       {showFeeBreakdown && (
         <Box sx={{ mb: 4 }}>

--- a/apps/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ReconciliationPage.tsx
@@ -86,7 +86,7 @@ const ReconciliationPage: React.FC<Props> = ({
             </Typography>
           </Box>
         )}
-        <Typography variant="h2">
+        <Typography variant="h2" id="reconciliation-heading">
           Review your {hasSections ? "progress" : "answers"} so far
         </Typography>
         {hasSections ? (
@@ -109,6 +109,7 @@ const ReconciliationPage: React.FC<Props> = ({
             changeAnswer={changeAnswer}
             showChangeButton={false}
             sectionComponent="h3"
+            titleId="reconciliation-heading"
           />
         )}
         {buttonText && (

--- a/apps/editor.planx.uk/src/ui/public/ApplicationSummary.tsx
+++ b/apps/editor.planx.uk/src/ui/public/ApplicationSummary.tsx
@@ -15,7 +15,11 @@ const getApplicationTypeDescriptionFromPassportValue = (
   return description;
 };
 
-const ApplicationSummary: React.FC = () => {
+interface Props {
+  titleId?: string;
+}
+
+const ApplicationSummary: React.FC<Props> = ({ titleId }) => {
   const [sessionId, passport, govUkPayment, flowName] = useStore((state) => [
     state.sessionId,
     state.computePassport(),
@@ -48,7 +52,7 @@ const ApplicationSummary: React.FC = () => {
   >;
 
   return (
-    <SummaryListTable>
+    <SummaryListTable aria-labelledby={titleId}>
       {Object.entries(applicableDetails).map(([k, v], i) => (
         <Fragment key={`detail-${i}`}>
           <Box component="dt">{k}</Box>

--- a/apps/editor.planx.uk/src/ui/public/Banner.tsx
+++ b/apps/editor.planx.uk/src/ui/public/Banner.tsx
@@ -9,6 +9,7 @@ import { getContrastTextColor } from "styleUtils";
 
 interface BannerProps {
   heading?: string;
+  headingId?: string;
   Icon?: typeof SvgIcon;
   iconTitle?: string;
   color?: { background: string; text: string };
@@ -64,7 +65,11 @@ function Banner(props: BannerProps) {
           />
         )}
         {props.heading && (
-          <Typography variant="h1" sx={{ textWrap: "balance" }}>
+          <Typography
+            variant="h1"
+            id={props.headingId}
+            sx={{ textWrap: "balance" }}
+          >
             {props.heading}
           </Typography>
         )}


### PR DESCRIPTION
## Issue

Relates to:
p.43 - DAC_SR_Feedback_04 - https://trello.com/c/oNyhpDtr/3726-usability-screen-reader-feedback-04-list-item-descriptions

Multiple tables or description lists do not have accessible titles or headings:

> Viewing the table after adding my residential unit I found it did not have a clear caption to
inform me what it contained. Without a clear title it meant I needed to navigate around the
table in order to understand what it contained. Giving the table a clear title will allow me to
understand what it contains without having to go into it first. This was a medium impact
issue for me. I found this issue with all tables.

## Solution

Ensure that all tables or description lists in the public interface are described by an accessible title.

Changes applied to instances on:
- List component review card (as highlighted in report)
- Review page
- Property information
- Fee breakdown (manually added a `<caption>` of "Fee breakdown" to the table)
- Reconciliation / "your answers so far"
- Confirmation - application summary table on the "Application sent" page
- Application viewer (overview + your responses)
