### PR TITLE
fix(a11y): Ensure JAWS retains focus order on details/summary

### DIFF
--- a/apps/localplanning.services/src/components/Accordion.astro
+++ b/apps/localplanning.services/src/components/Accordion.astro
@@ -23,3 +23,15 @@ const { title, id } = Astro.props;
     <slot />
   </section>
 </details>
+
+<script>
+  // A11y: Workaround for JAWS focus loss on <details> collapse
+  document.querySelectorAll("details").forEach((details) => {
+    details.addEventListener("toggle", () => {
+      const summary = details.querySelector("summary");
+      if (!details.open && summary) {
+        summary.focus();
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## What's the problem?
> When collapsing certain details components, screen reader focus did not consistently
remain on the control that was activated. Instead, focus occasionally moved to the next
details component in the page. For example, after collapsing the ‘Doncaster’ section, focus
was sometimes moved directly to the ‘Epsom & Ewell’ details component.
>
> This unexpected movement reduced users’ control over keyboard focus and could make it
difficult for screen reader users to understand their current location within the page. Users
would typically expect focus to remain on the details summary after expanding or collapsing
the section, allowing them to decide whether to continue navigating or activate another
control.

Source: 2026 DAC Report, p.14 - 2.4.3 Focus Order (Level A)

Trello ticket - https://trello.com/c/L5Et42N4/3712-a-focus-order-01

## What's the cause?
I actually failed to recreate this after a good while trying - I'm not sure if anybody else has managed to? There's a changes it's a JAWS-only issue (as described in the report - _"I detected the issue with JAWS only"_).

There's a few GH issues which look tangentially related, I wasn't able to find anything more specific than these three open issues - 

- https://github.com/FreedomScientific/standards-support/issues/701
- https://github.com/FreedomScientific/standards-support/issues/774
- https://github.com/FreedomScientific/standards-support/issues/869

These sort of describe the same issue - JAWS losing focus/order when navigating active elements.

## What's the solution?
Outwith a proper solution, I've added a `<script>` which just enforces focus on the summary. This should be no-op in browsers if the element is already focused, but just correct any issues encountered by JAWS.
