### PR TITLE
feat: Create templates explore widget with preview modal

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -16,6 +16,7 @@ import SchoolIcon from "@mui/icons-material/School";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
+import type { Role } from "@opensystemslab/planx-core/types";
 import {
   useLocation,
   useMatches,
@@ -163,7 +164,11 @@ function EditorNavMenu() {
                   title: "Explore",
                   Icon: ExploreIcon,
                   route: `/app/${teamSlug}/explore`,
-                  accessibleBy: "*" as const,
+                  accessibleBy: [
+                    "platformAdmin",
+                    "teamAdmin",
+                    "teamEditor",
+                  ] as Role[],
                 },
               ]
             : []),

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -41,13 +41,16 @@ const Initial = styled("span", {
 }));
 
 export const Badge: React.FC<BadgeProps> = (props) => {
-  const { size = "default" } = props;
+  const { size = "default", sx } = props;
 
   if (props.variant === BadgeVariant.SourceTemplate) {
     return (
       <Root
         size={size}
-        sx={{ backgroundColor: "template.light" }}
+        sx={[
+          { backgroundColor: "template.light" },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
         role="img"
         aria-label="Source template"
         data-testid="badge-source-template"
@@ -61,10 +64,13 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        sx={{
-          backgroundColor: props.backgroundColour,
-          color: props.iconColour,
-        }}
+        sx={[
+          {
+            backgroundColor: props.backgroundColour,
+            color: props.iconColour,
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
         data-testid="badge-custom"
       >
         {props.icon}
@@ -79,7 +85,10 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        sx={{ backgroundColor: backgroundColour }}
+        sx={[
+          { backgroundColor: backgroundColour },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
         role="img"
         aria-label={team.name}
         data-testid="badge-team-logo"
@@ -94,7 +103,10 @@ export const Badge: React.FC<BadgeProps> = (props) => {
   return (
     <Root
       size={size}
-      sx={{ backgroundColor: backgroundColour }}
+      sx={[
+        { backgroundColor: backgroundColour },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       role="img"
       aria-label={team.name}
       data-testid="badge-team-initial"

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -41,16 +41,13 @@ const Initial = styled("span", {
 }));
 
 export const Badge: React.FC<BadgeProps> = (props) => {
-  const { size = "default", sx } = props;
+  const { size = "default" } = props;
 
   if (props.variant === BadgeVariant.SourceTemplate) {
     return (
       <Root
         size={size}
-        sx={[
-          { backgroundColor: "template.light" },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
+        sx={{ backgroundColor: "template.light" }}
         role="img"
         aria-label="Source template"
         data-testid="badge-source-template"
@@ -64,13 +61,10 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        sx={[
-          {
-            backgroundColor: props.backgroundColour,
-            color: props.iconColour,
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
+        sx={{
+          backgroundColor: props.backgroundColour,
+          color: props.iconColour,
+        }}
         data-testid="badge-custom"
       >
         {props.icon}
@@ -85,10 +79,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        sx={[
-          { backgroundColor: backgroundColour },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
+        sx={{ backgroundColor: backgroundColour }}
         role="img"
         aria-label={team.name}
         data-testid="badge-team-logo"
@@ -103,10 +94,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
   return (
     <Root
       size={size}
-      sx={[
-        { backgroundColor: backgroundColour },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
+      sx={{ backgroundColor: backgroundColour }}
       role="img"
       aria-label={team.name}
       data-testid="badge-team-initial"

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -9,8 +9,8 @@ import type { BadgeProps, BadgeSize } from "./types";
 import { BadgeVariant } from "./types";
 
 const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
-  default: { box: 54, borderRadius: 6 },
-  compact: { box: 46, borderRadius: 4 },
+  default: { box: 56, borderRadius: 6 },
+  compact: { box: 50, borderRadius: 5 },
 };
 
 const Root = styled(Box, {

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
@@ -1,4 +1,3 @@
-import type { SxProps, Theme } from "@mui/material/styles";
 import type React from "react";
 
 export const BadgeVariant = {
@@ -23,7 +22,6 @@ interface BadgeTeam {
 
 interface BadgeBaseProps {
   size?: BadgeSize;
-  sx?: SxProps<Theme>;
 }
 
 interface SourceTemplateBadgeProps extends BadgeBaseProps {

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/types.ts
@@ -1,3 +1,4 @@
+import type { SxProps, Theme } from "@mui/material/styles";
 import type React from "react";
 
 export const BadgeVariant = {
@@ -22,6 +23,7 @@ interface BadgeTeam {
 
 interface BadgeBaseProps {
   size?: BadgeSize;
+  sx?: SxProps<Theme>;
 }
 
 interface SourceTemplateBadgeProps extends BadgeBaseProps {

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -7,7 +7,6 @@ import DialogContent from "@mui/material/DialogContent";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import type { FlowStatus } from "@opensystemslab/planx-core/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "hooks/useToast";
 import { SYSTEM_TEAMS } from "lib/systemTeams";
@@ -31,7 +30,6 @@ interface TemplateDetails {
   }[];
   publishedFlows: { hasSendComponent: boolean }[];
   usedByTeams: {
-    status: FlowStatus;
     team: {
       id: number;
       name: string;
@@ -68,7 +66,6 @@ const GET_TEMPLATE_DETAILS = gql`
         order_by: [{ team_id: asc }, { created_at: desc }]
         where: { team: { slug: { _nin: $systemTeams } } }
       ) {
-        status
         team {
           id
           name
@@ -169,10 +166,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
       ).formatted
     : undefined;
 
-  const onlineTeams =
-    details?.usedByTeams.filter(({ status }) => status === "online") ?? [];
-  const copiedTeams =
-    details?.usedByTeams.filter(({ status }) => status !== "online") ?? [];
+  const usedByCount = details?.usedByTeams.length ?? 0;
 
   return (
     <Dialog
@@ -212,34 +206,15 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
           </Typography>
         )}
       </DialogContent>
-      {onlineTeams.length > 0 && (
+      {usedByCount > 0 && (
         <>
           <Divider />
           <Box sx={{ p: 2 }}>
             <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
-              {`Online with ${onlineTeams.length} team${onlineTeams.length === 1 ? "" : "s"}:`}
+              {`Subscribed to by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`}
             </Typography>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-              {onlineTeams.map(({ team }) => (
-                <Tooltip key={team.id} title={team.name}>
-                  <span>
-                    <Badge variant={BadgeVariant.Team} team={team} />
-                  </span>
-                </Tooltip>
-              ))}
-            </Box>
-          </Box>
-        </>
-      )}
-      {copiedTeams.length > 0 && (
-        <>
-          <Divider />
-          <Box sx={{ p: 2 }}>
-            <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
-              {`Subscribed to by ${copiedTeams.length} team${copiedTeams.length === 1 ? "" : "s"} (not online):`}
-            </Typography>
-            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-              {copiedTeams.map(({ team }) => (
+              {details!.usedByTeams.map(({ team }) => (
                 <Tooltip key={team.id} title={team.name}>
                   <span>
                     <Badge variant={BadgeVariant.Team} team={team} />

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -8,14 +8,17 @@ import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
+import { ConfirmationDialog } from "components/ConfirmationDialog";
 import { useToast } from "hooks/useToast";
 import { SYSTEM_TEAMS } from "lib/systemTeams";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { formatLastEditMessage } from "pages/FlowEditor/utils";
 import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
-import React from "react";
+import React, { useState } from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
 import { FlowTagType } from "ui/editor/FlowTag/types";
+import CheckCircleIcon from "ui/icons/CheckCircle";
 import { slugify } from "utils";
 
 import { Badge } from "./Badge/Badge";
@@ -94,6 +97,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
   const toast = useToast();
   const [
     teamId,
+    teamName,
     teamSlug,
     canUserEditTeam,
     showLoading,
@@ -101,6 +105,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
     setLoadingCompleteCallback,
   ] = useStore((state) => [
     state.teamId,
+    state.teamName,
     state.teamSlug,
     state.canUserEditTeam,
     state.showLoading,
@@ -118,6 +123,12 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
 
   const details = data?.flows[0];
   const { mutate: createFlow, isPending } = useCreateFlow();
+
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
+
+  const isAlreadySubscribed = Boolean(
+    details?.usedByTeams.some(({ team }) => team.id === teamId),
+  );
 
   const handleAddToTeam = () => {
     const name = `${template.name} (templated)`;
@@ -168,6 +179,15 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
 
   const usedByCount = details?.usedByTeams.length ?? 0;
 
+  const usedByLabel = (() => {
+    if (canUserEditTeam(teamSlug) && isAlreadySubscribed) {
+      const otherTeamsCount = usedByCount - 1;
+      if (otherTeamsCount === 0) return `Subscribed to by ${teamName}:`;
+      return `Subscribed to by ${teamName} and ${otherTeamsCount} other team${otherTeamsCount === 1 ? "" : "s"}:`;
+    }
+    return `Subscribed to by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`;
+  })();
+
   return (
     <Dialog
       open={open}
@@ -187,6 +207,19 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
             {details?.team.name ?? template.team.name}
           </Typography>
         </Box>
+        {canUserEditTeam(teamSlug) && isAlreadySubscribed && (
+          <Box
+            sx={{ display: "flex", alignItems: "center", gap: 0.33, mb: 0.5 }}
+          >
+            <CheckCircleIcon color="success" sx={{ fontSize: 20 }} />
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
+              Subscribed
+            </Typography>
+          </Box>
+        )}
         <Typography variant="h3" component="h2">
           {template.name}
         </Typography>
@@ -211,7 +244,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
           <Divider />
           <Box sx={{ p: 2 }}>
             <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
-              {`Subscribed to by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`}
+              {usedByLabel}
             </Typography>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
               {details!.usedByTeams.map(({ team }) => (
@@ -234,13 +267,32 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
           <Button
             variant="contained"
             color="primary"
-            onClick={handleAddToTeam}
+            onClick={() =>
+              isAlreadySubscribed
+                ? setIsConfirmationOpen(true)
+                : handleAddToTeam()
+            }
             disabled={isPending}
           >
             Add to my team
           </Button>
         )}
       </DialogActions>
+      <ConfirmationDialog
+        open={isConfirmationOpen}
+        onClose={(confirmed) => {
+          setIsConfirmationOpen(false);
+          if (confirmed) handleAddToTeam();
+        }}
+        title="Add template to your team?"
+        confirmText="Continue"
+        cancelText="Cancel"
+      >
+        <Typography>
+          You already subscribe to this template, subscribing again would mean
+          maintaining more than one instance of this template.
+        </Typography>
+      </ConfirmationDialog>
     </Dialog>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -9,6 +9,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "hooks/useToast";
+import { SYSTEM_TEAMS } from "lib/systemTeams";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { formatLastEditMessage } from "pages/FlowEditor/utils";
 import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
@@ -41,7 +42,7 @@ interface TemplateDetails {
 }
 
 const GET_TEMPLATE_DETAILS = gql`
-  query GetTemplateDetails($id: uuid!) {
+  query GetTemplateDetails($id: uuid!, $systemTeams: [String!]!) {
     flows(where: { id: { _eq: $id } }, limit: 1) {
       id
       team {
@@ -63,6 +64,7 @@ const GET_TEMPLATE_DETAILS = gql`
       usedByTeams: templated_flows(
         distinct_on: team_id
         order_by: [{ team_id: asc }, { created_at: desc }]
+        where: { team: { slug: { _nin: $systemTeams } } }
       ) {
         team {
           id
@@ -109,7 +111,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
   const { data } = useQuery<{ flows: TemplateDetails[] }>(
     GET_TEMPLATE_DETAILS,
     {
-      variables: { id: template.id },
+      variables: { id: template.id, systemTeams: SYSTEM_TEAMS },
       skip: !open,
     },
   );
@@ -167,8 +169,18 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
   const usedByCount = details?.usedByTeams.length ?? 0;
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogContent>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="formWrap"
+      slotProps={{
+        paper: {
+          sx: (theme) => ({ maxWidth: theme.breakpoints.values.formWrap }),
+        },
+      }}
+    >
+      <DialogContent sx={{ backgroundColor: "background.default" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
           <Badge variant={BadgeVariant.SourceTemplate} size="compact" />
           <Typography variant="body1" sx={{ fontWeight: "bold" }}>

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -1,0 +1,238 @@
+import { gql, useQuery } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import Divider from "@mui/material/Divider";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { useNavigate } from "@tanstack/react-router";
+import { useToast } from "hooks/useToast";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { formatLastEditMessage } from "pages/FlowEditor/utils";
+import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
+import React from "react";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType } from "ui/editor/FlowTag/types";
+import { slugify } from "utils";
+
+import { Badge } from "./Badge/Badge";
+import { BadgeVariant } from "./Badge/types";
+import type { Template } from "./types";
+
+interface TemplateDetails {
+  team: { name: string };
+  operations: {
+    createdAt: string;
+    actor?: { firstName: string; lastName: string };
+  }[];
+  publishedFlows: { hasSendComponent: boolean }[];
+  usedByTeams: {
+    team: {
+      id: number;
+      name: string;
+      theme: {
+        primaryColour?: string | null;
+        logo?: string | null;
+      };
+    };
+  }[];
+}
+
+const GET_TEMPLATE_DETAILS = gql`
+  query GetTemplateDetails($id: uuid!) {
+    flows(where: { id: { _eq: $id } }, limit: 1) {
+      id
+      team {
+        name
+      }
+      operations(limit: 1, order_by: { created_at: desc }) {
+        createdAt: created_at
+        actor {
+          firstName: first_name
+          lastName: last_name
+        }
+      }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        hasSendComponent: has_send_component
+      }
+      usedByTeams: templated_flows(
+        distinct_on: team_id
+        order_by: [{ team_id: asc }, { created_at: desc }]
+      ) {
+        team {
+          id
+          name
+          theme {
+            primaryColour: primary_colour
+            logo
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface TemplateDetailsModalProps {
+  template: Template;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
+  template,
+  open,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [
+    teamId,
+    teamSlug,
+    canUserEditTeam,
+    showLoading,
+    hideLoading,
+    setLoadingCompleteCallback,
+  ] = useStore((state) => [
+    state.teamId,
+    state.teamSlug,
+    state.canUserEditTeam,
+    state.showLoading,
+    state.hideLoading,
+    state.setLoadingCompleteCallback,
+  ]);
+
+  const { data } = useQuery<{ flows: TemplateDetails[] }>(
+    GET_TEMPLATE_DETAILS,
+    {
+      variables: { id: template.id },
+      skip: !open,
+    },
+  );
+
+  const details = data?.flows[0];
+  const { mutate: createFlow, isPending } = useCreateFlow();
+
+  const handleAddToTeam = () => {
+    const name = `${template.name} (templated)`;
+
+    setLoadingCompleteCallback(() => {
+      toast.success("Flow created successfully");
+      setLoadingCompleteCallback(undefined);
+    });
+    showLoading("Creating flow...");
+
+    createFlow(
+      {
+        mode: "template",
+        flow: {
+          sourceId: template.id,
+          teamId,
+          name,
+          slug: slugify(name),
+          isPattern: false,
+          isTemplate: false,
+          isService: false,
+        },
+      },
+      {
+        onSuccess: async ({ flow }) => {
+          onClose();
+          await navigate({
+            to: "/app/$team/$flow",
+            params: { team: teamSlug, flow: flow.slug },
+          });
+          hideLoading();
+        },
+        onError: () => {
+          setLoadingCompleteCallback(undefined);
+          hideLoading();
+          toast.error("Failed to add template to your team");
+        },
+      },
+    );
+  };
+
+  const editMessage = details?.operations[0]
+    ? formatLastEditMessage(
+        details.operations[0].createdAt,
+        details.operations[0].actor,
+      ).formatted
+    : undefined;
+
+  const usedByCount = details?.usedByTeams.length ?? 0;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogContent>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+          <Badge variant={BadgeVariant.SourceTemplate} size="compact" />
+          <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+            {details?.team.name ?? template.team.name}
+          </Typography>
+        </Box>
+        <Typography variant="h3" component="h2">
+          {template.name}
+        </Typography>
+        {editMessage && (
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+            {editMessage}
+          </Typography>
+        )}
+        {details?.publishedFlows[0]?.hasSendComponent && (
+          <Box sx={{ mt: 1.5, display: "flex" }}>
+            <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+          </Box>
+        )}
+        {template.summary && (
+          <Typography variant="body1" sx={{ mt: 2 }}>
+            {template.summary}
+          </Typography>
+        )}
+      </DialogContent>
+      {usedByCount > 0 && (
+        <>
+          <Divider />
+          <Box sx={{ p: 2 }}>
+            <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
+              {`Used by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`}
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {details!.usedByTeams.map(({ team }) => (
+                <Tooltip key={team.id} title={team.name}>
+                  <span>
+                    <Badge
+                      variant={BadgeVariant.Team}
+                      size="compact"
+                      team={team}
+                    />
+                  </span>
+                </Tooltip>
+              ))}
+            </Box>
+          </Box>
+        </>
+      )}
+      <Divider />
+      <DialogActions>
+        <Button variant="contained" color="secondary" onClick={onClose}>
+          Close
+        </Button>
+        {canUserEditTeam(teamSlug) && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleAddToTeam}
+            disabled={isPending}
+          >
+            Add to my team
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -7,6 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import type { FlowStatus } from "@opensystemslab/planx-core/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "hooks/useToast";
 import { SYSTEM_TEAMS } from "lib/systemTeams";
@@ -30,6 +31,7 @@ interface TemplateDetails {
   }[];
   publishedFlows: { hasSendComponent: boolean }[];
   usedByTeams: {
+    status: FlowStatus;
     team: {
       id: number;
       name: string;
@@ -66,6 +68,7 @@ const GET_TEMPLATE_DETAILS = gql`
         order_by: [{ team_id: asc }, { created_at: desc }]
         where: { team: { slug: { _nin: $systemTeams } } }
       ) {
+        status
         team {
           id
           name
@@ -166,7 +169,10 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
       ).formatted
     : undefined;
 
-  const usedByCount = details?.usedByTeams.length ?? 0;
+  const onlineTeams =
+    details?.usedByTeams.filter(({ status }) => status === "online") ?? [];
+  const copiedTeams =
+    details?.usedByTeams.filter(({ status }) => status !== "online") ?? [];
 
   return (
     <Dialog
@@ -206,15 +212,34 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
           </Typography>
         )}
       </DialogContent>
-      {usedByCount > 0 && (
+      {onlineTeams.length > 0 && (
         <>
           <Divider />
           <Box sx={{ p: 2 }}>
             <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
-              {`Used by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`}
+              {`Online with ${onlineTeams.length} team${onlineTeams.length === 1 ? "" : "s"}:`}
             </Typography>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-              {details!.usedByTeams.map(({ team }) => (
+              {onlineTeams.map(({ team }) => (
+                <Tooltip key={team.id} title={team.name}>
+                  <span>
+                    <Badge variant={BadgeVariant.Team} team={team} />
+                  </span>
+                </Tooltip>
+              ))}
+            </Box>
+          </Box>
+        </>
+      )}
+      {copiedTeams.length > 0 && (
+        <>
+          <Divider />
+          <Box sx={{ p: 2 }}>
+            <Typography variant="body1" sx={{ fontWeight: "bold", mb: 1.5 }}>
+              {`Subscribed to by ${copiedTeams.length} team${copiedTeams.length === 1 ? "" : "s"} (not online):`}
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {copiedTeams.map(({ team }) => (
                 <Tooltip key={team.id} title={team.name}>
                   <span>
                     <Badge variant={BadgeVariant.Team} team={team} />

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -217,11 +217,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
               {details!.usedByTeams.map(({ team }) => (
                 <Tooltip key={team.id} title={team.name}>
                   <span>
-                    <Badge
-                      variant={BadgeVariant.Team}
-                      size="compact"
-                      team={team}
-                    />
+                    <Badge variant={BadgeVariant.Team} team={team} />
                   </span>
                 </Tooltip>
               ))}

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
@@ -1,7 +1,11 @@
 import Box from "@mui/material/Box";
 import ListItemButton from "@mui/material/ListItemButton";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import CheckCircleIcon from "ui/icons/CheckCircle";
 
 import { Badge } from "./Badge/Badge";
 import { BadgeVariant } from "./Badge/types";
@@ -15,21 +19,53 @@ interface TemplateListItemProps {
 export const TemplateListItem: React.FC<TemplateListItemProps> = ({
   template,
   onClick,
-}) => (
-  <ListItemButton
-    onClick={() => onClick(template)}
-    sx={{ px: 2, py: 1.5, gap: 1.5 }}
-  >
-    <Badge variant={BadgeVariant.SourceTemplate} />
-    <Box>
-      <Typography variant="body1" sx={{ fontWeight: "bold" }}>
-        {template.name}
-      </Typography>
-      {template.summary && (
-        <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          {template.summary}
+}) => {
+  const [teamSlug, canUserEditTeam] = useStore((state) => [
+    state.teamSlug,
+    state.canUserEditTeam,
+  ]);
+
+  const isSubscribed =
+    canUserEditTeam(teamSlug) && Boolean(template.subscribedTeams?.length);
+
+  return (
+    <ListItemButton
+      onClick={() => onClick(template)}
+      alignItems="flex-start"
+      sx={{ px: 2, py: 1.5, gap: 1.5 }}
+    >
+      <Badge variant={BadgeVariant.SourceTemplate} sx={{ mt: 0.25 }} />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 0.25,
+          justifyContent: "center",
+          minHeight: "56px",
+        }}
+      >
+        {isSubscribed && (
+          <Box
+            sx={{ display: "flex", alignItems: "center", gap: 0.33, mt: 0.5 }}
+          >
+            <CheckCircleIcon color="success" sx={{ fontSize: 18 }} />
+            <Typography
+              variant="body3"
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
+              Subscribed
+            </Typography>
+          </Box>
+        )}
+        <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+          {template.name}
         </Typography>
-      )}
-    </Box>
-  </ListItemButton>
-);
+        {template.summary && (
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            {template.summary}
+          </Typography>
+        )}
+      </Box>
+    </ListItemButton>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import ListItemButton from "@mui/material/ListItemButton";
-import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
@@ -34,7 +33,9 @@ export const TemplateListItem: React.FC<TemplateListItemProps> = ({
       alignItems="flex-start"
       sx={{ px: 2, py: 1.5, gap: 1.5 }}
     >
-      <Badge variant={BadgeVariant.SourceTemplate} sx={{ mt: 0.25 }} />
+      <Box sx={{ mt: 0.25 }}>
+        <Badge variant={BadgeVariant.SourceTemplate} />
+      </Box>
       <Box
         sx={{
           display: "flex",

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateListItem.tsx
@@ -1,0 +1,35 @@
+import Box from "@mui/material/Box";
+import ListItemButton from "@mui/material/ListItemButton";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import { Badge } from "./Badge/Badge";
+import { BadgeVariant } from "./Badge/types";
+import type { Template } from "./types";
+
+interface TemplateListItemProps {
+  template: Template;
+  onClick: (template: Template) => void;
+}
+
+export const TemplateListItem: React.FC<TemplateListItemProps> = ({
+  template,
+  onClick,
+}) => (
+  <ListItemButton
+    onClick={() => onClick(template)}
+    sx={{ px: 2, py: 1.5, gap: 1.5 }}
+  >
+    <Badge variant={BadgeVariant.SourceTemplate} />
+    <Box>
+      <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+        {template.name}
+      </Typography>
+      {template.summary && (
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {template.summary}
+        </Typography>
+      )}
+    </Box>
+  </ListItemButton>
+);

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
@@ -18,32 +18,28 @@ const meta = {
       {
         id: "1",
         name: "Apply for planning permission",
-        slug: "apply-for-planning-permission",
         summary: "This service submits an application for planning permission",
-        team: { slug: "planx" },
+        team: { name: "Open Systems Lab" },
       },
       {
         id: "2",
         name: "Find out if you need planning permission",
-        slug: "find-out-if-you-need-planning-permission",
         summary:
           "Use this service to find out if a project needs planning permission",
-        team: { slug: "planx" },
+        team: { name: "Open Systems Lab" },
       },
       {
         id: "3",
         name: "Apply for works to trees",
-        slug: "apply-for-works-to-trees",
         summary: "This service submits an application for works to trees",
-        team: { slug: "planx" },
+        team: { name: "Open Systems Lab" },
       },
       {
         id: "4",
         name: "Apply for a lawful development certificate",
-        slug: "apply-for-a-lawful-development-certificate",
         summary:
           "This service submits an application for a lawful development certificate",
-        team: { slug: "planx" },
+        team: { name: "Open Systems Lab" },
       },
     ],
   },

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { TemplatesWidget } from "./TemplatesWidget";
+
+const meta = {
+  title: "Editor Components/Explore/TemplatesWidget",
+  component: TemplatesWidget,
+  decorators: [
+    (Story) => (
+      <DashboardWidget title="Templates">
+        <Story />
+      </DashboardWidget>
+    ),
+  ],
+  args: {
+    templates: [
+      {
+        id: "1",
+        name: "Apply for planning permission",
+        slug: "apply-for-planning-permission",
+        summary: "This service submits an application for planning permission",
+        team: { slug: "planx" },
+      },
+      {
+        id: "2",
+        name: "Find out if you need planning permission",
+        slug: "find-out-if-you-need-planning-permission",
+        summary:
+          "Use this service to find out if a project needs planning permission",
+        team: { slug: "planx" },
+      },
+      {
+        id: "3",
+        name: "Apply for works to trees",
+        slug: "apply-for-works-to-trees",
+        summary: "This service submits an application for works to trees",
+        team: { slug: "planx" },
+      },
+      {
+        id: "4",
+        name: "Apply for a lawful development certificate",
+        slug: "apply-for-a-lawful-development-certificate",
+        summary:
+          "This service submits an application for a lawful development certificate",
+        team: { slug: "planx" },
+      },
+    ],
+  },
+} satisfies Meta<typeof TemplatesWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: {
+    templates: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    templates: undefined,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React, { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 
@@ -84,7 +85,7 @@ export function TemplatesWidget({
 }
 
 const GET_ONLINE_SOURCE_TEMPLATES = gql`
-  query GetOnlineSourceTemplates {
+  query GetOnlineSourceTemplates($teamId: Int!) {
     templates: flows(
       where: {
         is_template: { _eq: true }
@@ -99,13 +100,21 @@ const GET_ONLINE_SOURCE_TEMPLATES = gql`
       team {
         name
       }
+      subscribedTeams: templated_flows(
+        where: { team_id: { _eq: $teamId } }
+        limit: 1
+      ) {
+        id
+      }
     }
   }
 `;
 
 export default function ConnectedTemplatesWidget() {
+  const teamId = useStore((state) => state.teamId);
   const { data, loading } = useQuery<{ templates: Template[] }>(
     GET_ONLINE_SOURCE_TEMPLATES,
+    { variables: { teamId } },
   );
 
   return <TemplatesWidget templates={data?.templates} loading={loading} />;

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -2,25 +2,13 @@ import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import Typography from "@mui/material/Typography";
-import { Link } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import React from "react";
+import React, { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 
-import { Badge } from "./Badge/Badge";
-import { BadgeVariant } from "./Badge/types";
-
-export interface Template {
-  id: string;
-  name: string;
-  slug: string;
-  summary: string;
-  team: {
-    slug: string;
-  };
-}
+import { TemplateDetailsModal } from "./TemplateDetailsModal";
+import { TemplateListItem } from "./TemplateListItem";
+import type { Template } from "./types";
 
 interface TemplatesWidgetProps {
   templates?: Template[];
@@ -31,6 +19,10 @@ export function TemplatesWidget({
   templates,
   loading = false,
 }: TemplatesWidgetProps) {
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(
+    null,
+  );
+
   if (loading) {
     return (
       <List
@@ -60,40 +52,34 @@ export function TemplatesWidget({
   }
 
   return (
-    <List
-      disablePadding
-      sx={{
-        overflowY: "auto",
-        flex: 1,
-        borderTop: "1px solid",
-        borderColor: "divider",
-      }}
-    >
-      {templates.map((template, index) => (
-        <React.Fragment key={template.id}>
-          {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
-          <ListItem sx={{ position: "relative", px: 2, py: 1.5, gap: 1.5 }}>
-            <Link
-              to="/app/$team/$flow"
-              params={{ team: template.team.slug, flow: template.slug }}
-              style={{ position: "absolute", inset: 0, zIndex: 1 }}
-              aria-label={template.name}
+    <>
+      <List
+        disablePadding
+        sx={{
+          overflowY: "auto",
+          flex: 1,
+          borderTop: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        {templates.map((template, index) => (
+          <React.Fragment key={template.id}>
+            {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
+            <TemplateListItem
+              template={template}
+              onClick={setSelectedTemplate}
             />
-            <Badge variant={BadgeVariant.SourceTemplate} />
-            <Box>
-              <Typography variant="body1" sx={{ fontWeight: "bold" }}>
-                {template.name}
-              </Typography>
-              {template.summary && (
-                <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                  {template.summary}
-                </Typography>
-              )}
-            </Box>
-          </ListItem>
-        </React.Fragment>
-      ))}
-    </List>
+          </React.Fragment>
+        ))}
+      </List>
+      {selectedTemplate && (
+        <TemplateDetailsModal
+          template={selectedTemplate}
+          open={Boolean(selectedTemplate)}
+          onClose={() => setSelectedTemplate(null)}
+        />
+      )}
+    </>
   );
 }
 
@@ -109,10 +95,9 @@ const GET_ONLINE_SOURCE_TEMPLATES = gql`
     ) {
       id
       name
-      slug
       summary
       team {
-        slug
+        name
       }
     }
   }

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -1,0 +1,127 @@
+import { gql, useQuery } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import { Link } from "@tanstack/react-router";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
+
+import { Badge } from "./Badge/Badge";
+import { BadgeVariant } from "./Badge/types";
+
+export interface Template {
+  id: string;
+  name: string;
+  slug: string;
+  summary: string;
+  team: {
+    slug: string;
+  };
+}
+
+interface TemplatesWidgetProps {
+  templates?: Template[];
+  loading?: boolean;
+}
+
+export function TemplatesWidget({
+  templates,
+  loading = false,
+}: TemplatesWidgetProps) {
+  if (loading) {
+    return (
+      <List
+        disablePadding
+        sx={{
+          display: "flex",
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+      </List>
+    );
+  }
+
+  if (!templates?.length) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <EmptyState
+          size="small"
+          title="No templates available"
+          description="Source templates will appear here once published"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <List
+      disablePadding
+      sx={{
+        overflowY: "auto",
+        flex: 1,
+        borderTop: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      {templates.map((template, index) => (
+        <React.Fragment key={template.id}>
+          {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
+          <ListItem sx={{ position: "relative", px: 2, py: 1.5, gap: 1.5 }}>
+            <Link
+              to="/app/$team/$flow"
+              params={{ team: template.team.slug, flow: template.slug }}
+              style={{ position: "absolute", inset: 0, zIndex: 1 }}
+              aria-label={template.name}
+            />
+            <Badge variant={BadgeVariant.SourceTemplate} />
+            <Box>
+              <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+                {template.name}
+              </Typography>
+              {template.summary && (
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {template.summary}
+                </Typography>
+              )}
+            </Box>
+          </ListItem>
+        </React.Fragment>
+      ))}
+    </List>
+  );
+}
+
+const GET_ONLINE_SOURCE_TEMPLATES = gql`
+  query GetOnlineSourceTemplates {
+    templates: flows(
+      where: {
+        is_template: { _eq: true }
+        can_create_from_copy: { _eq: true }
+        archived_at: { _is_null: true }
+      }
+      order_by: { name: asc }
+    ) {
+      id
+      name
+      slug
+      summary
+      team {
+        slug
+      }
+    }
+  }
+`;
+
+export default function ConnectedTemplatesWidget() {
+  const { data, loading } = useQuery<{ templates: Template[] }>(
+    GET_ONLINE_SOURCE_TEMPLATES,
+  );
+
+  return <TemplatesWidget templates={data?.templates} loading={loading} />;
+}

--- a/apps/editor.planx.uk/src/pages/Explore/components/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/types.ts
@@ -5,4 +5,5 @@ export interface Template {
   team: {
     name: string;
   };
+  subscribedTeams?: { id: string }[];
 }

--- a/apps/editor.planx.uk/src/pages/Explore/components/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/types.ts
@@ -1,0 +1,8 @@
+export interface Template {
+  id: string;
+  name: string;
+  summary: string;
+  team: {
+    name: string;
+  };
+}

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -2,11 +2,11 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import { linkOptions } from "@tanstack/react-router";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import NumbersWidget from "./components/NumbersWidget";
+import TemplatesWidget from "./components/TemplatesWidget";
 
 export default function Explore() {
   const team = useStore((state) => state.getTeam());
@@ -41,16 +41,8 @@ export default function Explore() {
           <DashboardWidget title="Plan✕ in numbers" subtitle="last 30 days">
             <NumbersWidget />
           </DashboardWidget>
-          <DashboardWidget
-            title="Featured templates"
-            link={linkOptions({
-              // TODO: Update to point to filtered search view for templates
-              to: "/app/$team/flows",
-              params: { team: team.slug },
-              label: "view all templates",
-            })}
-          >
-            <i>templates content</i>
+          <DashboardWidget title="Templates">
+            <TemplatesWidget />
           </DashboardWidget>
         </Box>
       </Container>

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/explore.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/explore.tsx
@@ -1,12 +1,18 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
 import Explore from "pages/Explore";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 export const Route = createFileRoute("/_authenticated/app/$team/explore")({
   beforeLoad: ({ params }) => {
     if (!hasFeatureFlag("EXPLORE")) {
       throw redirect({ to: "/app/$team", params });
+    }
+
+    const isAuthorised = useStore.getState().canUserEditTeam(params.team);
+    if (!isAuthorised) {
+      throw notFound();
     }
   },
   component: Explore,


### PR DESCRIPTION
## What does this PR do?

Toggle `explore` feature flag to test

- Sets explore as viewable for a user with edit permission only (making the below template interaction make sense)
- Introduces list of templates to the explore page, with information about which are already subscribed to

<img width="739" height="424" alt="image" src="https://github.com/user-attachments/assets/afd4d1d2-2166-4f44-b2cf-bb033a5aefe0" />

- Clicking a template opens a modal with details (reused from the search results design), allowing you to add the template to you team

<img width="739" height="584" alt="image" src="https://github.com/user-attachments/assets/5f19af37-ff69-4f61-a810-49f4d3654630" />

- If the template already exists in your team, present a confirmation step to advise on multiples

<img width="915" height="584" alt="image" src="https://github.com/user-attachments/assets/42204bc5-a83f-48a2-960b-6bc8b953c17d" />

### Testing

Toggle `explore` feature flag to test:
https://7178.planx.pizza/app/barnet/explore

