### PR TITLE
[chore] update db sync workflow to use node v24

### DIFF
--- a/.github/actions/setup-pizza-env/action.yml
+++ b/.github/actions/setup-pizza-env/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: ./scripts/pull-secrets.sh
     - name: Check if .env files exist
-      uses: andstor/file-existence-action@v2
+      uses: andstor/file-existence-action@v3
       with:
         files: ".env, .env.staging, ${{ inputs.api-directory }}/.env.test, ${{ inputs.hasura-directory }}/.env.test"
         fail: true

--- a/.github/workflows/sync-staging-db.yml
+++ b/.github/workflows/sync-staging-db.yml
@@ -19,13 +19,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: Install pulumi
-        uses: pulumi/setup-pulumi@v2
-      - run: |
-          echo "STAGING_PG_URL=$(pulumi stack output --stack staging --show-secrets dbRootUrl)" >> $GITHUB_ENV
-        working-directory: infrastructure/data
+      - name: Get staging database URL
+        id: pulumi
+        uses: pulumi/actions@v7
+        with:
+          command: output
+          stack-name: staging
+          work-dir: infrastructure/data
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - run: echo "STAGING_PG_URL=${{ steps.pulumi.outputs.dbRootUrl }}" >> $GITHUB_ENV
       - uses: ./.github/actions/setup-pizza-env
         with:
           aws-access-key-id: ${{ secrets.PIZZA_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Should resolve the following warning seen in latest runs of Nightly staging database sync action. 

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: andstor/file-existence-action@v2, pulumi/setup-pulumi@v2. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/