### PR TITLE
feat: Sanitise user-derived values injected into GovNotify emails

### DIFF
--- a/apps/api.planx.uk/lib/notify/index.test.ts
+++ b/apps/api.planx.uk/lib/notify/index.test.ts
@@ -8,6 +8,7 @@ vi.mock("notifications-node-client");
 
 const mockConfig: TemplateRegistry["save"]["config"] = {
   emailReplyToId: "test",
+  sanitiseContentFor: ["address"],
   personalisation: {
     serviceName: "test",
     sessionId: "test",

--- a/apps/api.planx.uk/lib/notify/templates/index.ts
+++ b/apps/api.planx.uk/lib/notify/templates/index.ts
@@ -54,7 +54,18 @@ import {
   userConfirmationTemplate,
 } from "./saveAndReturn/user-confirmation.js";
 
-export type NotifyConfig<T> = { personalisation: T; emailReplyToId: string };
+export type NotifyConfig<T> = {
+  personalisation: T;
+  emailReplyToId: string;
+  /**
+   * Each template must identify which values are user-derived
+   * These must be sanitised before injection into an email
+   * This stops markdown such as (Click me!)[http://evil.com] being used as a name/address
+   *
+   * @docs https://docs.notifications.service.gov.uk/node.html#sanitisecontentfor-optional
+   */
+  sanitiseContentFor: string[];
+};
 
 export type Access =
   /**

--- a/apps/api.planx.uk/modules/lps/service/login.ts
+++ b/apps/api.planx.uk/modules/lps/service/login.ts
@@ -55,6 +55,7 @@ const sendLoginEmail = async (email: string, magicLink: string) => {
     personalisation: { magicLink },
     // TODO: This should be a LPS specific email
     emailReplyToId: DEVOPS_EMAIL_REPLY_TO_ID,
+    sanitiseContentFor: [],
   };
 
   await sendEmail("lps-login", email, config);

--- a/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
+++ b/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.test.ts
@@ -63,6 +63,7 @@ describe("sendAgentAndPayeeConfirmationEmail", () => {
 
     const expectedConfig = {
       emailReplyToId: "123",
+      sanitiseContentFor: ["address", "payeeName", "applicantName"],
       personalisation: {
         applicantName: "xyz",
         payeeName: "payeeName",

--- a/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
+++ b/apps/api.planx.uk/modules/pay/service/inviteToPay/sendConfirmationEmail.ts
@@ -27,6 +27,7 @@ export async function sendAgentAndPayeeConfirmationEmail(sessionId: string) {
       projectType,
     },
     emailReplyToId,
+    sanitiseContentFor: ["address", "payeeName", "applicantName"],
   };
   await sendEmail(
     resolveNotifyTemplate("confirmation-agent", emailTemplate),

--- a/apps/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
+++ b/apps/api.planx.uk/modules/pay/service/inviteToPay/sendPaymentEmail.ts
@@ -130,6 +130,7 @@ const getInviteToPayNotifyConfig = (
 
   return {
     emailReplyToId: settings.emailReplyToId,
+    sanitiseContentFor: ["address", "agentName", "payeeName"],
     personalisation: {
       helpEmail: settings.helpEmail,
       helpPhone: settings.helpPhone,

--- a/apps/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/resumeApplication.ts
@@ -24,6 +24,7 @@ const resumeApplication = async (teamSlug: string, email: string) => {
     personalisation: await getPersonalisation(sessions, team),
     reference: null,
     emailReplyToId: team.settings.emailReplyToId,
+    sanitiseContentFor: ["content"],
   };
   const hasGeneralSession = sessions.some(
     (s) => s.flow.email_template === "general",

--- a/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/utils.ts
@@ -67,6 +67,7 @@ const sendSingleApplicationEmail = async ({
       personalisation: getPersonalisation(session, flowSlug, flowName, team),
       reference: null,
       emailReplyToId: team.settings.emailReplyToId,
+      sanitiseContentFor: ["address"],
     };
     const firstSave = !session.hasUserSaved;
     if (firstSave && !session.submittedAt)


### PR DESCRIPTION
## What does this PR do?
This PR adds a `sanitiseContentFor` property to the `NotifyConfig` type. We then populate this, per-template, with a list of user-derived properties (values entered by end-users when completing a PlanX application).

Please see Trello card for full write up of the problem - https://trello.com/c/j7sBXNxL/3735-sanitise-all-user-generated-content-displayed-in-govnotify-emails

## Testing
Enter a value which should be sanitised, trigger an email - content is sanitised and not rendered as a link (full workflow listed on Trello card above).

<img width="1045" height="356" alt="image" src="https://github.com/user-attachments/assets/986b8e19-7f17-4ed4-b8ab-b6afdbe8125d" />

<img width="1031" height="520" alt="image" src="https://github.com/user-attachments/assets/8238d8fd-1a06-4a59-b735-30bcb2ec4700" />
