### PR TITLE
feat: styled grouped submissions log

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -23,6 +23,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
         ) {
           flowId: flow_id
           id: session_id
+          eventType: event_type
           status: status
           address: address
           eventCreatedAt: created_at
@@ -38,6 +39,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   );
 
   const submissions = useMemo(() => data?.submissions || [], [data]);
+
   // filter by flow if flowId prop is passed from route params
   const filteredSubmissions = submissions.filter(
     (submission) => !flowSlug || slugify(submission.flowName) === flowSlug,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -20,8 +20,6 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
       query GetSubmissions($team_id: Int!) {
         submissions: submissions_grouped(
           where: { team_id: { _eq: $team_id } }
-          order_by: [{ session_id: asc }, { created_at: desc }]
-          distinct_on: session_id
         ) {
           flowId: flow_id
           id: session_id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -16,7 +16,7 @@ import { submissionStatusOptions } from "../submissionFilterOptions";
 import type { EventsLogGroupedProps, SubmissionSummary } from "../types";
 import { StatusChip } from "./StatusChip";
 
-const EventsLog: React.FC<EventsLogGroupedProps> = ({
+const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
   submissions,
   loading,
   error,
@@ -101,4 +101,4 @@ const EventsLog: React.FC<EventsLogGroupedProps> = ({
   );
 };
 
-export default EventsLog;
+export default EventsLogGrouped;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import ErrorFallback from "components/Error/ErrorFallback";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { EmptyState } from "ui/editor/EmptyState";
 import { DataTable } from "ui/shared/DataTable/DataTable";
@@ -12,8 +12,13 @@ import type { ColumnConfig } from "ui/shared/DataTable/types";
 import { ColumnFilterType } from "ui/shared/DataTable/types";
 import { dateFormatter } from "ui/shared/DataTable/utils";
 
-import { submissionStatusOptions } from "../submissionFilterOptions";
-import type { EventsLogGroupedProps, SubmissionSummary } from "../types";
+import { submissionStatusGroupedOptions } from "../submissionFilterOptions";
+import type {
+  EventsLogGroupedProps,
+  Submission,
+  SubmissionSummary,
+} from "../types";
+import { getConsolidatedStatus } from "../utils";
 import { StatusChip } from "./StatusChip";
 
 const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
@@ -24,6 +29,20 @@ const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
 }) => {
   const navigate = useNavigate();
   const teamSlug = useStore((state) => state.teamSlug);
+
+  const [selectedSubmission, setSelectedSubmission] =
+    useState<Submission | null>(null);
+
+  // consolidate event types and statuses into single status
+  const submissionsWithConsolidatedStatus = useMemo(() => {
+    return submissions.map((submission) => ({
+      ...submission,
+      consolidatedStatus: getConsolidatedStatus(
+        submission.status,
+        submission.eventType,
+      ),
+    }));
+  }, [submissions]);
 
   if (loading)
     return (
@@ -62,13 +81,13 @@ const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
       width: 250,
     },
     {
-      field: "status",
+      field: "consolidatedStatus",
       headerName: "Status",
       width: 125,
       type: ColumnFilterType.SINGLE_SELECT,
       customComponent: StatusChip,
       columnOptions: {
-        valueOptions: submissionStatusOptions,
+        valueOptions: submissionStatusGroupedOptions,
       },
     },
     {
@@ -86,7 +105,7 @@ const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <DataTable
         columns={columns}
-        rows={submissions}
+        rows={submissionsWithConsolidatedStatus}
         onRowClick={(params) => {
           navigate({
             to: "/app/$team/submissions/$sessionId",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
@@ -3,9 +3,19 @@ import React from "react";
 import type { RenderCellParams } from "ui/shared/DataTable/types";
 
 export const StatusChip = (params: RenderCellParams) => {
-  return params.value === "Success" ? (
-    <Chip label="Success" size="small" color="success" />
-  ) : (
-    <Chip label={params.value} size="small" color="error" />
-  );
+  if (params.value.includes("failed")) {
+    return <Chip label={params.value} size="small" color="error" />;
+  }
+  if (params.value === "Sending") {
+    return <Chip label={params.value} size="small" color="sending" />;
+  }
+  if (
+    params.value === "Invited to pay" ||
+    params.value === "Payment in progress"
+  ) {
+    return <Chip label={params.value} size="small" color="paymentPending" />;
+  }
+  if (params.value === "Success") {
+    return <Chip label={params.value} size="small" color="success" />;
+  }
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/submissionFilterOptions.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/submissionFilterOptions.ts
@@ -1,6 +1,7 @@
 import type { Submission } from "./types";
 
 export const submissionEventTypes: Array<Submission["eventType"]> = [
+  // TODO: delete after removing feature flag, no more event type column to filter on
   "Send to email",
   "Pay",
   "Submit to BOPS",
@@ -11,6 +12,7 @@ export const submissionEventTypes: Array<Submission["eventType"]> = [
 ];
 
 export const submissionStatusOptions: Required<Array<Submission["status"]>> = [
+  // TODO: delete after feature flag removal ^
   "Success",
   "Failed (500)",
   "Failed (502)",
@@ -25,4 +27,16 @@ export const submissionStatusOptions: Required<Array<Submission["status"]>> = [
   "Cancelled",
   "Error",
   "Unknown",
+];
+
+export const submissionStatusGroupedOptions = [
+  "Success",
+  "Invited to pay",
+  "Payment in progress",
+  "Sending",
+  "Send to BOPS failed",
+  "Send to Uniform failed",
+  "Send to email failed",
+  "Upload to AWS S3 failed",
+  "Submit to Idox Nexus failed",
 ];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -38,8 +38,9 @@ export interface SubmissionSummary {
   flowName: string;
   address: string | null;
   eventCreatedAt: string;
-  mostRecentEventType: Submission["eventType"];
+  eventType: Submission["eventType"];
   status: Submission["status"];
+  consolidatedStatus?: string;
 }
 
 export interface EventsLogProps {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
@@ -1,0 +1,19 @@
+export const getConsolidatedStatus = (
+  status: string | undefined,
+  eventType: string,
+): string => {
+  if (status === "Invited to pay") {
+    return status;
+  } else if (status === "Started" || status === "Capturable") {
+    return "Payment in progress";
+  } else if (status === "Submitted") {
+    // "Submitted" status only possible on Pay events, hence "Sending" status
+    return "Sending";
+  } else if (status === "Success") {
+    return "Success";
+  } else if (typeof status === "string" && status.includes("Failed")) {
+    return eventType.replace("(no notification)", "").concat(" failed"); // shortening possible status "Upload to AWS S3 (no notification)"
+  } else {
+    return "Failed";
+  }
+};

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -80,6 +80,12 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     contrastText: "#FFFFFF",
     light: "#EBF4FD",
   },
+  paymentPending: {
+    main: "#7B4724",
+  },
+  sending: {
+    main: "#676767",
+  },
   border: {
     main: "#B1B4B6",
     input: "#0B0C0C",
@@ -443,15 +449,17 @@ const getThemeOptions = ({
               color: darken(palette.info.main, 0.8),
             },
           },
-          {
-            props: { variant: "notApplicableTag" },
-            style: {
-              backgroundColor: lighten(palette.warning.light, 0.7),
-              fontWeight: FONT_WEIGHT_SEMI_BOLD,
-              color: palette.text.primary,
-            },
-          },
         ],
+        styleOverrides: {
+          colorPaymentPending: {
+            backgroundColor: palette.paymentPending.main,
+            color: palette.common.white,
+          },
+          colorSending: {
+            backgroundColor: palette.sending.main,
+            color: palette.common.white,
+          },
+        },
       },
       MuiContainer: {
         styleOverrides: {

--- a/apps/editor.planx.uk/src/themeOverrides.d.ts
+++ b/apps/editor.planx.uk/src/themeOverrides.d.ts
@@ -21,7 +21,7 @@ declare module "@mui/material/Chip" {
 
 declare module "@mui/material/Chip" {
   interface ChipClasses {
-    colorInvitedToPay: string;
+    colorPaymentPending: string;
     colorSending: string;
   }
 }

--- a/apps/editor.planx.uk/src/themeOverrides.d.ts
+++ b/apps/editor.planx.uk/src/themeOverrides.d.ts
@@ -10,6 +10,22 @@ declare module "@mui/material/Chip" {
   }
 }
 
+declare module "@mui/material/Chip" {
+  interface ChipPropsColorOverrides {
+    uploadedFileTag: true;
+    notApplicableTag: true;
+    paymentPending: true;
+    sending: true;
+  }
+}
+
+declare module "@mui/material/Chip" {
+  interface ChipClasses {
+    colorInvitedToPay: string;
+    colorSending: string;
+  }
+}
+
 // Add our custom breakpoints
 declare module "@mui/material/styles" {
   interface BreakpointOverrides {
@@ -55,6 +71,8 @@ declare module "@mui/material/styles" {
       dark: string;
       icon: string;
     };
+    paymentPending: { main: string };
+    sending: { main: string };
   }
 
   interface PaletteOptions {
@@ -90,6 +108,12 @@ declare module "@mui/material/styles" {
       light: string;
       dark: string;
       icon: string;
+    };
+    paymentPending?: {
+      main: string;
+    };
+    sending?: {
+      main: string;
     };
   }
 


### PR DESCRIPTION
This PR:
- Fixes submission log date desc ordering
- Consolidates the status chip, combining event type and status into 5 different chips
    - '[Send event] failed'
    - 'Sending' (eg if Pay was Submitted)
    - 'Invited to pay' or 'Payment in progress' (wanted to preserve both for more transparency / as ITP is a common help-issue)
    - 'Success'
- Adds two custom colour styles for StatusChip

While there is interest in "Paid" status existing _alongside_ rather than being replaced by the "Success" status, I'm thinking of using this single consolidated status for now and we can have multiple statuses as a nice-to-have or additional small ticket later on? Just to avoid too much creep / sprawl!

See [thread](https://opensystemslab.slack.com/archives/C04DZ1NBUMR/p1786539752941109?thread_ts=1783699904.490609&cid=C04DZ1NBUMR) for further context. 

