### PR TITLE
Revert "chore: disable `Internal notes` input ahead of migration"

### DIFF
--- a/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -31,8 +31,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             multiline
             placeholder="Internal notes"
             rows={3}
-            // disabled while migrating, to be deprecated soon !
-            disabled={true}
+            disabled={disabled}
           />
         </InputRow>
       </ModalSectionContent>


### PR DESCRIPTION
Reverts theopensystemslab/planx-new#7118

See https://opensystemslab.slack.com/archives/C5Q59R3HB/p1787240789615319?thread_ts=1787068052.760349&cid=C5Q59R3HB