### PR TITLE
fix(editor): Spacing and layout for Question and Checklist text inputs

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
@@ -50,27 +50,25 @@ export const BaseChecklistComponent: React.FC<Props> = (props) => {
       <ModalSection>
         <ModalSectionContent>
           <InputGroup>
-            <ErrorWrapper error={formik.errors.text}>
-              <InputRow>
-                <Input
-                  format="large"
-                  name="text"
-                  value={formik.values.text}
-                  placeholder="Text"
-                  onChange={formik.handleChange}
-                  inputRef={focusRef}
-                  errorMessage={formik.errors.text}
-                  disabled={props.disabled}
-                />
-                <ImgInput
-                  img={formik.values.img}
-                  onChange={(newUrl) => {
-                    formik.setFieldValue("img", newUrl);
-                  }}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-            </ErrorWrapper>
+            <InputRow>
+              <Input
+                format="large"
+                name="text"
+                value={formik.values.text}
+                placeholder="Text"
+                onChange={formik.handleChange}
+                inputRef={focusRef}
+                errorMessage={formik.errors.text}
+                disabled={props.disabled}
+              />
+              <ImgInput
+                img={formik.values.img}
+                onChange={(newUrl) => {
+                  formik.setFieldValue("img", newUrl);
+                }}
+                disabled={props.disabled}
+              />
+            </InputRow>
             <InputRow>
               <RichTextInput
                 name="description"

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -79,26 +79,25 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
       <ModalSection>
         <ModalSectionContent>
           <InputGroup>
-            <ErrorWrapper error={formik.errors.text}>
-              <InputRow>
-                <Input
-                  format="large"
-                  name="text"
-                  value={formik.values.text}
-                  placeholder="Text"
-                  onChange={formik.handleChange}
-                  inputRef={focusRef}
-                  disabled={props.disabled}
-                />
-                <ImgInput
-                  img={formik.values.img}
-                  onChange={(newUrl) => {
-                    formik.setFieldValue("img", newUrl);
-                  }}
-                  disabled={props.disabled}
-                />
-              </InputRow>
-            </ErrorWrapper>
+            <InputRow>
+              <Input
+                errorMessage={formik.errors.text}
+                format="large"
+                name="text"
+                value={formik.values.text}
+                placeholder="Text"
+                onChange={formik.handleChange}
+                inputRef={focusRef}
+                disabled={props.disabled}
+              />
+              <ImgInput
+                img={formik.values.img}
+                onChange={(newUrl) => {
+                  formik.setFieldValue("img", newUrl);
+                }}
+                disabled={props.disabled}
+              />
+            </InputRow>
             <InputRow>
               <RichTextInput
                 name="description"

--- a/apps/editor.planx.uk/src/ui/shared/InputRow.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/InputRow.tsx
@@ -7,7 +7,7 @@ const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "childRow",
 })<BoxProps & { childRow?: boolean }>(({ childRow }) => ({
   display: "flex",
-  alignItems: "center",
+  alignItems: "flex-end",
   width: "100%",
   "&:not(:last-child)": {
     marginBottom: 5,


### PR DESCRIPTION
## What's the problem?
Spacing is missing beneath the text / title inputs on Question and Checklist components.

## What's the cause?
This was introduced here when an `ErrorWrapper` was added for the new error condition - https://github.com/theopensystemslab/planx-new/pull/7127

A new wrapping element broke the `:last-child` styling, and the `marginBottom` was not applied as a result.

## What's the solution?
Reach for the existing `errorMessage` prop instead of using a wrapper - the `Input` element has a built in `ErrorWrapper` already.

| Before | After |
|--------|--------|
| <img width="896" height="447" alt="image" src="https://github.com/user-attachments/assets/e99b3c7f-427c-4fe3-a896-734587ea98de" /> | <img width="888" height="473" alt="image" src="https://github.com/user-attachments/assets/8cd7f85e-9609-44bd-82d8-91c0cdefb2a4" /> | 