### PR TITLE
chore(api): Upgrade http-proxy-middleware to v4.2.0

### DIFF
--- a/apps/api.planx.uk/modules/auth/middleware.ts
+++ b/apps/api.planx.uk/modules/auth/middleware.ts
@@ -3,8 +3,8 @@ import assert from "assert";
 import { AsyncLocalStorage } from "async_hooks";
 import crypto from "crypto";
 import type { CookieOptions, Request } from "express";
+import type { RequestHandler } from "express";
 import { expressjwt, type IsRevoked } from "express-jwt";
-import type { RequestHandler } from "http-proxy-middleware";
 import { generators } from "openid-client";
 import type { Authenticator } from "passport";
 

--- a/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
+++ b/apps/api.planx.uk/modules/ordnanceSurvey/controller.ts
@@ -12,8 +12,10 @@ export const useOrdnanceSurveyProxy = async (
 ) =>
   useProxy({
     target: OS_DOMAIN,
-    onProxyRes: (proxyRes) => setCORPHeaders(proxyRes),
-    pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req),
+    on: {
+      proxyRes: (proxyRes) => setCORPHeaders(proxyRes),
+    },
+    pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req as Request),
   })(req, res, next);
 
 const setCORPHeaders = (proxyRes: IncomingMessage): void => {

--- a/apps/api.planx.uk/modules/pay/controller.ts
+++ b/apps/api.planx.uk/modules/pay/controller.ts
@@ -49,22 +49,24 @@ export const makePaymentViaProxy: PaymentProxyController = async (
     {
       pathRewrite: (path) => path.replace(/^\/pay.*$/, ""),
       selfHandleResponse: true,
-      onProxyRes: responseInterceptor(
-        async (responseBuffer, _proxyRes, _req, { statusCode }) => {
-          const responseString = responseBuffer.toString("utf8");
-          const govUkResponse = JSON.parse(responseString);
+      on: {
+        proxyRes: responseInterceptor(
+          async (responseBuffer, _proxyRes, _req, { statusCode }) => {
+            const responseString = responseBuffer.toString("utf8");
+            const govUkResponse = JSON.parse(responseString);
 
-          if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
+            if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
 
-          await logPaymentStatus({
-            sessionId,
-            flowId,
-            teamSlug,
-            govUkResponse,
-          });
-          return responseBuffer;
-        },
-      ),
+            await logPaymentStatus({
+              sessionId,
+              flowId,
+              teamSlug,
+              govUkResponse,
+            });
+            return responseBuffer;
+          },
+        ),
+      },
     },
     req,
     res,
@@ -86,32 +88,34 @@ export const makeInviteToPayPaymentViaProxy: PaymentRequestProxyController = (
     {
       pathRewrite: (path) => path.replace(/^\/pay.*$/, ""),
       selfHandleResponse: true,
-      onProxyRes: responseInterceptor(
-        async (responseBuffer, _proxyRes, _req, { statusCode }) => {
-          const responseString = responseBuffer.toString("utf8");
-          const govUkResponse = JSON.parse(responseString);
+      on: {
+        proxyRes: responseInterceptor(
+          async (responseBuffer, _proxyRes, _req, { statusCode }) => {
+            const responseString = responseBuffer.toString("utf8");
+            const govUkResponse = JSON.parse(responseString);
 
-          if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
+            if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
 
-          await logPaymentStatus({
-            sessionId,
-            flowId,
-            teamSlug,
-            govUkResponse,
-          });
-
-          try {
-            await addGovPayPaymentIdToPaymentRequest(
-              paymentRequestId,
+            await logPaymentStatus({
+              sessionId,
+              flowId,
+              teamSlug,
               govUkResponse,
-            );
-          } catch (error) {
-            throw Error(error as string);
-          }
+            });
 
-          return responseBuffer;
-        },
-      ),
+            try {
+              await addGovPayPaymentIdToPaymentRequest(
+                paymentRequestId,
+                govUkResponse,
+              );
+            } catch (error) {
+              throw Error(error as string);
+            }
+
+            return responseBuffer;
+          },
+        ),
+      },
     },
     req,
     res,
@@ -137,36 +141,38 @@ export function fetchPaymentViaProxyWithCallback(
       {
         pathRewrite: () => `/${req.params.paymentId}`,
         selfHandleResponse: true,
-        onProxyRes: responseInterceptor(
-          async (responseBuffer, _proxyRes, _req, { statusCode }) => {
-            const govUkResponse = JSON.parse(responseBuffer.toString("utf8"));
+        on: {
+          proxyRes: responseInterceptor(
+            async (responseBuffer, _proxyRes, _req, { statusCode }) => {
+              const govUkResponse = JSON.parse(responseBuffer.toString("utf8"));
 
-            if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
+              if (statusCode >= 400) return handleGovPayErrors(govUkResponse);
 
-            await logPaymentStatus({
-              sessionId,
-              flowId,
-              teamSlug,
-              govUkResponse,
-            });
+              await logPaymentStatus({
+                sessionId,
+                flowId,
+                teamSlug,
+                govUkResponse,
+              });
 
-            try {
-              await callback(req, govUkResponse);
-            } catch (e) {
-              throw Error(e as string);
-            }
+              try {
+                await callback(req, govUkResponse);
+              } catch (e) {
+                throw Error(e as string);
+              }
 
-            // only return payment status, filter out PII
-            return JSON.stringify({
-              payment_id: govUkResponse.payment_id,
-              amount: govUkResponse.amount,
-              state: govUkResponse.state,
-              _links: {
-                next_url: govUkResponse._links?.next_url,
-              },
-            });
-          },
-        ),
+              // only return payment status, filter out PII
+              return JSON.stringify({
+                payment_id: govUkResponse.payment_id,
+                amount: govUkResponse.amount,
+                state: govUkResponse.state,
+                _links: {
+                  next_url: govUkResponse._links?.next_url,
+                },
+              });
+            },
+          ),
+        },
       },
       req,
       res,

--- a/apps/api.planx.uk/modules/pay/proxy.ts
+++ b/apps/api.planx.uk/modules/pay/proxy.ts
@@ -9,14 +9,19 @@ export const usePayProxy = (
   req: Request,
   res: Response,
 ) => {
+  const { on: onEvents, ...restOptions } = options;
+
   return useProxy({
     target: "https://publicapi.payments.service.gov.uk/v1/payments",
-    onProxyReq: fixRequestBody,
+    on: {
+      proxyReq: fixRequestBody,
+      ...onEvents,
+    },
     headers: {
       ...(req.headers as NodeJS.Dict<string | string[]>),
       "content-type": "application/json",
       Authorization: `Bearer ${res.locals.govPayToken}`,
     },
-    ...options,
+    ...restOptions,
   });
 };

--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -37,7 +37,7 @@
     "graphql-request": "catalog:graphql",
     "he": "^1.2.0",
     "helmet": "^8.2.0",
-    "http-proxy-middleware": "^2.0.10",
+    "http-proxy-middleware": "^4.2.0",
     "isomorphic-fetch": "^3.0.0",
     "jsdom": "catalog:",
     "jsondiffpatch": "^0.7.6",

--- a/apps/api.planx.uk/session.ts
+++ b/apps/api.planx.uk/session.ts
@@ -1,4 +1,4 @@
-import type { RequestHandler } from "http-proxy-middleware";
+import type { RequestHandler } from "express";
 
 // this middleware registers dummy methods on req.session to resolve passport/cookie-session incompatibility
 export const registerSessionStubs: RequestHandler = (req, _res, next): void => {

--- a/apps/api.planx.uk/shared/middleware/proxy.ts
+++ b/apps/api.planx.uk/shared/middleware/proxy.ts
@@ -1,19 +1,27 @@
+import { ServerResponse } from "http";
 import type { Options } from "http-proxy-middleware";
 import { createProxyMiddleware } from "http-proxy-middleware";
 
-// debug, info, warn, error, silent
-const LOG_LEVEL = process.env.NODE_ENV === "test" ? "silent" : "debug";
-
 export const useProxy = (options: Partial<Options> = {}) => {
+  const { on: onEvents, ...restOptions } = options;
+
   return createProxyMiddleware({
     changeOrigin: true,
-    logLevel: LOG_LEVEL,
-    onError: (_err, _req, res, _target) => {
-      res.json({
-        status: 500,
-        message: "Something went wrong",
-      });
+    logger: process.env.NODE_ENV === "test" ? undefined : console,
+    on: {
+      error: (_err, _req, res) => {
+        if (res instanceof ServerResponse && !res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              status: 500,
+              message: "Something went wrong",
+            }),
+          );
+        }
+      },
+      ...onEvents,
     },
-    ...options,
+    ...restOptions,
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       http-proxy-middleware:
-        specifier: ^2.0.10
-        version: 2.0.10(@types/express@4.17.25)
+        specifier: ^4.2.0
+        version: 4.2.0
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0
@@ -5201,9 +5201,6 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.17':
-    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
-
   '@types/isomorphic-fetch@0.0.36':
     resolution: {integrity: sha512-ulw4d+vW1HKn4oErSmNN2HYEcHGq0N1C5exlrMM0CRqX1UUpFhGb5lwiom5j9KN3LBJJDLRmYIZz1ghm7FIzZw==}
 
@@ -7132,9 +7129,6 @@ packages:
   eventemitter3@3.1.2:
     resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
 
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -7720,18 +7714,9 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@2.0.10:
-    resolution: {integrity: sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/express': ^4.17.13
-    peerDependenciesMeta:
-      '@types/express':
-        optional: true
-
-  http-proxy@1.18.1:
-    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
-    engines: {node: '>=8.0.0'}
+  http-proxy-middleware@4.2.0:
+    resolution: {integrity: sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==}
+    engines: {node: ^22.15.0 || ^24.0.0 || >=26.0.0}
 
   https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
@@ -7743,6 +7728,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -8007,10 +7995,6 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
-
-  is-plain-obj@3.0.0:
-    resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
-    engines: {node: '>=10'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -10135,9 +10119,6 @@ packages:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
 
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -12122,7 +12103,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       js-yaml: 4.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.2.0
       smol-toml: 1.6.1
@@ -14464,7 +14445,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -14685,7 +14666,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.2
 
@@ -15931,10 +15912,6 @@ snapshots:
       hoist-non-react-statics: 3.3.2
 
   '@types/http-errors@2.0.5': {}
-
-  '@types/http-proxy@1.17.17':
-    dependencies:
-      '@types/node': 24.10.15
 
   '@types/isomorphic-fetch@0.0.36': {}
 
@@ -18321,8 +18298,6 @@ snapshots:
 
   eventemitter3@3.1.2: {}
 
-  eventemitter3@4.0.7: {}
-
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -18501,6 +18476,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fflate@0.8.2: {}
 
@@ -19060,25 +19039,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25):
+  http-proxy-middleware@4.2.0:
     dependencies:
-      '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      debug: 4.4.3(supports-color@8.1.1)
+      httpxy: 0.5.5
       is-glob: 4.0.3
-      is-plain-obj: 3.0.0
+      is-plain-obj: 4.1.0
       micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.25
     transitivePeerDependencies:
-      - debug
-
-  http-proxy@1.18.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
+      - supports-color
 
   https-browserify@1.0.0: {}
 
@@ -19095,6 +19064,8 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.5: {}
 
   human-signals@2.1.0: {}
 
@@ -19314,8 +19285,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
-
-  is-plain-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -21926,8 +21895,6 @@ snapshots:
 
   requireindex@1.2.0: {}
 
-  requires-port@1.0.0: {}
-
   reselect@5.1.1: {}
 
   resend@6.16.0:
@@ -22920,8 +22887,8 @@ snapshots:
 
   tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/7199

Looking through http-proxy-middleware issues it looks like the upgrade to v4 offers some improvements (inc. over memory leaks which we _may_ be experiencing based on the current setup).

Followed migration guides here - https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION_V3.md & https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0