### PR TITLE
chore: adjust `flow_note_*` schemas for soft delete pattern

### DIFF
--- a/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
+++ b/apps/editor.planx.uk/src/hooks/data/useFlowNotes.ts
@@ -60,7 +60,7 @@ export type FlowNote = AttachedNote | PositionedNote;
 const GET_FLOW_NOTES = gql`
   subscription GetFlowNotes($flowId: uuid!) {
     flowNotePositions: flow_note_positions(
-      where: { flow_id: { _eq: $flowId } }
+      where: { flow_id: { _eq: $flowId }, deleted_at: { _is_null: true } }
       order_by: { created_at: asc, id: asc }
     ) {
       positionId: id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -41,6 +41,7 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
   const { deleteFlowNote, loading: deleting } = useDeleteFlowNote();
 
   const isEditing = mode === "edit";
+  // TODO account for max last updated between `flow_note_content` and `flow_note_position`, currently exclusively content
   const lastEditMessage =
     props.mode === "edit"
       ? formatLastEditMessage(props.note.updatedAt, props.note.updatedByUser)

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCreateFlowNote.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useCreateFlowNote.ts
@@ -31,6 +31,7 @@ export const useCreateFlowNote = () => {
           node_id: nodeId ?? null,
           placement: placement ?? null,
           created_by: userId,
+          updated_by: userId,
           note: {
             data: {
               text,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useDeleteFlowNote.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/useDeleteFlowNote.ts
@@ -1,8 +1,12 @@
 import { gql, useMutation } from "@apollo/client";
 
+// TODO also set updated_by
 const DELETE_FLOW_NOTE_POSITION = gql`
   mutation DeleteFlowNotePosition($id: uuid!) {
-    delete_flow_note_positions_by_pk(id: $id) {
+    update_flow_note_positions_by_pk(
+      pk_columns: { id: $id }
+      _set: { deleted_at: "now()" }
+    ) {
       id
     }
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteClone.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteClone.ts
@@ -28,6 +28,7 @@ export const usePasteFlowNoteClone = () => {
           node_id: nodeId ?? null,
           placement: placement ?? null,
           created_by: userId,
+          updated_by: userId,
           note_id: noteContentId,
         },
       },

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteCopy.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/hooks/usePasteFlowNoteCopy.ts
@@ -28,6 +28,7 @@ export const usePasteFlowNoteCopy = () => {
           node_id: nodeId ?? null,
           placement: placement ?? null,
           created_by: userId,
+          updated_by: userId,
           note: {
             data: {
               text: copied.text,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/copyNotesForNodes.ts
@@ -19,7 +19,11 @@ interface AttachedFlowNoteRow {
 const GET_ATTACHED_FLOW_NOTES_FOR_NODES = gql`
   query GetAttachedFlowNotesForNodes($flowId: uuid!, $nodeIds: [String!]!) {
     flow_note_positions(
-      where: { flow_id: { _eq: $flowId }, node_id: { _in: $nodeIds } }
+      where: {
+        flow_id: { _eq: $flowId }
+        node_id: { _in: $nodeIds }
+        deleted_at: { _is_null: true }
+      }
     ) {
       node_id
       note {
@@ -76,6 +80,7 @@ export const pasteAttachedFlowNotes = async (
             flow_id: flowId,
             node_id: newNodeId,
             created_by: userId,
+            updated_by: userId,
             note: {
               data: {
                 text,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/lib/repositionNotes.ts
@@ -11,19 +11,24 @@ interface FlowNotePositionRowForReposition {
   node_id: string | null;
   placement: NotePlacement | null;
   created_by: number;
+  updated_by: number;
 }
 
 const GET_FLOW_NOTE_POSITIONS_FOR_REPOSITION = gql`
   query GetFlowNotePositionsForReposition($flowId: uuid!) {
-    flow_note_positions(where: { flow_id: { _eq: $flowId } }) {
+    flow_note_positions(
+      where: { flow_id: { _eq: $flowId }, deleted_at: { _is_null: true } }
+    ) {
       id
       node_id
       placement
       created_by
+      updated_by
     }
   }
 `;
 
+// TODO update to soft delete
 const DELETE_FLOW_NOTE_POSITIONS = gql`
   mutation DeleteFlowNotePositions($ids: [uuid!]!) {
     delete_flow_note_positions(where: { id: { _in: $ids } }) {
@@ -32,6 +37,7 @@ const DELETE_FLOW_NOTE_POSITIONS = gql`
   }
 `;
 
+// TODO update to set `updated_by`
 const REANCHOR_FLOW_NOTE_POSITION = gql`
   mutation ReanchorFlowNotePosition($id: uuid!, $placement: jsonb!) {
     update_flow_note_positions_by_pk(

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_note_content.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_note_content.yaml
@@ -55,6 +55,7 @@ select_permissions:
       columns:
         - created_at
         - created_by
+        - deleted_at
         - id
         - text
         - updated_at
@@ -66,6 +67,7 @@ select_permissions:
       columns:
         - created_at
         - created_by
+        - deleted_at
         - id
         - text
         - updated_at

--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_note_positions.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_flow_note_positions.yaml
@@ -29,6 +29,15 @@ object_relationships:
         remote_table:
           name: flow_note_content
           schema: public
+  - name: updatedByUser
+    using:
+      manual_configuration:
+        column_mapping:
+          updated_by: id
+        insertion_order: null
+        remote_table:
+          name: users
+          schema: public
 insert_permissions:
   - role: platformAdmin
     permission:
@@ -65,27 +74,31 @@ select_permissions:
   - role: platformAdmin
     permission:
       columns:
-        - id
-        - note_id
-        - flow_id
-        - node_id
-        - placement
-        - created_by
         - created_at
+        - created_by
+        - deleted_at
+        - flow_id
+        - id
+        - node_id
+        - note_id
+        - placement
         - updated_at
+        - updated_by
       filter: {}
     comment: ""
   - role: teamEditor
     permission:
       columns:
-        - id
-        - note_id
-        - flow_id
-        - node_id
-        - placement
-        - created_by
         - created_at
+        - created_by
+        - deleted_at
+        - flow_id
+        - id
+        - node_id
+        - note_id
+        - placement
         - updated_at
+        - updated_by
       filter:
         flow:
           team:

--- a/apps/hasura.planx.uk/migrations/default/1787269575166_alter_table_public_flow_note_positions_add_column_updated_by/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787269575166_alter_table_public_flow_note_positions_add_column_updated_by/down.sql
@@ -1,0 +1,54 @@
+ALTER TABLE flow_note_content DROP COLUMN deleted_at;
+ALTER TABLE flow_note_positions DROP COLUMN deleted_at;
+ALTER TABLE flow_note_positions DROP COLUMN updated_by;
+
+CREATE OR REPLACE FUNCTION public.copy_flow(source_flow_id uuid, team_id integer, slug text, name text, flow_data jsonb, is_service boolean, is_pattern boolean, replace_value text, creator_id integer)
+ RETURNS flows
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  new_flow flows;
+  note_map jsonb := '{}'::jsonb;
+  note_row record;
+  new_note_id uuid;
+BEGIN
+  IF creator_id IS NULL THEN
+    RAISE EXCEPTION 'copy_flow requires a creator_id - flows cannot be copied without an authenticated user';
+  END IF;
+
+  INSERT INTO flows (team_id, slug, name, data, version, copied_from, is_template, is_service, is_pattern, creator_id)
+  VALUES (team_id, slug, name, flow_data, 1, source_flow_id, false, is_service, is_pattern, creator_id)
+  RETURNING * INTO new_flow;
+
+  -- needed for ShareDB
+  INSERT INTO operations (flow_id, version, data)
+  VALUES (new_flow.id, 1, '{}'::jsonb);
+
+  -- one new flow_note_content row per unique note referenced by the source flow
+  FOR note_row IN
+    SELECT DISTINCT c.id, c.text
+    FROM flow_note_content c
+    JOIN flow_note_positions p ON p.note_id = c.id
+    WHERE p.flow_id = source_flow_id
+  LOOP
+    INSERT INTO flow_note_content (text, created_by, updated_by)
+    VALUES (note_row.text, creator_id, creator_id)
+    RETURNING id INTO new_note_id;
+
+    note_map := note_map || jsonb_build_object(note_row.id::text, new_note_id::text);
+  END LOOP;
+
+  -- every position (original + clone) now points at the copied note
+  INSERT INTO flow_note_positions (note_id, flow_id, node_id, placement, created_by)
+  SELECT
+    (note_map ->> p.note_id::text)::uuid,
+    new_flow.id,
+    public.rename_node_id(p.node_id, replace_value),
+    public.remap_note_placement(p.placement, replace_value),
+    creator_id
+  FROM flow_note_positions p
+  WHERE p.flow_id = source_flow_id;
+
+  RETURN new_flow;
+END;
+$function$;

--- a/apps/hasura.planx.uk/migrations/default/1787269575166_alter_table_public_flow_note_positions_add_column_updated_by/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787269575166_alter_table_public_flow_note_positions_add_column_updated_by/up.sql
@@ -1,0 +1,70 @@
+-- Each content and positions should use a 'soft' delete pattern
+ALTER TABLE "public"."flow_note_content" 
+ADD COLUMN "deleted_at" timestamptz NULL;
+
+ALTER TABLE "public"."flow_note_positions" 
+ADD COLUMN "deleted_at" timestamptz NULL;
+
+-- Positions should consistently capture `updated_by`
+ALTER TABLE "public"."flow_note_positions" 
+ADD COLUMN "updated_by" integer NULL;
+
+-- Initially populate based on `created_by` so that we can enforce a not null constraint
+UPDATE flow_note_positions 
+SET updated_by = created_by;
+
+ALTER TABLE flow_note_positions 
+ALTER COLUMN updated_by SET NOT NULL;
+
+-- 'Replace' `copy_flow` function which populates `flow_note_positions` and should now also account for `updated_by`
+CREATE OR REPLACE FUNCTION public.copy_flow(source_flow_id uuid, team_id integer, slug text, name text, flow_data jsonb, is_service boolean, is_pattern boolean, replace_value text, creator_id integer)
+ RETURNS flows
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  new_flow flows;
+  note_map jsonb := '{}'::jsonb;
+  note_row record;
+  new_note_id uuid;
+BEGIN
+  IF creator_id IS NULL THEN
+    RAISE EXCEPTION 'copy_flow requires a creator_id - flows cannot be copied without an authenticated user';
+  END IF;
+
+  INSERT INTO flows (team_id, slug, name, data, version, copied_from, is_template, is_service, is_pattern, creator_id)
+  VALUES (team_id, slug, name, flow_data, 1, source_flow_id, false, is_service, is_pattern, creator_id)
+  RETURNING * INTO new_flow;
+
+  -- needed for ShareDB
+  INSERT INTO operations (flow_id, version, data)
+  VALUES (new_flow.id, 1, '{}'::jsonb);
+
+  -- one new flow_note_content row per unique note referenced by the source flow
+  FOR note_row IN
+    SELECT DISTINCT c.id, c.text
+    FROM flow_note_content c
+    JOIN flow_note_positions p ON p.note_id = c.id
+    WHERE p.flow_id = source_flow_id
+  LOOP
+    INSERT INTO flow_note_content (text, created_by, updated_by)
+    VALUES (note_row.text, creator_id, creator_id)
+    RETURNING id INTO new_note_id;
+
+    note_map := note_map || jsonb_build_object(note_row.id::text, new_note_id::text);
+  END LOOP;
+
+  -- every position (original + clone) now points at the copied note
+  INSERT INTO flow_note_positions (note_id, flow_id, node_id, placement, created_by, updated_by)
+  SELECT
+    (note_map ->> p.note_id::text)::uuid,
+    new_flow.id,
+    public.rename_node_id(p.node_id, replace_value),
+    public.remap_note_placement(p.placement, replace_value),
+    creator_id,
+    creator_id
+  FROM flow_note_positions p
+  WHERE p.flow_id = source_flow_id;
+
+  RETURN new_flow;
+END;
+$function$;

--- a/apps/hasura.planx.uk/tests/copy_flow.test.js
+++ b/apps/hasura.planx.uk/tests/copy_flow.test.js
@@ -67,9 +67,9 @@ describe("copy_flow", () => {
         `
         mutation Insert($flowId: uuid!, $userId: Int!, $soloNoteId: uuid!, $cloneNoteId: uuid!) {
           insert_flow_note_positions(objects: [
-            { flow_id: $flowId, note_id: $soloNoteId, node_id: "soloNode", created_by: $userId }
-            { flow_id: $flowId, note_id: $cloneNoteId, placement: { parent: "_root", before: "beforeNode" }, created_by: $userId }
-            { flow_id: $flowId, note_id: $cloneNoteId, node_id: "cloneNode", created_by: $userId }
+            { flow_id: $flowId, note_id: $soloNoteId, node_id: "soloNode", created_by: $userId, updated_by: $userId }
+            { flow_id: $flowId, note_id: $cloneNoteId, placement: { parent: "_root", before: "beforeNode" }, created_by: $userId, updated_by: $userId }
+            { flow_id: $flowId, note_id: $cloneNoteId, node_id: "cloneNode", created_by: $userId, updated_by: $userId }
           ]) { affected_rows }
         }
         `,

--- a/apps/hasura.planx.uk/tests/copy_flow.test.sql
+++ b/apps/hasura.planx.uk/tests/copy_flow.test.sql
@@ -26,8 +26,8 @@ BEGIN
   VALUES ('A note', test_user_id, test_user_id)
   RETURNING id INTO content_id;
 
-  INSERT INTO flow_note_positions (note_id, flow_id, node_id, created_by)
-  VALUES (content_id, source_flow_id, 'a', test_user_id);
+  INSERT INTO flow_note_positions (note_id, flow_id, node_id, created_by, updated_by)
+  VALUES (content_id, source_flow_id, 'a', test_user_id, test_user_id);
 
   -- sanity check: a normal call succeeds and copies the flow, its operation, and its note
   copied := copy_flow(
@@ -41,8 +41,8 @@ BEGIN
   -- make a dangling note position on the source flow: a note_id that doesn't reference any flow_note_content row,
   -- violating the NOT NULL constraint, thus should fail and cause the whole transaction to rollback
   SET session_replication_role = replica;
-  INSERT INTO flow_note_positions (note_id, flow_id, node_id, created_by)
-  VALUES (gen_random_uuid(), source_flow_id, 'dangling', test_user_id);
+  INSERT INTO flow_note_positions (note_id, flow_id, node_id, created_by, updated_by)
+  VALUES (gen_random_uuid(), source_flow_id, 'dangling', test_user_id, test_user_id);
   SET session_replication_role = origin;
 
   BEGIN

--- a/apps/hasura.planx.uk/tests/flow_note_content.test.js
+++ b/apps/hasura.planx.uk/tests/flow_note_content.test.js
@@ -35,6 +35,7 @@ describe("flow note content", () => {
       expect(i.mutations).toContain("update_flow_note_content_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_content", () => {
       expect(i.mutations).toContain("delete_flow_note_content");
       expect(i.mutations).toContain("delete_flow_note_content_by_pk");
@@ -60,6 +61,7 @@ describe("flow note content", () => {
       expect(i.mutations).toContain("update_flow_note_content_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_content", () => {
       expect(i.mutations).toContain("delete_flow_note_content");
       expect(i.mutations).toContain("delete_flow_note_content_by_pk");
@@ -85,6 +87,7 @@ describe("flow note content", () => {
       expect(i.mutations).toContain("update_flow_note_content_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_content", () => {
       expect(i.mutations).toContain("delete_flow_note_content");
       expect(i.mutations).toContain("delete_flow_note_content_by_pk");
@@ -110,6 +113,7 @@ describe("flow note content", () => {
       expect(i.mutations).toContain("update_flow_note_content_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_content", () => {
       expect(i.mutations).toContain("delete_flow_note_content");
       expect(i.mutations).toContain("delete_flow_note_content_by_pk");

--- a/apps/hasura.planx.uk/tests/flow_note_positions.test.js
+++ b/apps/hasura.planx.uk/tests/flow_note_positions.test.js
@@ -35,6 +35,7 @@ describe("flow note positions", () => {
       expect(i.mutations).toContain("update_flow_note_positions_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_positions", () => {
       expect(i.mutations).toContain("delete_flow_note_positions");
       expect(i.mutations).toContain("delete_flow_note_positions_by_pk");
@@ -60,6 +61,7 @@ describe("flow note positions", () => {
       expect(i.mutations).toContain("update_flow_note_positions_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_positions", () => {
       expect(i.mutations).toContain("delete_flow_note_positions");
       expect(i.mutations).toContain("delete_flow_note_positions_by_pk");
@@ -85,6 +87,7 @@ describe("flow note positions", () => {
       expect(i.mutations).toContain("update_flow_note_positions_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_positions", () => {
       expect(i.mutations).toContain("delete_flow_note_positions");
       expect(i.mutations).toContain("delete_flow_note_positions_by_pk");
@@ -110,6 +113,7 @@ describe("flow note positions", () => {
       expect(i.mutations).toContain("update_flow_note_positions_by_pk");
     });
 
+    // TODO remove permissions once soft delete pattern implemented
     test("can delete flow_note_positions", () => {
       expect(i.mutations).toContain("delete_flow_note_positions");
       expect(i.mutations).toContain("delete_flow_note_positions_by_pk");

--- a/e2e/tests/api-driven/src/copyFlow/helpers.ts
+++ b/e2e/tests/api-driven/src/copyFlow/helpers.ts
@@ -109,18 +109,21 @@ const createNotes = async ({
               note_id: $soloNoteId
               node_id: "soloNode"
               created_by: $userId
+              updated_by: $userId
             }
             {
               flow_id: $flowId
               note_id: $cloneNoteId
               placement: { parent: "_root", before: "beforeNode" }
               created_by: $userId
+              updated_by: $userId
             }
             {
               flow_id: $flowId
               note_id: $cloneNoteId
               node_id: "cloneNode"
               created_by: $userId
+              updated_by: $userId
             }
           ]
         ) {
@@ -218,7 +221,7 @@ export const getNotePositions = async (flowId: string) => {
     gql`
       query GetNotePositions($flowId: uuid!) {
         flowNotePositions: flow_note_positions(
-          where: { flow_id: { _eq: $flowId } }
+          where: { flow_id: { _eq: $flowId }, deleted_at: { _is_null: true } }
         ) {
           noteId: note_id
           nodeId: node_id


### PR DESCRIPTION
All changes here stem from two key schema updates:
- `flow_notes_*` get `deleted_at` nullable timestamp column for soft-delete pattern to enable future "restore" behavior
- `flow_note_positions` consistently captures `updated_by`

Actual "restore" functionality coming in a follow-up PR.