### PR TITLE
feat(editor): Improve pattern counts to include clones and nested flows

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/PatternDetailPanel.tsx
@@ -6,7 +6,7 @@ import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 import type { Pattern } from "./queries";
 import { usePatternData } from "./usePatterns";
-import { getComponentCount } from "./utils";
+import { getPatternCounts } from "./utils";
 
 export const DETAIL_PANEL_WIDTH = 300;
 
@@ -19,7 +19,7 @@ export const PatternDetailPanel: React.FC<Props> = ({ pattern }) => {
   const graph = data?.pattern?.data;
 
   // Null while there's no graph data (loading, error, or nothing previewed)
-  const componentCount = graph ? getComponentCount(graph) : null;
+  const counts = graph ? getPatternCounts(graph) : null;
 
   if (!pattern) {
     return (
@@ -31,12 +31,24 @@ export const PatternDetailPanel: React.FC<Props> = ({ pattern }) => {
     );
   }
 
-  const componentCountLabel =
-    componentCount !== null && componentCount >= 1
-      ? `${componentCount} component${componentCount === 1 ? "" : "s"}`
-      : null;
+  const componentCountLabel = (() => {
+    if (!counts) return null;
+    const parts: string[] = [];
+    if (counts.components > 0) {
+      parts.push(
+        `${counts.components} component${counts.components === 1 ? "" : "s"}`,
+      );
+    }
+    if (counts.nestedFlows > 0) {
+      parts.push(
+        `${counts.nestedFlows} nested flow${counts.nestedFlows === 1 ? "" : "s"}`,
+      );
+    }
+    return parts.length ? parts.join(", ") : null;
+  })();
 
-  const isEmpty = componentCount === 0;
+  const isEmpty =
+    counts !== null && counts.components === 0 && counts.nestedFlows === 0;
 
   return (
     <Box

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/index.tsx
@@ -10,7 +10,7 @@ import { PatternDetailPanel } from "./PatternDetailPanel";
 import { PatternRow } from "./PatternRow";
 import type { Pattern } from "./queries";
 import { useFetchPatternGraph, usePatterns } from "./usePatterns";
-import { getComponentCount } from "./utils";
+import { getPatternCounts } from "./utils";
 
 interface Props {
   onInsert: (graph: Graph) => void;
@@ -36,7 +36,8 @@ export const PatternsTab: React.FC<Props> = ({ onInsert }) => {
     const patternGraph = await fetchPatternGraph(id);
     // A pattern needs at least one component to be insertable
     // We should aim to catch this when a pattern is made copyable
-    if (patternGraph && getComponentCount(patternGraph) > 0)
+    const counts = patternGraph && getPatternCounts(patternGraph);
+    if (counts && counts.components + counts.nestedFlows > 0)
       onInsert(patternGraph);
   };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/utils.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/utils.test.ts
@@ -1,0 +1,65 @@
+import { ComponentType } from "@opensystemslab/planx-core/types";
+import type { Graph } from "@planx/graph";
+
+import { getPatternCounts } from "./utils";
+
+describe("getPatternCounts", () => {
+  it("returns zeros for an empty graph", () => {
+    const graph: Graph = { _root: { edges: [] } };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 0, nestedFlows: 0 });
+  });
+
+  it("counts regular components", () => {
+    const graph: Graph = {
+      _root: { edges: ["a", "b"] },
+      a: { type: ComponentType.Question },
+      b: { type: ComponentType.Notice },
+    };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 2, nestedFlows: 0 });
+  });
+
+  it("excludes Answer nodes from the count", () => {
+    const graph: Graph = {
+      _root: { edges: ["q"] },
+      q: { type: ComponentType.Question, edges: ["a1", "a2"] },
+      a1: { type: ComponentType.Answer },
+      a2: { type: ComponentType.Answer },
+    };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 1, nestedFlows: 0 });
+  });
+
+  it("counts ExternalPortals as nested flows", () => {
+    const graph: Graph = {
+      _root: { edges: ["a", "ep"] },
+      a: { type: ComponentType.Question },
+      ep: { type: ComponentType.ExternalPortal, data: { flowId: "xyz" } },
+    };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 1, nestedFlows: 1 });
+  });
+
+  it("counts InternalPortals as components", () => {
+    const graph: Graph = {
+      _root: { edges: ["a", "ip"] },
+      a: { type: ComponentType.Question },
+      ip: { type: ComponentType.InternalPortal, edges: ["b"] },
+      b: { type: ComponentType.Notice },
+    };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 3, nestedFlows: 0 });
+  });
+
+  it("counts clones each time they appear in an edge array", () => {
+    const graph: Graph = {
+      _root: { edges: ["q1", "q2"] },
+      q1: { type: ComponentType.Question, edges: ["shared"] },
+      q2: { type: ComponentType.Question, edges: ["shared"] },
+      shared: { type: ComponentType.Notice },
+    };
+
+    expect(getPatternCounts(graph)).toEqual({ components: 4, nestedFlows: 0 });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/utils.ts
@@ -1,10 +1,32 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import type { Graph } from "@planx/graph";
 
+export interface PatternCounts {
+  components: number;
+  nestedFlows: number;
+}
+
 /**
- * Count all nodes (minus root and Answer components)
+ * Traverse graph to count components and nested flows
+ * Traversal is required to properly account for clones
  */
-export const getComponentCount = (graph: Graph) =>
-  Object.entries(graph).filter(
-    ([id, { type }]) => id !== "_root" && type !== ComponentType.Answer,
-  ).length;
+export const getPatternCounts = (graph: Graph): PatternCounts => {
+  let components = 0;
+  let nestedFlows = 0;
+
+  for (const node of Object.values(graph)) {
+    for (const childId of node.edges ?? []) {
+      const child = graph[childId];
+      if (!child) continue;
+      if (child.type === ComponentType.Answer) continue;
+
+      if (child.type === ComponentType.ExternalPortal) {
+        nestedFlows++;
+      } else {
+        components++;
+      }
+    }
+  }
+
+  return { components, nestedFlows };
+};


### PR DESCRIPTION
## What does this PR do?
Updates `getComponentCount()` to an improved `getPatternCounts()` helper which - 
 - Counts nested flows separately
 - Correctly handles clones
 - Still ignores `_root` and `Option` nodes

<img width="688" height="373" alt="image" src="https://github.com/user-attachments/assets/f5ae9207-142f-4a5d-9429-a3ec70148be4" />
