### PR TITLE
fix(a11y): Progressive loading for assistive technology

### DIFF
--- a/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.test.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.test.tsx
@@ -1,0 +1,52 @@
+import { act, screen } from "@testing-library/react";
+import React from "react";
+import { setup } from "test/utils";
+import { axe } from "vitest-axe";
+
+import ProgressiveLoading from "./ProgressiveLoading";
+
+const STAGES = ["Stage one", "Stage two", "Stage three"];
+
+describe("ProgressiveLoading", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces all stages at once in a live region", async () => {
+    await setup(<ProgressiveLoading stages={STAGES} interval={1000} />);
+
+    const liveRegion = screen.getByRole("status");
+    expect(liveRegion).toHaveTextContent(STAGES.join(". "));
+    expect(liveRegion).toHaveAttribute("aria-live", "polite");
+
+    // The live region should receive all stages at once
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(liveRegion).toHaveTextContent(STAGES.join(". "));
+  });
+
+  it("hides the decorative stage list from assistive technology", async () => {
+    const { container } = await setup(
+      <ProgressiveLoading stages={STAGES} interval={1000} />,
+    );
+
+    expect(container.querySelector('[aria-hidden="true"]')).toHaveTextContent(
+      "Stage one",
+    );
+    expect(screen.getByRole("status")).not.toHaveAttribute("aria-hidden");
+  });
+
+  it("does not contain accessibility violations", async () => {
+    const { container } = await setup(
+      <ProgressiveLoading stages={STAGES} interval={1000} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import { keyframes, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { visuallyHidden } from "@mui/utils";
 import React, { useEffect, useState } from "react";
 
 const pulseAnimation = keyframes`
@@ -77,8 +78,15 @@ const ProgressiveLoading: React.FC<ProgressiveLoadingProps> = ({
         mt: 2,
         maxWidth: "100%",
       }}
+      aria-busy="true"
     >
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box role="status" aria-live="polite" style={visuallyHidden}>
+        {stages.join(". ")}
+      </Box>
+      <Box
+        aria-hidden="true"
+        sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}
+      >
         {stages.map((stage, index) => {
           const isVisible = index <= visibleStages;
           return (
@@ -88,10 +96,7 @@ const ProgressiveLoading: React.FC<ProgressiveLoadingProps> = ({
                 ...(isVisible && { opacity: 1 }),
               }}
             >
-              <Loader
-                aria-hidden="true"
-                sx={{ visibility: isVisible ? "visible" : "hidden" }}
-              />
+              <Loader sx={{ visibility: isVisible ? "visible" : "hidden" }} />
               <Typography variant="body1">{stage}</Typography>
             </LoadingStage>
           );


### PR DESCRIPTION
## Issue

Not flagged by DAC, but preempting forthcoming review on enhanced project descriptions:

- Currently the progressive loading is staged visually but does not announce correctly to screen readers or assistive technologies

## Solution

- Hide the visual loading state from non-visual users, and insert all statuses together, marked up with `role="status" aria-live="polite"`, so that they are announced correctly

### Testing

https://7182.planx.pizza/lambeth/project-description-accessibility-testing/published