### PR TITLE
refactor: Integrate patterns to Add new flow form

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Radio/BasicRadio/BasicRadio.tsx
@@ -10,10 +10,42 @@ export interface Props {
   label: FormControlLabelProps["label"];
   description?: string;
   onChange: FormControlLabelProps["onChange"];
-  variant?: "default" | "compact";
+  variant?: "default" | "compact" | "inline";
   value?: string;
   disabled?: boolean;
 }
+
+const getLabel = (
+  label: FormControlLabelProps["label"],
+  description: string | undefined,
+  variant: NonNullable<Props["variant"]>,
+) => {
+  if (!description) return label;
+
+  if (variant === "inline") {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "flex-start",
+          gap: 1,
+        }}
+      >
+        <Box sx={{ fontWeight: "bold" }}>{label}</Box>
+        <Box sx={{ color: "text.secondary" }}>–</Box>
+        <Box sx={{ color: "text.secondary" }}>{description}</Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ fontWeight: "bold", mb: 1 }}>{label}</Box>
+      <Box sx={{ color: "text.secondary" }}>{description}</Box>
+    </Box>
+  );
+};
 
 const BasicRadio: React.FC<Props> = ({
   id,
@@ -26,17 +58,8 @@ const BasicRadio: React.FC<Props> = ({
   <FormControlLabel
     value={id}
     onChange={onChange}
-    control={<Radio variant={variant} />}
-    label={
-      description ? (
-        <Box>
-          <Box sx={{ fontWeight: "bold", mb: 1 }}>{label}</Box>
-          <Box sx={{ color: "text.secondary" }}>{description}</Box>
-        </Box>
-      ) : (
-        label
-      )
-    }
+    control={<Radio variant={variant === "inline" ? "compact" : variant} />}
+    label={getLabel(label, description, variant)}
     disabled={disabled}
     sx={(theme) => ({
       ml: theme.spacing(-1),

--- a/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/BaseFormSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/BaseFormSection.tsx
@@ -1,5 +1,6 @@
 import MenuItem from "@mui/material/MenuItem";
 import RadioGroup from "@mui/material/RadioGroup";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import BasicRadio from "@planx/components/shared/Radio/BasicRadio/BasicRadio";
 import { useFormikContext } from "formik";
@@ -14,28 +15,50 @@ import { slugify } from "utils";
 
 import { CreateFromCopyFormSection } from "./CreateFromCopyFormSection";
 import { CreateFromTemplateFormSection } from "./CreateFromTemplateFormSection";
-import type { CreateFlow } from "./types";
-import { CREATE_FLOW_MODES, FLOW_SERVICE_OPTIONS } from "./types";
+import type { CreateFlow, FlowTypeOption } from "./types";
+import {
+  CREATE_FLOW_MODES,
+  FLOW_TYPE_OPTIONS,
+  PATTERN_TYPE_OPTION,
+} from "./types";
 
 export const BaseFormSection: React.FC = () => {
   const { values, setFieldValue, getFieldProps, errors } =
     useFormikContext<CreateFlow>();
+
+  let flowType: FlowTypeOption = "flow";
+  if (values.flow.isPattern) flowType = "pattern";
+  else if (values.flow.isService) flowType = "service";
+
+  const handleFlowTypeChange: React.ComponentProps<
+    typeof BasicRadio
+  >["onChange"] = (e) => {
+    const value = (e.target as HTMLInputElement).value as FlowTypeOption;
+    setFieldValue("flow.isService", value === "service");
+    setFieldValue("flow.isPattern", value === "pattern");
+  };
+
+  let nameLabel = "Flow name";
+  if (values.mode === "new") {
+    if (flowType === "pattern") nameLabel = "Pattern name";
+    else if (flowType === "service") nameLabel = "Service name";
+  }
+
   return (
     <>
-      <InputLabel
-        label="How do you want to create a new flow?"
-        id="create-flow-mode"
-      >
+      <InputLabel label="How do you want to start?" id="create-flow-mode">
         <SelectInput
           value={values.mode}
           name="mode"
           bordered
           required={true}
-          title={"How do you want to create a new flow?"}
+          title={"How do you want to start?"}
           labelId="create-flow-mode"
           onChange={(e) => {
             setFieldValue("mode", e.target.value);
-            setFieldValue("flow.source.id", undefined);
+            setFieldValue("flow.sourceId", "");
+            setFieldValue("flow.name", "");
+            setFieldValue("flow.slug", "");
           }}
         >
           {CREATE_FLOW_MODES.map(({ mode, title }) => (
@@ -45,9 +68,47 @@ export const BaseFormSection: React.FC = () => {
           ))}
         </SelectInput>
       </InputLabel>
+      {values.mode === "new" && (
+        <Stack spacing={1}>
+          <Typography variant="body1">What are you creating?</Typography>
+          <RadioGroup value={flowType}>
+            {FLOW_TYPE_OPTIONS.map((option) => (
+              <BasicRadio
+                key={option.value}
+                id={option.value}
+                label={option.title}
+                description={option.description}
+                variant="inline"
+                onChange={handleFlowTypeChange}
+              />
+            ))}
+            <Permission.IsPlatformAdmin>
+              <BasicRadio
+                id={PATTERN_TYPE_OPTION.value}
+                label={PATTERN_TYPE_OPTION.title}
+                description={PATTERN_TYPE_OPTION.description}
+                variant="inline"
+                onChange={handleFlowTypeChange}
+              />
+            </Permission.IsPlatformAdmin>
+          </RadioGroup>
+        </Stack>
+      )}
+      {values.mode === "new" && flowType !== "pattern" && (
+        <Permission.IsPlatformAdmin>
+          <Switch
+            name="isTemplate"
+            checked={values.flow.isTemplate}
+            onChange={() =>
+              setFieldValue("flow.isTemplate", !values.flow.isTemplate)
+            }
+            label={"Source template"}
+          />
+        </Permission.IsPlatformAdmin>
+      )}
       <CreateFromTemplateFormSection />
       <CreateFromCopyFormSection />
-      <InputLabel label="Flow name" htmlFor="flow.name">
+      <InputLabel label={nameLabel} htmlFor="flow.name">
         <Input
           {...getFieldProps("flow.name")}
           id="flow.name"
@@ -69,49 +130,6 @@ export const BaseFormSection: React.FC = () => {
           startAdornment={<URLPrefix mode="flow" />}
         />
       </InputLabel>
-      {values.mode === "new" && (
-        <>
-          <Permission.IsPlatformAdmin>
-            <Switch
-              name="isPattern"
-              checked={values.flow.isPattern}
-              onChange={() =>
-                setFieldValue("flow.isPattern", !values.flow.isPattern)
-              }
-              label={"Pattern"}
-            />
-            <Switch
-              name="isTemplate"
-              checked={values.flow.isTemplate}
-              onChange={() =>
-                setFieldValue("flow.isTemplate", !values.flow.isTemplate)
-              }
-              label={"Source template"}
-            />
-          </Permission.IsPlatformAdmin>
-          <Typography variant="h4">Is this a flow or a service?</Typography>
-          <RadioGroup
-            defaultValue={false}
-            value={values.flow.isService}
-            sx={{ gap: 1 }}
-          >
-            {FLOW_SERVICE_OPTIONS.map((option) => (
-              <BasicRadio
-                id={option.isService}
-                label={option.title}
-                description={option.description}
-                variant="compact"
-                onChange={(e) =>
-                  setFieldValue(
-                    "flow.isService",
-                    (e.target as HTMLInputElement).value === "true",
-                  )
-                }
-              />
-            ))}
-          </RadioGroup>
-        </>
-      )}
     </>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/index.tsx
@@ -101,61 +101,69 @@ export const AddFlow: React.FC = () => {
         validationSchema={validationSchema}
         enableReinitialize
       >
-        {({ resetForm, isSubmitting, status }) => (
-          <Dialog
-            open={dialogOpen}
-            onClose={() => {
-              setDialogOpen(false);
-              resetForm();
-            }}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-            fullWidth
-          >
-            <DialogTitle variant="h3" component="h1" id="dialog-heading">
-              Add a new flow
-            </DialogTitle>
-            <Form
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                overflow: "hidden",
+        {({ resetForm, isSubmitting, status, values }) => {
+          let addButtonLabel = "Add flow";
+          if (values.mode === "new") {
+            if (values.flow.isPattern) addButtonLabel = "Add pattern";
+            else if (values.flow.isService) addButtonLabel = "Add service";
+          }
+
+          return (
+            <Dialog
+              open={dialogOpen}
+              onClose={() => {
+                setDialogOpen(false);
+                resetForm();
               }}
+              aria-labelledby="alert-dialog-title"
+              aria-describedby="alert-dialog-description"
+              fullWidth
             >
-              <DialogContent dividers>
-                <ErrorWrapper error={status?.error}>
-                  <Box
-                    sx={{
-                      gap: 2,
-                      display: "flex",
-                      flexDirection: "column",
-                    }}
+              <DialogTitle variant="h3" component="h1" id="dialog-heading">
+                Add a new flow
+              </DialogTitle>
+              <Form
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  overflow: "hidden",
+                }}
+              >
+                <DialogContent dividers>
+                  <ErrorWrapper error={status?.error}>
+                    <Box
+                      sx={{
+                        gap: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                      }}
+                    >
+                      <BaseFormSection />
+                    </Box>
+                  </ErrorWrapper>
+                </DialogContent>
+                <DialogActions>
+                  <Button
+                    onClick={() => setDialogOpen(false)}
+                    disabled={isSubmitting}
+                    variant="contained"
+                    color="secondary"
                   >
-                    <BaseFormSection />
-                  </Box>
-                </ErrorWrapper>
-              </DialogContent>
-              <DialogActions>
-                <Button
-                  onClick={() => setDialogOpen(false)}
-                  disabled={isSubmitting}
-                  variant="contained"
-                  color="secondary"
-                >
-                  Back
-                </Button>
-                <Button
-                  type="submit"
-                  color="primary"
-                  variant="contained"
-                  disabled={isSubmitting}
-                >
-                  Add flow
-                </Button>
-              </DialogActions>
-            </Form>
-          </Dialog>
-        )}
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    color="primary"
+                    variant="contained"
+                    disabled={isSubmitting}
+                  >
+                    {addButtonLabel}
+                  </Button>
+                </DialogActions>
+              </Form>
+            </Dialog>
+          );
+        }}
       </Formik>
     </Box>
   );

--- a/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/types.ts
+++ b/apps/editor.planx.uk/src/pages/Flows/components/AddFlow/types.ts
@@ -7,7 +7,7 @@ export const validationSchema = object().shape({
     slug: string().required("Slug is required"),
     name: string().required("Name is required"),
     teamId: number().integer().required("Team ID is required"),
-    isPattern: boolean(), // TODO error if isTemplate or isService are true?
+    isPattern: boolean(),
     isTemplate: boolean(),
     isService: boolean(),
     sourceId: string().when("$mode", {
@@ -38,15 +38,28 @@ export const CREATE_FLOW_MODES = [
   },
 ] as const;
 
-export const FLOW_SERVICE_OPTIONS = [
+export type FlowTypeOption = "flow" | "service" | "pattern";
+
+export const FLOW_TYPE_OPTIONS: {
+  value: FlowTypeOption;
+  title: string;
+  description: string;
+}[] = [
   {
-    isService: false,
+    value: "flow",
     title: "Flow",
     description: "Used as a modular building block within services",
   },
   {
-    isService: true,
+    value: "service",
     title: "Service",
     description: "A user-facing form that will be published and set online",
   },
 ];
+
+export const PATTERN_TYPE_OPTION = {
+  value: "pattern",
+  title: "Pattern",
+  description:
+    "A set of components that can be inserted into a flow or service",
+} as const;


### PR DESCRIPTION
## What does this PR do?

Integrates `Pattern` as a category of flow type, alongside `Flow` and `Service`. This prevents a separate pattern toggle, prevents conflict around `pattern=true` + `source template=true`, and allows conditional wording of the form and button elements.

- Refactor from `isService` as a boolean option to defining a string union type `FlowTypeOption`, which includes `flow`, `service` and `pattern`
- Template toggle only shown for `flow` or `service`, move up to sit with other config options
- Flow name label and add button respond to selected flow type
- Update `BasicRadio` to allow an inline description
- Reorder form so that all options are selected before choosing a name

https://github.com/user-attachments/assets/74a925c5-0688-468e-86f7-2edbdac613fb

