### PR TITLE
chore(api): Re-introduce `express-async-errors`

### DIFF
--- a/apps/api.planx.uk/server.ts
+++ b/apps/api.planx.uk/server.ts
@@ -1,4 +1,5 @@
 import "isomorphic-fetch";
+import "express-async-errors";
 
 import type { Role } from "@opensystemslab/planx-core/types";
 import assert from "assert";


### PR DESCRIPTION
Please see https://github.com/theopensystemslab/planx-new/pull/7225

`express-async-errors` is already installed, but never invoked. This regression was introduced here, appears to be a simple mistake - https://github.com/theopensystemslab/planx-new/pull/3528/changes#diff-a23b8e0cdc75fc858dc3a73983f67d257f78158596c37832202cf963efcf0a6aL9

We should probably migrate to Express v5 which will remove the need for this, but this one-liner is a quick/pragmatic option here!