### PR TITLE
[infra] advance Newcastle custom domain to `cutover-ongoing` state

### DIFF
--- a/infrastructure/common/customDomains.ts
+++ b/infrastructure/common/customDomains.ts
@@ -75,7 +75,7 @@ export const getCustomDomains = (env: string): CustomDomain[] =>
         {
           name: "newcastle",
           domain: "planningservices.newcastle.gov.uk",
-          cloudFrontState: "legacy-with-validation",
+          cloudFrontState: "cutover-ongoing",
           certificateLocation: "pulumiConfig",
         },
         {


### PR DESCRIPTION
as per title - [ticket](https://trello.com/c/DXMOGj8i)