### PR TITLE
fix(api): Instantiate single OS proxy at module level

### DIFF
--- a/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -10,7 +10,7 @@ export const useOrdnanceSurveyProxy = useProxy({
   on: {
     proxyRes: (proxyRes) => setCORPHeaders(proxyRes),
   },
-  pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req as Request),
+  pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req),
 });
 
 const setCORPHeaders = (proxyRes: IncomingMessage): void => {

--- a/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -1,22 +1,17 @@
-import type { NextFunction, Request, Response } from "express";
+import type { Request } from "express";
 import type { IncomingMessage } from "http";
 
 import { useProxy } from "../../shared/middleware/proxy.js";
 
 export const OS_DOMAIN = "https://api.os.uk";
 
-export const useOrdnanceSurveyProxy = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) =>
-  useProxy({
-    target: OS_DOMAIN,
-    on: {
-      proxyRes: (proxyRes) => setCORPHeaders(proxyRes),
-    },
-    pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req as Request),
-  })(req, res, next);
+export const useOrdnanceSurveyProxy = useProxy({
+  target: OS_DOMAIN,
+  on: {
+    proxyRes: (proxyRes) => setCORPHeaders(proxyRes),
+  },
+  pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req as Request),
+});
 
 const setCORPHeaders = (proxyRes: IncomingMessage): void => {
   proxyRes.headers["Cross-Origin-Resource-Policy"] = "cross-origin";

--- a/apps/api.planx.uk/modules/pay/proxy.ts
+++ b/apps/api.planx.uk/modules/pay/proxy.ts
@@ -5,7 +5,7 @@ import { fixRequestBody } from "http-proxy-middleware";
 import { useProxy } from "../../shared/middleware/proxy.js";
 
 export const usePayProxy = (
-  options: Partial<Options>,
+  options: Partial<Options<Request, Response>>,
   req: Request,
   res: Response,
 ) => {

--- a/apps/api.planx.uk/shared/middleware/proxy.ts
+++ b/apps/api.planx.uk/shared/middleware/proxy.ts
@@ -1,8 +1,9 @@
+import type { Request, Response } from "express";
 import { ServerResponse } from "http";
 import type { Options } from "http-proxy-middleware";
 import { createProxyMiddleware } from "http-proxy-middleware";
 
-export const useProxy = (options: Partial<Options> = {}) => {
+export const useProxy = (options: Partial<Options<Request, Response>> = {}) => {
   const { on: onEvents, ...restOptions } = options;
 
   return createProxyMiddleware({


### PR DESCRIPTION
## What's the problem?
When looking at logs this morning for API downtime there's a bunch of OS proxy instantiation logs (as usual). These seem to align with CPU spikes in AWS CloudWatch.

I'm pretty unsure if this is the issue but it seems worth a fix / worthwhile to rule out, but reading through the `http-proxy-middleware` docs shows we're using a bit of an anti-pattern here. Rather than instantiate a proxy per request (of which there will be very many when panning for map tiles for example), we can instantiate once at module level.

Testing locally shows no issues hitting OS APIs, and much quieter logs when panning the map for example.

The below logs are generated when panning or zooming on the map (plus a whole lot more) - a new proxy per request.

```sh
2026-08-19 13:01:41 [HPM] Proxy created: /  -> https://api.os.uk
2026-08-19 13:01:41 [HPM] Subscribed to http-proxy events: [ 'error', 'proxyRes', 'close' ]
2026-08-19 13:01:41 [HPM] GET /proxy/ordnance-survey/maps/vector/v1/vts/resources/styles?srs=3857 ~> https://api.os.uk
2026-08-19 13:01:41 [HPM] Proxy created: /  -> https://api.os.uk
2026-08-19 13:01:41 [HPM] Subscribed to http-proxy events: [ 'error', 'proxyRes', 'close' ]
2026-08-19 13:01:41 [HPM] GET /proxy/ordnance-survey/maps/vector/v1/vts/tile/19/174109/261220.pbf?srs=3857 ~> https://api.os.uk
2026-08-19 13:01:41 [HPM] Proxy created: /  -> https://api.os.uk
2026-08-19 13:01:41 [HPM] Subscribed to http-proxy events: [ 'error', 'proxyRes', 'close' ]
2026-08-19 13:01:41 [HPM] GET /proxy/ordnance-survey/maps/vector/v1/vts/tile/19/174108/261220.pbf?srs=3857 ~> https://api.os.uk
2026-08-19 13:01:41 [HPM] Proxy created: /  -> https://api.os.uk
2026-08-19 13:01:41 [HPM] Subscribed to http-proxy events: [ 'error', 'proxyRes', 'close' ]
2026-08-19 13:01:41 [HPM] GET /proxy/ordnance-survey/maps/vector/v1/vts/tile/19/174108/261221.pbf?srs=3857 ~> https://api.os.uk
2026-08-19 13:01:41 [HPM] Proxy created: /  -> https://api.os.uk
2026-08-19 13:01:41 [HPM] Subscribed to http-proxy events: [ 'error', 'proxyRes', 'close' ]
2026-08-19 13:01:41 [HPM] GET /proxy/ordnance-survey/maps/vector/v1/vts/tile/19/174109/261221.pbf?srs=3857 ~> https://api.os.uk
```

Again - this might not be the underlying issue but it will at a minimum silence noisy logs and likely also reduce memory spikes if there are a lot of OS requests at once.

## Testing
On Pizza - OS APIs work as expected, `docker logs` on Pizza don't spam `Proxy created` per-request but just once on container startup. This is also quite easily testable locally.

## Next up...
Updating `http-proxy-middleware` seems like a good idea - we're on v2, v4 is now out which seems to have many fixes (see https://github.com/chimurai/http-proxy-middleware/issues/782)

I'll also take a look at the noisy `error: TokenExpiredError: jwt expired` messages in API logs.
