### PR TITLE
chore(editor): Make copy on Editor Pay component provider agnostic

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.test.tsx
@@ -32,7 +32,7 @@ describe("Pay component - Editor Modal", () => {
     expect(results).toHaveNoViolations();
   });
 
-  describe("GOV.UK Pay Metadata section", () => {
+  describe("Payment Metadata section", () => {
     // Set up mock state with platformAdmin user so all Editor features are enabled
     const { getState, setState } = useStore;
     const mockUser: User = {
@@ -57,11 +57,11 @@ describe("Pay component - Editor Modal", () => {
           <PayComponent id="test" />
         </DndProvider>,
       );
-      expect(getByText("GOV.UK Pay metadata")).toBeInTheDocument();
+      expect(getByText("Payment metadata")).toBeInTheDocument();
     });
 
     it("lists the default values", async () => {
-      const { getByDisplayValue, getByRole } = await setup(
+      const { getByDisplayValue } = await setup(
         <DndProvider backend={HTML5Backend}>
           <PayComponent id="test" />
         </DndProvider>,

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/GovPayMetadataSection.tsx
@@ -17,10 +17,13 @@ import ErrorWrapper from "ui/shared/ErrorWrapper";
 import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 
+import { usePaymentProvider } from "../Public/hooks/usePaymentProvider";
 import { isFieldDisabled, parseError, parseTouched } from "./helpers";
 
 const GOVPAY_DOCS_URL =
   "https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39";
+
+const STRIPE_DOCS_URL = "https://docs.stripe.com/metadata";
 
 export type FormikGovPayMetadata =
   Record<keyof GovPayMetadata, string>[] | string | undefined;
@@ -142,6 +145,7 @@ const Headers: React.FC<{ title: string }> = ({ title }) => (
 export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
   disabled,
 }) => {
+  const provider = usePaymentProvider();
   const { errors, setFieldValue, setTouched, touched, values } =
     useFormikContext<Pay>();
 
@@ -161,16 +165,16 @@ export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
 
   return (
     <ModalSection>
-      <ModalSectionContent title="GOV.UK Pay metadata" Icon={DataObjectIcon}>
+      <ModalSectionContent title="Payment metadata" Icon={DataObjectIcon}>
         <Typography variant="subtitle2" sx={{ mb: 2 }}>
           Include metadata alongside payments, such as VAT codes, cost centers,
           or ledger codes. See{" "}
           <Link
-            href={GOVPAY_DOCS_URL}
+            href={provider === "stripe" ? STRIPE_DOCS_URL : GOVPAY_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
           >
-            GOV.UK Pay documentation
+            payment provider documentation
           </Link>{" "}
           for more details.
         </Typography>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
@@ -726,7 +726,7 @@ describe("pay fields", () => {
     });
 
     expect(output).toStrictEqual<Output>({
-      key: "GOV.UK Pay metadata (key)",
+      key: "Payment metadata (key)",
       iconKey: ComponentType.Pay,
       componentType: "Pay",
       title: "Jaguar",
@@ -742,7 +742,7 @@ describe("pay fields", () => {
     });
 
     expect(output).toStrictEqual<Output>({
-      key: "GOV.UK Pay metadata (value)",
+      key: "Payment metadata (value)",
       iconKey: ComponentType.Pay,
       componentType: "Pay",
       title: "Jaguar",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
@@ -166,10 +166,10 @@ const keyFormatters: KeyMap = {
     getDisplayKey: () => "Label (your details)",
   },
   "data.govPayMetadata.key": {
-    getDisplayKey: () => "GOV.UK Pay metadata (key)",
+    getDisplayKey: () => "Payment metadata (key)",
   },
   "data.govPayMetadata.value": {
-    getDisplayKey: () => "GOV.UK Pay metadata (value)",
+    getDisplayKey: () => "Payment metadata (value)",
   },
   // Calculate contains both input and output data values
   formula: {


### PR DESCRIPTION
## What does this PR do?
Updates text of Editor-facing Pay component to be generic - no specific mentions of GovPay.

Ticket - https://github.com/orgs/theopensystemslab/projects/11?pane=issue&itemId=223918293

## Next steps...
- Update internal references (variable names, component names, etc)
- Take a pass through `SetFee` also