### PR TITLE
feat: List templates on explore page

### DIFF
--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -168,7 +168,7 @@ function EditorNavMenu() {
                     "platformAdmin",
                     "teamAdmin",
                     "teamEditor",
-                  ] as Role[],
+                  ] satisfies Role[],
                 },
               ]
             : []),

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/EditorNavMenu.tsx
@@ -16,6 +16,7 @@ import SchoolIcon from "@mui/icons-material/School";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
+import type { Role } from "@opensystemslab/planx-core/types";
 import {
   useLocation,
   useMatches,
@@ -163,7 +164,11 @@ function EditorNavMenu() {
                   title: "Explore",
                   Icon: ExploreIcon,
                   route: `/app/${teamSlug}/explore`,
-                  accessibleBy: "*" as const,
+                  accessibleBy: [
+                    "platformAdmin",
+                    "teamAdmin",
+                    "teamEditor",
+                  ] as Role[],
                 },
               ]
             : []),

--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -9,8 +9,8 @@ import type { BadgeProps, BadgeSize } from "./types";
 import { BadgeVariant } from "./types";
 
 const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
-  default: { box: 54, borderRadius: 6 },
-  compact: { box: 46, borderRadius: 4 },
+  default: { box: 56, borderRadius: 6 },
+  compact: { box: 50, borderRadius: 5 },
 };
 
 const Root = styled(Box, {

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -1,0 +1,57 @@
+import Box from "@mui/material/Box";
+import ListItem from "@mui/material/ListItem";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import CheckCircleIcon from "ui/icons/CheckCircle";
+
+interface SearchListItemProps {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  statusLabel?: string;
+}
+
+export const SearchListItem: React.FC<SearchListItemProps> = ({
+  icon,
+  title,
+  description,
+  statusLabel,
+}) => {
+  return (
+    <ListItem alignItems="flex-start" sx={{ px: 2, py: 1.5, gap: 1.5 }}>
+      <Box sx={{ mt: 0.25 }}>{icon}</Box>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 0.25,
+          justifyContent: "center",
+          minHeight: "56px",
+        }}
+      >
+        {statusLabel && (
+          <Box
+            sx={{ display: "flex", alignItems: "center", gap: 0.33, mt: 0.5 }}
+          >
+            <CheckCircleIcon color="success" sx={{ fontSize: 18 }} />
+            <Typography
+              variant="body3"
+              sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+            >
+              {statusLabel}
+            </Typography>
+          </Box>
+        )}
+        <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+          {title}
+        </Typography>
+        {description && (
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            {description}
+          </Typography>
+        )}
+      </Box>
+    </ListItem>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { DashboardWidget } from "ui/editor/DashboardWidget";
+
+import { TemplatesWidget } from "./TemplatesWidget";
+
+const meta = {
+  title: "Editor Components/Explore/TemplatesWidget",
+  component: TemplatesWidget,
+  decorators: [
+    (Story) => {
+      useStore.setState({
+        teamSlug: "open-systems-lab",
+        canUserEditTeam: (slug: string) => slug === "open-systems-lab",
+      });
+
+      return (
+        <DashboardWidget title="Templates">
+          <Story />
+        </DashboardWidget>
+      );
+    },
+  ],
+  args: {
+    templates: [
+      {
+        id: "1",
+        name: "Apply for planning permission",
+        summary: "This service submits an application for planning permission",
+        team: { name: "Open Systems Lab" },
+        subscribedTeams: [{ id: "team-1" }],
+      },
+      {
+        id: "2",
+        name: "Find out if you need planning permission",
+        summary:
+          "Use this service to find out if a project needs planning permission",
+        team: { name: "Open Systems Lab" },
+      },
+      {
+        id: "3",
+        name: "Apply for works to trees",
+        summary: "This service submits an application for works to trees",
+        team: { name: "Open Systems Lab" },
+      },
+      {
+        id: "4",
+        name: "Apply for a lawful development certificate",
+        summary:
+          "This service submits an application for a lawful development certificate",
+        team: { name: "Open Systems Lab" },
+        subscribedTeams: [{ id: "team-1" }],
+      },
+    ],
+  },
+} satisfies Meta<typeof TemplatesWidget>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllSubscribed: Story = {
+  args: {
+    templates: meta.args.templates?.map((template) => ({
+      ...template,
+      subscribedTeams: [{ id: "team-1" }],
+    })),
+  },
+};
+
+export const NoneSubscribed: Story = {
+  args: {
+    templates: meta.args.templates?.map((template) => ({
+      ...template,
+      subscribedTeams: [],
+    })),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    templates: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    templates: undefined,
+  },
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
         name: "Apply for planning permission",
         summary: "This service submits an application for planning permission",
         team: { name: "Open Systems Lab" },
-        subscribedTeams: [{ id: "team-1" }],
+        subscription: [{ id: "team-1" }],
       },
       {
         id: "2",
@@ -49,7 +49,7 @@ const meta = {
         summary:
           "This service submits an application for a lawful development certificate",
         team: { name: "Open Systems Lab" },
-        subscribedTeams: [{ id: "team-1" }],
+        subscription: [{ id: "team-1" }],
       },
     ],
   },
@@ -74,7 +74,7 @@ export const NoneSubscribed: Story = {
   args: {
     templates: meta.args.templates?.map((template) => ({
       ...template,
-      subscribedTeams: [],
+      subscription: [],
     })),
   },
 };

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -100,6 +100,7 @@ const GET_ONLINE_SOURCE_TEMPLATES = gql`
       summary
       team {
         name
+        id
       }
       subscribedTeams: templated_flows(
         where: { team_id: { _eq: $teamId } }

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -66,8 +66,7 @@ export function TemplatesWidget({
     >
       {templates.map((template, index) => {
         const isSubscribed =
-          canUserEditTeam(teamSlug) &&
-          Boolean(template.subscribedTeams?.length);
+          canUserEditTeam(teamSlug) && Boolean(template.subscription?.length);
 
         return (
           <React.Fragment key={template.id}>
@@ -102,7 +101,7 @@ const GET_ONLINE_SOURCE_TEMPLATES = gql`
         name
         id
       }
-      subscribedTeams: templated_flows(
+      subscription: templated_flows(
         where: { team_id: { _eq: $teamId } }
         limit: 1
       ) {

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -1,0 +1,122 @@
+import { gql, useQuery } from "@apollo/client";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React from "react";
+import { EmptyState } from "ui/editor/EmptyState";
+
+import { Badge } from "./Badge/Badge";
+import { BadgeVariant } from "./Badge/types";
+import { SearchListItem } from "./SearchListItem";
+import type { Template } from "./types";
+
+interface TemplatesWidgetProps {
+  templates?: Template[];
+  loading?: boolean;
+}
+
+export function TemplatesWidget({
+  templates,
+  loading = false,
+}: TemplatesWidgetProps) {
+  const [teamSlug, canUserEditTeam] = useStore((state) => [
+    state.teamSlug,
+    state.canUserEditTeam,
+  ]);
+
+  if (loading) {
+    return (
+      <List
+        disablePadding
+        sx={{
+          display: "flex",
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+      </List>
+    );
+  }
+
+  if (!templates?.length) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <EmptyState
+          size="small"
+          title="No templates available"
+          description="Source templates will appear here once published"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <List
+      disablePadding
+      sx={{
+        overflowY: "auto",
+        flex: 1,
+        borderTop: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      {templates.map((template, index) => {
+        const isSubscribed =
+          canUserEditTeam(teamSlug) &&
+          Boolean(template.subscribedTeams?.length);
+
+        return (
+          <React.Fragment key={template.id}>
+            {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
+            <SearchListItem
+              icon={<Badge variant={BadgeVariant.SourceTemplate} />}
+              title={template.name}
+              description={template.summary}
+              statusLabel={isSubscribed ? "Subscribed" : undefined}
+            />
+          </React.Fragment>
+        );
+      })}
+    </List>
+  );
+}
+
+const GET_ONLINE_SOURCE_TEMPLATES = gql`
+  query GetOnlineSourceTemplates($teamId: Int!) {
+    templates: flows(
+      where: {
+        is_template: { _eq: true }
+        can_create_from_copy: { _eq: true }
+        archived_at: { _is_null: true }
+      }
+      order_by: { name: asc }
+    ) {
+      id
+      name
+      summary
+      team {
+        name
+      }
+      subscribedTeams: templated_flows(
+        where: { team_id: { _eq: $teamId } }
+        limit: 1
+      ) {
+        id
+      }
+    }
+  }
+`;
+
+export default function ConnectedTemplatesWidget() {
+  const teamId = useStore((state) => state.teamId);
+  const { data, loading } = useQuery<{ templates: Template[] }>(
+    GET_ONLINE_SOURCE_TEMPLATES,
+    { variables: { teamId } },
+  );
+
+  return <TemplatesWidget templates={data?.templates} loading={loading} />;
+}

--- a/apps/editor.planx.uk/src/pages/Explore/components/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/types.ts
@@ -1,0 +1,9 @@
+export interface Template {
+  id: string;
+  name: string;
+  summary: string;
+  team: {
+    name: string;
+  };
+  subscribedTeams?: { id: string }[];
+}

--- a/apps/editor.planx.uk/src/pages/Explore/components/types.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/types.ts
@@ -5,5 +5,5 @@ export interface Template {
   team: {
     name: string;
   };
-  subscribedTeams?: { id: string }[];
+  subscription?: { id: string }[];
 }

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -2,11 +2,11 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import { linkOptions } from "@tanstack/react-router";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import NumbersWidget from "./components/NumbersWidget";
+import TemplatesWidget from "./components/TemplatesWidget";
 
 export default function Explore() {
   const team = useStore((state) => state.getTeam());
@@ -41,16 +41,8 @@ export default function Explore() {
           <DashboardWidget title="Plan✕ in numbers" subtitle="last 30 days">
             <NumbersWidget />
           </DashboardWidget>
-          <DashboardWidget
-            title="Featured templates"
-            link={linkOptions({
-              // TODO: Update to point to filtered search view for templates
-              to: "/app/$team/flows",
-              params: { team: team.slug },
-              label: "view all templates",
-            })}
-          >
-            <i>templates content</i>
+          <DashboardWidget title="Templates">
+            <TemplatesWidget />
           </DashboardWidget>
         </Box>
       </Container>

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/explore.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/explore.tsx
@@ -1,12 +1,18 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { hasFeatureFlag } from "lib/featureFlags";
 import Explore from "pages/Explore";
+import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
 export const Route = createFileRoute("/_authenticated/app/$team/explore")({
   beforeLoad: ({ params }) => {
     if (!hasFeatureFlag("EXPLORE")) {
       throw redirect({ to: "/app/$team", params });
+    }
+
+    const isAuthorised = useStore.getState().canUserEditTeam(params.team);
+    if (!isAuthorised) {
+      throw notFound();
     }
   },
   component: Explore,


### PR DESCRIPTION
## What does this PR do?

- Sets explore as viewable for a user with edit permission only (making the below template interaction make sense)
- Introduces list of templates to the explore page, with information about which are already subscribed to
- Sets up a generic `SearchListItem` that will be eventually used to list all flow types as search results
- Sets up Storybook file for templates widget

<img width="731" height="420" alt="image" src="https://github.com/user-attachments/assets/8b39988e-6b10-4d38-bd6a-a64e0ee6a8c3" />


### Testing

https://storybook.7226.planx.pizza/?path=/docs/editor-components-explore-templateswidget--docs

Toggle `explore` feature flag to test in app:
https://7226.planx.pizza/app/barnet/explore
