### PR TITLE
fix: Allow settings tabs to scroll

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
@@ -1,9 +1,10 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import { styled } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import type { SvgIconProps } from "@mui/material/SvgIcon";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useNavigate } from "@tanstack/react-router";
 import React from "react";
 import { useLocation } from "react-use";
@@ -24,9 +25,10 @@ interface Props {
   topOffset?: number;
 }
 
-const TabList = styled(Box)(() => ({
+const TabList = styled(Box)(({ theme }) => ({
   position: "relative",
-  marginLeft: "-12px",
+  marginLeft: theme.spacing(-0.75),
+  width: `(calc(100% + ${theme.spacing(1.5)}))`,
   [`& .${tabsClasses.indicator}`]: {
     display: "none",
   },
@@ -41,6 +43,8 @@ const SettingsLayout: React.FC<Props> = ({
 }) => {
   const navigate = useNavigate();
   const pathname = useLocation();
+  const theme = useTheme();
+  const isScrollable = useMediaQuery(theme.breakpoints.down("contentWrap"));
 
   const filteredLinks = settingsLinks.filter(
     (link) => link.condition === undefined || link.condition,
@@ -78,8 +82,8 @@ const SettingsLayout: React.FC<Props> = ({
           {settingsLinks && (
             <TabList>
               <Tabs
-                variant="scrollable"
-                scrollButtons={false}
+                variant={isScrollable ? "scrollable" : "standard"}
+                scrollButtons="auto"
                 onChange={handleChange}
                 value={activeTab}
                 aria-label={title}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/SettingsLayout.tsx
@@ -78,6 +78,8 @@ const SettingsLayout: React.FC<Props> = ({
           {settingsLinks && (
             <TabList>
               <Tabs
+                variant="scrollable"
+                scrollButtons={false}
                 onChange={handleChange}
                 value={activeTab}
                 aria-label={title}

--- a/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
@@ -1,7 +1,6 @@
 import { styled } from "@mui/material/styles";
 import type { TabProps } from "@mui/material/Tab";
 import Tab, { tabClasses } from "@mui/material/Tab";
-import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 
 interface StyledTabProps extends TabProps {
@@ -24,7 +23,7 @@ const TabLabel = styled("span")(() => ({
 }));
 
 const StyledTab = styled(
-  ({ size, label, ...props }: StyledTabProps) => (
+  ({ label, ...props }: StyledTabProps) => (
     <Tab
       {...props}
       label={<TabLabel data-text={label}>{label}</TabLabel>}
@@ -46,12 +45,17 @@ const StyledTab = styled(
   minWidth: 0,
   minHeight: size === "large" ? "48px" : "36px",
   margin: theme.spacing(0, size === "large" ? 1 : 0.5),
-  padding: "0.75em",
+  padding: size === "large" ? theme.spacing(0.75) : theme.spacing(0.75),
   fontSize: fontSize ?? (size === "large" ? "1rem" : undefined),
+  gap: 0.25,
   "& svg": {
     marginRight: "7px !important",
-    fontSize: 18,
+    fontSize: 17,
     opacity: 0.8,
+    // Hide icon on smaller screens
+    [theme.breakpoints.down("lg")]: {
+      display: "none",
+    },
   },
   [`&.${tabClasses.selected}`]: {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,

--- a/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/StyledTab.tsx
@@ -45,7 +45,7 @@ const StyledTab = styled(
   minWidth: 0,
   minHeight: size === "large" ? "48px" : "36px",
   margin: theme.spacing(0, size === "large" ? 1 : 0.5),
-  padding: size === "large" ? theme.spacing(0.75) : theme.spacing(0.75),
+  padding: theme.spacing(0.75),
   fontSize: fontSize ?? (size === "large" ? "1rem" : undefined),
   gap: 0.25,
   "& svg": {


### PR DESCRIPTION
## Issue

As reported in Slack, settings tabs overflow the container and scroll is not enabled:
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1786094923420729

## Solution

- Enable scroll on tabs

https://7196.planx.pizza/app/barnet/apply-for-a-lawful-development-certificate/settings/visibility