### PR TITLE
feat: Return template details as search result

### DIFF
--- a/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/Badge/Badge.tsx
@@ -9,8 +9,8 @@ import type { BadgeProps, BadgeSize } from "./types";
 import { BadgeVariant } from "./types";
 
 const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
-  default: { box: 56, borderRadius: 6 },
-  compact: { box: 50, borderRadius: 5 },
+  default: { box: 60, borderRadius: 50 },
+  compact: { box: 50, borderRadius: 50 },
 };
 
 const Root = styled(Box, {

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -19,7 +19,7 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
 }) => {
   const content = (
     <>
-      <Box sx={{ mt: 0.25 }}>{icon}</Box>
+      <Box>{icon}</Box>
       <Box
         sx={{
           display: "flex",
@@ -30,9 +30,7 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
         }}
       >
         {statusLabel && (
-          <Box
-            sx={{ display: "flex", alignItems: "center", gap: 0.33, mt: 0.5 }}
-          >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.33 }}>
             <CheckCircleIcon color="success" sx={{ fontSize: 18 }} />
             <Typography
               variant="body3"
@@ -46,7 +44,7 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
           {title}
         </Typography>
         {description && (
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          <Typography variant="body3" sx={{ color: "text.secondary" }}>
             {description}
           </Typography>
         )}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -1,25 +1,24 @@
 import Box from "@mui/material/Box";
 import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import CheckCircleIcon from "ui/icons/CheckCircle";
 
+import type { SearchResult } from "./SearchResult";
+
 interface SearchListItemProps {
-  icon: React.ReactNode;
-  title: string;
-  description?: string;
-  statusLabel?: string;
+  result: SearchResult;
+  onClick?: () => void;
 }
 
 export const SearchListItem: React.FC<SearchListItemProps> = ({
-  icon,
-  title,
-  description,
-  statusLabel,
+  result: { icon, title, description, statusLabel },
+  onClick,
 }) => {
-  return (
-    <ListItem alignItems="flex-start" sx={{ px: 2, py: 1.5, gap: 1.5 }}>
+  const content = (
+    <>
       <Box sx={{ mt: 0.25 }}>{icon}</Box>
       <Box
         sx={{
@@ -52,6 +51,24 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
           </Typography>
         )}
       </Box>
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <ListItemButton
+        onClick={onClick}
+        alignItems="flex-start"
+        sx={{ px: 2, py: 1.5, gap: 1.5 }}
+      >
+        {content}
+      </ListItemButton>
+    );
+  }
+
+  return (
+    <ListItem alignItems="flex-start" sx={{ px: 2, py: 1.5, gap: 1.5 }}>
+      {content}
     </ListItem>
   );
 };

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -27,6 +27,7 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
           gap: 0.25,
           justifyContent: "center",
           minHeight: "56px",
+          pt: 0.33,
         }}
       >
         {statusLabel && (

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
@@ -1,0 +1,85 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import CheckCircleIcon from "ui/icons/CheckCircle";
+
+import type { SearchResult } from "./SearchResult";
+
+interface SearchListItemDetailProps {
+  result: SearchResult;
+}
+
+export const SearchListItemDetail: React.FC<SearchListItemDetailProps> = ({
+  result: {
+    icon,
+    sourceTeam,
+    statusLabel,
+    title,
+    meta,
+    tag,
+    description,
+    relatedItems,
+  },
+}) => {
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+        {icon}
+        {sourceTeam && (
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+          >
+            {sourceTeam}
+          </Typography>
+        )}
+      </Box>
+      {statusLabel && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.33, mb: 0.5 }}>
+          <CheckCircleIcon color="success" sx={{ fontSize: 20 }} />
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD }}
+          >
+            {statusLabel}
+          </Typography>
+        </Box>
+      )}
+      <Typography variant="h3" component="h2">
+        {title}
+      </Typography>
+      {meta && (
+        <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+          {meta}
+        </Typography>
+      )}
+      {tag && <Box sx={{ mt: 1.5, display: "flex" }}>{tag}</Box>}
+      {description && (
+        <Typography variant="body1" sx={{ mt: 2 }}>
+          {description}
+        </Typography>
+      )}
+      {relatedItems && relatedItems.items.length > 0 && (
+        <>
+          <Divider sx={{ my: 2 }} />
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, mb: 1.5 }}
+          >
+            {relatedItems.label}
+          </Typography>
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            {relatedItems.items.map((item) => (
+              <Tooltip key={item.key} title={item.tooltip}>
+                <span>{item.icon}</span>
+              </Tooltip>
+            ))}
+          </Box>
+        </>
+      )}
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
@@ -71,7 +71,7 @@ export const SearchListItemDetail: React.FC<SearchListItemDetailProps> = ({
           >
             {relatedItems.label}
           </Typography>
-          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
             {relatedItems.items.map((item) => (
               <Tooltip key={item.key} title={item.tooltip}>
                 <span>{item.icon}</span>

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
@@ -1,0 +1,40 @@
+import Button from "@mui/material/Button";
+import DialogActions from "@mui/material/DialogActions";
+import Divider from "@mui/material/Divider";
+import React from "react";
+
+import type { SearchResult } from "./SearchResult";
+
+interface SearchListItemDetailActionsProps {
+  primaryAction?: SearchResult["primaryAction"];
+  onClose?: () => void;
+}
+
+export const SearchListItemDetailActions: React.FC<
+  SearchListItemDetailActionsProps
+> = ({ primaryAction, onClose }) => {
+  if (!onClose && !primaryAction) return null;
+
+  return (
+    <>
+      <Divider />
+      <DialogActions>
+        {onClose && (
+          <Button variant="contained" color="secondary" onClick={onClose}>
+            Close
+          </Button>
+        )}
+        {primaryAction && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={primaryAction.onClick}
+            disabled={primaryAction.disabled}
+          >
+            {primaryAction.label}
+          </Button>
+        )}
+      </DialogActions>
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchResult.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchResult.ts
@@ -1,0 +1,30 @@
+import type React from "react";
+
+export interface SearchResultRelatedItem {
+  key: string | number;
+  tooltip: string;
+  icon: React.ReactNode;
+}
+
+export interface SearchResultRelatedItems {
+  label: string;
+  items: SearchResultRelatedItem[];
+}
+
+export interface SearchResultAction {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export interface SearchResult {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  sourceTeam?: string;
+  statusLabel?: string;
+  meta?: string;
+  tag?: React.ReactNode;
+  relatedItems?: SearchResultRelatedItems;
+  primaryAction?: SearchResultAction;
+}

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -1,0 +1,267 @@
+import { gql, useQuery } from "@apollo/client";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import Typography from "@mui/material/Typography";
+import { useNavigate } from "@tanstack/react-router";
+import { ConfirmationDialog } from "components/ConfirmationDialog";
+import { useToast } from "hooks/useToast";
+import { SYSTEM_TEAMS } from "lib/systemTeams";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { formatLastEditMessage } from "pages/FlowEditor/utils";
+import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
+import React, { useState } from "react";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType } from "ui/editor/FlowTag/types";
+import { slugify } from "utils";
+
+import { Badge } from "./Badge/Badge";
+import { BadgeVariant } from "./Badge/types";
+import { SearchListItemDetail } from "./SearchListItemDetail";
+import { SearchListItemDetailActions } from "./SearchListItemDetailActions";
+import type { SearchResult } from "./SearchResult";
+import type { Template } from "./types";
+
+interface TemplateDetails {
+  team: { name: string };
+  operations: {
+    createdAt: string;
+    actor?: { firstName: string; lastName: string };
+  }[];
+  publishedFlows: { hasSendComponent: boolean }[];
+  usedByTeams: {
+    team: {
+      id: number;
+      name: string;
+      theme: {
+        primaryColour?: string | null;
+        logo?: string | null;
+      };
+    };
+  }[];
+}
+
+const GET_TEMPLATE_DETAILS = gql`
+  query GetTemplateDetails($id: uuid!, $systemTeams: [String!]!) {
+    flows(where: { id: { _eq: $id } }, limit: 1) {
+      id
+      team {
+        name
+      }
+      operations(limit: 1, order_by: { created_at: desc }) {
+        createdAt: created_at
+        actor {
+          firstName: first_name
+          lastName: last_name
+        }
+      }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        hasSendComponent: has_send_component
+      }
+      usedByTeams: templated_flows(
+        distinct_on: team_id
+        order_by: [{ team_id: asc }, { created_at: desc }]
+        where: { team: { slug: { _nin: $systemTeams } } }
+      ) {
+        team {
+          id
+          name
+          theme {
+            primaryColour: primary_colour
+            logo
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface TemplateDetailsModalProps {
+  template: Template;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
+  template,
+  open,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [
+    teamId,
+    teamName,
+    teamSlug,
+    canUserEditTeam,
+    showLoading,
+    hideLoading,
+    setLoadingCompleteCallback,
+  ] = useStore((state) => [
+    state.teamId,
+    state.teamName,
+    state.teamSlug,
+    state.canUserEditTeam,
+    state.showLoading,
+    state.hideLoading,
+    state.setLoadingCompleteCallback,
+  ]);
+
+  const { data } = useQuery<{ flows: TemplateDetails[] }>(
+    GET_TEMPLATE_DETAILS,
+    {
+      variables: { id: template.id, systemTeams: SYSTEM_TEAMS },
+      skip: !open,
+    },
+  );
+
+  const details = data?.flows[0];
+  const { mutate: createFlow, isPending } = useCreateFlow();
+
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
+
+  const isAlreadySubscribed = Boolean(
+    details?.usedByTeams.some(({ team }) => team.id === teamId),
+  );
+
+  const handleAddToTeam = () => {
+    const name = `${template.name} (templated)`;
+
+    setLoadingCompleteCallback(() => {
+      toast.success("Flow created successfully");
+      setLoadingCompleteCallback(undefined);
+    });
+    showLoading("Creating flow...");
+
+    createFlow(
+      {
+        mode: "template",
+        flow: {
+          sourceId: template.id,
+          teamId,
+          name,
+          slug: slugify(name),
+          isPattern: false,
+          isTemplate: false,
+          isService: false,
+        },
+      },
+      {
+        onSuccess: async ({ flow }) => {
+          onClose();
+          await navigate({
+            to: "/app/$team/$flow",
+            params: { team: teamSlug, flow: flow.slug },
+          });
+          hideLoading();
+        },
+        onError: () => {
+          setLoadingCompleteCallback(undefined);
+          hideLoading();
+          toast.error("Failed to add template to your team");
+        },
+      },
+    );
+  };
+
+  const editMessage = details?.operations[0]
+    ? formatLastEditMessage(
+        details.operations[0].createdAt,
+        details.operations[0].actor,
+      ).formatted
+    : undefined;
+
+  const usedByTeams = [...(details?.usedByTeams ?? [])].sort((a, b) => {
+    if (a.team.id === teamId) return -1;
+    if (b.team.id === teamId) return 1;
+    return 0;
+  });
+
+  const usedByCount = usedByTeams.length;
+
+  const usedByLabel = (() => {
+    if (canUserEditTeam(teamSlug) && isAlreadySubscribed) {
+      const otherTeamsCount = usedByCount - 1;
+      if (otherTeamsCount === 0) return `Subscribed to by ${teamName}:`;
+      return `Subscribed to by ${teamName} and ${otherTeamsCount} other team${otherTeamsCount === 1 ? "" : "s"}:`;
+    }
+    return `Subscribed to by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`;
+  })();
+
+  const result: SearchResult = {
+    icon: <Badge variant={BadgeVariant.SourceTemplate} size="compact" />,
+    sourceTeam: details?.team.name ?? template.team.name,
+    statusLabel:
+      canUserEditTeam(teamSlug) && isAlreadySubscribed
+        ? "Subscribed"
+        : undefined,
+    title: template.name,
+    meta: editMessage,
+    tag: details?.publishedFlows[0]?.hasSendComponent ? (
+      <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+    ) : undefined,
+    description: template.summary,
+    relatedItems:
+      usedByCount > 0
+        ? {
+            label: usedByLabel,
+            items: usedByTeams.map(({ team }) => ({
+              key: team.id,
+              tooltip: team.name,
+              icon: <Badge variant={BadgeVariant.Team} team={team} />,
+            })),
+          }
+        : undefined,
+    primaryAction: canUserEditTeam(teamSlug)
+      ? {
+          label: "Add to my team",
+          onClick: () =>
+            isAlreadySubscribed
+              ? setIsConfirmationOpen(true)
+              : handleAddToTeam(),
+          disabled: isPending,
+        }
+      : undefined,
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="formWrap"
+        slotProps={{
+          paper: {
+            sx: (theme) => ({ maxWidth: theme.breakpoints.values.formWrap }),
+          },
+        }}
+      >
+        <DialogContent sx={{ backgroundColor: "background.default" }}>
+          <SearchListItemDetail result={result} />
+        </DialogContent>
+        <SearchListItemDetailActions
+          primaryAction={result.primaryAction}
+          onClose={onClose}
+        />
+      </Dialog>
+      <ConfirmationDialog
+        open={isConfirmationOpen}
+        onClose={(confirmed) => {
+          setIsConfirmationOpen(false);
+          if (confirmed) handleAddToTeam();
+        }}
+        title="Add template to your team?"
+        confirmText="Continue"
+        cancelText="Cancel"
+      >
+        <Typography>
+          You already subscribe to this template, subscribing again would mean
+          maintaining more than one instance of this template.
+        </Typography>
+      </ConfirmationDialog>
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -42,7 +42,7 @@ interface TemplateDetails {
 
 const GET_TEMPLATE_DETAILS = gql`
   query GetTemplateDetails($id: uuid!, $systemTeams: [String!]!) {
-    flows(where: { id: { _eq: $id } }, limit: 1) {
+    flow: flows_by_pk(id: $id) {
       id
       team {
         name
@@ -109,7 +109,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
     state.setLoadingCompleteCallback,
   ]);
 
-  const { data } = useQuery<{ flows: TemplateDetails[] }>(
+  const { data } = useQuery<{ flow: TemplateDetails | null }>(
     GET_TEMPLATE_DETAILS,
     {
       variables: { id: template.id, systemTeams: SYSTEM_TEAMS },
@@ -117,7 +117,7 @@ export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
     },
   );
 
-  const details = data?.flows[0];
+  const details = data?.flow ?? undefined;
   const { mutate: createFlow, isPending } = useCreateFlow();
 
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsModal.tsx
@@ -24,11 +24,13 @@ import type { Template } from "./types";
 interface TemplateDetails {
   team: { name: string };
   operations: {
+    id: number;
     createdAt: string;
     actor?: { firstName: string; lastName: string };
   }[];
-  publishedFlows: { hasSendComponent: boolean }[];
+  publishedFlows: { id: number; hasSendComponent: boolean }[];
   usedByTeams: {
+    id: string;
     team: {
       id: number;
       name: string;
@@ -48,6 +50,7 @@ const GET_TEMPLATE_DETAILS = gql`
         name
       }
       operations(limit: 1, order_by: { created_at: desc }) {
+        id
         createdAt: created_at
         actor {
           firstName: first_name
@@ -58,6 +61,7 @@ const GET_TEMPLATE_DETAILS = gql`
         order_by: { created_at: desc }
         limit: 1
       ) {
+        id
         hasSendComponent: has_send_component
       }
       usedByTeams: templated_flows(
@@ -65,6 +69,7 @@ const GET_TEMPLATE_DETAILS = gql`
         order_by: [{ team_id: asc }, { created_at: desc }]
         where: { team: { slug: { _nin: $systemTeams } } }
       ) {
+        id
         team {
           id
           name

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -72,8 +72,7 @@ export function TemplatesWidget({
       >
         {templates.map((template, index) => {
           const isSubscribed =
-            canUserEditTeam(teamSlug) &&
-            Boolean(template.subscription?.length);
+            canUserEditTeam(teamSlug) && Boolean(template.subscription?.length);
 
           const result: SearchResult = {
             icon: <Badge variant={BadgeVariant.SourceTemplate} />,

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplatesWidget.tsx
@@ -4,12 +4,14 @@ import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
+import React, { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 
 import { Badge } from "./Badge/Badge";
 import { BadgeVariant } from "./Badge/types";
 import { SearchListItem } from "./SearchListItem";
+import type { SearchResult } from "./SearchResult";
+import { TemplateDetailsModal } from "./TemplateDetailsModal";
 import type { Template } from "./types";
 
 interface TemplatesWidgetProps {
@@ -25,6 +27,9 @@ export function TemplatesWidget({
     state.teamSlug,
     state.canUserEditTeam,
   ]);
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(
+    null,
+  );
 
   if (loading) {
     return (
@@ -55,32 +60,47 @@ export function TemplatesWidget({
   }
 
   return (
-    <List
-      disablePadding
-      sx={{
-        overflowY: "auto",
-        flex: 1,
-        borderTop: "1px solid",
-        borderColor: "divider",
-      }}
-    >
-      {templates.map((template, index) => {
-        const isSubscribed =
-          canUserEditTeam(teamSlug) && Boolean(template.subscription?.length);
+    <>
+      <List
+        disablePadding
+        sx={{
+          overflowY: "auto",
+          flex: 1,
+          borderTop: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        {templates.map((template, index) => {
+          const isSubscribed =
+            canUserEditTeam(teamSlug) &&
+            Boolean(template.subscription?.length);
 
-        return (
-          <React.Fragment key={template.id}>
-            {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
-            <SearchListItem
-              icon={<Badge variant={BadgeVariant.SourceTemplate} />}
-              title={template.name}
-              description={template.summary}
-              statusLabel={isSubscribed ? "Subscribed" : undefined}
-            />
-          </React.Fragment>
-        );
-      })}
-    </List>
+          const result: SearchResult = {
+            icon: <Badge variant={BadgeVariant.SourceTemplate} />,
+            title: template.name,
+            description: template.summary,
+            statusLabel: isSubscribed ? "Subscribed" : undefined,
+          };
+
+          return (
+            <React.Fragment key={template.id}>
+              {index > 0 && <Divider sx={{ borderColor: "border.main" }} />}
+              <SearchListItem
+                result={result}
+                onClick={() => setSelectedTemplate(template)}
+              />
+            </React.Fragment>
+          );
+        })}
+      </List>
+      {selectedTemplate && (
+        <TemplateDetailsModal
+          template={selectedTemplate}
+          open={Boolean(selectedTemplate)}
+          onClose={() => setSelectedTemplate(null)}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

- Builds on initial work to list templates on explore page - https://github.com/theopensystemslab/planx-new/pull/7226
- Adds a generic `SearchListItemDetail` that will later be used for 2-panel view of search results
- Adds `TemplateDetailsModal` to display templates as an isolated search result
- Warns about adding a duplicate template to a team with an additional dialog confirmation step

<img width="932" height="601" alt="image" src="https://github.com/user-attachments/assets/a5eeccb9-2dd4-4fc4-8c01-31279248aa91" />

<img width="932" height="601" alt="image" src="https://github.com/user-attachments/assets/e1d854fb-13b3-453a-b3a6-3ca56d0c9a71" />

### Testing

Toggle `explore` feature flag to test in app:
https://7228.planx.pizza/app/barnet/explore