### PR TITLE
fix: File upload info only headings, print button disclaimer

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.test.tsx
@@ -193,11 +193,7 @@ describe("Info-only mode with hidden drop zone", () => {
     const { queryByRole } = await setup(
       <FileUploadAndLabelComponent
         title="Test title"
-        fileTypes={[
-          mockFileTypes.AlwaysRequired,
-          mockFileTypes.AlwaysRecommended,
-          mockFileTypes.NotRequired,
-        ]}
+        fileTypes={mockFileTypesUniqueKeys}
         hideDropZone={true}
       />,
     );

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Public/index.tsx
@@ -141,7 +141,9 @@ export default function Component(props: Props) {
   };
 
   const isCategoryVisible = (category: keyof typeof state.fileList) => {
-    if (props.hideDropZone) return true;
+    if (props.hideDropZone) {
+      return state.fileList[category].length > 0;
+    }
 
     switch (category) {
       case "optional":
@@ -256,7 +258,7 @@ export default function Component(props: Props) {
           </Box>
         </ErrorWrapper>
       </FullWidthWrapper>
-      {props.hideDropZone && <PrintButton />}
+      {props.hideDropZone && <PrintButton showSubmissionDisclaimer={false} />}
     </Card>
   );
 }

--- a/apps/editor.planx.uk/src/components/PrintButton.tsx
+++ b/apps/editor.planx.uk/src/components/PrintButton.tsx
@@ -17,16 +17,25 @@ const StyledTimestamp = styled(Typography)(() => ({
   },
 }));
 
-const PrintedAt = () => {
+const PrintedAt = ({
+  showSubmissionDisclaimer,
+}: {
+  showSubmissionDisclaimer: boolean;
+}) => {
   return (
     <StyledTimestamp>
-      Printed at {new Date().toLocaleString("en-GB")}. This is a record of your
-      responses so far and does not confirm submission.
+      Printed at {new Date().toLocaleString("en-GB")}.
+      {showSubmissionDisclaimer &&
+        " This is a record of your responses so far and does not confirm submission."}
     </StyledTimestamp>
   );
 };
 
-export const PrintButton = () => {
+export const PrintButton = ({
+  showSubmissionDisclaimer = true,
+}: {
+  showSubmissionDisclaimer?: boolean;
+}) => {
   return (
     <>
       <StyledPrintButton
@@ -39,7 +48,7 @@ export const PrintButton = () => {
         Print this page
       </StyledPrintButton>
 
-      <PrintedAt />
+      <PrintedAt showSubmissionDisclaimer={showSubmissionDisclaimer} />
     </>
   );
 };


### PR DESCRIPTION
## Issue

Addresses two issues present when viewing upload and label in information only mode:
- Headings appear when no information types are present in category
- Print disclaimer reads `This is a record of your responses so far and does not confirm submission.`, which is misleading at this point

<img width="590" height="409" alt="image" src="https://github.com/user-attachments/assets/40ec651d-7d07-4685-b232-8c5575bf15a4" />

## Solution
- Make headings conditional on information type being present for that category
- Add an optional `showSubmissionDisclaimer` to use wording around responses so far

<img width="590" height="331" alt="image" src="https://github.com/user-attachments/assets/4283b08b-1e80-4988-9189-a16c33d0be17" />
