### PR TITLE
style: grouped submissions log detail modal

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
@@ -16,7 +16,7 @@ const isGridCellParams = (props: Props): props is GridCellParams => {
 };
 
 export const OpenResponseButton = (props: Props) => {
-  const submission = isGridCellParams(props) ? props.row : props.attempt;
+  const submission = isGridCellParams(props) ? props.row : props.attempt; // TODO: when removing feature flag, conditional isGridCellParams not needed
   const sessionId = isGridCellParams(props)
     ? props.row.sessionId
     : props.sessionId;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
@@ -6,11 +6,17 @@ import type { GridCellParams } from "@mui/x-data-grid";
 import React, { useState } from "react";
 import { DataTableModal } from "ui/shared/DataTable/components/DataTableModal";
 
-import type { Submission } from "../types";
+import type { Attempt, Submission } from "../types";
 import { FormattedResponse } from "./FormattedResponse";
 
-export const OpenResponseButton = (props: GridCellParams) => {
-  const { row } = props;
+type Props = GridCellParams | { attempt: Attempt };
+
+const isGridCellParams = (props: Props): props is GridCellParams => {
+  return "row" in props;
+};
+
+export const OpenResponseButton = (props: Props) => {
+  const submission = isGridCellParams(props) ? props.row : props.attempt;
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [response, setResponse] = useState<Record<string, any> | null>(null);
 
@@ -24,7 +30,7 @@ export const OpenResponseButton = (props: GridCellParams) => {
   const handleButtonClick = () => {
     setModalIsOpen(true);
     if (!response) {
-      let parsedData = getResponse(row);
+      let parsedData = getResponse(submission);
       try {
         parsedData =
           typeof parsedData === "string" ? JSON.parse(parsedData) : parsedData;
@@ -43,7 +49,7 @@ export const OpenResponseButton = (props: GridCellParams) => {
         </IconButton>
       </Tooltip>
       <DataTableModal
-        title={`Response for ${row.sessionId || "unknown"}`}
+        title={`Response for ${submission.sessionId || "unknown"}`}
         open={modalIsOpen}
         onClose={() => setModalIsOpen(false)}
       >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButton.tsx
@@ -9,7 +9,7 @@ import { DataTableModal } from "ui/shared/DataTable/components/DataTableModal";
 import type { Attempt, Submission } from "../types";
 import { FormattedResponse } from "./FormattedResponse";
 
-type Props = GridCellParams | { attempt: Attempt };
+type Props = GridCellParams | { attempt: Attempt; sessionId: string };
 
 const isGridCellParams = (props: Props): props is GridCellParams => {
   return "row" in props;
@@ -17,6 +17,10 @@ const isGridCellParams = (props: Props): props is GridCellParams => {
 
 export const OpenResponseButton = (props: Props) => {
   const submission = isGridCellParams(props) ? props.row : props.attempt;
+  const sessionId = isGridCellParams(props)
+    ? props.row.sessionId
+    : props.sessionId;
+
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [response, setResponse] = useState<Record<string, any> | null>(null);
 
@@ -49,7 +53,7 @@ export const OpenResponseButton = (props: Props) => {
         </IconButton>
       </Tooltip>
       <DataTableModal
-        title={`Response for ${submission.sessionId || "unknown"}`}
+        title={`Response for ${sessionId || "unknown"}`}
         open={modalIsOpen}
         onClose={() => setModalIsOpen(false)}
       >

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
@@ -7,6 +7,7 @@ import type { Submission } from "../types";
 type Props = RenderCellParams | { status: Submission["status"] };
 
 const isRenderCellParams = (props: Props): props is RenderCellParams => {
+  // TODO: when removing feature flag, conditional isRenderCellParams not needed
   return "value" in props;
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
@@ -2,20 +2,20 @@ import Chip from "@mui/material/Chip";
 import React from "react";
 import type { RenderCellParams } from "ui/shared/DataTable/types";
 
-export const StatusChip = (params: RenderCellParams) => {
-  if (params.value.includes("failed")) {
-    return <Chip label={params.value} size="small" color="error" />;
-  }
-  if (params.value === "Sending") {
-    return <Chip label={params.value} size="small" color="sending" />;
-  }
-  if (
-    params.value === "Invited to pay" ||
-    params.value === "Payment in progress"
-  ) {
-    return <Chip label={params.value} size="small" color="paymentPending" />;
-  }
-  if (params.value === "Success") {
-    return <Chip label={params.value} size="small" color="success" />;
-  }
+import type { Submission } from "../types";
+
+type Props = RenderCellParams | { status: Submission["status"] };
+
+const isRenderCellParams = (props: Props): props is RenderCellParams => {
+  return "value" in props;
+};
+
+export const StatusChip = (props: Props) => {
+  const statusValue = isRenderCellParams(props) ? props.value : props.status;
+
+  return statusValue === "Success" ? (
+    <Chip label="Success" size="small" color="success" />
+  ) : (
+    <Chip label={statusValue} size="small" color="error" />
+  );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusChip.tsx
@@ -3,9 +3,19 @@ import React from "react";
 import type { RenderCellParams } from "ui/shared/DataTable/types";
 
 export const StatusChip = (params: RenderCellParams) => {
-  return params.value === "Success" ? (
-    <Chip label="Success" size="small" color="success" />
-  ) : (
-    <Chip label={params.value} size="small" color="error" />
-  );
+  if (params.value.includes("failed")) {
+    return <Chip label={params.value} size="small" color="error" />;
+  }
+  if (params.value === "Sending") {
+    return <Chip label={params.value} size="small" color="sending" />;
+  }
+  if (
+    params.value === "Invited to pay" ||
+    params.value === "Payment in progress"
+  ) {
+    return <Chip label={params.value} size="small" color="paymentPending" />;
+  }
+  if (params.value === "Success") {
+    return <Chip label={params.value} size="small" color="success" />;
+  }
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusIcon.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusIcon.tsx
@@ -1,0 +1,36 @@
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import PendingIcon from "@mui/icons-material/Pending";
+import React from "react";
+
+import type { Submission } from "../types";
+
+interface Props {
+  status: Submission["status"];
+}
+
+const StatusIconMap: Record<
+  NonNullable<Submission["status"]>,
+  React.ReactElement
+> = {
+  Success: <CheckCircleIcon color="success" fontSize="small" />,
+  Submitted: <CheckCircleIcon color="success" fontSize="small" />,
+  Failed: <CancelIcon color="error" fontSize="small" />,
+  "Failed (500)": <CancelIcon color="error" fontSize="small" />,
+  "Failed (502)": <CancelIcon color="error" fontSize="small" />,
+  "Failed (503)": <CancelIcon color="error" fontSize="small" />,
+  "Failed (504)": <CancelIcon color="error" fontSize="small" />,
+  "Failed (400)": <CancelIcon color="error" fontSize="small" />,
+  "Failed (401)": <CancelIcon color="error" fontSize="small" />,
+  Started: <PendingIcon color="info" fontSize="small" />,
+  Capturable: <PendingIcon color="warning" fontSize="small" />,
+  Cancelled: <CancelIcon color="disabled" fontSize="small" />,
+  Error: <ErrorIcon color="error" fontSize="small" />,
+  Unknown: <PendingIcon color="disabled" fontSize="small" />,
+};
+
+export const StatusIcon: React.FC<Props> = ({ status }) => {
+  if (!status) return null;
+  return StatusIconMap[status] || null;
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusIcon.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/StatusIcon.tsx
@@ -1,6 +1,5 @@
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import ErrorIcon from "@mui/icons-material/Error";
 import PendingIcon from "@mui/icons-material/Pending";
 import React from "react";
 
@@ -14,20 +13,20 @@ const StatusIconMap: Record<
   NonNullable<Submission["status"]>,
   React.ReactElement
 > = {
-  Success: <CheckCircleIcon color="success" fontSize="small" />,
-  Submitted: <CheckCircleIcon color="success" fontSize="small" />,
-  Failed: <CancelIcon color="error" fontSize="small" />,
-  "Failed (500)": <CancelIcon color="error" fontSize="small" />,
-  "Failed (502)": <CancelIcon color="error" fontSize="small" />,
-  "Failed (503)": <CancelIcon color="error" fontSize="small" />,
-  "Failed (504)": <CancelIcon color="error" fontSize="small" />,
-  "Failed (400)": <CancelIcon color="error" fontSize="small" />,
-  "Failed (401)": <CancelIcon color="error" fontSize="small" />,
-  Started: <PendingIcon color="info" fontSize="small" />,
-  Capturable: <PendingIcon color="warning" fontSize="small" />,
-  Cancelled: <CancelIcon color="disabled" fontSize="small" />,
-  Error: <ErrorIcon color="error" fontSize="small" />,
-  Unknown: <PendingIcon color="disabled" fontSize="small" />,
+  Success: <CheckCircleIcon color="success" fontSize="medium" />,
+  Submitted: <CheckCircleIcon color="success" fontSize="medium" />,
+  Failed: <CancelIcon color="error" fontSize="medium" />,
+  "Failed (500)": <CancelIcon color="error" fontSize="medium" />,
+  "Failed (502)": <CancelIcon color="error" fontSize="medium" />,
+  "Failed (503)": <CancelIcon color="error" fontSize="medium" />,
+  "Failed (504)": <CancelIcon color="error" fontSize="medium" />,
+  "Failed (400)": <CancelIcon color="error" fontSize="medium" />,
+  "Failed (401)": <CancelIcon color="error" fontSize="medium" />,
+  Started: <PendingIcon color="info" fontSize="medium" />,
+  Capturable: <PendingIcon color="warning" fontSize="medium" />,
+  Cancelled: <CancelIcon color="disabled" fontSize="medium" />,
+  Error: <CancelIcon color="error" fontSize="medium" />,
+  Unknown: <CancelIcon color="error" fontSize="medium" />,
 };
 
 export const StatusIcon: React.FC<Props> = ({ status }) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import Grid from "@mui/material/Grid";
 import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
@@ -11,6 +12,9 @@ import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedL
 import { useStore } from "pages/FlowEditor/lib/store";
 
 import type { Submission } from "../types";
+import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
+import { SubmissionDetails } from "./SubmissionDetails";
+import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
 const GET_SUBMISSION_EVENTS = gql`
   query GetSubmissionEvents($sessionId: uuid!) {
@@ -56,36 +60,45 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   if (loading) return <DelayedLoadingIndicator />;
   if (error) throw error;
   return (
-    <Dialog open>
+    <Dialog
+      open
+      slotProps={{
+        paper: {
+          sx: {
+            width: "66.67%",
+            maxWidth: "66.67%",
+            margin: "auto",
+          },
+        },
+      }}
+    >
       <Typography variant="h2" component="h1" gutterBottom>
-        Submission Details
+        Submission details
       </Typography>
+      <Grid container>
+        <Grid size={6}>
+          <SubmissionDetails sessionId={sessionId} latestEvent={latestEvent} />
+        </Grid>
 
-      <Box sx={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: 3 }}>
-        <Box>
-          <Typography variant="h4">Details</Typography>
-          <Typography>Address: {latestEvent?.address}</Typography>
-          <Typography>Service: {latestEvent?.flowName}</Typography>
-          <Typography>Session ID: {sessionId}</Typography>
-        </Box>
-
-        <Box>
-          <Typography variant="h4">Event History</Typography>
-          {events.map((event, index) => (
-            <ListItem key={`${event.eventId}-${index}`}>
-              <Box>
-                <Typography>
-                  {event.eventType} {event.retry && "[Retry]"}
-                </Typography>
-                <Typography>
-                  Status: {event.status},{" "}
-                  {new Date(event.createdAt).toLocaleString()}
-                </Typography>
-              </Box>
-            </ListItem>
-          ))}
-        </Box>
-      </Box>
+        <Grid size={6}>
+          <DialogContent>
+            <Typography variant="h4">Event History</Typography>
+            {events.map((event, index) => (
+              <ListItem key={`${event.eventId}-${index}`}>
+                <Box>
+                  <Typography>
+                    {event.eventType} {event.retry && "[Retry]"}
+                  </Typography>
+                  <Typography>
+                    Status: {event.status},{" "}
+                    {new Date(event.createdAt).toLocaleString()}
+                  </Typography>
+                </Box>
+              </ListItem>
+            ))}
+          </DialogContent>
+        </Grid>
+      </Grid>
       <DialogActions>
         <Button
           onClick={() =>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,11 +1,9 @@
 import { gql, useQuery } from "@apollo/client";
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
-import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
@@ -73,32 +71,37 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
         },
       }}
     >
-      <Typography variant="h2" component="h1" gutterBottom>
-        Submission details
-      </Typography>
-      <Grid container>
-        <Grid size={6}>
-          <SubmissionDetails sessionId={sessionId} latestEvent={latestEvent} />
-        </Grid>
+      <DialogContent>
+        <Typography variant="h2" component="h1" gutterBottom>
+          Submission details
+        </Typography>
+        <Grid container>
+          <Grid size={6}>
+            <SubmissionDetails
+              sessionId={sessionId}
+              latestEvent={latestEvent}
+            />
+          </Grid>
 
-        <Grid size={6}>
-          <SubmissionEventsHistory events={events} />
+          <Grid size={6}>
+            <SubmissionEventsHistory events={events} />
+          </Grid>
         </Grid>
-      </Grid>
-      <DialogActions>
-        <Button
-          onClick={() =>
-            navigate({
-              to: "/app/$team/submissions",
-              params: {
-                team: teamSlug,
-              },
-            })
-          }
-        >
-          Back
-        </Button>
-      </DialogActions>
+        <DialogActions>
+          <Button
+            onClick={() =>
+              navigate({
+                to: "/app/$team/submissions",
+                params: {
+                  team: teamSlug,
+                },
+              })
+            }
+          >
+            Back
+          </Button>
+        </DialogActions>
+      </DialogContent>
     </Dialog>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -15,6 +15,7 @@ import { SubmissionDetails } from "./SubmissionDetails";
 import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
 import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
+// TODO: refactor into hooks / queries pattern
 const GET_SUBMISSION_EVENTS = gql`
   query GetSubmissionEvents($sessionId: uuid!) {
     submissions: submission_services_log(
@@ -80,6 +81,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
             <SubmissionDetails
               sessionId={sessionId}
               latestEvent={latestEvent}
+              teamSlug={teamSlug}
             />
           </Grid>
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -14,6 +14,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import type { Submission } from "../types";
 import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
 import { SubmissionDetails } from "./SubmissionDetails";
+import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
 import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
 const GET_SUBMISSION_EVENTS = gql`
@@ -81,22 +82,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
         </Grid>
 
         <Grid size={6}>
-          <DialogContent>
-            <Typography variant="h4">Event History</Typography>
-            {events.map((event, index) => (
-              <ListItem key={`${event.eventId}-${index}`}>
-                <Box>
-                  <Typography>
-                    {event.eventType} {event.retry && "[Retry]"}
-                  </Typography>
-                  <Typography>
-                    Status: {event.status},{" "}
-                    {new Date(event.createdAt).toLocaleString()}
-                  </Typography>
-                </Box>
-              </ListItem>
-            ))}
-          </DialogContent>
+          <SubmissionEventsHistory events={events} />
         </Grid>
       </Grid>
       <DialogActions>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -35,8 +35,8 @@ const DetailRow: React.FC<DetailRowProps> = ({ label, value, border }) => (
 
 export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
   const { data } = useTeamLogo(props.teamSlug);
-  const teamLogo = data?.teamThemes[0].logo;
-  const teamName = data?.teamThemes[0].team.name;
+  const teamLogo = data?.teams[0].theme.logo;
+  const teamName = data?.teams[0].name;
 
   return (
     <Box

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,0 +1,44 @@
+import DialogContent from "@mui/material/DialogContent";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+
+import type { Submission } from "../types";
+
+type Props = {
+  sessionId: string;
+  latestEvent: Submission;
+};
+
+export const SubmissionDetails: React.FC<Props> = (props) => {
+  return (
+    <DialogContent>
+      <Typography variant="h3" sx={{ mb: 2 }}>
+        {props.latestEvent?.flowName}
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid size={4}>
+          <Typography sx={{ fontWeight: "bold" }}>Property address</Typography>
+        </Grid>
+        <Grid size={8}>
+          <Typography>{props.latestEvent?.address}</Typography>
+        </Grid>
+
+        <Grid size={4}>
+          <Typography sx={{ fontWeight: "bold" }}>Reference</Typography>
+        </Grid>
+        <Grid size={8}>
+          <Typography>{props.sessionId}</Typography>
+        </Grid>
+
+        <Grid size={4}>
+          <Typography sx={{ fontWeight: "bold" }}>Submitted on</Typography>
+        </Grid>
+        <Grid size={8}>
+          <Typography>
+            {new Date(props.latestEvent?.createdAt).toLocaleDateString()}
+          </Typography>
+        </Grid>
+      </Grid>
+    </DialogContent>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,6 +1,7 @@
-import DialogContent from "@mui/material/DialogContent";
+import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import { background } from "storybook/theming";
 
 import type { Submission } from "../types";
 
@@ -11,7 +12,15 @@ type Props = {
 
 export const SubmissionDetails: React.FC<Props> = (props) => {
   return (
-    <DialogContent>
+    <Box
+      sx={{
+        background: "background",
+        padding: 4,
+        margin: 4,
+        border: 1,
+        borderColor: "border.main",
+      }}
+    >
       <Typography variant="h3" sx={{ mb: 2 }}>
         {props.latestEvent?.flowName}
       </Typography>
@@ -39,6 +48,6 @@ export const SubmissionDetails: React.FC<Props> = (props) => {
           </Typography>
         </Grid>
       </Grid>
-    </DialogContent>
+    </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,8 +1,11 @@
 import Box from "@mui/material/Box";
+// import DialogActions from "@mui/material/DialogActions";
 import Typography from "@mui/material/Typography";
 
 import { useTeamLogo } from "../hooks";
+// import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
 import type { Submission } from "../types";
+// import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
 type SubmissionDetailsProps = {
   sessionId: string;
@@ -80,6 +83,11 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
           value={new Date(props.latestEvent?.createdAt).toLocaleDateString()}
         />
       </Box>
+
+      {/* <DialogActions>
+        <ViewSubmissionButton />
+        <DownloadSubmissionButton />
+      </DialogActions> */}
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,16 +1,21 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
-import { background } from "storybook/theming";
 
+import { useTeamLogo } from "../hooks";
 import type { Submission } from "../types";
 
 type Props = {
   sessionId: string;
   latestEvent: Submission;
+  teamSlug: string;
 };
 
 export const SubmissionDetails: React.FC<Props> = (props) => {
+  const { data } = useTeamLogo(props.teamSlug);
+  const teamLogo = data?.teamThemes[0].logo;
+  const teamName = data?.teamThemes[0].team.name;
+
   return (
     <Box
       sx={{
@@ -21,6 +26,26 @@ export const SubmissionDetails: React.FC<Props> = (props) => {
         borderColor: "border.main",
       }}
     >
+      <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+        {teamLogo ? (
+          <Box
+            component="img"
+            src={teamLogo}
+            alt={teamName}
+            sx={{
+              maxWidth: 100,
+              width: "100%",
+              height: 50,
+              objectFit: "contain",
+              objectPosition: "left",
+              display: "block",
+            }}
+          />
+        ) : null}
+
+        <Typography sx={{ fontWeight: "bold" }}>{teamName}</Typography>
+      </Box>
+
       <Typography variant="h3" sx={{ mb: 2 }}>
         {props.latestEvent?.flowName}
       </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,17 +1,36 @@
 import Box from "@mui/material/Box";
-import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
 import { useTeamLogo } from "../hooks";
 import type { Submission } from "../types";
 
-type Props = {
+type SubmissionDetailsProps = {
   sessionId: string;
   latestEvent: Submission;
   teamSlug: string;
 };
 
-export const SubmissionDetails: React.FC<Props> = (props) => {
+type DetailRowProps = {
+  label: string;
+  value: string | null;
+  border?: boolean;
+};
+
+const DetailRow: React.FC<DetailRowProps> = ({ label, value, border }) => (
+  <Box
+    sx={{
+      display: "flex",
+      py: 2,
+      borderBottom: border ? 1 : 0,
+      borderColor: "border.main",
+    }}
+  >
+    <Typography sx={{ fontWeight: "bold", width: "33%" }}>{label}</Typography>
+    <Typography sx={{ width: "66%" }}>{value}</Typography>
+  </Box>
+);
+
+export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
   const { data } = useTeamLogo(props.teamSlug);
   const teamLogo = data?.teamThemes[0].logo;
   const teamName = data?.teamThemes[0].team.name;
@@ -49,30 +68,18 @@ export const SubmissionDetails: React.FC<Props> = (props) => {
       <Typography variant="h3" sx={{ mb: 2 }}>
         {props.latestEvent?.flowName}
       </Typography>
-      <Grid container spacing={2}>
-        <Grid size={4}>
-          <Typography sx={{ fontWeight: "bold" }}>Property address</Typography>
-        </Grid>
-        <Grid size={8}>
-          <Typography>{props.latestEvent?.address}</Typography>
-        </Grid>
-
-        <Grid size={4}>
-          <Typography sx={{ fontWeight: "bold" }}>Reference</Typography>
-        </Grid>
-        <Grid size={8}>
-          <Typography>{props.sessionId}</Typography>
-        </Grid>
-
-        <Grid size={4}>
-          <Typography sx={{ fontWeight: "bold" }}>Submitted on</Typography>
-        </Grid>
-        <Grid size={8}>
-          <Typography>
-            {new Date(props.latestEvent?.createdAt).toLocaleDateString()}
-          </Typography>
-        </Grid>
-      </Grid>
+      <Box>
+        <DetailRow
+          label="Property address"
+          value={props.latestEvent?.address}
+          border={true}
+        />
+        <DetailRow label="Reference" value={props.sessionId} border={true} />
+        <DetailRow
+          label="Submitted on"
+          value={new Date(props.latestEvent?.createdAt).toLocaleDateString()}
+        />
+      </Box>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -18,7 +18,8 @@ const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
     if (!currentGroup || currentGroup.eventType !== submission.eventType) {
       currentGroup = {
         eventType: submission.eventType,
-        id: submission.eventId,
+        sessionId: submission.sessionId,
+        eventId: submission.eventId,
         events: [
           {
             createdAt: submission.createdAt,
@@ -85,21 +86,28 @@ const SubmissionEvent: React.FC<{ groupedEvent: GroupedEvent }> = ({
                 {new Date(groupedEvent.events[0].createdAt).toLocaleString()}
               </Typography>
               <Box sx={{ marginLeft: "auto" }}>
-                <OpenResponseButton attempt={groupedEvent.events[0]} />
+                <OpenResponseButton
+                  attempt={groupedEvent.events[0]}
+                  sessionId={groupedEvent.sessionId}
+                />
               </Box>
             </Box>
           </>
         ) : (
-          <SubmissionAttempts attempts={groupedEvent.events} />
+          <SubmissionAttempts
+            attempts={groupedEvent.events}
+            sessionId={groupedEvent.sessionId}
+          />
         )}
       </Box>
     </Box>
   );
 };
 
-const SubmissionAttempts: React.FC<{ attempts: Attempt[] }> = ({
-  attempts,
-}) => {
+const SubmissionAttempts: React.FC<{
+  attempts: Attempt[];
+  sessionId: string;
+}> = ({ attempts, sessionId }) => {
   const numberAttempts = attempts.length;
 
   return (
@@ -116,7 +124,7 @@ const SubmissionAttempts: React.FC<{ attempts: Attempt[] }> = ({
             </Box>
 
             <Box sx={{ marginLeft: "auto" }}>
-              <OpenResponseButton attempt={attempt} />
+              <OpenResponseButton attempt={attempt} sessionId={sessionId} />
             </Box>
           </Box>
         </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -58,7 +58,6 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
         borderColor: "border.main",
       }}
     >
-      <Typography variant="h3">Event history</Typography>
       {groupedEvents.map((groupedEvent) => (
         <SubmissionEvent groupedEvent={groupedEvent} />
       ))}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 
 import type { Submission } from "../types";
+import { StatusIcon } from "./StatusIcon";
 
 export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
   events,
@@ -24,14 +25,14 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
 const SubmissionEvent: React.FC<{ event: Submission }> = ({ event }) => {
   return (
     <Box>
-      <Typography sx={{ fontWeight: "bold" }}>
-        {event.eventType} {event.retry && "[Retry]"}
-      </Typography>
-
-      <Typography>Status: {event.status}, </Typography>
+      <Box sx={{ display: "flex", gap: 2 }}>
+        <StatusIcon status={event.status} />
+        <Typography sx={{ fontWeight: "bold" }}>
+          {event.eventType} {event.retry && "[Retry]"}
+        </Typography>
+      </Box>
 
       <Typography>{new Date(event.createdAt).toLocaleString()}</Typography>
-      {/* TODO: refactor date formatting */}
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -1,0 +1,37 @@
+import Box from "@mui/material/Box";
+import DialogContent from "@mui/material/DialogContent";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import type { Submission } from "../types";
+
+export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
+  events,
+}) => {
+  return (
+    <DialogContent>
+      <Typography variant="h4">Event history</Typography>
+      {events.map((event, index) => (
+        <ListItem key={`${event.eventId}-${index}`}>
+          <SubmissionEvent event={event} />
+        </ListItem>
+      ))}
+    </DialogContent>
+  );
+};
+
+const SubmissionEvent: React.FC<{ event: Submission }> = ({ event }) => {
+  return (
+    <Box>
+      <Typography sx={{ fontWeight: "bold" }}>
+        {event.eventType} {event.retry && "[Retry]"}
+      </Typography>
+
+      <Typography>Status: {event.status}, </Typography>
+
+      <Typography>{new Date(event.createdAt).toLocaleString()}</Typography>
+      {/* TODO: refactor date formatting */}
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -3,12 +3,50 @@ import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-import type { Submission } from "../types";
+import type { Attempt, GroupedEvent, Submission } from "../types";
+import { OpenResponseButton } from "./OpenResponseButton";
+import { StatusChip } from "./StatusChip";
 import { StatusIcon } from "./StatusIcon";
+
+const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
+  if (submissions.length === 0) return [];
+
+  const result: GroupedEvent[] = [];
+  let currentGroup: GroupedEvent | null = null;
+
+  for (const submission of submissions) {
+    if (!currentGroup || currentGroup.eventType !== submission.eventType) {
+      currentGroup = {
+        eventType: submission.eventType,
+        id: submission.eventId,
+        events: [
+          {
+            createdAt: submission.createdAt,
+            retry: submission.retry,
+            response: submission.response,
+            status: submission.status,
+          },
+        ],
+      };
+      result.push(currentGroup);
+    } else {
+      currentGroup.events.push({
+        createdAt: submission.createdAt,
+        retry: submission.retry,
+        response: submission.response,
+        status: submission.status,
+      });
+    }
+  }
+
+  return result;
+};
 
 export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
   events,
 }) => {
+  const groupedEvents = groupEvents(events);
+
   return (
     <Box
       sx={{
@@ -19,27 +57,70 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
         borderColor: "border.main",
       }}
     >
-      <Typography variant="h4">Event history</Typography>
-      {events.map((event, index) => (
-        <ListItem key={`${event.eventId}-${index}`}>
-          <SubmissionEvent event={event} />
-        </ListItem>
+      <Typography variant="h3">Event history</Typography>
+      {groupedEvents.map((groupedEvent) => (
+        <SubmissionEvent groupedEvent={groupedEvent} />
       ))}
     </Box>
   );
 };
 
-const SubmissionEvent: React.FC<{ event: Submission }> = ({ event }) => {
+const SubmissionEvent: React.FC<{ groupedEvent: GroupedEvent }> = ({
+  groupedEvent,
+}) => {
   return (
-    <Box>
-      <Box sx={{ display: "flex", gap: 2 }}>
-        <StatusIcon status={event.status} />
-        <Typography sx={{ fontWeight: "bold" }}>
-          {event.eventType} {event.retry && "[Retry]"}
-        </Typography>
+    <Box sx={{ display: "flex", width: "100%", alignItems: "flex-start" }}>
+      <Box>
+        <StatusIcon status={groupedEvent.events[0].status} />
       </Box>
 
-      <Typography>{new Date(event.createdAt).toLocaleString()}</Typography>
+      <Box sx={{ flex: 1, paddingLeft: 2 }}>
+        <Typography sx={{ fontWeight: "bold" }}>
+          {groupedEvent.eventType}
+        </Typography>
+        {groupedEvent.events.length === 1 ? (
+          <>
+            <Box sx={{ display: "flex" }}>
+              <Typography>
+                {new Date(groupedEvent.events[0].createdAt).toLocaleString()}
+              </Typography>
+              <Box sx={{ marginLeft: "auto" }}>
+                <OpenResponseButton attempt={groupedEvent.events[0]} />
+              </Box>
+            </Box>
+          </>
+        ) : (
+          <SubmissionAttempts attempts={groupedEvent.events} />
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const SubmissionAttempts: React.FC<{ attempts: Attempt[] }> = ({
+  attempts,
+}) => {
+  const numberAttempts = attempts.length;
+
+  return (
+    <Box>
+      {attempts.map((attempt, index) => (
+        <>
+          <Box key={`${index}`} sx={{ display: "flex", gap: 2, marginTop: 1 }}>
+            <StatusChip status={attempt.status} />
+            <Box>
+              <Typography>Attempt {numberAttempts - index}</Typography>
+              <Typography>
+                {new Date(attempt.createdAt).toLocaleString()}
+              </Typography>
+            </Box>
+
+            <Box sx={{ marginLeft: "auto" }}>
+              <OpenResponseButton attempt={attempt} />
+            </Box>
+          </Box>
+        </>
+      ))}
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import DialogContent from "@mui/material/DialogContent";
 import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import React from "react";
@@ -11,14 +10,22 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
   events,
 }) => {
   return (
-    <DialogContent>
+    <Box
+      sx={{
+        background: "background",
+        padding: 4,
+        margin: 4,
+        border: 1,
+        borderColor: "border.main",
+      }}
+    >
       <Typography variant="h4">Event history</Typography>
       {events.map((event, index) => (
         <ListItem key={`${event.eventId}-${index}`}>
           <SubmissionEvent event={event} />
         </ListItem>
       ))}
-    </DialogContent>
+    </Box>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/hooks.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/hooks.ts
@@ -1,1 +1,17 @@
+import { useQuery } from "@apollo/client";
+
+import { GET_TEAM_LOGO } from "./queries";
+import type { GetTeamLogoQuery, GetTeamLogoVariables } from "./types";
+
+export const useTeamLogo = (teamSlug: string) => {
+  const query = useQuery<GetTeamLogoQuery, GetTeamLogoVariables>(
+    GET_TEAM_LOGO,
+    {
+      variables: { teamSlug },
+    },
+  );
+
+  return query;
+};
+
 // useGetSubmissionHistory

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/queries.ts
@@ -1,0 +1,12 @@
+import { gql } from "@apollo/client";
+
+export const GET_TEAM_LOGO = gql`
+  query GetTeamLogo($teamSlug: String!) {
+    teamThemes: team_themes(where: { team: { slug: { _eq: $teamSlug } } }) {
+      logo
+      team {
+        name
+      }
+    }
+  }
+`;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/queries.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/queries.ts
@@ -2,11 +2,12 @@ import { gql } from "@apollo/client";
 
 export const GET_TEAM_LOGO = gql`
   query GetTeamLogo($teamSlug: String!) {
-    teamThemes: team_themes(where: { team: { slug: { _eq: $teamSlug } } }) {
-      logo
-      team {
-        name
+    teams(where: { slug: { _eq: $teamSlug } }) {
+      theme {
+        logo
       }
+      id
+      name
     }
   }
 `;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -32,6 +32,19 @@ export interface Submission {
   address: string | null;
 }
 
+export interface GroupedEvent {
+  eventType: Submission["eventType"];
+  id: Submission["eventId"];
+  events: Attempt[];
+}
+
+export type Attempt = {
+  createdAt: Submission["createdAt"];
+  retry: Submission["retry"];
+  response: Submission["response"];
+  status: Submission["status"];
+};
+
 export interface SubmissionSummary {
   id: string;
   flowId: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -74,3 +74,16 @@ export interface EventsLogGroupedProps {
 export interface SubmissionsProps {
   flowSlug?: string;
 }
+
+export type GetTeamLogoQuery = {
+  teamThemes: {
+    logo: string;
+    team: {
+      name: string;
+    };
+  }[];
+};
+
+export type GetTeamLogoVariables = {
+  teamSlug: string;
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -34,7 +34,8 @@ export interface Submission {
 
 export interface GroupedEvent {
   eventType: Submission["eventType"];
-  id: Submission["eventId"];
+  sessionId: Submission["sessionId"];
+  eventId: Submission["eventId"];
   events: Attempt[];
 }
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -76,11 +76,12 @@ export interface SubmissionsProps {
 }
 
 export type GetTeamLogoQuery = {
-  teamThemes: {
-    logo: string;
-    team: {
-      name: string;
+  teams: {
+    theme: {
+      logo: string;
     };
+    id: number;
+    name: string;
   }[];
 };
 


### PR DESCRIPTION
This PR handles much of the styling for the (still feature flagged!) grouped submissions log submission detail modal. It:
- Creates `SubmissionDetails` and `SubmissionEventsHistory` components for the two main info panels in the modal
    - Creates a `StatusIcon` for each event in `SubmissionEventsHistory`
    - In `SubmissionDetails`, fetches the team logo with new query / hook

Before this PR:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c479d76a-146e-421a-9c45-fa347ee74e9d" />

After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/92c90038-b277-4aa8-8fae-50a0d36f72f7" />

There are still some style nits to work through but I thought I would separate the PRs here. Next is the bulk of button functionality:
- View submission (and route)
- Download submission
- Resubmit buttons for failed events
- Close modal 