### PR TITLE
feat: submission detail modal buttons

### DIFF
--- a/apps/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/index.tsx
@@ -16,12 +16,12 @@ import {
 import { BackButton } from "pages/Preview/Questions";
 import React, { useState } from "react";
 import { usePrevious } from "react-use";
+import { CloseButton } from "ui/icons/CloseButton";
 import FeedbackOption from "ui/public/FeedbackOption";
 
 import FeedbackForm from "./FeedbackForm/FeedbackForm";
 import FeedbackPhaseBanner from "./FeedbackPhaseBanner";
 import {
-  CloseButton,
   FeedbackBody,
   FeedbackHeader,
   FeedbackRow,

--- a/apps/editor.planx.uk/src/components/Feedback/styled.ts
+++ b/apps/editor.planx.uk/src/components/Feedback/styled.ts
@@ -31,13 +31,6 @@ export const FeedbackTitle = styled(Box)(({ theme }) => ({
   },
 }));
 
-export const CloseButton = styled("div")(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "flex-end",
-  color: theme.palette.text.primary,
-}));
-
 export const FeedbackBody = styled(Box)(({ theme }) => ({
   maxWidth: theme.breakpoints.values.formWrap,
 }));

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -14,7 +14,6 @@ const SubmissionsGrouped: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   const [teamId] = useStore((state) => [state.teamId]);
 
   const { data, loading, error } = useQuery<{
-    //
     submissions: SubmissionSummary[];
   }>(
     gql`

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.tsx
@@ -10,10 +10,11 @@ import { useStore } from "../../lib/store";
 import EventsLogGrouped from "./components/EventsLogGrouped";
 import type { SubmissionsProps, SubmissionSummary } from "./types";
 
-const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
+const SubmissionsGrouped: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   const [teamId] = useStore((state) => [state.teamId]);
 
   const { data, loading, error } = useQuery<{
+    //
     submissions: SubmissionSummary[];
   }>(
     gql`
@@ -71,4 +72,4 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
   );
 };
 
-export default Submissions;
+export default SubmissionsGrouped;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
@@ -6,17 +6,15 @@ import React from "react";
 
 type Props = {
   sessionId: string;
-  submittedAt?: string;
+  submittedAt: string;
 };
 
 export const DownloadSubmissionButtonGrouped = (props: Props) => {
-  const submissionDataExpirationDate = props.submittedAt
-    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
-    : null;
-
-  const showDownloadButton = submissionDataExpirationDate
-    ? isBefore(new Date(), submissionDataExpirationDate)
-    : false;
+  const submissionDataExpirationDate = addDays(
+    new Date(props.submittedAt),
+    DAYS_UNTIL_EXPIRY,
+  );
+  const showDownloadButton = isBefore(new Date(), submissionDataExpirationDate);
 
   if (!showDownloadButton) return;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
@@ -9,7 +9,8 @@ type Props = {
   sessionId: string;
   createdAt: string;
 };
-export const DownloadSubmissionButton = (props: Props) => {
+
+export const DownloadSubmissionButtonGrouped = (props: Props) => {
   const submissionDataExpirationDate = addDays(
     new Date(props.createdAt),
     DAYS_UNTIL_EXPIRY,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
@@ -1,33 +1,36 @@
 import CloudDownload from "@mui/icons-material/CloudDownload";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
+import Button from "@mui/material/Button";
 import { addDays, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import React from "react";
 
 type Props = {
   sessionId: string;
-  createdAt: string;
+  submittedAt?: string;
 };
 
 export const DownloadSubmissionButtonGrouped = (props: Props) => {
-  const submissionDataExpirationDate = addDays(
-    new Date(props.createdAt),
-    DAYS_UNTIL_EXPIRY,
-  );
+  const submissionDataExpirationDate = props.submittedAt
+    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
+    : null;
 
-  if (!isBefore(new Date(), submissionDataExpirationDate)) return;
+  const showDownloadButton = submissionDataExpirationDate
+    ? isBefore(new Date(), submissionDataExpirationDate)
+    : false;
+
+  if (!showDownloadButton) return;
 
   const zipUrl = `${import.meta.env.VITE_APP_API_URL}/submission/${props.sessionId}/zip`;
 
   return (
-    <Tooltip title="Download application data">
-      <IconButton
-        aria-label="download application"
-        onClick={() => window.open(zipUrl, "_blank")}
-      >
-        <CloudDownload />
-      </IconButton>
-    </Tooltip>
+    <Button
+      color="primary"
+      variant="contained"
+      onClick={() => window.open(zipUrl, "_blank")}
+      disabled={!props.submittedAt}
+    >
+      <CloudDownload sx={{ mr: 1 }} />
+      Download
+    </Button>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
@@ -1,0 +1,32 @@
+import CloudDownload from "@mui/icons-material/CloudDownload";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import { addDays, isBefore } from "date-fns";
+import { DAYS_UNTIL_EXPIRY } from "lib/pay";
+import React from "react";
+
+type Props = {
+  sessionId: string;
+  createdAt: string;
+};
+export const DownloadSubmissionButton = (props: Props) => {
+  const submissionDataExpirationDate = addDays(
+    new Date(props.createdAt),
+    DAYS_UNTIL_EXPIRY,
+  );
+
+  if (!isBefore(new Date(), submissionDataExpirationDate)) return;
+
+  const zipUrl = `${import.meta.env.VITE_APP_API_URL}/submission/${props.sessionId}/zip`;
+
+  return (
+    <Tooltip title="Download application data">
+      <IconButton
+        aria-label="download application"
+        onClick={() => window.open(zipUrl, "_blank")}
+      >
+        <CloudDownload />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
@@ -1,0 +1,58 @@
+import PreviewIcon from "@mui/icons-material/Preview";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import React, { useState } from "react";
+import { DataTableModal } from "ui/shared/DataTable/components/DataTableModal";
+
+import type { Attempt } from "../types";
+import { FormattedResponse } from "./FormattedResponse";
+
+type Props = { attempt: Attempt; sessionId: string };
+
+export const OpenResponseButtonGrouped = (props: Props) => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [response, setResponse] = useState<Record<string, any> | null>(null);
+
+  const getResponse = ({ eventType, status, response }: Attempt) => {
+    if (eventType === "Pay") return response;
+    if (status === "Success") return response?.data?.body;
+
+    return response?.data?.message;
+  };
+
+  const handleButtonClick = () => {
+    setModalIsOpen(true);
+    if (!response) {
+      let parsedData = getResponse(props.attempt);
+      try {
+        parsedData =
+          typeof parsedData === "string" ? JSON.parse(parsedData) : parsedData;
+      } catch (error) {
+        parsedData = { error: "Invalid JSON format", raw: parsedData };
+      }
+      setResponse(parsedData);
+    }
+  };
+
+  return (
+    <>
+      <Tooltip title="View response">
+        <IconButton aria-label="View response" onClick={handleButtonClick}>
+          <PreviewIcon />
+        </IconButton>
+      </Tooltip>
+      <DataTableModal
+        title={`Response for ${props.sessionId || "unknown"}`}
+        open={modalIsOpen}
+        onClose={() => setModalIsOpen(false)}
+      >
+        {response ? (
+          <FormattedResponse response={response} />
+        ) : (
+          <CircularProgress />
+        )}
+      </DataTableModal>
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
@@ -1,5 +1,4 @@
 import PreviewIcon from "@mui/icons-material/Preview";
-import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import React, { useState } from "react";
@@ -12,33 +11,31 @@ type Props = { attempt: Attempt; sessionId: string };
 
 export const OpenResponseButtonGrouped = (props: Props) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [response, setResponse] = useState<Record<string, any> | null>(null);
 
-  const getResponse = ({ eventType, status, response }: Attempt) => {
-    if (eventType === "Pay") return response;
-    if (status === "Success") return response?.data?.body;
+  const parseResponse = ({ eventType, status, response }: Attempt) => {
+    let data;
+    if (eventType === "Pay") data = response;
+    else if (status === "Success") data = response?.data?.body;
+    else data = response?.data?.message;
 
-    return response?.data?.message;
-  };
-
-  const handleButtonClick = () => {
-    setModalIsOpen(true);
-    if (!response) {
-      let parsedData = getResponse(props.attempt);
-      try {
-        parsedData =
-          typeof parsedData === "string" ? JSON.parse(parsedData) : parsedData;
-      } catch (error) {
-        parsedData = { error: "Invalid JSON format", raw: parsedData };
-      }
-      setResponse(parsedData);
+    try {
+      return typeof data === "string" ? JSON.parse(data) : data;
+    } catch (error) {
+      return {
+        error: "Unable to parse response data",
+        message: error instanceof Error ? error.message : "Invalid JSON format",
+        raw: data,
+      };
     }
   };
 
   return (
     <>
       <Tooltip title="View response">
-        <IconButton aria-label="View response" onClick={handleButtonClick}>
+        <IconButton
+          aria-label="View response"
+          onClick={() => setModalIsOpen(true)}
+        >
           <PreviewIcon />
         </IconButton>
       </Tooltip>
@@ -47,11 +44,7 @@ export const OpenResponseButtonGrouped = (props: Props) => {
         open={modalIsOpen}
         onClose={() => setModalIsOpen(false)}
       >
-        {response ? (
-          <FormattedResponse response={response} />
-        ) : (
-          <CircularProgress />
-        )}
+        <FormattedResponse response={parseResponse(props.attempt)} />
       </DataTableModal>
     </>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButtonGrouped.tsx
@@ -1,0 +1,89 @@
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
+import type { SendIntegration } from "@opensystemslab/planx-core/types";
+import { useMutation } from "@tanstack/react-query";
+import { ConfirmationDialog } from "components/ConfirmationDialog";
+import { useToast } from "hooks/useToast";
+import { createSendEvents } from "lib/api/send/requests";
+import type { CombinedEventsPayload } from "lib/api/send/types";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+
+import type { Submission } from "../types";
+
+type ResubmitEventType = Exclude<Submission["eventType"], "Pay">;
+
+type Props = {
+  sessionId: string;
+  eventType: Submission["eventType"];
+};
+export const ResubmitButtonGrouped = (props: Props) => {
+  const teamSlug = useStore((state) => state.teamSlug);
+  const toast = useToast();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const { mutate } = useMutation({
+    mutationFn: createSendEvents,
+    onSuccess: () =>
+      toast.success(`Created new send event for session ${props.sessionId}`),
+    onError: () =>
+      toast.error(
+        `Failed to create new sent event for session ${props.sessionId}`,
+      ),
+  });
+
+  const handleConfirm = (isConfirmed: boolean) => {
+    if (!isConfirmed) return setIsDialogOpen(false);
+
+    const destinationMap: Record<ResubmitEventType, SendIntegration> = {
+      "Submit to BOPS": "bops",
+      "Submit to Uniform": "uniform",
+      "Send to email": "email",
+      "Upload to AWS S3": "s3",
+      "Upload to AWS S3 (no notification)": "fme",
+      "Submit to Idox Nexus": "idox",
+    };
+
+    const destination = destinationMap[props.eventType as ResubmitEventType];
+
+    if (!destination) return;
+
+    const payload: CombinedEventsPayload = {
+      [destination]: {
+        localAuthority: teamSlug,
+        body: {
+          sessionId: props.sessionId,
+        },
+      },
+    };
+
+    mutate({ sessionId: props.sessionId, ...payload });
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <>
+      <Link
+        aria-label="resubmit application"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        <Typography sx={{ fontWeight: "bold" }}>
+          {props.eventType
+            .replace("Send", "Resubmit")
+            .replace("Submit", "Resubmit")
+            .replace("Upload", "Resubmit")}
+        </Typography>
+      </Link>
+      <ConfirmationDialog
+        open={isDialogOpen}
+        onClose={handleConfirm}
+        confirmText="Resubmit"
+      >
+        <Typography>
+          You're about to resubmit this application. Have you made the required
+          edits to ensure this is a valid payload?
+        </Typography>
+      </ConfirmationDialog>
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,13 +1,13 @@
 import { gql, useQuery } from "@apollo/client";
-import Button from "@mui/material/Button";
+import Close from "@mui/icons-material/CloseOutlined";
 import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { CloseButton } from "ui/icons/CloseButton";
 
 import type { Submission } from "../types";
 import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
@@ -72,6 +72,20 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
         },
       }}
     >
+      <CloseButton
+        aria-label="close"
+        onClick={() => {
+          navigate({
+            to: "/app/$team/submissions",
+            params: {
+              team: teamSlug,
+            },
+          });
+        }}
+        size="large"
+      >
+        <Close />
+      </CloseButton>
       <DialogContent>
         <Typography variant="h2" component="h1" gutterBottom>
           Submission details
@@ -89,20 +103,6 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
             <SubmissionEventsHistory events={events} />
           </Grid>
         </Grid>
-        <DialogActions>
-          <Button
-            onClick={() =>
-              navigate({
-                to: "/app/$team/submissions",
-                params: {
-                  team: teamSlug,
-                },
-              })
-            }
-          >
-            Back
-          </Button>
-        </DialogActions>
       </DialogContent>
     </Dialog>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -10,10 +10,10 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { CloseButton } from "ui/icons/CloseButton";
 
 import type { Submission } from "../types";
-import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
+import { DownloadSubmissionButtonGrouped } from "./DownloadSubmissionButtonGrouped";
 import { SubmissionDetails } from "./SubmissionDetails";
 import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
-import { ViewSubmissionButton } from "./ViewSubmissionButton";
+import { ViewSubmissionButtonGrouped } from "./ViewSubmissionButtonGrouped";
 
 // TODO: refactor into hooks / queries pattern
 const GET_SUBMISSION_EVENTS = gql`
@@ -40,6 +40,24 @@ interface SubmissionDetailModalProps {
   sessionId: string;
 }
 
+const getSubmittedAt = (events: Submission[]): string | undefined => {
+  const sendEventTypes: Submission["eventType"][] = [
+    "Submit to BOPS",
+    "Submit to Uniform",
+    "Send to email",
+    "Upload to AWS S3",
+    "Upload to AWS S3 (no notification)",
+    "Submit to Idox Nexus",
+  ];
+
+  const successfulSend = events.find(
+    (event) =>
+      sendEventTypes.includes(event.eventType) && event.status === "Success",
+  );
+
+  return successfulSend?.createdAt ?? undefined;
+};
+
 const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   sessionId,
 }) => {
@@ -56,6 +74,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
 
   const events = data?.submissions || [];
   const latestEvent = events[0];
+  const submittedAt = getSubmittedAt(events);
 
   if (loading) return <DelayedLoadingIndicator />;
   if (error) throw error;
@@ -96,6 +115,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
               sessionId={sessionId}
               latestEvent={latestEvent}
               teamSlug={teamSlug}
+              submittedAt={submittedAt}
             />
           </Grid>
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -10,10 +10,8 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { CloseButton } from "ui/icons/CloseButton";
 
 import type { Submission } from "../types";
-import { DownloadSubmissionButtonGrouped } from "./DownloadSubmissionButtonGrouped";
 import { SubmissionDetails } from "./SubmissionDetails";
 import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
-import { ViewSubmissionButtonGrouped } from "./ViewSubmissionButtonGrouped";
 
 // TODO: refactor into hooks / queries pattern
 const GET_SUBMISSION_EVENTS = gql`

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -39,18 +39,8 @@ interface SubmissionDetailModalProps {
 }
 
 const getSubmittedAt = (events: Submission[]): string | undefined => {
-  const sendEventTypes: Submission["eventType"][] = [
-    "Submit to BOPS",
-    "Submit to Uniform",
-    "Send to email",
-    "Upload to AWS S3",
-    "Upload to AWS S3 (no notification)",
-    "Submit to Idox Nexus",
-  ];
-
   const successfulSend = events.find(
-    (event) =>
-      sendEventTypes.includes(event.eventType) && event.status === "Success",
+    (event) => event.eventType !== "Pay" && event.status === "Success",
   );
 
   return successfulSend?.createdAt ?? undefined;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -2,8 +2,8 @@ import { gql, useQuery } from "@apollo/client";
 import Close from "@mui/icons-material/CloseOutlined";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
-import Typography from "@mui/material/Typography";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
@@ -103,10 +103,8 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
       >
         <Close />
       </CloseButton>
+      <DialogTitle variant="h2">Submission details</DialogTitle>
       <DialogContent>
-        <Typography variant="h2" component="h1" gutterBottom>
-          Submission details
-        </Typography>
         <Grid container>
           <Grid size={6}>
             <SubmissionDetails

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -43,49 +43,60 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
     <Box
       sx={{
         background: "background",
-        padding: 4,
-        margin: 4,
         border: 1,
+        margin: 1,
         borderColor: "border.main",
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
-        {teamLogo ? (
-          <Box
-            component="img"
-            src={teamLogo}
-            alt={teamName}
-            sx={{
-              maxWidth: 100,
-              width: "100%",
-              height: 50,
-              objectFit: "contain",
-              objectPosition: "left",
-              display: "block",
-            }}
+      <Box sx={{ padding: 1, margin: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+          {teamLogo ? (
+            <Box
+              component="img"
+              src={teamLogo}
+              alt={teamName}
+              sx={{
+                maxWidth: 100,
+                width: "100%",
+                height: 50,
+                objectFit: "contain",
+                objectPosition: "left",
+                display: "block",
+              }}
+            />
+          ) : null}
+
+          <Typography sx={{ fontWeight: "bold" }}>{teamName}</Typography>
+        </Box>
+
+        <Typography variant="h3" sx={{ mb: 2 }}>
+          {props.latestEvent?.flowName}
+        </Typography>
+        <Box>
+          <DetailRow
+            label="Property address"
+            value={props.latestEvent?.address}
+            border={true}
           />
-        ) : null}
-
-        <Typography sx={{ fontWeight: "bold" }}>{teamName}</Typography>
+          <DetailRow label="Reference" value={props.sessionId} border={true} />
+          <DetailRow
+            label="Submitted on"
+            value={new Date(props.latestEvent?.createdAt).toLocaleDateString()}
+          />
+        </Box>
       </Box>
 
-      <Typography variant="h3" sx={{ mb: 2 }}>
-        {props.latestEvent?.flowName}
-      </Typography>
-      <Box>
-        <DetailRow
-          label="Property address"
-          value={props.latestEvent?.address}
-          border={true}
-        />
-        <DetailRow label="Reference" value={props.sessionId} border={true} />
-        <DetailRow
-          label="Submitted on"
-          value={new Date(props.latestEvent?.createdAt).toLocaleDateString()}
-        />
-      </Box>
-
-      <DialogActions>
+      <Box
+        sx={{
+          display: "flex",
+          width: "100%",
+          backgroundColor: "background.paper",
+          padding: 1,
+          gap: 2,
+          borderTop: 1,
+          borderColor: "border.main",
+        }}
+      >
         <ViewSubmissionButtonGrouped
           sessionId={props.sessionId}
           submittedAt={props.submittedAt}
@@ -94,7 +105,7 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
           sessionId={props.sessionId}
           submittedAt={props.submittedAt}
         />
-      </DialogActions>
+      </Box>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,11 +1,11 @@
 import Box from "@mui/material/Box";
-// import DialogActions from "@mui/material/DialogActions";
+import DialogActions from "@mui/material/DialogActions";
 import Typography from "@mui/material/Typography";
 
 import { useTeamLogo } from "../hooks";
-// import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
 import type { Submission } from "../types";
-// import { ViewSubmissionButton } from "./ViewSubmissionButton";
+import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
+import { ViewSubmissionButton } from "./ViewSubmissionButton";
 
 type SubmissionDetailsProps = {
   sessionId: string;
@@ -84,10 +84,10 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         />
       </Box>
 
-      {/* <DialogActions>
-        <ViewSubmissionButton />
-        <DownloadSubmissionButton />
-      </DialogActions> */}
+      <DialogActions>
+        {/* <ViewSubmissionButton />
+        <DownloadSubmissionButton /> */}
+      </DialogActions>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import DialogActions from "@mui/material/DialogActions";
 import Typography from "@mui/material/Typography";
 
 import { useTeamLogo } from "../hooks";
@@ -86,26 +85,30 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         </Box>
       </Box>
 
-      <Box
-        sx={{
-          display: "flex",
-          width: "100%",
-          backgroundColor: "background.paper",
-          padding: 1,
-          gap: 2,
-          borderTop: 1,
-          borderColor: "border.main",
-        }}
-      >
-        <ViewSubmissionButtonGrouped
-          sessionId={props.sessionId}
-          submittedAt={props.submittedAt}
-        />
-        <DownloadSubmissionButtonGrouped
-          sessionId={props.sessionId}
-          submittedAt={props.submittedAt}
-        />
-      </Box>
+      {props.submittedAt ? (
+        <Box
+          sx={{
+            display: "flex",
+            width: "100%",
+            backgroundColor: "background.paper",
+            padding: 1,
+            gap: 2,
+            borderTop: 1,
+            borderColor: "border.main",
+          }}
+        >
+          <ViewSubmissionButtonGrouped
+            sessionId={props.sessionId}
+            submittedAt={props.submittedAt}
+          />
+          <DownloadSubmissionButtonGrouped
+            sessionId={props.sessionId}
+            submittedAt={props.submittedAt}
+          />
+        </Box>
+      ) : (
+        <></>
+      )}
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -90,7 +90,10 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
           sessionId={props.sessionId}
           submittedAt={props.submittedAt}
         />
-        {/* <DownloadSubmissionButtonGrouped /> */}
+        <DownloadSubmissionButtonGrouped
+          sessionId={props.sessionId}
+          submittedAt={props.submittedAt}
+        />
       </DialogActions>
     </Box>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -4,13 +4,14 @@ import Typography from "@mui/material/Typography";
 
 import { useTeamLogo } from "../hooks";
 import type { Submission } from "../types";
-import { DownloadSubmissionButton } from "./DownloadSubmissionButton";
-import { ViewSubmissionButton } from "./ViewSubmissionButton";
+import { DownloadSubmissionButtonGrouped } from "./DownloadSubmissionButtonGrouped";
+import { ViewSubmissionButtonGrouped } from "./ViewSubmissionButtonGrouped";
 
 type SubmissionDetailsProps = {
   sessionId: string;
   latestEvent: Submission;
   teamSlug: string;
+  submittedAt?: string;
 };
 
 type DetailRowProps = {
@@ -85,8 +86,11 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
       </Box>
 
       <DialogActions>
-        {/* <ViewSubmissionButton />
-        <DownloadSubmissionButton /> */}
+        <ViewSubmissionButtonGrouped
+          sessionId={props.sessionId}
+          submittedAt={props.submittedAt}
+        />
+        {/* <DownloadSubmissionButtonGrouped /> */}
       </DialogActions>
     </Box>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -4,7 +4,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import type { Attempt, GroupedEvent, Submission } from "../types";
-import { OpenResponseButton } from "./OpenResponseButton";
+import { OpenResponseButtonGrouped } from "./OpenResponseButtonGrouped";
 import { ResubmitButtonGrouped } from "./ResubmitButtonGrouped";
 import { StatusChip } from "./StatusChip";
 import { StatusIcon } from "./StatusIcon";
@@ -150,7 +150,7 @@ const SubmissionEvent: React.FC<{
                 {new Date(groupedEvent.events[0].createdAt).toLocaleString()}
               </Typography>
               <Box sx={{ marginLeft: "auto" }}>
-                <OpenResponseButton
+                <OpenResponseButtonGrouped
                   attempt={groupedEvent.events[0]}
                   sessionId={groupedEvent.sessionId}
                 />
@@ -188,7 +188,10 @@ const SubmissionAttempts: React.FC<{
             </Box>
 
             <Box sx={{ marginLeft: "auto" }}>
-              <OpenResponseButton attempt={attempt} sessionId={sessionId} />
+              <OpenResponseButtonGrouped
+                attempt={attempt}
+                sessionId={sessionId}
+              />
             </Box>
           </Box>
         </>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -15,13 +15,16 @@ const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
   let currentGroup: GroupedEvent | null = null;
 
   for (const submission of submissions) {
-    if (!currentGroup || currentGroup.eventType !== submission.eventType) {
+    if (
+      !currentGroup ||
+      currentGroup.events[0].eventType !== submission.eventType
+    ) {
       currentGroup = {
-        eventType: submission.eventType,
         sessionId: submission.sessionId,
         eventId: submission.eventId,
         events: [
           {
+            eventType: submission.eventType,
             createdAt: submission.createdAt,
             retry: submission.retry,
             response: submission.response,
@@ -32,6 +35,7 @@ const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
       result.push(currentGroup);
     } else {
       currentGroup.events.push({
+        eventType: submission.eventType,
         createdAt: submission.createdAt,
         retry: submission.retry,
         response: submission.response,
@@ -76,7 +80,7 @@ const SubmissionEvent: React.FC<{ groupedEvent: GroupedEvent }> = ({
 
       <Box sx={{ flex: 1, paddingLeft: 2 }}>
         <Typography sx={{ fontWeight: "bold" }}>
-          {groupedEvent.eventType}
+          {groupedEvent.events[0].eventType}
         </Typography>
         {groupedEvent.events.length === 1 ? (
           <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
+import Permission from "ui/editor/Permission";
 
 import type { Attempt, GroupedEvent, Submission } from "../types";
 import { OpenResponseButtonGrouped } from "./OpenResponseButtonGrouped";
@@ -103,10 +104,6 @@ const SubmissionEvent: React.FC<{
 }> = ({ groupedEvent: { sessionId, events: attempts }, isMostRecent }) => {
   const { eventType, createdAt, status } = attempts[0];
 
-  const isPlatformAdmin = useStore((state) =>
-    Boolean(state.user?.isPlatformAdmin),
-  );
-
   return (
     <Box
       sx={{
@@ -133,14 +130,14 @@ const SubmissionEvent: React.FC<{
       >
         <Typography sx={{ fontWeight: "bold" }}>{eventType}</Typography>
 
-        {isMostRecent &&
-        status !== "Success" &&
-        eventType !== "Pay" &&
-        isPlatformAdmin ? (
-          <ResubmitButtonGrouped sessionId={sessionId} eventType={eventType} />
-        ) : (
-          <></>
-        )}
+        <Permission.IsPlatformAdmin>
+          {isMostRecent && status !== "Success" && eventType !== "Pay" && (
+            <ResubmitButtonGrouped
+              sessionId={sessionId}
+              eventType={eventType}
+            />
+          )}
+        </Permission.IsPlatformAdmin>
 
         {attempts.length === 1 ? (
           <>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -48,30 +48,32 @@ const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
   return result;
 };
 
-const getMostRecentEventIndices = (
-  groupedEvents: GroupedEvent[],
-): Set<number> => {
-  const mostRecentMap = new Map<string, { index: number; timestamp: string }>();
+const getMostRecentEventId = (groupedEvents: GroupedEvent[]): Set<string> => {
+  const mostRecentMap = new Map<
+    string,
+    { eventId: string; timestamp: string }
+  >();
 
-  groupedEvents.forEach((group, index) => {
+  groupedEvents.forEach((group) => {
     const eventType = group.events[0].eventType;
-    const mostRecentEventInGroup = group.events[0];
-    const timestamp = mostRecentEventInGroup.createdAt;
+    const timestamp = group.events[0].createdAt;
 
     const existing = mostRecentMap.get(eventType);
     if (!existing || timestamp > existing.timestamp) {
-      mostRecentMap.set(eventType, { index, timestamp });
+      mostRecentMap.set(eventType, { eventId: group.eventId, timestamp });
     }
   });
 
-  return new Set(Array.from(mostRecentMap.values()).map((item) => item.index));
+  return new Set(
+    Array.from(mostRecentMap.values()).map((item) => item.eventId),
+  );
 };
 
 export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
   events,
 }) => {
   const groupedEvents = groupEvents(events);
-  const mostRecentIndices = getMostRecentEventIndices(groupedEvents);
+  const mostRecentIds = getMostRecentEventId(groupedEvents);
 
   return (
     <Box
@@ -83,11 +85,11 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
       }}
     >
       <Box sx={{ padding: 1, margin: 1 }}>
-        {groupedEvents.map((groupedEvent, index) => (
+        {groupedEvents.map((groupedEvent) => (
           <SubmissionEvent
             key={groupedEvent.eventId}
             groupedEvent={groupedEvent}
-            isMostRecent={mostRecentIndices.has(index)}
+            isMostRecent={mostRecentIds.has(groupedEvent.eventId)}
           />
         ))}
       </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -1,9 +1,11 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 import type { Attempt, GroupedEvent, Submission } from "../types";
 import { OpenResponseButton } from "./OpenResponseButton";
+import { ResubmitButtonGrouped } from "./ResubmitButtonGrouped";
 import { StatusChip } from "./StatusChip";
 import { StatusIcon } from "./StatusIcon";
 
@@ -46,10 +48,30 @@ const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
   return result;
 };
 
+const getMostRecentEventIndices = (
+  groupedEvents: GroupedEvent[],
+): Set<number> => {
+  const mostRecentMap = new Map<string, { index: number; timestamp: string }>();
+
+  groupedEvents.forEach((group, index) => {
+    const eventType = group.events[0].eventType;
+    const mostRecentEventInGroup = group.events[0];
+    const timestamp = mostRecentEventInGroup.createdAt;
+
+    const existing = mostRecentMap.get(eventType);
+    if (!existing || timestamp > existing.timestamp) {
+      mostRecentMap.set(eventType, { index, timestamp });
+    }
+  });
+
+  return new Set(Array.from(mostRecentMap.values()).map((item) => item.index));
+};
+
 export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
   events,
 }) => {
   const groupedEvents = groupEvents(events);
+  const mostRecentIndices = getMostRecentEventIndices(groupedEvents);
 
   return (
     <Box
@@ -61,27 +83,67 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
       }}
     >
       <Box sx={{ padding: 1, margin: 1 }}>
-        {groupedEvents.map((groupedEvent) => (
-          <SubmissionEvent groupedEvent={groupedEvent} />
+        {groupedEvents.map((groupedEvent, index) => (
+          <SubmissionEvent
+            key={groupedEvent.eventId}
+            groupedEvent={groupedEvent}
+            isMostRecent={mostRecentIndices.has(index)}
+          />
         ))}
       </Box>
     </Box>
   );
 };
 
-const SubmissionEvent: React.FC<{ groupedEvent: GroupedEvent }> = ({
-  groupedEvent,
-}) => {
+const SubmissionEvent: React.FC<{
+  groupedEvent: GroupedEvent;
+  isMostRecent: boolean;
+}> = ({ groupedEvent, isMostRecent }) => {
+  const isPlatformAdmin = useStore((state) =>
+    Boolean(state.user?.isPlatformAdmin),
+  );
+
   return (
-    <Box sx={{ display: "flex", width: "100%", alignItems: "flex-start" }}>
+    <Box
+      sx={{
+        display: "flex",
+        width: "100%",
+        alignItems: "flex-start",
+        mb: 1,
+        borderBottom: 1,
+        borderColor: "border.main",
+      }}
+    >
       <Box>
         <StatusIcon status={groupedEvent.events[0].status} />
       </Box>
 
-      <Box sx={{ flex: 1, paddingLeft: 2 }}>
+      <Box
+        sx={{
+          flex: 1,
+          paddingLeft: 2,
+          gap: 1,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
         <Typography sx={{ fontWeight: "bold" }}>
           {groupedEvent.events[0].eventType}
         </Typography>
+
+        {/* TODO: add something about pay events here? v */}
+        {isMostRecent &&
+        groupedEvent.events[0].status !== "Success" &&
+        groupedEvent.events[0].eventType !== "Pay" &&
+        isPlatformAdmin ? (
+          <ResubmitButtonGrouped
+            sessionId={groupedEvent.sessionId}
+            eventType={groupedEvent.events[0].eventType}
+          />
+        ) : (
+          <></>
+        )}
+
         {groupedEvent.events.length === 1 ? (
           <>
             <Box sx={{ display: "flex" }}>
@@ -117,7 +179,7 @@ const SubmissionAttempts: React.FC<{
     <Box>
       {attempts.map((attempt, index) => (
         <>
-          <Box key={`${index}`} sx={{ display: "flex", gap: 2, marginTop: 1 }}>
+          <Box key={`${index}`} sx={{ display: "flex", gap: 2, my: 1 }}>
             <StatusChip status={attempt.status} />
             <Box>
               <Typography>Attempt {numberAttempts - index}</Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -131,7 +131,6 @@ const SubmissionEvent: React.FC<{
           {groupedEvent.events[0].eventType}
         </Typography>
 
-        {/* TODO: add something about pay events here? v */}
         {isMostRecent &&
         groupedEvent.events[0].status !== "Success" &&
         groupedEvent.events[0].eventType !== "Pay" &&

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -1,5 +1,4 @@
 import Box from "@mui/material/Box";
-import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
@@ -56,15 +55,16 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
     <Box
       sx={{
         background: "background",
-        padding: 4,
-        margin: 4,
         border: 1,
+        margin: 1,
         borderColor: "border.main",
       }}
     >
-      {groupedEvents.map((groupedEvent) => (
-        <SubmissionEvent groupedEvent={groupedEvent} />
-      ))}
+      <Box sx={{ padding: 1, margin: 1 }}>
+        {groupedEvents.map((groupedEvent) => (
+          <SubmissionEvent groupedEvent={groupedEvent} />
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -100,7 +100,9 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
 const SubmissionEvent: React.FC<{
   groupedEvent: GroupedEvent;
   isMostRecent: boolean;
-}> = ({ groupedEvent, isMostRecent }) => {
+}> = ({ groupedEvent: { sessionId, events: attempts }, isMostRecent }) => {
+  const { eventType, createdAt, status } = attempts[0];
+
   const isPlatformAdmin = useStore((state) =>
     Boolean(state.user?.isPlatformAdmin),
   );
@@ -117,7 +119,7 @@ const SubmissionEvent: React.FC<{
       }}
     >
       <Box>
-        <StatusIcon status={groupedEvent.events[0].status} />
+        <StatusIcon status={status} />
       </Box>
 
       <Box
@@ -129,41 +131,31 @@ const SubmissionEvent: React.FC<{
           flexDirection: "column",
         }}
       >
-        <Typography sx={{ fontWeight: "bold" }}>
-          {groupedEvent.events[0].eventType}
-        </Typography>
+        <Typography sx={{ fontWeight: "bold" }}>{eventType}</Typography>
 
         {isMostRecent &&
-        groupedEvent.events[0].status !== "Success" &&
-        groupedEvent.events[0].eventType !== "Pay" &&
+        status !== "Success" &&
+        eventType !== "Pay" &&
         isPlatformAdmin ? (
-          <ResubmitButtonGrouped
-            sessionId={groupedEvent.sessionId}
-            eventType={groupedEvent.events[0].eventType}
-          />
+          <ResubmitButtonGrouped sessionId={sessionId} eventType={eventType} />
         ) : (
           <></>
         )}
 
-        {groupedEvent.events.length === 1 ? (
+        {attempts.length === 1 ? (
           <>
             <Box sx={{ display: "flex" }}>
-              <Typography>
-                {new Date(groupedEvent.events[0].createdAt).toLocaleString()}
-              </Typography>
+              <Typography>{new Date(createdAt).toLocaleString()}</Typography>
               <Box sx={{ marginLeft: "auto" }}>
                 <OpenResponseButtonGrouped
-                  attempt={groupedEvent.events[0]}
-                  sessionId={groupedEvent.sessionId}
+                  attempt={attempts[0]}
+                  sessionId={sessionId}
                 />
               </Box>
             </Box>
           </>
         ) : (
-          <SubmissionAttempts
-            attempts={groupedEvent.events}
-            sessionId={groupedEvent.sessionId}
-          />
+          <SubmissionAttempts attempts={attempts} sessionId={sessionId} />
         )}
       </Box>
     </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButton.tsx
@@ -31,7 +31,7 @@ export const ViewSubmissionButton = (params: RenderCellParams) => {
         aria-label="view application"
         onClick={() =>
           navigate({
-            to: `/app/$team/submission/$sessionId`,
+            to: `/app/$team/view-submission/$sessionId`,
             params: { team: teamSlug, sessionId: sessionId },
           })
         }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
@@ -32,7 +32,7 @@ export const ViewSubmissionButtonGrouped = (props: Props) => {
       variant="contained"
       onClick={() =>
         navigate({
-          to: `/app/$team/submission/$sessionId`,
+          to: `/app/$team/view-submission/$sessionId`,
           params: { team: teamSlug, sessionId: props.sessionId },
         })
       }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
@@ -1,43 +1,45 @@
 import PreviewIcon from "@mui/icons-material/Preview";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
+import Button from "@mui/material/Button";
 import { useNavigate } from "@tanstack/react-router";
 import { addDays, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import type { RenderCellParams } from "ui/shared/DataTable/types";
 
-export const ViewSubmissionButtonGrouped = (params: RenderCellParams) => {
-  const submissionDataExpirationDate = addDays(
-    new Date(params.row.createdAt),
-    DAYS_UNTIL_EXPIRY,
-  );
+type Props = {
+  sessionId: string;
+  submittedAt?: string;
+};
+
+export const ViewSubmissionButtonGrouped = (props: Props) => {
+  const submissionDataExpirationDate = props.submittedAt
+    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
+    : null;
+
   const teamSlug = useStore((state) => state.teamSlug);
-  const sessionId = params.row.sessionId;
 
-  const showViewButton =
-    params.row.status === "Success" &&
-    params.row.eventType !== "Pay" &&
-    isBefore(new Date(), submissionDataExpirationDate);
+  const showViewButton = submissionDataExpirationDate
+    ? isBefore(new Date(), submissionDataExpirationDate)
+    : false;
 
   const navigate = useNavigate();
 
   if (!showViewButton) return;
 
   return (
-    <Tooltip title="View application data">
-      <IconButton
-        aria-label="view application"
-        onClick={() =>
-          navigate({
-            to: `/app/$team/submission/$sessionId`,
-            params: { team: teamSlug, sessionId: sessionId },
-          })
-        }
-      >
-        <PreviewIcon />
-      </IconButton>
-    </Tooltip>
+    <Button
+      color="primary"
+      variant="contained"
+      onClick={() =>
+        navigate({
+          to: `/app/$team/submission/$sessionId`,
+          params: { team: teamSlug, sessionId: props.sessionId },
+        })
+      }
+      disabled={!props.submittedAt}
+    >
+      <PreviewIcon sx={{ mr: 1 }} />
+      View submission
+    </Button>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
@@ -8,7 +8,7 @@ import React from "react";
 
 type Props = {
   sessionId: string;
-  submittedAt?: string;
+  submittedAt: string;
 };
 
 export const ViewSubmissionButtonGrouped = (props: Props) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
@@ -1,0 +1,43 @@
+import PreviewIcon from "@mui/icons-material/Preview";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import { useNavigate } from "@tanstack/react-router";
+import { addDays, isBefore } from "date-fns";
+import { DAYS_UNTIL_EXPIRY } from "lib/pay";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import type { RenderCellParams } from "ui/shared/DataTable/types";
+
+export const ViewSubmissionButtonGrouped = (params: RenderCellParams) => {
+  const submissionDataExpirationDate = addDays(
+    new Date(params.row.createdAt),
+    DAYS_UNTIL_EXPIRY,
+  );
+  const teamSlug = useStore((state) => state.teamSlug);
+  const sessionId = params.row.sessionId;
+
+  const showViewButton =
+    params.row.status === "Success" &&
+    params.row.eventType !== "Pay" &&
+    isBefore(new Date(), submissionDataExpirationDate);
+
+  const navigate = useNavigate();
+
+  if (!showViewButton) return;
+
+  return (
+    <Tooltip title="View application data">
+      <IconButton
+        aria-label="view application"
+        onClick={() =>
+          navigate({
+            to: `/app/$team/submission/$sessionId`,
+            params: { team: teamSlug, sessionId: sessionId },
+          })
+        }
+      >
+        <PreviewIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -33,13 +33,13 @@ export interface Submission {
 }
 
 export interface GroupedEvent {
-  eventType: Submission["eventType"];
   sessionId: Submission["sessionId"];
   eventId: Submission["eventId"];
   events: Attempt[];
 }
 
 export type Attempt = {
+  eventType: Submission["eventType"];
   createdAt: Submission["createdAt"];
   retry: Submission["retry"];
   response: Submission["response"];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -21,6 +21,7 @@ import {
 import React, { useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
+import { CloseButton } from "ui/icons/CloseButton";
 import { Switch } from "ui/shared/Switch";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
@@ -33,12 +34,6 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
   "& > * > *": {
     backgroundColor: theme.palette.background.paper,
   },
-}));
-
-const CloseButton = styled(IconButton)(({ theme }) => ({
-  margin: "0 0 0 auto",
-  padding: theme.spacing(1),
-  color: theme.palette.grey[600],
 }));
 
 /**

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -9,107 +9,112 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as authLogoutRouteImport } from './routes/(auth)/logout'
 import { Route as authLoginRouteImport } from './routes/(auth)/login'
-import { Route as PublicCustomDomainRouteRouteImport } from './routes/_public/_customDomain/route'
+import { Route as authLogoutRouteImport } from './routes/(auth)/logout'
 import { Route as AuthenticatedAppRouteRouteImport } from './routes/_authenticated/app/route'
+import { Route as PublicCustomDomainRouteRouteImport } from './routes/_public/_customDomain/route'
 import { Route as AuthenticatedAppIndexRouteImport } from './routes/_authenticated/app/index'
-import { Route as AuthenticatedAppUsersRouteImport } from './routes/_authenticated/app/users'
-import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
-import { Route as PublicCustomDomainFlowRouteRouteImport } from './routes/_public/_customDomain/$flow/route'
-import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
 import { Route as AuthenticatedAppTeamRouteRouteImport } from './routes/_authenticated/app/$team/route'
-import { Route as PublicPlanXDomainDownloadSubmissionIndexRouteImport } from './routes/_public/_planXDomain/download-submission/index'
-import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
-import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
+import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
+import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
+import { Route as AuthenticatedAppUsersRouteImport } from './routes/_authenticated/app/users'
+import { Route as PublicCustomDomainFlowRouteRouteImport } from './routes/_public/_customDomain/$flow/route'
 import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
-import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
-import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
-import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
-import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
-import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
-import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
-import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
-import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
-import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
-import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
-import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
-import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
-import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
-import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
-import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
-import { Route as AuthenticatedAppTeamSubmissionsRouteRouteImport } from './routes/_authenticated/app/$team/submissions/route'
-import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
 import { Route as AuthenticatedAppTeamFlowRouteRouteImport } from './routes/_authenticated/app/$team/$flow/route'
-import { Route as PublicPlanXDomainTeamFlowIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/index'
-import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
-import { Route as AuthenticatedAppTeamSubmissionsIndexRouteImport } from './routes/_authenticated/app/$team/submissions/index'
-import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
-import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
-import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
-import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
-import { Route as AuthenticatedAppTeamViewSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/view-submission/$sessionId'
-import { Route as AuthenticatedAppTeamSubmissionsSessionIdRouteImport } from './routes/_authenticated/app/$team/submissions/$sessionId'
-import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
-import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
-import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
-import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
-import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
-import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
-import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
-import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
-import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
-import { Route as PublicPlanXDomainTeamFlowPublishedRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/route'
-import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
-import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
-import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
-import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
+import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
+import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
+import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
+import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
+import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
+import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
+import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
+import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
+import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
+import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
+import { Route as AuthenticatedAppTeamSubmissionsRouteRouteImport } from './routes/_authenticated/app/$team/submissions/route'
+import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
+import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
+import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
+import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
+import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
+import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
+import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
+import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
+import { Route as PublicPlanXDomainDownloadSubmissionIndexRouteImport } from './routes/_public/_planXDomain/download-submission/index'
 import { Route as AuthenticatedAppTeamFlowFlowEditorRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/route'
-import { Route as PublicPlanXDomainTeamFlowPublishedIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/index'
-import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
-import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
-import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
-import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
-import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
+import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
+import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
+import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
+import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
+import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
+import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
+import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
+import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
+import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
+import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
+import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
+import { Route as AuthenticatedAppTeamSubmissionsIndexRouteImport } from './routes/_authenticated/app/$team/submissions/index'
+import { Route as AuthenticatedAppTeamSubmissionsSessionIdRouteImport } from './routes/_authenticated/app/$team/submissions/$sessionId'
+import { Route as AuthenticatedAppTeamViewSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/view-submission/$sessionId'
+import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
+import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
+import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
+import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
+import { Route as PublicPlanXDomainTeamFlowIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/index'
+import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
+import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
+import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
+import { Route as PublicPlanXDomainTeamFlowPublishedRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/route'
 import { Route as AuthenticatedAppTeamFlowFlowEditorIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/index'
-import { Route as PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/view-application'
-import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
-import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
-import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
-import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
-import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
-import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
-import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
-import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
-import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
-import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
-import { Route as PublicPlanXDomainTeamFlowPayInviteIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/index'
-import { Route as PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
-import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
-import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
+import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
+import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
+import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
+import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
+import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
+import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
+import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
+import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
+import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
+import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
+import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
+import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
+import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
+import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
+import { Route as PublicPlanXDomainTeamFlowPublishedIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/index'
+import { Route as PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/view-application'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/add'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.index'
-import { Route as PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/pages.$page'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
+import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPayInviteIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/index'
+import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
+import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/pages.$page'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.index'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
+import { Route as PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/pages.$page'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.index'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.$before'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit.$before'
 
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
@@ -119,9 +124,9 @@ const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const authLoginRoute = authLoginRouteImport.update({
+  id: '/(auth)/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authLogoutRoute = authLogoutRouteImport.update({
@@ -129,41 +134,31 @@ const authLogoutRoute = authLogoutRouteImport.update({
   path: '/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const authLoginRoute = authLoginRouteImport.update({
-  id: '/(auth)/login',
-  path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PublicCustomDomainRouteRoute = PublicCustomDomainRouteRouteImport.update({
-  id: '/_public/_customDomain',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const AuthenticatedAppRouteRoute = AuthenticatedAppRouteRouteImport.update({
   id: '/app',
   path: '/app',
   getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const PublicCustomDomainRouteRoute = PublicCustomDomainRouteRouteImport.update({
+  id: '/_public/_customDomain',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedAppIndexRoute = AuthenticatedAppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthenticatedAppRouteRoute,
 } as any)
-const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => AuthenticatedAppRouteRoute,
-} as any)
+const AuthenticatedAppTeamRouteRoute =
+  AuthenticatedAppTeamRouteRouteImport.update({
+    id: '/$team',
+    path: '/$team',
+    getParentRoute: () => AuthenticatedAppRouteRoute,
+  } as any)
 const AuthenticatedAppAdminPanelRoute =
   AuthenticatedAppAdminPanelRouteImport.update({
     id: '/admin-panel',
     path: '/admin-panel',
     getParentRoute: () => AuthenticatedAppRouteRoute,
-  } as any)
-const PublicCustomDomainFlowRouteRoute =
-  PublicCustomDomainFlowRouteRouteImport.update({
-    id: '/$flow',
-    path: '/$flow',
-    getParentRoute: () => PublicCustomDomainRouteRoute,
   } as any)
 const AuthenticatedAppGlobalSettingsRouteRoute =
   AuthenticatedAppGlobalSettingsRouteRouteImport.update({
@@ -171,136 +166,21 @@ const AuthenticatedAppGlobalSettingsRouteRoute =
     path: '/global-settings',
     getParentRoute: () => AuthenticatedAppRouteRoute,
   } as any)
-const AuthenticatedAppTeamRouteRoute =
-  AuthenticatedAppTeamRouteRouteImport.update({
-    id: '/$team',
-    path: '/$team',
-    getParentRoute: () => AuthenticatedAppRouteRoute,
-  } as any)
-const PublicPlanXDomainDownloadSubmissionIndexRoute =
-  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
-    id: '/_public/_planXDomain/download-submission/',
-    path: '/download-submission/',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const PublicCustomDomainFlowIndexRoute =
-  PublicCustomDomainFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const AuthenticatedAppGlobalSettingsIndexRoute =
-  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AuthenticatedAppRouteRoute,
+} as any)
+const PublicCustomDomainFlowRouteRoute =
+  PublicCustomDomainFlowRouteRouteImport.update({
+    id: '/$flow',
+    path: '/$flow',
+    getParentRoute: () => PublicCustomDomainRouteRoute,
   } as any)
 const AuthenticatedAppTeamIndexRoute =
   AuthenticatedAppTeamIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const PublicCustomDomainFlowViewApplicationRoute =
-  PublicCustomDomainFlowViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const AuthenticatedAppGlobalSettingsFooterRoute =
-  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
-    id: '/footer',
-    path: '/footer',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamTutorialsRoute =
-  AuthenticatedAppTeamTutorialsRouteImport.update({
-    id: '/tutorials',
-    path: '/tutorials',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubscriptionRoute =
-  AuthenticatedAppTeamSubscriptionRouteImport.update({
-    id: '/subscription',
-    path: '/subscription',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamResourcesRoute =
-  AuthenticatedAppTeamResourcesRouteImport.update({
-    id: '/resources',
-    path: '/resources',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamOnboardingRoute =
-  AuthenticatedAppTeamOnboardingRouteImport.update({
-    id: '/onboarding',
-    path: '/onboarding',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamNotificationsRoute =
-  AuthenticatedAppTeamNotificationsRouteImport.update({
-    id: '/notifications',
-    path: '/notifications',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamMembersRoute =
-  AuthenticatedAppTeamMembersRouteImport.update({
-    id: '/members',
-    path: '/members',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowsRoute =
-  AuthenticatedAppTeamFlowsRouteImport.update({
-    id: '/flows',
-    path: '/flows',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFeedbackRoute =
-  AuthenticatedAppTeamFeedbackRouteImport.update({
-    id: '/feedback',
-    path: '/feedback',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamExploreRoute =
-  AuthenticatedAppTeamExploreRouteImport.update({
-    id: '/explore',
-    path: '/explore',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamDesignRoute =
-  AuthenticatedAppTeamDesignRouteImport.update({
-    id: '/design',
-    path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamDashboardRoute =
-  AuthenticatedAppTeamDashboardRouteImport.update({
-    id: '/dashboard',
-    path: '/dashboard',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowRouteRoute =
-  PublicPlanXDomainTeamFlowRouteRouteImport.update({
-    id: '/_public/_planXDomain/$team/$flow',
-    path: '/$team/$flow',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const PublicCustomDomainFlowPayRouteRoute =
-  PublicCustomDomainFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionsRouteRoute =
-  AuthenticatedAppTeamSubmissionsRouteRouteImport.update({
-    id: '/submissions',
-    path: '/submissions',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsRouteRoute =
-  AuthenticatedAppTeamSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowRouteRoute =
@@ -309,106 +189,129 @@ const AuthenticatedAppTeamFlowRouteRoute =
     path: '/$flow',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowIndexRoute =
-  PublicPlanXDomainTeamFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayIndexRoute =
-  PublicCustomDomainFlowPayIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionsIndexRoute =
-  AuthenticatedAppTeamSubmissionsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsIndexRoute =
-  AuthenticatedAppTeamSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayViewApplicationRoute =
-  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayNotFoundRoute =
-  PublicCustomDomainFlowPayNotFoundRouteImport.update({
-    id: '/not-found',
-    path: '/not-found',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPagesPageRoute =
-  PublicCustomDomainFlowPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamViewSubmissionSessionIdRoute =
-  AuthenticatedAppTeamViewSubmissionSessionIdRouteImport.update({
-    id: '/view-submission/$sessionId',
-    path: '/view-submission/$sessionId',
+const AuthenticatedAppTeamDashboardRoute =
+  AuthenticatedAppTeamDashboardRouteImport.update({
+    id: '/dashboard',
+    path: '/dashboard',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamSubmissionsSessionIdRoute =
-  AuthenticatedAppTeamSubmissionsSessionIdRouteImport.update({
-    id: '/$sessionId',
-    path: '/$sessionId',
-    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsPaymentsRoute =
-  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
-    id: '/payments',
-    path: '/payments',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsIntegrationsRoute =
-  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
-    id: '/integrations',
-    path: '/integrations',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsGisDataRoute =
-  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
-    id: '/gis-data',
-    path: '/gis-data',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsDesignRoute =
-  AuthenticatedAppTeamSettingsDesignRouteImport.update({
+const AuthenticatedAppTeamDesignRoute =
+  AuthenticatedAppTeamDesignRouteImport.update({
     id: '/design',
     path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsContactRoute =
-  AuthenticatedAppTeamSettingsContactRouteImport.update({
-    id: '/contact',
-    path: '/contact',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+const AuthenticatedAppTeamExploreRoute =
+  AuthenticatedAppTeamExploreRouteImport.update({
+    id: '/explore',
+    path: '/explore',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsAdvancedRoute =
-  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
-    id: '/advanced',
-    path: '/advanced',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSubmissionsRoute =
-  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
-    id: '/submissions',
-    path: '/submissions',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFeedbackRoute =
-  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
+const AuthenticatedAppTeamFeedbackRoute =
+  AuthenticatedAppTeamFeedbackRouteImport.update({
     id: '/feedback',
     path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowsRoute =
+  AuthenticatedAppTeamFlowsRouteImport.update({
+    id: '/flows',
+    path: '/flows',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamMembersRoute =
+  AuthenticatedAppTeamMembersRouteImport.update({
+    id: '/members',
+    path: '/members',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamNotificationsRoute =
+  AuthenticatedAppTeamNotificationsRouteImport.update({
+    id: '/notifications',
+    path: '/notifications',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamOnboardingRoute =
+  AuthenticatedAppTeamOnboardingRouteImport.update({
+    id: '/onboarding',
+    path: '/onboarding',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamResourcesRoute =
+  AuthenticatedAppTeamResourcesRouteImport.update({
+    id: '/resources',
+    path: '/resources',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsRouteRoute =
+  AuthenticatedAppTeamSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSubmissionsRouteRoute =
+  AuthenticatedAppTeamSubmissionsRouteRouteImport.update({
+    id: '/submissions',
+    path: '/submissions',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSubscriptionRoute =
+  AuthenticatedAppTeamSubscriptionRouteImport.update({
+    id: '/subscription',
+    path: '/subscription',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamTutorialsRoute =
+  AuthenticatedAppTeamTutorialsRouteImport.update({
+    id: '/tutorials',
+    path: '/tutorials',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppGlobalSettingsIndexRoute =
+  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppGlobalSettingsFooterRoute =
+  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
+    id: '/footer',
+    path: '/footer',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+  } as any)
+const PublicCustomDomainFlowIndexRoute =
+  PublicCustomDomainFlowIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayRouteRoute =
+  PublicCustomDomainFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const PublicCustomDomainFlowViewApplicationRoute =
+  PublicCustomDomainFlowViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowRouteRoute =
+  PublicPlanXDomainTeamFlowRouteRouteImport.update({
+    id: '/_public/_planXDomain/$team/$flow',
+    path: '/$team/$flow',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const PublicPlanXDomainDownloadSubmissionIndexRoute =
+  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
+    id: '/_public/_planXDomain/download-submission/',
+    path: '/download-submission/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
+    id: '/_flowEditor',
     getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowAboutRoute =
@@ -417,22 +320,112 @@ const AuthenticatedAppTeamFlowAboutRoute =
     path: '/about',
     getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedRouteRoute =
-  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
-    id: '/published',
-    path: '/published',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamFlowFeedbackRoute =
+  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPreviewRouteRoute =
-  PublicPlanXDomainTeamFlowPreviewRouteRouteImport.update({
-    id: '/preview',
-    path: '/preview',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamFlowSettingsRouteRoute =
+  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayRouteRoute =
-  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
+const AuthenticatedAppTeamFlowSubmissionsRoute =
+  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
+    id: '/submissions',
+    path: '/submissions',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsIndexRoute =
+  AuthenticatedAppTeamSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsAdvancedRoute =
+  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
+    id: '/advanced',
+    path: '/advanced',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsContactRoute =
+  AuthenticatedAppTeamSettingsContactRouteImport.update({
+    id: '/contact',
+    path: '/contact',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsDesignRoute =
+  AuthenticatedAppTeamSettingsDesignRouteImport.update({
+    id: '/design',
+    path: '/design',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsGisDataRoute =
+  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
+    id: '/gis-data',
+    path: '/gis-data',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsIntegrationsRoute =
+  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
+    id: '/integrations',
+    path: '/integrations',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsPaymentsRoute =
+  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
+    id: '/payments',
+    path: '/payments',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSubmissionsIndexRoute =
+  AuthenticatedAppTeamSubmissionsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSubmissionsSessionIdRoute =
+  AuthenticatedAppTeamSubmissionsSessionIdRouteImport.update({
+    id: '/$sessionId',
+    path: '/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamViewSubmissionSessionIdRoute =
+  AuthenticatedAppTeamViewSubmissionSessionIdRouteImport.update({
+    id: '/view-submission/$sessionId',
+    path: '/view-submission/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPagesPageRoute =
+  PublicCustomDomainFlowPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayIndexRoute =
+  PublicCustomDomainFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayNotFoundRoute =
+  PublicCustomDomainFlowPayNotFoundRouteImport.update({
+    id: '/not-found',
+    path: '/not-found',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayViewApplicationRoute =
+  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowIndexRoute =
+  PublicPlanXDomainTeamFlowIndexRouteImport.update({
+    id: '/',
+    path: '/',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowDraftRouteRoute =
@@ -441,135 +434,28 @@ const PublicPlanXDomainTeamFlowDraftRouteRoute =
     path: '/draft',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowSettingsRouteRoute =
-  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+const PublicPlanXDomainTeamFlowPayRouteRoute =
+  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
-    id: '/_flowEditor',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+const PublicPlanXDomainTeamFlowPreviewRouteRoute =
+  PublicPlanXDomainTeamFlowPreviewRouteRouteImport.update({
+    id: '/preview',
+    path: '/preview',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedIndexRoute =
-  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPreviewIndexRoute =
-  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPayIndexRoute =
-  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowDraftIndexRoute =
-  PublicPlanXDomainTeamFlowDraftIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteIndexRoute =
-  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
-    id: '/invite/',
-    path: '/invite/',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsIndexRoute =
-  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+const PublicPlanXDomainTeamFlowPublishedRouteRoute =
+  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
+    id: '/published',
+    path: '/published',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPayNotFoundRoute =
-  PublicPlanXDomainTeamFlowPayNotFoundRouteImport.update({
-    id: '/not-found',
-    path: '/not-found',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
-  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayPagesPageRoute =
-  PublicCustomDomainFlowPayPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteFailedRoute =
-  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
-    id: '/invite/failed',
-    path: '/invite/failed',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
-  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
-    id: '/visibility',
-    path: '/visibility',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
-  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
-    id: '/templates',
-    path: '/templates',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
-  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
-    id: '/legal-disclaimer',
-    path: '/legal-disclaimer',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsEmailsRoute =
-  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
-    id: '/emails',
-    path: '/emails',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsAboutRoute =
-  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
-    id: '/about',
-    path: '/about',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
-    id: '/note',
-    path: '/note',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
@@ -578,28 +464,154 @@ const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
     path: '/nodes',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
   } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
+    id: '/note',
+    path: '/note',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsIndexRoute =
+  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsAboutRoute =
+  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
+    id: '/about',
+    path: '/about',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsEmailsRoute =
+  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
+    id: '/emails',
+    path: '/emails',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
+  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
+    id: '/legal-disclaimer',
+    path: '/legal-disclaimer',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
+  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
+    id: '/templates',
+    path: '/templates',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
+  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
+    id: '/visibility',
+    path: '/visibility',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayInviteIndexRoute =
+  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
+    id: '/invite/',
+    path: '/invite/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayInviteFailedRoute =
+  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
+    id: '/invite/failed',
+    path: '/invite/failed',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayPagesPageRoute =
+  PublicCustomDomainFlowPayPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowDraftIndexRoute =
+  PublicPlanXDomainTeamFlowDraftIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
+  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayIndexRoute =
+  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayNotFoundRoute =
+  PublicPlanXDomainTeamFlowPayNotFoundRouteImport.update({
+    id: '/not-found',
+    path: '/not-found',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewIndexRoute =
+  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedIndexRoute =
+  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
+    id: '/add',
+    path: '/add',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
+  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
+    id: '/pages/help',
+    path: '/pages/help',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
+  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
+    id: '/pages/privacy',
+    path: '/pages/privacy',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayInvitePagesPageRoute =
+  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
+  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+  } as any)
 const PublicPlanXDomainTeamFlowPayInviteIndexRoute =
   PublicPlanXDomainTeamFlowPayInviteIndexRouteImport.update({
     id: '/invite/',
     path: '/invite/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
-  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
-  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPayPagesPageRoute =
-  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
@@ -608,59 +620,23 @@ const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
     path: '/invite/failed',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
-  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
+const PublicPlanXDomainTeamFlowPayPagesPageRoute =
+  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
     id: '/pages/$page',
     path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInvitePagesPageRoute =
-  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
-  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
-    id: '/pages/privacy',
-    path: '/pages/privacy',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
-  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
-    id: '/pages/help',
-    path: '/pages/help',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
-    id: '/add',
-    path: '/add',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport.update({
-    id: '/new/',
-    path: '/new/',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
-  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport.update({
-    id: '/$id/edit',
-    path: '/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
+const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
+  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
-    id: '/new/$before',
-    path: '/new/$before',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
+  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport.update({
@@ -668,11 +644,41 @@ const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
     path: '/$id/edit',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport.update({
+    id: '/new/',
+    path: '/new/',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
+    id: '/new/$before',
+    path: '/new/$before',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport.update({
+    id: '/$id/edit',
+    path: '/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
+  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport.update({
     id: '/$before',
     path: '/$before',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
+    id: '/$parent/nodes/$id/edit',
+    path: '/$parent/nodes/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport.update({
@@ -688,12 +694,6 @@ const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRoute =
       getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
     } as any,
   )
-const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
-    id: '/$parent/nodes/$id/edit',
-    path: '/$parent/nodes/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
-  } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport.update(
     {
@@ -716,7 +716,7 @@ export interface FileRoutesByFullPath {
   '/app/admin-panel': typeof AuthenticatedAppAdminPanelRoute
   '/app/users': typeof AuthenticatedAppUsersRoute
   '/app/': typeof AuthenticatedAppIndexRoute
-  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteWithChildren
+  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowRouteRouteWithChildren
   '/app/$team/settings': typeof AuthenticatedAppTeamSettingsRouteRouteWithChildren
   '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRouteRouteWithChildren
   '/$flow/pay': typeof PublicCustomDomainFlowPayRouteRouteWithChildren
@@ -1293,6 +1293,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$': {
       id: '/$'
       path: '/$'
@@ -1307,11 +1314,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/(auth)/login': {
+      id: '/(auth)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof authLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(auth)/logout': {
@@ -1321,12 +1328,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authLogoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(auth)/login': {
-      id: '/(auth)/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof authLoginRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_authenticated/app': {
+      id: '/_authenticated/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_public/_customDomain': {
       id: '/_public/_customDomain'
@@ -1335,46 +1342,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicCustomDomainRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/app': {
-      id: '/_authenticated/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
     '/_authenticated/app/': {
       id: '/_authenticated/app/'
       path: '/'
       fullPath: '/app/'
       preLoaderRoute: typeof AuthenticatedAppIndexRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/users': {
-      id: '/_authenticated/app/users'
-      path: '/users'
-      fullPath: '/app/users'
-      preLoaderRoute: typeof AuthenticatedAppUsersRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/admin-panel': {
-      id: '/_authenticated/app/admin-panel'
-      path: '/admin-panel'
-      fullPath: '/app/admin-panel'
-      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_public/_customDomain/$flow': {
-      id: '/_public/_customDomain/$flow'
-      path: '/$flow'
-      fullPath: '/$flow'
-      preLoaderRoute: typeof PublicCustomDomainFlowRouteRouteImport
-      parentRoute: typeof PublicCustomDomainRouteRoute
-    }
-    '/_authenticated/app/global-settings': {
-      id: '/_authenticated/app/global-settings'
-      path: '/global-settings'
-      fullPath: '/app/global-settings'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
     '/_authenticated/app/$team': {
@@ -1384,151 +1356,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamRouteRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
-    '/_public/_planXDomain/download-submission/': {
-      id: '/_public/_planXDomain/download-submission/'
-      path: '/download-submission'
-      fullPath: '/download-submission/'
-      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_authenticated/app/admin-panel': {
+      id: '/_authenticated/app/admin-panel'
+      path: '/admin-panel'
+      fullPath: '/app/admin-panel'
+      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
     }
-    '/_public/_customDomain/$flow/': {
-      id: '/_public/_customDomain/$flow/'
-      path: '/'
-      fullPath: '/$flow/'
-      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/global-settings': {
+      id: '/_authenticated/app/global-settings'
+      path: '/global-settings'
+      fullPath: '/app/global-settings'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
     }
-    '/_authenticated/app/global-settings/': {
-      id: '/_authenticated/app/global-settings/'
-      path: '/'
-      fullPath: '/app/global-settings/'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    '/_authenticated/app/users': {
+      id: '/_authenticated/app/users'
+      path: '/users'
+      fullPath: '/app/users'
+      preLoaderRoute: typeof AuthenticatedAppUsersRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
+    '/_public/_customDomain/$flow': {
+      id: '/_public/_customDomain/$flow'
+      path: '/$flow'
+      fullPath: '/$flow'
+      preLoaderRoute: typeof PublicCustomDomainFlowRouteRouteImport
+      parentRoute: typeof PublicCustomDomainRouteRoute
     }
     '/_authenticated/app/$team/': {
       id: '/_authenticated/app/$team/'
       path: '/'
       fullPath: '/app/$team/'
       preLoaderRoute: typeof AuthenticatedAppTeamIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_public/_customDomain/$flow/view-application': {
-      id: '/_public/_customDomain/$flow/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
-    }
-    '/_authenticated/app/global-settings/footer': {
-      id: '/_authenticated/app/global-settings/footer'
-      path: '/footer'
-      fullPath: '/app/global-settings/footer'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/tutorials': {
-      id: '/_authenticated/app/$team/tutorials'
-      path: '/tutorials'
-      fullPath: '/app/$team/tutorials'
-      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/subscription': {
-      id: '/_authenticated/app/$team/subscription'
-      path: '/subscription'
-      fullPath: '/app/$team/subscription'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubscriptionRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/resources': {
-      id: '/_authenticated/app/$team/resources'
-      path: '/resources'
-      fullPath: '/app/$team/resources'
-      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/onboarding': {
-      id: '/_authenticated/app/$team/onboarding'
-      path: '/onboarding'
-      fullPath: '/app/$team/onboarding'
-      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/notifications': {
-      id: '/_authenticated/app/$team/notifications'
-      path: '/notifications'
-      fullPath: '/app/$team/notifications'
-      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/members': {
-      id: '/_authenticated/app/$team/members'
-      path: '/members'
-      fullPath: '/app/$team/members'
-      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/flows': {
-      id: '/_authenticated/app/$team/flows'
-      path: '/flows'
-      fullPath: '/app/$team/flows'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/feedback': {
-      id: '/_authenticated/app/$team/feedback'
-      path: '/feedback'
-      fullPath: '/app/$team/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/explore': {
-      id: '/_authenticated/app/$team/explore'
-      path: '/explore'
-      fullPath: '/app/$team/explore'
-      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/design': {
-      id: '/_authenticated/app/$team/design'
-      path: '/design'
-      fullPath: '/app/$team/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/dashboard': {
-      id: '/_authenticated/app/$team/dashboard'
-      path: '/dashboard'
-      fullPath: '/app/$team/dashboard'
-      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow': {
-      id: '/_public/_planXDomain/$team/$flow'
-      path: '/$team/$flow'
-      fullPath: '/$team/$flow'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_public/_customDomain/$flow/pay': {
-      id: '/_public/_customDomain/$flow/pay'
-      path: '/pay'
-      fullPath: '/$flow/pay'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
-    }
-    '/_authenticated/app/$team/submissions': {
-      id: '/_authenticated/app/$team/submissions'
-      path: '/submissions'
-      fullPath: '/app/$team/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/settings': {
-      id: '/_authenticated/app/$team/settings'
-      path: '/settings'
-      fullPath: '/app/$team/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
     '/_authenticated/app/$team/$flow': {
@@ -1538,123 +1398,151 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/': {
-      id: '/_public/_planXDomain/$team/$flow/'
-      path: '/'
-      fullPath: '/$team/$flow/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/': {
-      id: '/_public/_customDomain/$flow/pay/'
-      path: '/'
-      fullPath: '/$flow/pay/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_authenticated/app/$team/submissions/': {
-      id: '/_authenticated/app/$team/submissions/'
-      path: '/'
-      fullPath: '/app/$team/submissions/'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/': {
-      id: '/_authenticated/app/$team/settings/'
-      path: '/'
-      fullPath: '/app/$team/settings/'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/view-application': {
-      id: '/_public/_customDomain/$flow/pay/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/not-found': {
-      id: '/_public/_customDomain/$flow/pay/not-found'
-      path: '/not-found'
-      fullPath: '/$flow/pay/not-found'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayNotFoundRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pages/$page': {
-      id: '/_public/_customDomain/$flow/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
-    }
-    '/_authenticated/app/$team/view-submission/$sessionId': {
-      id: '/_authenticated/app/$team/view-submission/$sessionId'
-      path: '/view-submission/$sessionId'
-      fullPath: '/app/$team/view-submission/$sessionId'
-      preLoaderRoute: typeof AuthenticatedAppTeamViewSubmissionSessionIdRouteImport
+    '/_authenticated/app/$team/dashboard': {
+      id: '/_authenticated/app/$team/dashboard'
+      path: '/dashboard'
+      fullPath: '/app/$team/dashboard'
+      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/submissions/$sessionId': {
-      id: '/_authenticated/app/$team/submissions/$sessionId'
-      path: '/$sessionId'
-      fullPath: '/app/$team/submissions/$sessionId'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/payments': {
-      id: '/_authenticated/app/$team/settings/payments'
-      path: '/payments'
-      fullPath: '/app/$team/settings/payments'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/integrations': {
-      id: '/_authenticated/app/$team/settings/integrations'
-      path: '/integrations'
-      fullPath: '/app/$team/settings/integrations'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/gis-data': {
-      id: '/_authenticated/app/$team/settings/gis-data'
-      path: '/gis-data'
-      fullPath: '/app/$team/settings/gis-data'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/design': {
-      id: '/_authenticated/app/$team/settings/design'
+    '/_authenticated/app/$team/design': {
+      id: '/_authenticated/app/$team/design'
       path: '/design'
-      fullPath: '/app/$team/settings/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+      fullPath: '/app/$team/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/settings/contact': {
-      id: '/_authenticated/app/$team/settings/contact'
-      path: '/contact'
-      fullPath: '/app/$team/settings/contact'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    '/_authenticated/app/$team/explore': {
+      id: '/_authenticated/app/$team/explore'
+      path: '/explore'
+      fullPath: '/app/$team/explore'
+      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/settings/advanced': {
-      id: '/_authenticated/app/$team/settings/advanced'
-      path: '/advanced'
-      fullPath: '/app/$team/settings/advanced'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/submissions': {
-      id: '/_authenticated/app/$team/$flow/submissions'
-      path: '/submissions'
-      fullPath: '/app/$team/$flow/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/feedback': {
-      id: '/_authenticated/app/$team/$flow/feedback'
+    '/_authenticated/app/$team/feedback': {
+      id: '/_authenticated/app/$team/feedback'
       path: '/feedback'
-      fullPath: '/app/$team/$flow/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
+      fullPath: '/app/$team/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/flows': {
+      id: '/_authenticated/app/$team/flows'
+      path: '/flows'
+      fullPath: '/app/$team/flows'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/members': {
+      id: '/_authenticated/app/$team/members'
+      path: '/members'
+      fullPath: '/app/$team/members'
+      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/notifications': {
+      id: '/_authenticated/app/$team/notifications'
+      path: '/notifications'
+      fullPath: '/app/$team/notifications'
+      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/onboarding': {
+      id: '/_authenticated/app/$team/onboarding'
+      path: '/onboarding'
+      fullPath: '/app/$team/onboarding'
+      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/resources': {
+      id: '/_authenticated/app/$team/resources'
+      path: '/resources'
+      fullPath: '/app/$team/resources'
+      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/settings': {
+      id: '/_authenticated/app/$team/settings'
+      path: '/settings'
+      fullPath: '/app/$team/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/submissions': {
+      id: '/_authenticated/app/$team/submissions'
+      path: '/submissions'
+      fullPath: '/app/$team/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/subscription': {
+      id: '/_authenticated/app/$team/subscription'
+      path: '/subscription'
+      fullPath: '/app/$team/subscription'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubscriptionRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/tutorials': {
+      id: '/_authenticated/app/$team/tutorials'
+      path: '/tutorials'
+      fullPath: '/app/$team/tutorials'
+      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/global-settings/': {
+      id: '/_authenticated/app/global-settings/'
+      path: '/'
+      fullPath: '/app/global-settings/'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    }
+    '/_authenticated/app/global-settings/footer': {
+      id: '/_authenticated/app/global-settings/footer'
+      path: '/footer'
+      fullPath: '/app/global-settings/footer'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    }
+    '/_public/_customDomain/$flow/': {
+      id: '/_public/_customDomain/$flow/'
+      path: '/'
+      fullPath: '/$flow/'
+      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay': {
+      id: '/_public/_customDomain/$flow/pay'
+      path: '/pay'
+      fullPath: '/$flow/pay'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_public/_customDomain/$flow/view-application': {
+      id: '/_public/_customDomain/$flow/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow': {
+      id: '/_public/_planXDomain/$team/$flow'
+      path: '/$team/$flow'
+      fullPath: '/$team/$flow'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_public/_planXDomain/download-submission/': {
+      id: '/_public/_planXDomain/download-submission/'
+      path: '/download-submission'
+      fullPath: '/download-submission/'
+      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor'
+      path: ''
+      fullPath: '/app/$team/$flow'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
     }
     '/_authenticated/app/$team/$flow/about': {
@@ -1664,25 +1552,130 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowAboutRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published': {
-      id: '/_public/_planXDomain/$team/$flow/published'
-      path: '/published'
-      fullPath: '/$team/$flow/published'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/$flow/feedback': {
+      id: '/_authenticated/app/$team/$flow/feedback'
+      path: '/feedback'
+      fullPath: '/app/$team/$flow/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/preview': {
-      id: '/_public/_planXDomain/$team/$flow/preview'
-      path: '/preview'
-      fullPath: '/$team/$flow/preview'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/$flow/settings': {
+      id: '/_authenticated/app/$team/$flow/settings'
+      path: '/settings'
+      fullPath: '/app/$team/$flow/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay': {
-      id: '/_public/_planXDomain/$team/$flow/pay'
-      path: '/pay'
-      fullPath: '/$team/$flow/pay'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
+    '/_authenticated/app/$team/$flow/submissions': {
+      id: '/_authenticated/app/$team/$flow/submissions'
+      path: '/submissions'
+      fullPath: '/app/$team/$flow/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/settings/': {
+      id: '/_authenticated/app/$team/settings/'
+      path: '/'
+      fullPath: '/app/$team/settings/'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/advanced': {
+      id: '/_authenticated/app/$team/settings/advanced'
+      path: '/advanced'
+      fullPath: '/app/$team/settings/advanced'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/contact': {
+      id: '/_authenticated/app/$team/settings/contact'
+      path: '/contact'
+      fullPath: '/app/$team/settings/contact'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/design': {
+      id: '/_authenticated/app/$team/settings/design'
+      path: '/design'
+      fullPath: '/app/$team/settings/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/gis-data': {
+      id: '/_authenticated/app/$team/settings/gis-data'
+      path: '/gis-data'
+      fullPath: '/app/$team/settings/gis-data'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/integrations': {
+      id: '/_authenticated/app/$team/settings/integrations'
+      path: '/integrations'
+      fullPath: '/app/$team/settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/payments': {
+      id: '/_authenticated/app/$team/settings/payments'
+      path: '/payments'
+      fullPath: '/app/$team/settings/payments'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/submissions/': {
+      id: '/_authenticated/app/$team/submissions/'
+      path: '/'
+      fullPath: '/app/$team/submissions/'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
+    }
+    '/_authenticated/app/$team/submissions/$sessionId': {
+      id: '/_authenticated/app/$team/submissions/$sessionId'
+      path: '/$sessionId'
+      fullPath: '/app/$team/submissions/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
+    }
+    '/_authenticated/app/$team/view-submission/$sessionId': {
+      id: '/_authenticated/app/$team/view-submission/$sessionId'
+      path: '/view-submission/$sessionId'
+      fullPath: '/app/$team/view-submission/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamViewSubmissionSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_public/_customDomain/$flow/pages/$page': {
+      id: '/_public/_customDomain/$flow/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/': {
+      id: '/_public/_customDomain/$flow/pay/'
+      path: '/'
+      fullPath: '/$flow/pay/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/not-found': {
+      id: '/_public/_customDomain/$flow/pay/not-found'
+      path: '/not-found'
+      fullPath: '/$flow/pay/not-found'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayNotFoundRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/view-application': {
+      id: '/_public/_customDomain/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/': {
+      id: '/_public/_planXDomain/$team/$flow/'
+      path: '/'
+      fullPath: '/$team/$flow/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/draft': {
@@ -1692,158 +1685,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/settings': {
-      id: '/_authenticated/app/$team/$flow/settings'
-      path: '/settings'
-      fullPath: '/app/$team/$flow/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    '/_public/_planXDomain/$team/$flow/pay': {
+      id: '/_public/_planXDomain/$team/$flow/pay'
+      path: '/pay'
+      fullPath: '/$team/$flow/pay'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor'
-      path: ''
-      fullPath: '/app/$team/$flow'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    '/_public/_planXDomain/$team/$flow/preview': {
+      id: '/_public/_planXDomain/$team/$flow/preview'
+      path: '/preview'
+      fullPath: '/$team/$flow/preview'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published/': {
-      id: '/_public/_planXDomain/$team/$flow/published/'
-      path: '/'
-      fullPath: '/$team/$flow/published/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/preview/': {
-      id: '/_public/_planXDomain/$team/$flow/preview/'
-      path: '/'
-      fullPath: '/$team/$flow/preview/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/pay/': {
-      id: '/_public/_planXDomain/$team/$flow/pay/'
-      path: '/'
-      fullPath: '/$team/$flow/pay/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/draft/': {
-      id: '/_public/_planXDomain/$team/$flow/draft/'
-      path: '/'
-      fullPath: '/$team/$flow/draft/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/': {
-      id: '/_public/_customDomain/$flow/pay/invite/'
-      path: '/invite'
-      fullPath: '/$flow/pay/invite/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/': {
-      id: '/_authenticated/app/$team/$flow/settings/'
-      path: '/'
-      fullPath: '/app/$team/$flow/settings/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    '/_public/_planXDomain/$team/$flow/published': {
+      id: '/_public/_planXDomain/$team/$flow/published'
+      path: '/published'
+      fullPath: '/$team/$flow/published'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/'
       path: '/'
       fullPath: '/app/$team/$flow/'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/published/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/published/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/preview/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/preview/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/pay/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/pay/not-found': {
-      id: '/_public/_planXDomain/$team/$flow/pay/not-found'
-      path: '/not-found'
-      fullPath: '/$team/$flow/pay/not-found'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayNotFoundRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/draft/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/draft/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/failed': {
-      id: '/_public/_customDomain/$flow/pay/invite/failed'
-      path: '/invite/failed'
-      fullPath: '/$flow/pay/invite/failed'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/visibility': {
-      id: '/_authenticated/app/$team/$flow/settings/visibility'
-      path: '/visibility'
-      fullPath: '/app/$team/$flow/settings/visibility'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/templates': {
-      id: '/_authenticated/app/$team/$flow/settings/templates'
-      path: '/templates'
-      fullPath: '/app/$team/$flow/settings/templates'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
-      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-      path: '/legal-disclaimer'
-      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/emails': {
-      id: '/_authenticated/app/$team/$flow/settings/emails'
-      path: '/emails'
-      fullPath: '/app/$team/$flow/settings/emails'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/about': {
-      id: '/_authenticated/app/$team/$flow/settings/about'
-      path: '/about'
-      fullPath: '/app/$team/$flow/settings/about'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
-      path: '/note'
-      fullPath: '/app/$team/$flow/note'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes': {
@@ -1853,32 +1720,179 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
     }
+    '/_authenticated/app/$team/$flow/_flowEditor/note': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
+      path: '/note'
+      fullPath: '/app/$team/$flow/note'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/': {
+      id: '/_authenticated/app/$team/$flow/settings/'
+      path: '/'
+      fullPath: '/app/$team/$flow/settings/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/about': {
+      id: '/_authenticated/app/$team/$flow/settings/about'
+      path: '/about'
+      fullPath: '/app/$team/$flow/settings/about'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/emails': {
+      id: '/_authenticated/app/$team/$flow/settings/emails'
+      path: '/emails'
+      fullPath: '/app/$team/$flow/settings/emails'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
+      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+      path: '/legal-disclaimer'
+      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/templates': {
+      id: '/_authenticated/app/$team/$flow/settings/templates'
+      path: '/templates'
+      fullPath: '/app/$team/$flow/settings/templates'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/visibility': {
+      id: '/_authenticated/app/$team/$flow/settings/visibility'
+      path: '/visibility'
+      fullPath: '/app/$team/$flow/settings/visibility'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/invite/': {
+      id: '/_public/_customDomain/$flow/pay/invite/'
+      path: '/invite'
+      fullPath: '/$flow/pay/invite/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/invite/failed': {
+      id: '/_public/_customDomain/$flow/pay/invite/failed'
+      path: '/invite/failed'
+      fullPath: '/$flow/pay/invite/failed'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/draft/': {
+      id: '/_public/_planXDomain/$team/$flow/draft/'
+      path: '/'
+      fullPath: '/$team/$flow/draft/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/draft/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/draft/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/': {
+      id: '/_public/_planXDomain/$team/$flow/pay/'
+      path: '/'
+      fullPath: '/$team/$flow/pay/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/not-found': {
+      id: '/_public/_planXDomain/$team/$flow/pay/not-found'
+      path: '/not-found'
+      fullPath: '/$team/$flow/pay/not-found'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayNotFoundRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/': {
+      id: '/_public/_planXDomain/$team/$flow/preview/'
+      path: '/'
+      fullPath: '/$team/$flow/preview/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/preview/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/': {
+      id: '/_public/_planXDomain/$team/$flow/published/'
+      path: '/'
+      fullPath: '/$team/$flow/published/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/published/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/published/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
+      path: '/add'
+      fullPath: '/app/$team/$flow/note/add'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/pages/help': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/help'
+      path: '/pages/help'
+      fullPath: '/app/$team/$flow/settings/pages/help'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
+      path: '/pages/privacy'
+      fullPath: '/app/$team/$flow/settings/pages/privacy'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/draft/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    }
     '/_public/_planXDomain/$team/$flow/pay/invite/': {
       id: '/_public/_planXDomain/$team/$flow/pay/invite/'
       path: '/invite'
       fullPath: '/$team/$flow/pay/invite/'
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/published/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/preview/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/invite/failed': {
@@ -1888,68 +1902,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteFailedRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
+    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
       path: '/pages/$page'
-      fullPath: '/$team/$flow/draft/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
-      path: '/pages/privacy'
-      fullPath: '/app/$team/$flow/settings/pages/privacy'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/help': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/help'
-      path: '/pages/help'
-      fullPath: '/app/$team/$flow/settings/pages/help'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
-      path: '/add'
-      fullPath: '/app/$team/$flow/note/add'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/'
-      path: '/new'
-      fullPath: '/app/$team/$flow/nodes/new/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$team/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
+      fullPath: '/$team/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit'
-      path: '/$id/edit'
-      fullPath: '/app/$team/$flow/note/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
+    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/preview/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
-      path: '/new/$before'
-      fullPath: '/app/$team/$flow/nodes/new/$before'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/published/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit'
@@ -1958,12 +1930,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/'
+      path: '/new'
+      fullPath: '/app/$team/$flow/nodes/new/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
+      path: '/new/$before'
+      fullPath: '/app/$team/$flow/nodes/new/$before'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit'
+      path: '/$id/edit'
+      fullPath: '/app/$team/$flow/note/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$team/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before'
       path: '/$before'
       fullPath: '/app/$team/$flow/nodes/$id/edit/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
+      path: '/$parent/nodes/$id/edit'
+      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/'
@@ -1977,13 +1984,6 @@ declare module '@tanstack/react-router' {
       path: '/$parent/nodes/new/$before'
       fullPath: '/app/$team/$flow/nodes/$parent/nodes/new/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
-      path: '/$parent/nodes/$id/edit'
-      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit/$before': {

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -752,8 +752,8 @@ export interface FileRoutesByFullPath {
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
-  '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
+  '/app/$team/view-submission/$sessionId': typeof AuthenticatedAppTeamViewSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
@@ -838,8 +838,8 @@ export interface FileRoutesByTo {
   '/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
-  '/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
+  '/app/$team/view-submission/$sessionId': typeof AuthenticatedAppTeamViewSubmissionSessionIdRoute
   '/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
@@ -940,8 +940,8 @@ export interface FileRoutesById {
   '/_authenticated/app/$team/settings/gis-data': typeof AuthenticatedAppTeamSettingsGisDataRoute
   '/_authenticated/app/$team/settings/integrations': typeof AuthenticatedAppTeamSettingsIntegrationsRoute
   '/_authenticated/app/$team/settings/payments': typeof AuthenticatedAppTeamSettingsPaymentsRoute
-  '/_authenticated/app/$team/submission/$sessionId': typeof AuthenticatedAppTeamSubmissionSessionIdRoute
   '/_authenticated/app/$team/submissions/$sessionId': typeof AuthenticatedAppTeamSubmissionsSessionIdRoute
+  '/_authenticated/app/$team/view-submission/$sessionId': typeof AuthenticatedAppTeamViewSubmissionSessionIdRoute
   '/_public/_customDomain/$flow/pages/$page': typeof PublicCustomDomainFlowPagesPageRoute
   '/_public/_customDomain/$flow/pay/not-found': typeof PublicCustomDomainFlowPayNotFoundRoute
   '/_public/_customDomain/$flow/pay/view-application': typeof PublicCustomDomainFlowPayViewApplicationRoute
@@ -1041,8 +1041,8 @@ export interface FileRouteTypes {
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
     | '/app/$team/settings/payments'
-    | '/app/$team/submission/$sessionId'
     | '/app/$team/submissions/$sessionId'
+    | '/app/$team/view-submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
     | '/$flow/pay/view-application'
@@ -1127,8 +1127,8 @@ export interface FileRouteTypes {
     | '/app/$team/settings/gis-data'
     | '/app/$team/settings/integrations'
     | '/app/$team/settings/payments'
-    | '/app/$team/submission/$sessionId'
     | '/app/$team/submissions/$sessionId'
+    | '/app/$team/view-submission/$sessionId'
     | '/$flow/pages/$page'
     | '/$flow/pay/not-found'
     | '/$flow/pay/view-application'
@@ -1228,8 +1228,8 @@ export interface FileRouteTypes {
     | '/_authenticated/app/$team/settings/gis-data'
     | '/_authenticated/app/$team/settings/integrations'
     | '/_authenticated/app/$team/settings/payments'
-    | '/_authenticated/app/$team/submission/$sessionId'
     | '/_authenticated/app/$team/submissions/$sessionId'
+    | '/_authenticated/app/$team/view-submission/$sessionId'
     | '/_public/_customDomain/$flow/pages/$page'
     | '/_public/_customDomain/$flow/pay/not-found'
     | '/_public/_customDomain/$flow/pay/view-application'
@@ -2224,7 +2224,7 @@ interface AuthenticatedAppTeamRouteRouteChildren {
   AuthenticatedAppTeamSubscriptionRoute: typeof AuthenticatedAppTeamSubscriptionRoute
   AuthenticatedAppTeamTutorialsRoute: typeof AuthenticatedAppTeamTutorialsRoute
   AuthenticatedAppTeamIndexRoute: typeof AuthenticatedAppTeamIndexRoute
-  AuthenticatedAppTeamSubmissionSessionIdRoute: typeof AuthenticatedAppTeamSubmissionSessionIdRoute
+  AuthenticatedAppTeamViewSubmissionSessionIdRoute: typeof AuthenticatedAppTeamViewSubmissionSessionIdRoute
 }
 
 const AuthenticatedAppTeamRouteRouteChildren: AuthenticatedAppTeamRouteRouteChildren =
@@ -2249,8 +2249,8 @@ const AuthenticatedAppTeamRouteRouteChildren: AuthenticatedAppTeamRouteRouteChil
       AuthenticatedAppTeamSubscriptionRoute,
     AuthenticatedAppTeamTutorialsRoute: AuthenticatedAppTeamTutorialsRoute,
     AuthenticatedAppTeamIndexRoute: AuthenticatedAppTeamIndexRoute,
-    AuthenticatedAppTeamSubmissionSessionIdRoute:
-      AuthenticatedAppTeamSubmissionSessionIdRoute,
+    AuthenticatedAppTeamViewSubmissionSessionIdRoute:
+      AuthenticatedAppTeamViewSubmissionSessionIdRoute,
   }
 
 const AuthenticatedAppTeamRouteRouteWithChildren =

--- a/apps/editor.planx.uk/src/routeTree.gen.ts
+++ b/apps/editor.planx.uk/src/routeTree.gen.ts
@@ -9,112 +9,107 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
-import { Route as authLoginRouteImport } from './routes/(auth)/login'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as authLogoutRouteImport } from './routes/(auth)/logout'
-import { Route as AuthenticatedAppRouteRouteImport } from './routes/_authenticated/app/route'
+import { Route as authLoginRouteImport } from './routes/(auth)/login'
 import { Route as PublicCustomDomainRouteRouteImport } from './routes/_public/_customDomain/route'
+import { Route as AuthenticatedAppRouteRouteImport } from './routes/_authenticated/app/route'
 import { Route as AuthenticatedAppIndexRouteImport } from './routes/_authenticated/app/index'
-import { Route as AuthenticatedAppTeamRouteRouteImport } from './routes/_authenticated/app/$team/route'
-import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
-import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
 import { Route as AuthenticatedAppUsersRouteImport } from './routes/_authenticated/app/users'
+import { Route as AuthenticatedAppAdminPanelRouteImport } from './routes/_authenticated/app/admin-panel'
 import { Route as PublicCustomDomainFlowRouteRouteImport } from './routes/_public/_customDomain/$flow/route'
-import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
-import { Route as AuthenticatedAppTeamFlowRouteRouteImport } from './routes/_authenticated/app/$team/$flow/route'
-import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
-import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
-import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
-import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
-import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
-import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
-import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
-import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
-import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
-import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
-import { Route as AuthenticatedAppTeamSubmissionsRouteRouteImport } from './routes/_authenticated/app/$team/submissions/route'
-import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
-import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
-import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
-import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
-import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
-import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
-import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
-import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
+import { Route as AuthenticatedAppGlobalSettingsRouteRouteImport } from './routes/_authenticated/app/global-settings/route'
+import { Route as AuthenticatedAppTeamRouteRouteImport } from './routes/_authenticated/app/$team/route'
 import { Route as PublicPlanXDomainDownloadSubmissionIndexRouteImport } from './routes/_public/_planXDomain/download-submission/index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/route'
-import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
-import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
-import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
-import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
-import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
-import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
-import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
-import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
-import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
-import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
-import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
-import { Route as AuthenticatedAppTeamSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/submission.$sessionId'
-import { Route as AuthenticatedAppTeamSubmissionsIndexRouteImport } from './routes/_authenticated/app/$team/submissions/index'
-import { Route as AuthenticatedAppTeamSubmissionsSessionIdRouteImport } from './routes/_authenticated/app/$team/submissions/$sessionId'
-import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
-import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
-import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
-import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
+import { Route as PublicCustomDomainFlowIndexRouteImport } from './routes/_public/_customDomain/$flow/index'
+import { Route as AuthenticatedAppGlobalSettingsIndexRouteImport } from './routes/_authenticated/app/global-settings/index'
+import { Route as AuthenticatedAppTeamIndexRouteImport } from './routes/_authenticated/app/$team/index'
+import { Route as PublicCustomDomainFlowViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/view-application'
+import { Route as AuthenticatedAppGlobalSettingsFooterRouteImport } from './routes/_authenticated/app/global-settings/footer'
+import { Route as AuthenticatedAppTeamTutorialsRouteImport } from './routes/_authenticated/app/$team/tutorials'
+import { Route as AuthenticatedAppTeamSubscriptionRouteImport } from './routes/_authenticated/app/$team/subscription'
+import { Route as AuthenticatedAppTeamResourcesRouteImport } from './routes/_authenticated/app/$team/resources'
+import { Route as AuthenticatedAppTeamOnboardingRouteImport } from './routes/_authenticated/app/$team/onboarding'
+import { Route as AuthenticatedAppTeamNotificationsRouteImport } from './routes/_authenticated/app/$team/notifications'
+import { Route as AuthenticatedAppTeamMembersRouteImport } from './routes/_authenticated/app/$team/members'
+import { Route as AuthenticatedAppTeamFlowsRouteImport } from './routes/_authenticated/app/$team/flows'
+import { Route as AuthenticatedAppTeamFeedbackRouteImport } from './routes/_authenticated/app/$team/feedback'
+import { Route as AuthenticatedAppTeamExploreRouteImport } from './routes/_authenticated/app/$team/explore'
+import { Route as AuthenticatedAppTeamDesignRouteImport } from './routes/_authenticated/app/$team/design'
+import { Route as AuthenticatedAppTeamDashboardRouteImport } from './routes/_authenticated/app/$team/dashboard'
+import { Route as PublicPlanXDomainTeamFlowRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/route'
+import { Route as PublicCustomDomainFlowPayRouteRouteImport } from './routes/_public/_customDomain/$flow/pay/route'
+import { Route as AuthenticatedAppTeamSubmissionsRouteRouteImport } from './routes/_authenticated/app/$team/submissions/route'
+import { Route as AuthenticatedAppTeamSettingsRouteRouteImport } from './routes/_authenticated/app/$team/settings/route'
+import { Route as AuthenticatedAppTeamFlowRouteRouteImport } from './routes/_authenticated/app/$team/$flow/route'
 import { Route as PublicPlanXDomainTeamFlowIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/index'
-import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
-import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
-import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
+import { Route as PublicCustomDomainFlowPayIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/index'
+import { Route as AuthenticatedAppTeamSubmissionsIndexRouteImport } from './routes/_authenticated/app/$team/submissions/index'
+import { Route as AuthenticatedAppTeamSettingsIndexRouteImport } from './routes/_authenticated/app/$team/settings/index'
+import { Route as PublicCustomDomainFlowPayViewApplicationRouteImport } from './routes/_public/_customDomain/$flow/pay/view-application'
+import { Route as PublicCustomDomainFlowPayNotFoundRouteImport } from './routes/_public/_customDomain/$flow/pay/not-found'
+import { Route as PublicCustomDomainFlowPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pages.$page'
+import { Route as AuthenticatedAppTeamViewSubmissionSessionIdRouteImport } from './routes/_authenticated/app/$team/view-submission/$sessionId'
+import { Route as AuthenticatedAppTeamSubmissionsSessionIdRouteImport } from './routes/_authenticated/app/$team/submissions/$sessionId'
+import { Route as AuthenticatedAppTeamSettingsPaymentsRouteImport } from './routes/_authenticated/app/$team/settings/payments'
+import { Route as AuthenticatedAppTeamSettingsIntegrationsRouteImport } from './routes/_authenticated/app/$team/settings/integrations'
+import { Route as AuthenticatedAppTeamSettingsGisDataRouteImport } from './routes/_authenticated/app/$team/settings/gis-data'
+import { Route as AuthenticatedAppTeamSettingsDesignRouteImport } from './routes/_authenticated/app/$team/settings/design'
+import { Route as AuthenticatedAppTeamSettingsContactRouteImport } from './routes/_authenticated/app/$team/settings/contact'
+import { Route as AuthenticatedAppTeamSettingsAdvancedRouteImport } from './routes/_authenticated/app/$team/settings/advanced'
+import { Route as AuthenticatedAppTeamFlowSubmissionsRouteImport } from './routes/_authenticated/app/$team/$flow/submissions'
+import { Route as AuthenticatedAppTeamFlowFeedbackRouteImport } from './routes/_authenticated/app/$team/$flow/feedback'
+import { Route as AuthenticatedAppTeamFlowAboutRouteImport } from './routes/_authenticated/app/$team/$flow/about'
 import { Route as PublicPlanXDomainTeamFlowPublishedRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/route'
-import { Route as AuthenticatedAppTeamFlowFlowEditorIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
-import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
-import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
-import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
-import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
-import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
-import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
-import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
-import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
-import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
-import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
-import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
-import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
-import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
-import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
+import { Route as PublicPlanXDomainTeamFlowPreviewRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/route'
+import { Route as PublicPlanXDomainTeamFlowPayRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/route'
+import { Route as PublicPlanXDomainTeamFlowDraftRouteRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/route'
+import { Route as AuthenticatedAppTeamFlowSettingsRouteRouteImport } from './routes/_authenticated/app/$team/$flow/settings/route'
+import { Route as AuthenticatedAppTeamFlowFlowEditorRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/route'
 import { Route as PublicPlanXDomainTeamFlowPublishedIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/index'
+import { Route as PublicPlanXDomainTeamFlowPreviewIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/index'
+import { Route as PublicPlanXDomainTeamFlowPayIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/index'
+import { Route as PublicPlanXDomainTeamFlowDraftIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/index'
+import { Route as PublicCustomDomainFlowPayInviteIndexRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/index'
+import { Route as AuthenticatedAppTeamFlowSettingsIndexRouteImport } from './routes/_authenticated/app/$team/$flow/settings/index'
+import { Route as AuthenticatedAppTeamFlowFlowEditorIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/index'
 import { Route as PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/view-application'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/add'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
-import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
-import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/view-application'
+import { Route as PublicPlanXDomainTeamFlowPayViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/view-application'
+import { Route as PublicPlanXDomainTeamFlowPayNotFoundRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/not-found'
+import { Route as PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/view-application'
+import { Route as PublicCustomDomainFlowPayPagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/pages.$page'
+import { Route as PublicCustomDomainFlowPayInviteFailedRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/failed'
+import { Route as AuthenticatedAppTeamFlowSettingsVisibilityRouteImport } from './routes/_authenticated/app/$team/$flow/settings/visibility'
+import { Route as AuthenticatedAppTeamFlowSettingsTemplatesRouteImport } from './routes/_authenticated/app/$team/$flow/settings/templates'
+import { Route as AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport } from './routes/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+import { Route as AuthenticatedAppTeamFlowSettingsEmailsRouteImport } from './routes/_authenticated/app/$team/$flow/settings/emails'
+import { Route as AuthenticatedAppTeamFlowSettingsAboutRouteImport } from './routes/_authenticated/app/$team/$flow/settings/about'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/route'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route'
 import { Route as PublicPlanXDomainTeamFlowPayInviteIndexRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/index'
-import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
-import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
-import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
 import { Route as PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/published/pages.$page'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit'
+import { Route as PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/preview/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPayPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/pages.$page'
+import { Route as PublicPlanXDomainTeamFlowPayInviteFailedRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/failed'
+import { Route as PublicPlanXDomainTeamFlowDraftPagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/draft/pages.$page'
+import { Route as PublicCustomDomainFlowPayInvitePagesPageRouteImport } from './routes/_public/_customDomain/$flow/pay/invite/pages.$page'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.privacy'
+import { Route as AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport } from './routes/_authenticated/app/$team/$flow/settings/pages.help'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/add'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.index'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
 import { Route as PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport } from './routes/_public/_planXDomain/$team/$flow/pay/invite/pages.$page'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/note/$id.edit'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/new.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$id.edit.$before'
-import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.index'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.new.$before'
+import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit'
 import { Route as AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport } from './routes/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent.nodes.$id.edit.$before'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const SplatRoute = SplatRouteImport.update({
   id: '/$',
   path: '/$',
@@ -124,9 +119,9 @@ const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
-const authLoginRoute = authLoginRouteImport.update({
-  id: '/(auth)/login',
-  path: '/login',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authLogoutRoute = authLogoutRouteImport.update({
@@ -134,31 +129,41 @@ const authLogoutRoute = authLogoutRouteImport.update({
   path: '/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AuthenticatedAppRouteRoute = AuthenticatedAppRouteRouteImport.update({
-  id: '/app',
-  path: '/app',
-  getParentRoute: () => AuthenticatedRouteRoute,
+const authLoginRoute = authLoginRouteImport.update({
+  id: '/(auth)/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PublicCustomDomainRouteRoute = PublicCustomDomainRouteRouteImport.update({
   id: '/_public/_customDomain',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthenticatedAppRouteRoute = AuthenticatedAppRouteRouteImport.update({
+  id: '/app',
+  path: '/app',
+  getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
 const AuthenticatedAppIndexRoute = AuthenticatedAppIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthenticatedAppRouteRoute,
 } as any)
-const AuthenticatedAppTeamRouteRoute =
-  AuthenticatedAppTeamRouteRouteImport.update({
-    id: '/$team',
-    path: '/$team',
-    getParentRoute: () => AuthenticatedAppRouteRoute,
-  } as any)
+const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AuthenticatedAppRouteRoute,
+} as any)
 const AuthenticatedAppAdminPanelRoute =
   AuthenticatedAppAdminPanelRouteImport.update({
     id: '/admin-panel',
     path: '/admin-panel',
     getParentRoute: () => AuthenticatedAppRouteRoute,
+  } as any)
+const PublicCustomDomainFlowRouteRoute =
+  PublicCustomDomainFlowRouteRouteImport.update({
+    id: '/$flow',
+    path: '/$flow',
+    getParentRoute: () => PublicCustomDomainRouteRoute,
   } as any)
 const AuthenticatedAppGlobalSettingsRouteRoute =
   AuthenticatedAppGlobalSettingsRouteRouteImport.update({
@@ -166,16 +171,29 @@ const AuthenticatedAppGlobalSettingsRouteRoute =
     path: '/global-settings',
     getParentRoute: () => AuthenticatedAppRouteRoute,
   } as any)
-const AuthenticatedAppUsersRoute = AuthenticatedAppUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => AuthenticatedAppRouteRoute,
-} as any)
-const PublicCustomDomainFlowRouteRoute =
-  PublicCustomDomainFlowRouteRouteImport.update({
-    id: '/$flow',
-    path: '/$flow',
-    getParentRoute: () => PublicCustomDomainRouteRoute,
+const AuthenticatedAppTeamRouteRoute =
+  AuthenticatedAppTeamRouteRouteImport.update({
+    id: '/$team',
+    path: '/$team',
+    getParentRoute: () => AuthenticatedAppRouteRoute,
+  } as any)
+const PublicPlanXDomainDownloadSubmissionIndexRoute =
+  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
+    id: '/_public/_planXDomain/download-submission/',
+    path: '/download-submission/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const PublicCustomDomainFlowIndexRoute =
+  PublicCustomDomainFlowIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+  } as any)
+const AuthenticatedAppGlobalSettingsIndexRoute =
+  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
   } as any)
 const AuthenticatedAppTeamIndexRoute =
   AuthenticatedAppTeamIndexRouteImport.update({
@@ -183,76 +201,22 @@ const AuthenticatedAppTeamIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowRouteRoute =
-  AuthenticatedAppTeamFlowRouteRouteImport.update({
-    id: '/$flow',
-    path: '/$flow',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+const PublicCustomDomainFlowViewApplicationRoute =
+  PublicCustomDomainFlowViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamDashboardRoute =
-  AuthenticatedAppTeamDashboardRouteImport.update({
-    id: '/dashboard',
-    path: '/dashboard',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+const AuthenticatedAppGlobalSettingsFooterRoute =
+  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
+    id: '/footer',
+    path: '/footer',
+    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamDesignRoute =
-  AuthenticatedAppTeamDesignRouteImport.update({
-    id: '/design',
-    path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamExploreRoute =
-  AuthenticatedAppTeamExploreRouteImport.update({
-    id: '/explore',
-    path: '/explore',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFeedbackRoute =
-  AuthenticatedAppTeamFeedbackRouteImport.update({
-    id: '/feedback',
-    path: '/feedback',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowsRoute =
-  AuthenticatedAppTeamFlowsRouteImport.update({
-    id: '/flows',
-    path: '/flows',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamMembersRoute =
-  AuthenticatedAppTeamMembersRouteImport.update({
-    id: '/members',
-    path: '/members',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamNotificationsRoute =
-  AuthenticatedAppTeamNotificationsRouteImport.update({
-    id: '/notifications',
-    path: '/notifications',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamOnboardingRoute =
-  AuthenticatedAppTeamOnboardingRouteImport.update({
-    id: '/onboarding',
-    path: '/onboarding',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamResourcesRoute =
-  AuthenticatedAppTeamResourcesRouteImport.update({
-    id: '/resources',
-    path: '/resources',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsRouteRoute =
-  AuthenticatedAppTeamSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionsRouteRoute =
-  AuthenticatedAppTeamSubmissionsRouteRouteImport.update({
-    id: '/submissions',
-    path: '/submissions',
+const AuthenticatedAppTeamTutorialsRoute =
+  AuthenticatedAppTeamTutorialsRouteImport.update({
+    id: '/tutorials',
+    path: '/tutorials',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
 const AuthenticatedAppTeamSubscriptionRoute =
@@ -261,41 +225,59 @@ const AuthenticatedAppTeamSubscriptionRoute =
     path: '/subscription',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamTutorialsRoute =
-  AuthenticatedAppTeamTutorialsRouteImport.update({
-    id: '/tutorials',
-    path: '/tutorials',
+const AuthenticatedAppTeamResourcesRoute =
+  AuthenticatedAppTeamResourcesRouteImport.update({
+    id: '/resources',
+    path: '/resources',
     getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppGlobalSettingsIndexRoute =
-  AuthenticatedAppGlobalSettingsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+const AuthenticatedAppTeamOnboardingRoute =
+  AuthenticatedAppTeamOnboardingRouteImport.update({
+    id: '/onboarding',
+    path: '/onboarding',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppGlobalSettingsFooterRoute =
-  AuthenticatedAppGlobalSettingsFooterRouteImport.update({
-    id: '/footer',
-    path: '/footer',
-    getParentRoute: () => AuthenticatedAppGlobalSettingsRouteRoute,
+const AuthenticatedAppTeamNotificationsRoute =
+  AuthenticatedAppTeamNotificationsRouteImport.update({
+    id: '/notifications',
+    path: '/notifications',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowIndexRoute =
-  PublicCustomDomainFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamMembersRoute =
+  AuthenticatedAppTeamMembersRouteImport.update({
+    id: '/members',
+    path: '/members',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowPayRouteRoute =
-  PublicCustomDomainFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamFlowsRoute =
+  AuthenticatedAppTeamFlowsRouteImport.update({
+    id: '/flows',
+    path: '/flows',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicCustomDomainFlowViewApplicationRoute =
-  PublicCustomDomainFlowViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
+const AuthenticatedAppTeamFeedbackRoute =
+  AuthenticatedAppTeamFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamExploreRoute =
+  AuthenticatedAppTeamExploreRouteImport.update({
+    id: '/explore',
+    path: '/explore',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamDesignRoute =
+  AuthenticatedAppTeamDesignRouteImport.update({
+    id: '/design',
+    path: '/design',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamDashboardRoute =
+  AuthenticatedAppTeamDashboardRouteImport.update({
+    id: '/dashboard',
+    path: '/dashboard',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowRouteRoute =
   PublicPlanXDomainTeamFlowRouteRouteImport.update({
@@ -303,88 +285,41 @@ const PublicPlanXDomainTeamFlowRouteRoute =
     path: '/$team/$flow',
     getParentRoute: () => rootRouteImport,
   } as any)
-const PublicPlanXDomainDownloadSubmissionIndexRoute =
-  PublicPlanXDomainDownloadSubmissionIndexRouteImport.update({
-    id: '/_public/_planXDomain/download-submission/',
-    path: '/download-submission/',
-    getParentRoute: () => rootRouteImport,
+const PublicCustomDomainFlowPayRouteRoute =
+  PublicCustomDomainFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
-    id: '/_flowEditor',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowAboutRoute =
-  AuthenticatedAppTeamFlowAboutRouteImport.update({
-    id: '/about',
-    path: '/about',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFeedbackRoute =
-  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
-    id: '/feedback',
-    path: '/feedback',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsRouteRoute =
-  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSubmissionsRoute =
-  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
+const AuthenticatedAppTeamSubmissionsRouteRoute =
+  AuthenticatedAppTeamSubmissionsRouteRouteImport.update({
     id: '/submissions',
     path: '/submissions',
-    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsIndexRoute =
-  AuthenticatedAppTeamSettingsIndexRouteImport.update({
+const AuthenticatedAppTeamSettingsRouteRoute =
+  AuthenticatedAppTeamSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowRouteRoute =
+  AuthenticatedAppTeamFlowRouteRouteImport.update({
+    id: '/$flow',
+    path: '/$flow',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowIndexRoute =
+  PublicPlanXDomainTeamFlowIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamSettingsAdvancedRoute =
-  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
-    id: '/advanced',
-    path: '/advanced',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsContactRoute =
-  AuthenticatedAppTeamSettingsContactRouteImport.update({
-    id: '/contact',
-    path: '/contact',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsDesignRoute =
-  AuthenticatedAppTeamSettingsDesignRouteImport.update({
-    id: '/design',
-    path: '/design',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsGisDataRoute =
-  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
-    id: '/gis-data',
-    path: '/gis-data',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsIntegrationsRoute =
-  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
-    id: '/integrations',
-    path: '/integrations',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSettingsPaymentsRoute =
-  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
-    id: '/payments',
-    path: '/payments',
-    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamSubmissionSessionIdRoute =
-  AuthenticatedAppTeamSubmissionSessionIdRouteImport.update({
-    id: '/submission/$sessionId',
-    path: '/submission/$sessionId',
-    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
+const PublicCustomDomainFlowPayIndexRoute =
+  PublicCustomDomainFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
 const AuthenticatedAppTeamSubmissionsIndexRoute =
   AuthenticatedAppTeamSubmissionsIndexRouteImport.update({
@@ -392,22 +327,16 @@ const AuthenticatedAppTeamSubmissionsIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
   } as any)
-const AuthenticatedAppTeamSubmissionsSessionIdRoute =
-  AuthenticatedAppTeamSubmissionsSessionIdRouteImport.update({
-    id: '/$sessionId',
-    path: '/$sessionId',
-    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPagesPageRoute =
-  PublicCustomDomainFlowPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayIndexRoute =
-  PublicCustomDomainFlowPayIndexRouteImport.update({
+const AuthenticatedAppTeamSettingsIndexRoute =
+  AuthenticatedAppTeamSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayViewApplicationRoute =
+  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
     getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
 const PublicCustomDomainFlowPayNotFoundRoute =
@@ -416,28 +345,82 @@ const PublicCustomDomainFlowPayNotFoundRoute =
     path: '/not-found',
     getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicCustomDomainFlowPayViewApplicationRoute =
-  PublicCustomDomainFlowPayViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+const PublicCustomDomainFlowPagesPageRoute =
+  PublicCustomDomainFlowPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowIndexRoute =
-  PublicPlanXDomainTeamFlowIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamViewSubmissionSessionIdRoute =
+  AuthenticatedAppTeamViewSubmissionSessionIdRouteImport.update({
+    id: '/view-submission/$sessionId',
+    path: '/view-submission/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowDraftRouteRoute =
-  PublicPlanXDomainTeamFlowDraftRouteRouteImport.update({
-    id: '/draft',
-    path: '/draft',
-    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+const AuthenticatedAppTeamSubmissionsSessionIdRoute =
+  AuthenticatedAppTeamSubmissionsSessionIdRouteImport.update({
+    id: '/$sessionId',
+    path: '/$sessionId',
+    getParentRoute: () => AuthenticatedAppTeamSubmissionsRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayRouteRoute =
-  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
-    id: '/pay',
-    path: '/pay',
+const AuthenticatedAppTeamSettingsPaymentsRoute =
+  AuthenticatedAppTeamSettingsPaymentsRouteImport.update({
+    id: '/payments',
+    path: '/payments',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsIntegrationsRoute =
+  AuthenticatedAppTeamSettingsIntegrationsRouteImport.update({
+    id: '/integrations',
+    path: '/integrations',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsGisDataRoute =
+  AuthenticatedAppTeamSettingsGisDataRouteImport.update({
+    id: '/gis-data',
+    path: '/gis-data',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsDesignRoute =
+  AuthenticatedAppTeamSettingsDesignRouteImport.update({
+    id: '/design',
+    path: '/design',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsContactRoute =
+  AuthenticatedAppTeamSettingsContactRouteImport.update({
+    id: '/contact',
+    path: '/contact',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamSettingsAdvancedRoute =
+  AuthenticatedAppTeamSettingsAdvancedRouteImport.update({
+    id: '/advanced',
+    path: '/advanced',
+    getParentRoute: () => AuthenticatedAppTeamSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSubmissionsRoute =
+  AuthenticatedAppTeamFlowSubmissionsRouteImport.update({
+    id: '/submissions',
+    path: '/submissions',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFeedbackRoute =
+  AuthenticatedAppTeamFlowFeedbackRouteImport.update({
+    id: '/feedback',
+    path: '/feedback',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowAboutRoute =
+  AuthenticatedAppTeamFlowAboutRouteImport.update({
+    id: '/about',
+    path: '/about',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedRouteRoute =
+  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
+    id: '/published',
+    path: '/published',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPreviewRouteRoute =
@@ -446,83 +429,46 @@ const PublicPlanXDomainTeamFlowPreviewRouteRoute =
     path: '/preview',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedRouteRoute =
-  PublicPlanXDomainTeamFlowPublishedRouteRouteImport.update({
-    id: '/published',
-    path: '/published',
+const PublicPlanXDomainTeamFlowPayRouteRoute =
+  PublicPlanXDomainTeamFlowPayRouteRouteImport.update({
+    id: '/pay',
+    path: '/pay',
     getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorIndexRoute =
-  AuthenticatedAppTeamFlowFlowEditorIndexRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftRouteRoute =
+  PublicPlanXDomainTeamFlowDraftRouteRouteImport.update({
+    id: '/draft',
+    path: '/draft',
+    getParentRoute: () => PublicPlanXDomainTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsRouteRoute =
+  AuthenticatedAppTeamFlowSettingsRouteRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorRouteRouteImport.update({
+    id: '/_flowEditor',
+    getParentRoute: () => AuthenticatedAppTeamFlowRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedIndexRoute =
+  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport.update({
-    id: '/nodes',
-    path: '/nodes',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
-    id: '/note',
-    path: '/note',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsIndexRoute =
-  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
+const PublicPlanXDomainTeamFlowPreviewIndexRoute =
+  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowSettingsAboutRoute =
-  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
-    id: '/about',
-    path: '/about',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsEmailsRoute =
-  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
-    id: '/emails',
-    path: '/emails',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
-  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
-    id: '/legal-disclaimer',
-    path: '/legal-disclaimer',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
-  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
-    id: '/templates',
-    path: '/templates',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
-  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
-    id: '/visibility',
-    path: '/visibility',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteIndexRoute =
-  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
-    id: '/invite/',
-    path: '/invite/',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInviteFailedRoute =
-  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
-    id: '/invite/failed',
-    path: '/invite/failed',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayPagesPageRoute =
-  PublicCustomDomainFlowPayPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+const PublicPlanXDomainTeamFlowPayIndexRoute =
+  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowDraftIndexRoute =
   PublicPlanXDomainTeamFlowDraftIndexRouteImport.update({
@@ -530,16 +476,40 @@ const PublicPlanXDomainTeamFlowDraftIndexRoute =
     path: '/',
     getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
-  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+const PublicCustomDomainFlowPayInviteIndexRoute =
+  PublicCustomDomainFlowPayInviteIndexRouteImport.update({
+    id: '/invite/',
+    path: '/invite/',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayIndexRoute =
-  PublicPlanXDomainTeamFlowPayIndexRouteImport.update({
+const AuthenticatedAppTeamFlowSettingsIndexRoute =
+  AuthenticatedAppTeamFlowSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorIndexRoute =
+  AuthenticatedAppTeamFlowFlowEditorIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
+  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
+    id: '/view-application',
+    path: '/view-application',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayNotFoundRoute =
@@ -548,70 +518,88 @@ const PublicPlanXDomainTeamFlowPayNotFoundRoute =
     path: '/not-found',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPayViewApplicationRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftViewApplicationRoute =
+  PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport.update({
     id: '/view-application',
     path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPreviewIndexRoute =
-  PublicPlanXDomainTeamFlowPreviewIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPreviewViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedIndexRoute =
-  PublicPlanXDomainTeamFlowPublishedIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowPublishedViewApplicationRoute =
-  PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport.update({
-    id: '/view-application',
-    path: '/view-application',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
-  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
-    id: '/add',
-    path: '/add',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
-  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
-    id: '/pages/help',
-    path: '/pages/help',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
-  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
-    id: '/pages/privacy',
-    path: '/pages/privacy',
-    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
-  } as any)
-const PublicCustomDomainFlowPayInvitePagesPageRoute =
-  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
-    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
-  } as any)
-const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
-  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
+const PublicCustomDomainFlowPayPagesPageRoute =
+  PublicCustomDomainFlowPayPagesPageRouteImport.update({
     id: '/pages/$page',
     path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const PublicCustomDomainFlowPayInviteFailedRoute =
+  PublicCustomDomainFlowPayInviteFailedRouteImport.update({
+    id: '/invite/failed',
+    path: '/invite/failed',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsVisibilityRoute =
+  AuthenticatedAppTeamFlowSettingsVisibilityRouteImport.update({
+    id: '/visibility',
+    path: '/visibility',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsTemplatesRoute =
+  AuthenticatedAppTeamFlowSettingsTemplatesRouteImport.update({
+    id: '/templates',
+    path: '/templates',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsLegalDisclaimerRoute =
+  AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport.update({
+    id: '/legal-disclaimer',
+    path: '/legal-disclaimer',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsEmailsRoute =
+  AuthenticatedAppTeamFlowSettingsEmailsRouteImport.update({
+    id: '/emails',
+    path: '/emails',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowSettingsAboutRoute =
+  AuthenticatedAppTeamFlowSettingsAboutRouteImport.update({
+    id: '/about',
+    path: '/about',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport.update({
+    id: '/note',
+    path: '/note',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport.update({
+    id: '/nodes',
+    path: '/nodes',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayInviteIndexRoute =
   PublicPlanXDomainTeamFlowPayInviteIndexRouteImport.update({
     id: '/invite/',
     path: '/invite/',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
+  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
+  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+  } as any)
+const PublicPlanXDomainTeamFlowPayPagesPageRoute =
+  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
+    id: '/pages/$page',
+    path: '/pages/$page',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
@@ -620,29 +608,35 @@ const PublicPlanXDomainTeamFlowPayInviteFailedRoute =
     path: '/invite/failed',
     getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayPagesPageRoute =
-  PublicPlanXDomainTeamFlowPayPagesPageRouteImport.update({
+const PublicPlanXDomainTeamFlowDraftPagesPageRoute =
+  PublicPlanXDomainTeamFlowDraftPagesPageRouteImport.update({
     id: '/pages/$page',
     path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+    getParentRoute: () => PublicPlanXDomainTeamFlowDraftRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPreviewPagesPageRoute =
-  PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPreviewRouteRoute,
+const PublicCustomDomainFlowPayInvitePagesPageRoute =
+  PublicCustomDomainFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicCustomDomainFlowPayRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPublishedPagesPageRoute =
-  PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport.update({
-    id: '/pages/$page',
-    path: '/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPublishedRouteRoute,
+const AuthenticatedAppTeamFlowSettingsPagesPrivacyRoute =
+  AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport.update({
+    id: '/pages/privacy',
+    path: '/pages/privacy',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport.update({
-    id: '/$id/edit',
-    path: '/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+const AuthenticatedAppTeamFlowSettingsPagesHelpRoute =
+  AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport.update({
+    id: '/pages/help',
+    path: '/pages/help',
+    getParentRoute: () => AuthenticatedAppTeamFlowSettingsRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNoteAddRoute =
+  AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport.update({
+    id: '/add',
+    path: '/add',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport.update({
@@ -650,11 +644,11 @@ const AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRoute =
     path: '/new/',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
-    id: '/new/$before',
-    path: '/new/$before',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
+  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
+    id: '/invite/pages/$page',
+    path: '/invite/pages/$page',
+    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
   AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport.update({
@@ -662,23 +656,23 @@ const AuthenticatedAppTeamFlowFlowEditorNoteIdEditRoute =
     path: '/$id/edit',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute,
   } as any)
-const PublicPlanXDomainTeamFlowPayInvitePagesPageRoute =
-  PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport.update({
-    id: '/invite/pages/$page',
-    path: '/invite/pages/$page',
-    getParentRoute: () => PublicPlanXDomainTeamFlowPayRouteRoute,
+const AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport.update({
+    id: '/new/$before',
+    path: '/new/$before',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
+const AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport.update({
+    id: '/$id/edit',
+    path: '/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport.update({
     id: '/$before',
     path: '/$before',
     getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute,
-  } as any)
-const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
-  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
-    id: '/$parent/nodes/$id/edit',
-    path: '/$parent/nodes/$id/edit',
-    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
   } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewIndexRouteImport.update({
@@ -694,6 +688,12 @@ const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRoute =
       getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
     } as any,
   )
+const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRoute =
+  AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport.update({
+    id: '/$parent/nodes/$id/edit',
+    path: '/$parent/nodes/$id/edit',
+    getParentRoute: () => AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute,
+  } as any)
 const AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRoute =
   AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditBeforeRouteImport.update(
     {
@@ -716,7 +716,7 @@ export interface FileRoutesByFullPath {
   '/app/admin-panel': typeof AuthenticatedAppAdminPanelRoute
   '/app/users': typeof AuthenticatedAppUsersRoute
   '/app/': typeof AuthenticatedAppIndexRoute
-  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowRouteRouteWithChildren
+  '/app/$team/$flow': typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteWithChildren
   '/app/$team/settings': typeof AuthenticatedAppTeamSettingsRouteRouteWithChildren
   '/app/$team/submissions': typeof AuthenticatedAppTeamSubmissionsRouteRouteWithChildren
   '/$flow/pay': typeof PublicCustomDomainFlowPayRouteRouteWithChildren
@@ -1293,13 +1293,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/$': {
       id: '/$'
       path: '/$'
@@ -1314,11 +1307,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(auth)/login': {
-      id: '/(auth)/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof authLoginRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(auth)/logout': {
@@ -1328,12 +1321,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authLogoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/app': {
-      id: '/_authenticated/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
+    '/(auth)/login': {
+      id: '/(auth)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof authLoginRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_public/_customDomain': {
       id: '/_public/_customDomain'
@@ -1342,32 +1335,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicCustomDomainRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/app': {
+      id: '/_authenticated/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AuthenticatedAppRouteRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/app/': {
       id: '/_authenticated/app/'
       path: '/'
       fullPath: '/app/'
       preLoaderRoute: typeof AuthenticatedAppIndexRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/$team': {
-      id: '/_authenticated/app/$team'
-      path: '/$team'
-      fullPath: '/app/$team'
-      preLoaderRoute: typeof AuthenticatedAppTeamRouteRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/admin-panel': {
-      id: '/_authenticated/app/admin-panel'
-      path: '/admin-panel'
-      fullPath: '/app/admin-panel'
-      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
-      parentRoute: typeof AuthenticatedAppRouteRoute
-    }
-    '/_authenticated/app/global-settings': {
-      id: '/_authenticated/app/global-settings'
-      path: '/global-settings'
-      fullPath: '/app/global-settings'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
     '/_authenticated/app/users': {
@@ -1377,12 +1356,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppUsersRouteImport
       parentRoute: typeof AuthenticatedAppRouteRoute
     }
+    '/_authenticated/app/admin-panel': {
+      id: '/_authenticated/app/admin-panel'
+      path: '/admin-panel'
+      fullPath: '/app/admin-panel'
+      preLoaderRoute: typeof AuthenticatedAppAdminPanelRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
     '/_public/_customDomain/$flow': {
       id: '/_public/_customDomain/$flow'
       path: '/$flow'
       fullPath: '/$flow'
       preLoaderRoute: typeof PublicCustomDomainFlowRouteRouteImport
       parentRoute: typeof PublicCustomDomainRouteRoute
+    }
+    '/_authenticated/app/global-settings': {
+      id: '/_authenticated/app/global-settings'
+      path: '/global-settings'
+      fullPath: '/app/global-settings'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
+    '/_authenticated/app/$team': {
+      id: '/_authenticated/app/$team'
+      path: '/$team'
+      fullPath: '/app/$team'
+      preLoaderRoute: typeof AuthenticatedAppTeamRouteRouteImport
+      parentRoute: typeof AuthenticatedAppRouteRoute
+    }
+    '/_public/_planXDomain/download-submission/': {
+      id: '/_public/_planXDomain/download-submission/'
+      path: '/download-submission'
+      fullPath: '/download-submission/'
+      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_public/_customDomain/$flow/': {
+      id: '/_public/_customDomain/$flow/'
+      path: '/'
+      fullPath: '/$flow/'
+      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    }
+    '/_authenticated/app/global-settings/': {
+      id: '/_authenticated/app/global-settings/'
+      path: '/'
+      fullPath: '/app/global-settings/'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
     }
     '/_authenticated/app/$team/': {
       id: '/_authenticated/app/$team/'
@@ -1391,88 +1412,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/$flow': {
-      id: '/_authenticated/app/$team/$flow'
-      path: '/$flow'
-      fullPath: '/app/$team/$flow'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    '/_public/_customDomain/$flow/view-application': {
+      id: '/_public/_customDomain/$flow/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_authenticated/app/$team/dashboard': {
-      id: '/_authenticated/app/$team/dashboard'
-      path: '/dashboard'
-      fullPath: '/app/$team/dashboard'
-      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    '/_authenticated/app/global-settings/footer': {
+      id: '/_authenticated/app/global-settings/footer'
+      path: '/footer'
+      fullPath: '/app/global-settings/footer'
+      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
+      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
     }
-    '/_authenticated/app/$team/design': {
-      id: '/_authenticated/app/$team/design'
-      path: '/design'
-      fullPath: '/app/$team/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/explore': {
-      id: '/_authenticated/app/$team/explore'
-      path: '/explore'
-      fullPath: '/app/$team/explore'
-      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/feedback': {
-      id: '/_authenticated/app/$team/feedback'
-      path: '/feedback'
-      fullPath: '/app/$team/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/flows': {
-      id: '/_authenticated/app/$team/flows'
-      path: '/flows'
-      fullPath: '/app/$team/flows'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/members': {
-      id: '/_authenticated/app/$team/members'
-      path: '/members'
-      fullPath: '/app/$team/members'
-      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/notifications': {
-      id: '/_authenticated/app/$team/notifications'
-      path: '/notifications'
-      fullPath: '/app/$team/notifications'
-      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/onboarding': {
-      id: '/_authenticated/app/$team/onboarding'
-      path: '/onboarding'
-      fullPath: '/app/$team/onboarding'
-      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/resources': {
-      id: '/_authenticated/app/$team/resources'
-      path: '/resources'
-      fullPath: '/app/$team/resources'
-      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/settings': {
-      id: '/_authenticated/app/$team/settings'
-      path: '/settings'
-      fullPath: '/app/$team/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamRouteRoute
-    }
-    '/_authenticated/app/$team/submissions': {
-      id: '/_authenticated/app/$team/submissions'
-      path: '/submissions'
-      fullPath: '/app/$team/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteImport
+    '/_authenticated/app/$team/tutorials': {
+      id: '/_authenticated/app/$team/tutorials'
+      path: '/tutorials'
+      fullPath: '/app/$team/tutorials'
+      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
     '/_authenticated/app/$team/subscription': {
@@ -1482,47 +1440,68 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamSubscriptionRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/$team/tutorials': {
-      id: '/_authenticated/app/$team/tutorials'
-      path: '/tutorials'
-      fullPath: '/app/$team/tutorials'
-      preLoaderRoute: typeof AuthenticatedAppTeamTutorialsRouteImport
+    '/_authenticated/app/$team/resources': {
+      id: '/_authenticated/app/$team/resources'
+      path: '/resources'
+      fullPath: '/app/$team/resources'
+      preLoaderRoute: typeof AuthenticatedAppTeamResourcesRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/global-settings/': {
-      id: '/_authenticated/app/global-settings/'
-      path: '/'
-      fullPath: '/app/global-settings/'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    '/_authenticated/app/$team/onboarding': {
+      id: '/_authenticated/app/$team/onboarding'
+      path: '/onboarding'
+      fullPath: '/app/$team/onboarding'
+      preLoaderRoute: typeof AuthenticatedAppTeamOnboardingRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_authenticated/app/global-settings/footer': {
-      id: '/_authenticated/app/global-settings/footer'
-      path: '/footer'
-      fullPath: '/app/global-settings/footer'
-      preLoaderRoute: typeof AuthenticatedAppGlobalSettingsFooterRouteImport
-      parentRoute: typeof AuthenticatedAppGlobalSettingsRouteRoute
+    '/_authenticated/app/$team/notifications': {
+      id: '/_authenticated/app/$team/notifications'
+      path: '/notifications'
+      fullPath: '/app/$team/notifications'
+      preLoaderRoute: typeof AuthenticatedAppTeamNotificationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/': {
-      id: '/_public/_customDomain/$flow/'
-      path: '/'
-      fullPath: '/$flow/'
-      preLoaderRoute: typeof PublicCustomDomainFlowIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/members': {
+      id: '/_authenticated/app/$team/members'
+      path: '/members'
+      fullPath: '/app/$team/members'
+      preLoaderRoute: typeof AuthenticatedAppTeamMembersRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/pay': {
-      id: '/_public/_customDomain/$flow/pay'
-      path: '/pay'
-      fullPath: '/$flow/pay'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/flows': {
+      id: '/_authenticated/app/$team/flows'
+      path: '/flows'
+      fullPath: '/app/$team/flows'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_customDomain/$flow/view-application': {
-      id: '/_public/_customDomain/$flow/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
+    '/_authenticated/app/$team/feedback': {
+      id: '/_authenticated/app/$team/feedback'
+      path: '/feedback'
+      fullPath: '/app/$team/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/explore': {
+      id: '/_authenticated/app/$team/explore'
+      path: '/explore'
+      fullPath: '/app/$team/explore'
+      preLoaderRoute: typeof AuthenticatedAppTeamExploreRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/design': {
+      id: '/_authenticated/app/$team/design'
+      path: '/design'
+      fullPath: '/app/$team/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/dashboard': {
+      id: '/_authenticated/app/$team/dashboard'
+      path: '/dashboard'
+      fullPath: '/app/$team/dashboard'
+      preLoaderRoute: typeof AuthenticatedAppTeamDashboardRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
     '/_public/_planXDomain/$team/$flow': {
       id: '/_public/_planXDomain/$team/$flow'
@@ -1531,103 +1510,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_public/_planXDomain/download-submission/': {
-      id: '/_public/_planXDomain/download-submission/'
-      path: '/download-submission'
-      fullPath: '/download-submission/'
-      preLoaderRoute: typeof PublicPlanXDomainDownloadSubmissionIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_public/_customDomain/$flow/pay': {
+      id: '/_public/_customDomain/$flow/pay'
+      path: '/pay'
+      fullPath: '/$flow/pay'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayRouteRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor'
-      path: ''
-      fullPath: '/app/$team/$flow'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/about': {
-      id: '/_authenticated/app/$team/$flow/about'
-      path: '/about'
-      fullPath: '/app/$team/$flow/about'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowAboutRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/feedback': {
-      id: '/_authenticated/app/$team/$flow/feedback'
-      path: '/feedback'
-      fullPath: '/app/$team/$flow/feedback'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings': {
-      id: '/_authenticated/app/$team/$flow/settings'
-      path: '/settings'
-      fullPath: '/app/$team/$flow/settings'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/submissions': {
-      id: '/_authenticated/app/$team/$flow/submissions'
+    '/_authenticated/app/$team/submissions': {
+      id: '/_authenticated/app/$team/submissions'
       path: '/submissions'
-      fullPath: '/app/$team/$flow/submissions'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
-    }
-    '/_authenticated/app/$team/settings/': {
-      id: '/_authenticated/app/$team/settings/'
-      path: '/'
-      fullPath: '/app/$team/settings/'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/advanced': {
-      id: '/_authenticated/app/$team/settings/advanced'
-      path: '/advanced'
-      fullPath: '/app/$team/settings/advanced'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/contact': {
-      id: '/_authenticated/app/$team/settings/contact'
-      path: '/contact'
-      fullPath: '/app/$team/settings/contact'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/design': {
-      id: '/_authenticated/app/$team/settings/design'
-      path: '/design'
-      fullPath: '/app/$team/settings/design'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/gis-data': {
-      id: '/_authenticated/app/$team/settings/gis-data'
-      path: '/gis-data'
-      fullPath: '/app/$team/settings/gis-data'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/integrations': {
-      id: '/_authenticated/app/$team/settings/integrations'
-      path: '/integrations'
-      fullPath: '/app/$team/settings/integrations'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/settings/payments': {
-      id: '/_authenticated/app/$team/settings/payments'
-      path: '/payments'
-      fullPath: '/app/$team/settings/payments'
-      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/submission/$sessionId': {
-      id: '/_authenticated/app/$team/submission/$sessionId'
-      path: '/submission/$sessionId'
-      fullPath: '/app/$team/submission/$sessionId'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionSessionIdRouteImport
+      fullPath: '/app/$team/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsRouteRouteImport
       parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/settings': {
+      id: '/_authenticated/app/$team/settings'
+      path: '/settings'
+      fullPath: '/app/$team/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_authenticated/app/$team/$flow': {
+      id: '/_authenticated/app/$team/$flow'
+      path: '/$flow'
+      fullPath: '/app/$team/$flow'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/': {
+      id: '/_public/_planXDomain/$team/$flow/'
+      path: '/'
+      fullPath: '/$team/$flow/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/': {
+      id: '/_public/_customDomain/$flow/pay/'
+      path: '/'
+      fullPath: '/$flow/pay/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
     '/_authenticated/app/$team/submissions/': {
       id: '/_authenticated/app/$team/submissions/'
@@ -1636,25 +1559,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
     }
-    '/_authenticated/app/$team/submissions/$sessionId': {
-      id: '/_authenticated/app/$team/submissions/$sessionId'
-      path: '/$sessionId'
-      fullPath: '/app/$team/submissions/$sessionId'
-      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRouteImport
-      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pages/$page': {
-      id: '/_public/_customDomain/$flow/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/': {
-      id: '/_public/_customDomain/$flow/pay/'
+    '/_authenticated/app/$team/settings/': {
+      id: '/_authenticated/app/$team/settings/'
       path: '/'
-      fullPath: '/$flow/pay/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayIndexRouteImport
+      fullPath: '/app/$team/settings/'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_public/_customDomain/$flow/pay/view-application': {
+      id: '/_public/_customDomain/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
     '/_public/_customDomain/$flow/pay/not-found': {
@@ -1664,32 +1580,95 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicCustomDomainFlowPayNotFoundRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_customDomain/$flow/pay/view-application': {
-      id: '/_public/_customDomain/$flow/pay/view-application'
-      path: '/view-application'
-      fullPath: '/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    '/_public/_customDomain/$flow/pages/$page': {
+      id: '/_public/_customDomain/$flow/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/': {
-      id: '/_public/_planXDomain/$team/$flow/'
-      path: '/'
-      fullPath: '/$team/$flow/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/view-submission/$sessionId': {
+      id: '/_authenticated/app/$team/view-submission/$sessionId'
+      path: '/view-submission/$sessionId'
+      fullPath: '/app/$team/view-submission/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamViewSubmissionSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft': {
-      id: '/_public/_planXDomain/$team/$flow/draft'
-      path: '/draft'
-      fullPath: '/$team/$flow/draft'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    '/_authenticated/app/$team/submissions/$sessionId': {
+      id: '/_authenticated/app/$team/submissions/$sessionId'
+      path: '/$sessionId'
+      fullPath: '/app/$team/submissions/$sessionId'
+      preLoaderRoute: typeof AuthenticatedAppTeamSubmissionsSessionIdRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSubmissionsRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay': {
-      id: '/_public/_planXDomain/$team/$flow/pay'
-      path: '/pay'
-      fullPath: '/$team/$flow/pay'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
+    '/_authenticated/app/$team/settings/payments': {
+      id: '/_authenticated/app/$team/settings/payments'
+      path: '/payments'
+      fullPath: '/app/$team/settings/payments'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsPaymentsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/integrations': {
+      id: '/_authenticated/app/$team/settings/integrations'
+      path: '/integrations'
+      fullPath: '/app/$team/settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/gis-data': {
+      id: '/_authenticated/app/$team/settings/gis-data'
+      path: '/gis-data'
+      fullPath: '/app/$team/settings/gis-data'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsGisDataRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/design': {
+      id: '/_authenticated/app/$team/settings/design'
+      path: '/design'
+      fullPath: '/app/$team/settings/design'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsDesignRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/contact': {
+      id: '/_authenticated/app/$team/settings/contact'
+      path: '/contact'
+      fullPath: '/app/$team/settings/contact'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsContactRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/settings/advanced': {
+      id: '/_authenticated/app/$team/settings/advanced'
+      path: '/advanced'
+      fullPath: '/app/$team/settings/advanced'
+      preLoaderRoute: typeof AuthenticatedAppTeamSettingsAdvancedRouteImport
+      parentRoute: typeof AuthenticatedAppTeamSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/submissions': {
+      id: '/_authenticated/app/$team/$flow/submissions'
+      path: '/submissions'
+      fullPath: '/app/$team/$flow/submissions'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSubmissionsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/feedback': {
+      id: '/_authenticated/app/$team/$flow/feedback'
+      path: '/feedback'
+      fullPath: '/app/$team/$flow/feedback'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFeedbackRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/about': {
+      id: '/_authenticated/app/$team/$flow/about'
+      path: '/about'
+      fullPath: '/app/$team/$flow/about'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowAboutRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published': {
+      id: '/_public/_planXDomain/$team/$flow/published'
+      path: '/published'
+      fullPath: '/$team/$flow/published'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/preview': {
@@ -1699,96 +1678,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published': {
-      id: '/_public/_planXDomain/$team/$flow/published'
-      path: '/published'
-      fullPath: '/$team/$flow/published'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRouteImport
+    '/_public/_planXDomain/$team/$flow/pay': {
+      id: '/_public/_planXDomain/$team/$flow/pay'
+      path: '/pay'
+      fullPath: '/$team/$flow/pay'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayRouteRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/'
+    '/_public/_planXDomain/$team/$flow/draft': {
+      id: '/_public/_planXDomain/$team/$flow/draft'
+      path: '/draft'
+      fullPath: '/$team/$flow/draft'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings': {
+      id: '/_authenticated/app/$team/$flow/settings'
+      path: '/settings'
+      fullPath: '/app/$team/$flow/settings'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor'
+      path: ''
+      fullPath: '/app/$team/$flow'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/': {
+      id: '/_public/_planXDomain/$team/$flow/published/'
       path: '/'
-      fullPath: '/app/$team/$flow/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+      fullPath: '/$team/$flow/published/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes'
-      path: '/nodes'
-      fullPath: '/app/$team/$flow/nodes'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
-      path: '/note'
-      fullPath: '/app/$team/$flow/note'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/': {
-      id: '/_authenticated/app/$team/$flow/settings/'
+    '/_public/_planXDomain/$team/$flow/preview/': {
+      id: '/_public/_planXDomain/$team/$flow/preview/'
       path: '/'
-      fullPath: '/app/$team/$flow/settings/'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+      fullPath: '/$team/$flow/preview/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
     }
-    '/_authenticated/app/$team/$flow/settings/about': {
-      id: '/_authenticated/app/$team/$flow/settings/about'
-      path: '/about'
-      fullPath: '/app/$team/$flow/settings/about'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/emails': {
-      id: '/_authenticated/app/$team/$flow/settings/emails'
-      path: '/emails'
-      fullPath: '/app/$team/$flow/settings/emails'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
-      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
-      path: '/legal-disclaimer'
-      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/templates': {
-      id: '/_authenticated/app/$team/$flow/settings/templates'
-      path: '/templates'
-      fullPath: '/app/$team/$flow/settings/templates'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/visibility': {
-      id: '/_authenticated/app/$team/$flow/settings/visibility'
-      path: '/visibility'
-      fullPath: '/app/$team/$flow/settings/visibility'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/': {
-      id: '/_public/_customDomain/$flow/pay/invite/'
-      path: '/invite'
-      fullPath: '/$flow/pay/invite/'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/failed': {
-      id: '/_public/_customDomain/$flow/pay/invite/failed'
-      path: '/invite/failed'
-      fullPath: '/$flow/pay/invite/failed'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
-      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    '/_public/_planXDomain/$team/$flow/pay/': {
+      id: '/_public/_planXDomain/$team/$flow/pay/'
+      path: '/'
+      fullPath: '/$team/$flow/pay/'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/draft/': {
       id: '/_public/_planXDomain/$team/$flow/draft/'
@@ -1797,18 +1734,46 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftIndexRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/draft/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/': {
+      id: '/_public/_customDomain/$flow/pay/invite/'
+      path: '/invite'
+      fullPath: '/$flow/pay/invite/'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteIndexRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/': {
-      id: '/_public/_planXDomain/$team/$flow/pay/'
+    '/_authenticated/app/$team/$flow/settings/': {
+      id: '/_authenticated/app/$team/$flow/settings/'
       path: '/'
-      fullPath: '/$team/$flow/pay/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayIndexRouteImport
+      fullPath: '/app/$team/$flow/settings/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/'
+      path: '/'
+      fullPath: '/app/$team/$flow/'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorIndexRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/published/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/published/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/preview/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
+      path: '/view-application'
+      fullPath: '/$team/$flow/pay/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/not-found': {
@@ -1818,81 +1783,102 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayNotFoundRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/pay/view-application'
+    '/_public/_planXDomain/$team/$flow/draft/view-application': {
+      id: '/_public/_planXDomain/$team/$flow/draft/view-application'
       path: '/view-application'
-      fullPath: '/$team/$flow/pay/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+      fullPath: '/$team/$flow/draft/view-application'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftViewApplicationRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/preview/': {
-      id: '/_public/_planXDomain/$team/$flow/preview/'
-      path: '/'
-      fullPath: '/$team/$flow/preview/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/preview/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/preview/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/preview/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/': {
-      id: '/_public/_planXDomain/$team/$flow/published/'
-      path: '/'
-      fullPath: '/$team/$flow/published/'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedIndexRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_public/_planXDomain/$team/$flow/published/view-application': {
-      id: '/_public/_planXDomain/$team/$flow/published/view-application'
-      path: '/view-application'
-      fullPath: '/$team/$flow/published/view-application'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedViewApplicationRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
-      path: '/add'
-      fullPath: '/app/$team/$flow/note/add'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/help': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/help'
-      path: '/pages/help'
-      fullPath: '/app/$team/$flow/settings/pages/help'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
-      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
-      path: '/pages/privacy'
-      fullPath: '/app/$team/$flow/settings/pages/privacy'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
-    }
-    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
-      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
+    '/_public/_customDomain/$flow/pay/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayPagesPageRouteImport
       parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/draft/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/failed': {
+      id: '/_public/_customDomain/$flow/pay/invite/failed'
+      path: '/invite/failed'
+      fullPath: '/$flow/pay/invite/failed'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInviteFailedRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/visibility': {
+      id: '/_authenticated/app/$team/$flow/settings/visibility'
+      path: '/visibility'
+      fullPath: '/app/$team/$flow/settings/visibility'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsVisibilityRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/templates': {
+      id: '/_authenticated/app/$team/$flow/settings/templates'
+      path: '/templates'
+      fullPath: '/app/$team/$flow/settings/templates'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsTemplatesRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/legal-disclaimer': {
+      id: '/_authenticated/app/$team/$flow/settings/legal-disclaimer'
+      path: '/legal-disclaimer'
+      fullPath: '/app/$team/$flow/settings/legal-disclaimer'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsLegalDisclaimerRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/emails': {
+      id: '/_authenticated/app/$team/$flow/settings/emails'
+      path: '/emails'
+      fullPath: '/app/$team/$flow/settings/emails'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsEmailsRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/settings/about': {
+      id: '/_authenticated/app/$team/$flow/settings/about'
+      path: '/about'
+      fullPath: '/app/$team/$flow/settings/about'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsAboutRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note'
+      path: '/note'
+      fullPath: '/app/$team/$flow/note'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes'
+      path: '/nodes'
+      fullPath: '/app/$team/$flow/nodes'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/invite/': {
       id: '/_public/_planXDomain/$team/$flow/pay/invite/'
       path: '/invite'
       fullPath: '/$team/$flow/pay/invite/'
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteIndexRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/published/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/preview/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    }
+    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
+      path: '/pages/$page'
+      fullPath: '/$team/$flow/pay/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_public/_planXDomain/$team/$flow/pay/invite/failed': {
@@ -1902,33 +1888,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInviteFailedRouteImport
       parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/pages/$page'
+    '/_public/_planXDomain/$team/$flow/draft/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/draft/pages/$page'
       path: '/pages/$page'
-      fullPath: '/$team/$flow/pay/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+      fullPath: '/$team/$flow/draft/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowDraftPagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowDraftRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/preview/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/preview/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/preview/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPreviewPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPreviewRouteRoute
+    '/_public/_customDomain/$flow/pay/invite/pages/$page': {
+      id: '/_public/_customDomain/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicCustomDomainFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicCustomDomainFlowPayRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/published/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/published/pages/$page'
-      path: '/pages/$page'
-      fullPath: '/$team/$flow/published/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPublishedPagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPublishedRouteRoute
+    '/_authenticated/app/$team/$flow/settings/pages/privacy': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/privacy'
+      path: '/pages/privacy'
+      fullPath: '/app/$team/$flow/settings/pages/privacy'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesPrivacyRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit'
-      path: '/$id/edit'
-      fullPath: '/app/$team/$flow/nodes/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    '/_authenticated/app/$team/$flow/settings/pages/help': {
+      id: '/_authenticated/app/$team/$flow/settings/pages/help'
+      path: '/pages/help'
+      fullPath: '/app/$team/$flow/settings/pages/help'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowSettingsPagesHelpRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowSettingsRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/note/add': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/note/add'
+      path: '/add'
+      fullPath: '/app/$team/$flow/note/add'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteAddRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/'
@@ -1937,12 +1930,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewIndexRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
-      path: '/new/$before'
-      fullPath: '/app/$team/$flow/nodes/new/$before'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
+      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
+      path: '/invite/pages/$page'
+      fullPath: '/$team/$flow/pay/invite/pages/$page'
+      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
+      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/note/$id/edit'
@@ -1951,12 +1944,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNoteRouteRoute
     }
-    '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page': {
-      id: '/_public/_planXDomain/$team/$flow/pay/invite/pages/$page'
-      path: '/invite/pages/$page'
-      fullPath: '/$team/$flow/pay/invite/pages/$page'
-      preLoaderRoute: typeof PublicPlanXDomainTeamFlowPayInvitePagesPageRouteImport
-      parentRoute: typeof PublicPlanXDomainTeamFlowPayRouteRoute
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/new/$before'
+      path: '/new/$before'
+      fullPath: '/app/$team/$flow/nodes/new/$before'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesNewBeforeRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit'
+      path: '/$id/edit'
+      fullPath: '/app/$team/$flow/nodes/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$id/edit/$before'
@@ -1964,13 +1964,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/app/$team/$flow/nodes/$id/edit/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditBeforeRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesIdEditRoute
-    }
-    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
-      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
-      path: '/$parent/nodes/$id/edit'
-      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
-      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
-      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/': {
       id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/new/'
@@ -1984,6 +1977,13 @@ declare module '@tanstack/react-router' {
       path: '/$parent/nodes/new/$before'
       fullPath: '/app/$team/$flow/nodes/$parent/nodes/new/$before'
       preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesNewBeforeRouteImport
+      parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
+    }
+    '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit': {
+      id: '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit'
+      path: '/$parent/nodes/$id/edit'
+      fullPath: '/app/$team/$flow/nodes/$parent/nodes/$id/edit'
+      preLoaderRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesParentNodesIdEditRouteImport
       parentRoute: typeof AuthenticatedAppTeamFlowFlowEditorNodesRouteRoute
     }
     '/_authenticated/app/$team/$flow/_flowEditor/nodes/$parent/nodes/$id/edit/$before': {

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/view-submission/$sessionId.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/view-submission/$sessionId.tsx
@@ -3,7 +3,7 @@ import SubmissionHTML from "pages/FlowEditor/components/Submissions/components/S
 import React from "react";
 
 export const Route = createFileRoute(
-  "/_authenticated/app/$team/submission/$sessionId",
+  "/_authenticated/app/$team/view-submission/$sessionId",
 )({
   loader: async ({ params }) => ({
     sessionId: params.sessionId,

--- a/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
+++ b/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
@@ -1,0 +1,8 @@
+import IconButton from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+
+export const CloseButton = styled(IconButton)(({ theme }) => ({
+  margin: "0 0 0 auto",
+  padding: theme.spacing(1),
+  color: theme.palette.grey[600],
+}));

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
@@ -1,11 +1,11 @@
-import Close from "@mui/icons-material/CloseOutlined";
+import Close from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";
 import React from "react";
+import { CloseButton } from "ui/icons/CloseButton";
 
 interface DataTableModalProps {
   open: boolean;
@@ -13,12 +13,6 @@ interface DataTableModalProps {
   title: string;
   children?: ReactNode;
 }
-
-const CloseButton = styled(IconButton)(({ theme }) => ({
-  margin: "0 0 0 auto",
-  padding: theme.spacing(1),
-  color: theme.palette.grey[600],
-}));
 
 const ModalHeader = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2),


### PR DESCRIPTION
# What's in this PR? 
New button
- Close modal button
    - Refactors / shares `CloseButton` now (there were a couple similar close buttons that existed elsewhere)

Versions of existing buttons; will have `Grouped` suffix removed as a last step / when feature flag comes off
- DownloadSubmissionButtonGrouped
- ViewSubmissionButtonGrouped
- OpenResponseButtonGrouped
- ResubmitButtonGrouped

# Testing
- In the Testing team, I've made a simple submission with some mock applications, please switch the `Grouped_submissions` feature flag on and then view and test modals, buttons, etc.: https://7201.planx.pizza/app/testing/submissions

Locally, I have tested submissions log buttons with feature flag off to ensure no regressions too. 

<img width="600" alt="Screenshot 2026-08-19 130019" src="https://github.com/user-attachments/assets/579403dd-39f2-4bfd-b560-1bbb72fe6975" />

# Next steps
- More manual testing
- Some refactoring / tidying
- Tests!
- Stories
- Remove feature flag and rename / delete parallel features