### PR TITLE
chore(api): Reduce JWT validaiton noise in CloudWatch logs

### DIFF
--- a/apps/api.planx.uk/modules/auth/controller.ts
+++ b/apps/api.planx.uk/modules/auth/controller.ts
@@ -138,7 +138,7 @@ export const isJWTRevoked: RequestHandler = async (req, res) => {
     const isRevoked = await isTokenRevoked(tokenDigest);
 
     if (isRevoked) {
-      console.error("Token is revoked", { tokenDigest });
+      console.debug("Token is revoked", { tokenDigest });
       res.set("Cache-Control", "no-store");
       return res.status(401).send();
     }
@@ -150,7 +150,13 @@ export const isJWTRevoked: RequestHandler = async (req, res) => {
 
     return res.status(200).json(decoded);
   } catch (error) {
-    console.error("Unhandled error in JWT validation", { error });
+    if (error instanceof jwt.TokenExpiredError) {
+      console.debug("JWT expired", { expiredAt: error.expiredAt });
+    } else if (error instanceof jwt.JsonWebTokenError) {
+      console.debug("JWT validation failed", { message: error.message });
+    } else {
+      console.error("Unhandled error in JWT validation", { error });
+    }
     return res.status(401).send();
   }
 };

--- a/apps/api.planx.uk/modules/auth/validateJWT.test.ts
+++ b/apps/api.planx.uk/modules/auth/validateJWT.test.ts
@@ -2,7 +2,11 @@ import supertest from "supertest";
 
 import app from "../../server.js";
 import { queryMock } from "../../tests/graphqlQueryMock.js";
-import { authHeader, getTestJWT } from "../../tests/mockJWT.js";
+import {
+  authHeader,
+  expiredAuthHeader,
+  getTestJWT,
+} from "../../tests/mockJWT.js";
 
 const mockRevokedToken = () => {
   queryMock.mockQuery({
@@ -48,6 +52,13 @@ describe("JWT in auth header", async () => {
       .set({ authorization: "Bearer NOT_A_JWT" })
       .expect(401);
   });
+
+  test("expired JWT", async () => {
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set(expiredAuthHeader({ role: "platformAdmin" }))
+      .expect(401);
+  });
 });
 
 describe("JWT in cookie", () => {
@@ -82,6 +93,15 @@ describe("JWT in cookie", () => {
       .set("Cookie", `jwt=NOT_A_JWT`)
       .expect(401);
   });
+
+  test("expired JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor", isExpired: true });
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set("Cookie", `jwt=${jwt}`)
+      .expect(401);
+  });
 });
 
 describe("JWT in query params", () => {
@@ -109,8 +129,72 @@ describe("JWT in query params", () => {
   test("invalid JWT", async () => {
     await supertest(app).get(`/auth/validate-jwt?token=NOT_A_JWT`).expect(401);
   });
+
+  test("expired JWT", async () => {
+    const jwt = getTestJWT({ role: "teamEditor", isExpired: true });
+
+    await supertest(app).get(`/auth/validate-jwt?token=${jwt}`).expect(401);
+  });
 });
 
 test("no JWT", async () => {
   await supertest(app).get("/auth/validate-jwt").expect(401);
+});
+
+describe("log levels", () => {
+  test("expired JWT logs at debug level, not error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set(expiredAuthHeader({ role: "platformAdmin" }))
+      .expect(401);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      "JWT expired",
+      expect.objectContaining({ expiredAt: expect.any(Date) }),
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  test("revoked JWT logs at debug level, not error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    mockRevokedToken();
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set(authHeader({ role: "platformAdmin" }))
+      .expect(401);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Token is revoked",
+      expect.objectContaining({ tokenDigest: expect.any(String) }),
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  test("invalid JWT logs at debug level, not error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    await supertest(app)
+      .get("/auth/validate-jwt")
+      .set({ authorization: "Bearer NOT_A_JWT" })
+      .expect(401);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      "JWT validation failed",
+      expect.objectContaining({ message: expect.any(String) }),
+    );
+
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## What does this PR do?
Reduced noise in AWS CloudWatch logs (all API logs in fact) by changing calls to `console.error()` with `console.debug()`.

Right now AWS CloudWatch logs are polluted with these logs, which appear genuine to me - over a period yesterday morning (see https://github.com/theopensystemslab/planx-new/pull/7199) there were large numbers of calls from a small number of JWTs (same `expiresAt` timestamp) which looks like a few logged out users.

## Next steps...
Once deployed to `main` and `production`, sense check logs over the next few days 👌 