### PR TITLE
fix(editor): Setup `onError` fallback for logo component

### DIFF
--- a/apps/editor.planx.uk/src/components/Header/Header.test.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.test.tsx
@@ -1,6 +1,6 @@
 import type { Team } from "@opensystemslab/planx-core/types";
 import * as TanStackRouter from "@tanstack/react-router";
-import { act, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import { setup } from "test/utils";
@@ -169,6 +169,28 @@ for (const route of ["/published", "/preview", "/draft", "/pay", "/invite"]) {
         "src",
         "logo.jpg",
       );
+    });
+
+    it("falls back to the team name when the logo fails to load", async () => {
+      act(() => {
+        setState({
+          previewEnvironment: "standalone",
+          teamTheme: mockTeam1.theme,
+          teamName: mockTeam1.name,
+          teamSlug: mockTeam1.slug,
+        });
+      });
+      await setup(<Header />);
+      const logo = screen.getByAltText(`${mockTeam1.name} Logo`);
+
+      act(() => {
+        fireEvent.error(logo);
+      });
+
+      expect(
+        screen.queryByAltText(`${mockTeam1.name} Logo`),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(mockTeam1.name)).toBeInTheDocument();
     });
 
     it("falls back to the team name when a logo is not present", async () => {

--- a/apps/editor.planx.uk/src/components/Header/Header.tsx
+++ b/apps/editor.planx.uk/src/components/Header/Header.tsx
@@ -99,12 +99,22 @@ const TeamBrand: React.FC = () => {
     state.teamTheme,
   ]);
 
-  if (teamTheme?.logo) {
+  const [logoFailed, setLogoFailed] = useState(false);
+
+  const showLogo = teamTheme?.logo && !logoFailed;
+
+  if (showLogo) {
     const altText = teamSettings?.homepage
       ? `${teamName} Homepage (opens in a new tab)`
       : `${teamName} Logo`;
 
-    const logo = <Logo alt={altText} src={teamTheme.logo} />;
+    const logo = (
+      <Logo
+        alt={altText}
+        src={teamTheme.logo!}
+        onError={() => setLogoFailed(true)}
+      />
+    );
 
     return teamSettings?.homepage ? (
       <CustomLink


### PR DESCRIPTION
## What's the problem?
If a logo URL errors (4xx, 5xx) then it just shows a broken image icon, and does not fall back to plain text.

This was raised here during a GitHub outage - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1787063943428389

## What's the solution?
Use the existing `onError` prop to handle the fallback ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#image_loading_errors)).

## Testing
Either update the Pizza DB to have a broken logo URL for a given team, or block the URL via dev tools. The header will fall back to using the plain text team name -

<img width="1917" height="955" alt="image" src="https://github.com/user-attachments/assets/557fcd80-04c2-41b1-92f2-26036e3606d9" />
