### PR TITLE
fix: truncate flow notes as part of `reset_flows` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The root of the project has several scripts set up to help you manage your docke
 - `pnpm recreate` will build and (re)start your docker containers from scratch
 - `pnpm destroy` will remove volumes (i.e. database data) for your docker containers (dev or e2e) and can be a useful hard reset when necessary
 - `pnpm sync-data` will sync production records with modified data in your database
+- `pnpm test-sync` emulates the command performed by the nightly staging sync (see `sync-staging-db.yml`)
 - `pnpm clean-data` will sync production records and reset any modified data
 - `pnpm dev` will tear down any e2e containers and recreate your dev docker containers from scratch, *without* re-seeding the database - useful when switching from a test environment
 - `pnpm tests` will tear down any dev containers and recreate your docker containers and include test services - useful when switching from a dev environment

--- a/scripts/seed-database/container.sh
+++ b/scripts/seed-database/container.sh
@@ -60,6 +60,7 @@ echo published_flows downloaded
 
 if [[ ${RESET} == "reset_flows" ]]; then
   cat 'write/truncate_flows.sql' >> '/tmp/sync.sql'
+  cat 'write/truncate_flow_notes.sql' >> '/tmp/sync.sql'
   cat 'write/truncate_team_members.sql' >> '/tmp/sync.sql'
 fi
 

--- a/scripts/seed-database/write/truncate_flow_notes.sql
+++ b/scripts/seed-database/write/truncate_flow_notes.sql
@@ -1,0 +1,3 @@
+-- flow_note_positions.note_id has FK to flow_note_content, so truncating content cascades to positions
+TRUNCATE TABLE flow_note_content CASCADE;
+


### PR DESCRIPTION
#7214 did not fix nightly db sync because that script uses the `reset_flows` option and the `TRUNCATE` command to `flows` table does cascade through to because they are essentially disconnected.

That is, neither `flow_note_content` or `flow_note_positions` has an FK to flows.

Therefore we add an additional line here to explicitly truncate the former, which will then cascade to the latter.

See also [here](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1787226339748609) and [here](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1787239070911579) on Slack.