### PR TITLE
fix: Feedback component options layout

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Public/Public.tsx
@@ -120,7 +120,10 @@ const FeedbackComponent = (props: PublicProps<Feedback>): FCReturn => {
               container
               columnSpacing={2}
               component="fieldset"
-              sx={{ flexDirection: { xs: "column", formWrap: "row" } }}
+              sx={{
+                width: "100%",
+                flexDirection: { xs: "column", formWrap: "row" },
+              }}
             >
               <FaceBox
                 value={1}

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/components/FaceBox.tsx
@@ -21,7 +21,7 @@ export const FaceBox = ({
   value,
 }: FaceBoxProps): ReactElement => {
   return (
-    <Grid size={2.4} key={label}>
+    <Grid size={{ xs: 12, formWrap: 2.4 }} key={label}>
       <ToggleButton
         value={value}
         data-testid={testId}


### PR DESCRIPTION
## Issue

Layout of feedback component does not allow options to expand fully.

(desktop vs mobile):
<img width="2424" height="934" alt="image" src="https://github.com/user-attachments/assets/407c7efc-c5c6-4991-9948-1560ffc448a1" />


## Solution

Ensure that container is 100% width and options expand to fill layout.

(desktop vs mobile):
<img width="2424" height="934" alt="image" src="https://github.com/user-attachments/assets/a4bd8876-ab63-4a0e-8a75-a3a3b8c30eb1" />


