### PR TITLE
fix(a11y): Visual feedback for all LPS links

### DIFF
--- a/apps/localplanning.services/src/styles/global.css
+++ b/apps/localplanning.services/src/styles/global.css
@@ -135,10 +135,17 @@
   .paragraph-link,
   .button-link {
     @apply underline underline-offset-6;
+    text-decoration-thickness: 3px;
+    text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
+    transition: text-decoration-color 150ms ease;
   }
   .styled-content a.external::after,
   .paragraph-link--external::after {
     content: " ↗";
+  }
+  .styled-content a:not(.button):hover,
+  .paragraph-link:hover {
+    text-decoration-color: currentColor;
   }
   .button-link {
     cursor: pointer;


### PR DESCRIPTION
## Issue

Relates to:
p.58 - Cognitive Feedback 01 - Menu hover state - https://trello.com/c/dbL9x0EI/3731-usability-cognitive-feedback-01-menu-hover-state

- Text links on LPS do not provide hover feedback suggesting that they are interactible

## Solution

- Include a hover state on all text links

https://localplanning.7205.planx.pizza/