### PR TITLE
chore: double `sanitise_application_data` hasura cron timeout

### DIFF
--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -30,6 +30,11 @@
   schedule: 0 2 * * *
   include_in_metadata: true
   payload: {}
+  retry_conf:
+    num_retries: 0
+    retry_interval_seconds: 10
+    timeout_seconds: 120
+    tolerance_seconds: 21600
   headers:
     - name: authorization
       value_from_env: HASURA_PLANX_API_KEY


### PR DESCRIPTION
Previously was the default value of 60, proposing bump because of recent string of failures, see thread: https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1786586483482069