### PR TITLE
feat: show ITP and session started in submission history

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/Submissions.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/Submissions.tsx
@@ -18,7 +18,10 @@ const Submissions: React.FC<SubmissionsProps> = ({ flowSlug }) => {
     gql`
       query GetSubmissions($team_id: Int!) {
         submissions: submission_services_log(
-          where: { team_id: { _eq: $team_id } }
+          where: {
+            team_id: { _eq: $team_id }
+            event_type: { _nin: ["Started session", "Invited to pay"] }
+          }
           order_by: { created_at: desc }
         ) {
           flowId: flow_id

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/OpenResponseButtonGrouped.tsx
@@ -7,10 +7,11 @@ import { DataTableModal } from "ui/shared/DataTable/components/DataTableModal";
 import type { Attempt } from "../types";
 import { FormattedResponse } from "./FormattedResponse";
 
-type Props = { attempt: Attempt; sessionId: string };
+type Props = { attempt: Attempt; sessionId: string; disabled?: boolean };
 
 export const OpenResponseButtonGrouped = (props: Props) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
+  if (props.disabled) return;
 
   const parseResponse = ({ eventType, status, response }: Attempt) => {
     let data;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -103,6 +103,8 @@ const SubmissionEvent: React.FC<{
   isMostRecent: boolean;
 }> = ({ groupedEvent: { sessionId, events: attempts }, isMostRecent }) => {
   const { eventType, createdAt, status } = attempts[0];
+  const hideResponse =
+    eventType === "Invited to pay" || eventType === "Started session";
 
   return (
     <Box
@@ -131,12 +133,16 @@ const SubmissionEvent: React.FC<{
         <Typography sx={{ fontWeight: "bold" }}>{eventType}</Typography>
 
         <Permission.IsPlatformAdmin>
-          {isMostRecent && status !== "Success" && eventType !== "Pay" && (
-            <ResubmitButtonGrouped
-              sessionId={sessionId}
-              eventType={eventType}
-            />
-          )}
+          {isMostRecent &&
+            status !== "Success" &&
+            eventType !== "Pay" &&
+            eventType !== "Invited to pay" &&
+            eventType !== "Started session" && ( // TODO: refactor
+              <ResubmitButtonGrouped
+                sessionId={sessionId}
+                eventType={eventType}
+              />
+            )}
         </Permission.IsPlatformAdmin>
 
         {attempts.length === 1 ? (
@@ -147,6 +153,7 @@ const SubmissionEvent: React.FC<{
                 <OpenResponseButtonGrouped
                   attempt={attempts[0]}
                   sessionId={sessionId}
+                  disabled={hideResponse}
                 />
               </Box>
             </Box>
@@ -182,6 +189,7 @@ const SubmissionAttempts: React.FC<{
               <OpenResponseButtonGrouped
                 attempt={attempt}
                 sessionId={sessionId}
+                disabled={hideResponse}
               />
             </Box>
           </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -1,10 +1,10 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 import Permission from "ui/editor/Permission";
 
 import type { Attempt, GroupedEvent, Submission } from "../types";
+import { canResubmit } from "../utils";
 import { OpenResponseButtonGrouped } from "./OpenResponseButtonGrouped";
 import { ResubmitButtonGrouped } from "./ResubmitButtonGrouped";
 import { StatusChip } from "./StatusChip";
@@ -143,16 +143,12 @@ const SubmissionEvent: React.FC<{
         <Typography sx={{ fontWeight: "bold" }}>{eventType}</Typography>
 
         <Permission.IsPlatformAdmin>
-          {isMostRecent &&
-            status !== "Success" &&
-            eventType !== "Pay" &&
-            eventType !== "Invited to pay" &&
-            eventType !== "Started session" && ( // TODO: refactor
-              <ResubmitButtonGrouped
-                sessionId={sessionId}
-                eventType={eventType}
-              />
-            )}
+          {canResubmit(isMostRecent, status, eventType) && (
+            <ResubmitButtonGrouped
+              sessionId={sessionId}
+              eventType={eventType}
+            />
+          )}
         </Permission.IsPlatformAdmin>
 
         {attempts.length === 1 ? (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -85,7 +85,19 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
         borderColor: "border.main",
       }}
     >
-      <Box sx={{ padding: 1, margin: 1 }}>
+      <Box
+        sx={{
+          padding: 1,
+          margin: 1,
+          "& > *": {
+            borderBottom: 1,
+            borderColor: "border.main",
+          },
+          "& > *:last-child": {
+            borderBottom: 0,
+          },
+        }}
+      >
         {groupedEvents.map((groupedEvent) => (
           <SubmissionEvent
             key={groupedEvent.eventId}
@@ -113,8 +125,6 @@ const SubmissionEvent: React.FC<{
         width: "100%",
         alignItems: "flex-start",
         mb: 1,
-        borderBottom: 1,
-        borderColor: "border.main",
       }}
     >
       <Box>
@@ -189,7 +199,6 @@ const SubmissionAttempts: React.FC<{
               <OpenResponseButtonGrouped
                 attempt={attempt}
                 sessionId={sessionId}
-                disabled={hideResponse}
               />
             </Box>
           </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -39,14 +39,14 @@ export interface GroupedEvent {
 }
 
 export type Attempt = {
-  eventType: Submission["eventType"] | LifecycleEvent;
+  eventType: Submission["eventType"] | SessionEvent;
   createdAt: Submission["createdAt"];
   retry: Submission["retry"];
   response: Submission["response"];
   status: Submission["status"];
 };
 
-type LifecycleEvent = "Invited to pay" | "Started session";
+export type SessionEvent = "Invited to pay" | "Started session";
 
 export interface SubmissionSummary {
   id: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -39,12 +39,14 @@ export interface GroupedEvent {
 }
 
 export type Attempt = {
-  eventType: Submission["eventType"];
+  eventType: Submission["eventType"] | LifecycleEvent;
   createdAt: Submission["createdAt"];
   retry: Submission["retry"];
   response: Submission["response"];
   status: Submission["status"];
 };
+
+type LifecycleEvent = "Invited to pay" | "Started session";
 
 export interface SubmissionSummary {
   id: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
@@ -1,3 +1,5 @@
+import type { SessionEvent, Submission } from "./types";
+
 export const getConsolidatedStatus = (
   status: string | undefined,
   eventType: string,
@@ -16,4 +18,22 @@ export const getConsolidatedStatus = (
   } else {
     return "Failed";
   }
+};
+
+const NON_RESUBMITTABLE_EVENT_TYPES = [
+  "Pay",
+  "Invited to pay",
+  "Started session",
+];
+
+export const canResubmit = (
+  isMostRecent: boolean,
+  status: string | undefined,
+  eventType: Submission["eventType"] | SessionEvent,
+): eventType is Submission["eventType"] => {
+  return (
+    isMostRecent &&
+    status !== "Success" &&
+    !NON_RESUBMITTABLE_EVENT_TYPES.includes(eventType)
+  );
 };

--- a/apps/hasura.planx.uk/migrations/default/1787318310045_add_itp_and_session_started_to_submission_services_log/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787318310045_add_itp_and_session_started_to_submission_services_log/down.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%?notify=false%'::text) THEN 'Upload to AWS S3 (no notification)'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE ((seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone) AND (((se.webhook_conf)::text ~~ '%bops%'::text) OR ((se.webhook_conf)::text ~~ '%uniform%'::text) OR ((se.webhook_conf)::text ~~ '%email-submission%'::text) OR ((se.webhook_conf)::text ~~ '%?notify=false%'::text) OR ((se.webhook_conf)::text ~~ '%upload-submission%'::text) OR ((se.webhook_conf)::text ~~ '%idox%'::text)))
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name,
+    coalesce(
+      ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), 
+      ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)
+   )  AS address
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1787318310045_add_itp_and_session_started_to_submission_services_log/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787318310045_add_itp_and_session_started_to_submission_services_log/up.sql
@@ -1,0 +1,118 @@
+CREATE OR REPLACE VIEW "public"."submission_services_log" AS 
+ WITH payments AS (
+         SELECT ps.session_id,
+            ps.payment_id AS event_id,
+            'Pay'::text AS event_type,
+            initcap(ps.status) AS status,
+            jsonb_build_object('status', ps.status, 'description', pse.comment, 'govuk_pay_reference', ps.payment_id, 'govuk_pay_metadata', ps.gov_pay_metadata) AS response,
+            ps.created_at,
+            false AS retry
+           FROM (payment_status ps
+             LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status)))
+          WHERE ((ps.status <> 'created'::text) AND (ps.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone))
+        ), retries AS (
+         SELECT hdb_scheduled_event_invocation_logs.id
+           FROM hdb_catalog.hdb_scheduled_event_invocation_logs
+          WHERE ((hdb_scheduled_event_invocation_logs.event_id, hdb_scheduled_event_invocation_logs.created_at) IN ( SELECT seil.event_id,
+                    max(seil.created_at) AS max
+                   FROM (hdb_catalog.hdb_scheduled_event_invocation_logs seil
+                     LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id)))
+                  WHERE (se.tries > 1)
+                  GROUP BY seil.event_id))
+        ), submissions AS (
+         SELECT ((((seil.request -> 'payload'::text) -> 'payload'::text) ->> 'sessionId'::text))::uuid AS session_id,
+            se.id AS event_id,
+                CASE
+                    WHEN ((se.webhook_conf)::text ~~ '%bops%'::text) THEN 'Submit to BOPS'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%uniform%'::text) THEN 'Submit to Uniform'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%email-submission%'::text) THEN 'Send to email'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%?notify=false%'::text) THEN 'Upload to AWS S3 (no notification)'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%upload-submission%'::text) THEN 'Upload to AWS S3'::text
+                    WHEN ((se.webhook_conf)::text ~~ '%idox%'::text) THEN 'Submit to Idox Nexus'::text
+                    ELSE (se.webhook_conf)::text
+                END AS event_type,
+                CASE
+                    WHEN (seil.status = 200) THEN 'Success'::text
+                    ELSE format('Failed (%s)'::text, seil.status)
+                END AS status,
+            (seil.response)::jsonb AS response,
+            seil.created_at,
+            (EXISTS ( SELECT 1
+                   FROM retries r
+                  WHERE (r.id = seil.id))) AS retry
+           FROM (hdb_catalog.hdb_scheduled_events se
+             LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id)))
+          WHERE ((seil.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone) AND (((se.webhook_conf)::text ~~ '%bops%'::text) OR ((se.webhook_conf)::text ~~ '%uniform%'::text) OR ((se.webhook_conf)::text ~~ '%email-submission%'::text) OR ((se.webhook_conf)::text ~~ '%?notify=false%'::text) OR ((se.webhook_conf)::text ~~ '%upload-submission%'::text) OR ((se.webhook_conf)::text ~~ '%idox%'::text)))
+        ), session_starts AS (
+         SELECT ls_1.id AS session_id,
+            (ls_1.id)::text AS event_id,
+            'Started session'::text AS event_type,
+            'Success'::text AS status,
+            NULL::jsonb AS response,
+            ls_1.created_at,
+            false AS retry
+           FROM lowcal_sessions ls_1
+          WHERE ((ls_1.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone) AND (ls_1.created_at IS NOT NULL))
+        ), payment_invites AS (
+         SELECT pr.session_id,
+            (pr.id)::text AS event_id,
+            'Invited to pay'::text AS event_type,
+            'Success'::text AS status,
+            jsonb_build_object('payee_email', pr.payee_email, 'payee_name', pr.payee_name, 'paid_at', pr.paid_at) AS response,
+            pr.created_at,
+            false AS retry
+           FROM payment_requests pr
+          WHERE (pr.created_at >= '2024-01-01 00:00:00+00'::timestamp with time zone)
+        ), all_events AS (
+         SELECT payments.session_id,
+            payments.event_id,
+            payments.event_type,
+            payments.status,
+            payments.response,
+            payments.created_at,
+            payments.retry
+           FROM payments
+        UNION ALL
+         SELECT submissions.session_id,
+            submissions.event_id,
+            submissions.event_type,
+            submissions.status,
+            submissions.response,
+            submissions.created_at,
+            submissions.retry
+           FROM submissions
+        UNION ALL
+         SELECT session_starts.session_id,
+            session_starts.event_id,
+            session_starts.event_type,
+            session_starts.status,
+            session_starts.response,
+            session_starts.created_at,
+            session_starts.retry
+           FROM session_starts
+        UNION ALL
+         SELECT payment_invites.session_id,
+            payment_invites.event_id,
+            payment_invites.event_type,
+            payment_invites.status,
+            payment_invites.response,
+            payment_invites.created_at,
+            payment_invites.retry
+           FROM payment_invites
+        )
+ SELECT ls.flow_id,
+    ae.session_id,
+    ae.event_id,
+    ae.event_type,
+    ae.status,
+    ae.response,
+    ae.created_at,
+    ae.retry,
+    f.team_id,
+    f.name AS flow_name,
+    COALESCE(((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'single_line_address'::text), ((((ls.data -> 'passport'::text) -> 'data'::text) -> '_address'::text) ->> 'title'::text)) AS address
+   FROM ((all_events ae
+     LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id)))
+     LEFT JOIN flows f ON ((f.id = ls.flow_id)))
+  WHERE (ls.flow_id IS NOT NULL)
+  ORDER BY ae.created_at DESC;


### PR DESCRIPTION
# What does this PR do
Preventing empty `<SubmissionEventHistory>` (which Daf pointed out in #7201) which were rendering for submissions with "Sending" and "Invited to pay" statuses. 

- Adds session started and payment request times to `submission_services_log`
- Renders them in the `SubmissionEventHistory` component, ensuring that view response + resubmit don't render for them

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6cdf7bf1-6fe0-4efa-b2e2-652414bc4f76" />

After: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0f74abf3-58cd-444b-b924-7d8eccccb150" />

(Aware there's some awkward spacing here, struggled to fix it--might bring to dev call or Ian)

# Why
Some histories were empty because `payment_requests` was queried in the `submission_grouped` view but not in `submission_services_log`, which is where the list of all events was being stored. (Ian's design also included "Started session" in the history.)

First I tried creating a new view (since existing `submission_services_log` was complex and had performance issues before. This led me down a rabbit hole of convoluted types and aggregation logic, so I went back to adding CTEs to `submission_services_log`. This works, makes for simpler code but is still imperfect and we might have some performance issues on prod--thoughts welcome!