### PR TITLE
fix: sync `flow_note_*` tables from prod db in correct order

### DIFF
--- a/scripts/seed-database/write/main.sql
+++ b/scripts/seed-database/write/main.sql
@@ -8,8 +8,8 @@
 \include write/team_integrations.sql
 \include write/team_themes.sql
 \include write/team_settings.sql
-\include write/flow_note_positions.sql
 \include write/flow_note_content.sql
+\include write/flow_note_positions.sql
 
 -- Optional tables
 -- \include write/feedback.sql


### PR DESCRIPTION
As per title - see [Slack](https://opensystemslab.slack.com/archives/C04EEBR1E0P/p1787199487798469).