### PR TITLE
fix(editor): Configure more robust fetch policy for `usePatterns()`

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/usePatterns.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/PatternsTab/usePatterns.ts
@@ -7,7 +7,11 @@ import type {
 } from "./queries";
 import { GET_PATTERN_DATA, GET_PATTERNS } from "./queries";
 
-export const usePatterns = () => useQuery<GetPatternsQuery>(GET_PATTERNS);
+export const usePatterns = () =>
+  useQuery<GetPatternsQuery>(GET_PATTERNS, {
+    // Ensure a pattern toggled "not copiable by others" does not persist in the cache
+    fetchPolicy: "cache-and-network",
+  });
 
 export const usePatternData = (id: string | null) =>
   useQuery<GetPatternDataQuery, GetPatternDataVars>(GET_PATTERN_DATA, {


### PR DESCRIPTION
## What does this PR do?
Change the `fetchPolicy` to `"cache-and-network"` for the `usePatterns()` hook. This ensures that we always check the "copiable" status of the pattern list before allowing users to insert them. Without this change it's possible for the cache to contain stale items - allowing users to insert patterns no longer "copiable" (until the next refresh).

Please see https://opensystemslab.slack.com/archives/C5Q59R3HB/p1787215523036939?thread_ts=1787209920.554459&cid=C5Q59R3HB (OSL Slack) for further context.