### PR TITLE
fix(api): Handle async errors on JWT checks

### DIFF
--- a/apps/api.planx.uk/modules/send/downloadSubmission/index.test.ts
+++ b/apps/api.planx.uk/modules/send/downloadSubmission/index.test.ts
@@ -59,6 +59,19 @@ describe("downloading submission data with an access token", () => {
         );
     });
 
+    it("fails with a malformed (non-UUID) token", async () => {
+      await supertest(app)
+        .get("/download-submission")
+        .set({ authorization: "Bearer abc123-not-a-uuid" })
+        .expect(400)
+        .then((res) =>
+          expect(res.body.issues[0]).toHaveProperty(
+            "message",
+            "Invalid token format",
+          ),
+        );
+    });
+
     it("errors if matching token is not found", async () => {
       queryMock.mockQuery({
         name: "GetApplicationAccessToken",

--- a/apps/api.planx.uk/modules/send/downloadSubmission/middleware.ts
+++ b/apps/api.planx.uk/modules/send/downloadSubmission/middleware.ts
@@ -21,7 +21,12 @@ export const useAccessTokenAuth: UseAccessTokenAuth = async (
 ) => {
   const { authorization: token } = res.locals.parsedReq.headers;
 
-  const record = await getTokenRecord(token);
+  let record: AccessToken | null;
+  try {
+    record = await getTokenRecord(token);
+  } catch {
+    return res.status(401).json({ error: "INVALID_ACCESS_TOKEN" });
+  }
 
   if (!record) {
     return res.status(404).json({ error: "INVALID_ACCESS_TOKEN" });

--- a/apps/api.planx.uk/modules/send/downloadSubmission/types.ts
+++ b/apps/api.planx.uk/modules/send/downloadSubmission/types.ts
@@ -7,7 +7,8 @@ export const useAccessTokenAuthSchema = z.object({
     authorization: z
       .string({ message: "Authorization headers are required" })
       .startsWith("Bearer ", "Invalid token format")
-      .transform((val) => val.replace("Bearer ", "")),
+      .transform((val) => val.replace("Bearer ", ""))
+      .pipe(z.string().uuid("Invalid token format")),
   }),
 });
 


### PR DESCRIPTION
## What's the problem?
The API went down at ~01:30am on 2026-08-21, causing about 1 minute of downtime.

```
unhandled rejection ClientError: invalid input syntax for type uuid: "79d78722-2b6e-434a-9ac5-4c"
    at makeRequest (graphql-request/src/index.ts:426:11)
    at async getTokenRecord (/api/modules/send/downloadSubmission/middleware.ts:46:22)
    at async useAccessTokenAuth (/api/modules/send/downloadSubmission/middleware.ts:24:18)
```

This has happened a few times recently and I've been trying to narrow down the cause. A bit of a case of whack-a-mole to clear up logging so far but this one is a genuine bug.

## What's the cause?
A request hit `GET /download-submission` with an invalid token (see above - `79d78722-2b6e-434a-9ac5-4c` is not a valid UUID). This passed through our validation middleware, got passed into a Hasura request and threw an error. Express v4 can't catch async unhandled errors (this is why we have `try/catch` so often) and this then crashed the process.

Looking at request headers this is just a bot looking for exposed endpoints - US ISP, very old version of Chrome. We see this all the time.

`express-async-errors` should be handling this for us (already installed!) but we're not invoking this anywhere 🤦 This regression was introduced here - https://github.com/theopensystemslab/planx-new/pull/3528/changes#diff-a23b8e0cdc75fc858dc3a73983f67d257f78158596c37832202cf963efcf0a6aL9

I think this was a mistake, but let me cross-check this PR properly.

## What's the solution?
- Stronger Zod validation on the token - we should reject invalid requests early, before hitting Hasura if we get malformed data
- Added `try/catch` - if anything else goes wrong this is now a handled error, not an async unhandled error which will bring down express.

## Testing
You can bring down the staging API as follows (please use with caution 😅) - 

```sh
curl -v "https://api.editor.planx.dev/download-submission" \
  -H "Authorization: Bearer not-a-valid-uuid"
```

The Pizza API handles this though, it stays up and just gives a validation error - 

```sh
curl -v "https://api.7225.planx.pizza/download-submission" \
  -H "Authorization: Bearer not-a-valid-uuid"
```

## Next steps...
I'm looking at `express-async-errors` again now.

We could upgrade to Express v5 which handles async errors natively and clean up a bunch of `try/catch` code. An upgrade would be nice but I'd like to understand the level or work (and any tradeoffs!) https://expressjs.com/en/guide/migrating-5/