### PR TITLE
revert: re-enable Question pseudo-notes only

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -36,10 +36,10 @@ export const QuestionComponent: React.FC<Props> = (props) => {
       },
       validate: ({ options, ...values }) => {
         const errors: FormikErrors<FormikValues> = {};
-        if (values.text && !options.length) {
-          errors.text =
-            "Questions can no longer be used as notes and must have at least one option";
-        }
+        // if (values.text && !options.length) {
+        //   errors.text =
+        //     "Questions can no longer be used as notes and must have at least one option";
+        // }
         if (values.fn && !options.some((option) => option.data.val)) {
           errors.fn = "At least one option must also set a data field";
         }


### PR DESCRIPTION
Partially reverts https://github.com/theopensystemslab/planx-new/pull/7127

See https://opensystemslab.slack.com/archives/C5Q59R3HB/p1787240789615319?thread_ts=1787068052.760349&cid=C5Q59R3HB

Intentionally still preventing Checklists, Responsive Questions, and Responsive Checklists from being created as or updated to pseudo "notes"