### PR TITLE
chore: Bump osl/map

### DIFF
--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -17,7 +17,7 @@
     "@mui/utils": "^9.0.0",
     "@mui/x-charts": "^9.0.0",
     "@mui/x-data-grid": "^9.0.0",
-    "@opensystemslab/map": "1.0.0-alpha.14",
+    "@opensystemslab/map": "catalog:",
     "@opensystemslab/planx-core": "catalog:",
     "@planx/file-upload": "workspace:*",
     "@tanstack/react-query": "^5.101.1",

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -18,7 +18,7 @@
     "@astrojs/react": "^5.0.0",
     "@astrojs/sitemap": "^3.7.0",
     "@nanostores/react": "^1.0.0",
-    "@opensystemslab/map": "1.0.0-alpha.11",
+    "@opensystemslab/map": "catalog:",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.101.1",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@opensystemslab/map':
+      specifier: 1.0.0-alpha.15
+      version: 1.0.0-alpha.15
     '@opensystemslab/planx-core':
       specifier: github:theopensystemslab/planx-core#fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb
       version: 1.0.0
@@ -461,8 +464,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.2(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mui/system@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@opensystemslab/map':
-        specifier: 1.0.0-alpha.14
-        version: 1.0.0-alpha.14
+        specifier: 'catalog:'
+        version: 1.0.0-alpha.15(geotiff@3.0.5)
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
         version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -844,8 +847,8 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0(nanostores@1.3.0)(react@19.2.5)
       '@opensystemslab/map':
-        specifier: 1.0.0-alpha.11
-        version: 1.0.0-alpha.11
+        specifier: 'catalog:'
+        version: 1.0.0-alpha.15(geotiff@3.0.5)
       '@planx/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -2987,15 +2990,8 @@ packages:
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
     engines: {node: '>= 0.6'}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
-
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
-
-  '@maplibre/maplibre-gl-style-spec@23.3.0':
-    resolution: {integrity: sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==}
-    hasBin: true
 
   '@maplibre/maplibre-gl-style-spec@24.10.0':
     resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
@@ -3283,11 +3279,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opensystemslab/map@1.0.0-alpha.11':
-    resolution: {integrity: sha512-ETACPCk5Coef1L2kNT3MhIzLxVPDpyopxsTNcgeRyEqL71HBfTklGyC5+t7HgEgxRkX5wlUXqmKPNL9DdpVj8g==}
-
-  '@opensystemslab/map@1.0.0-alpha.14':
-    resolution: {integrity: sha512-kIVrXtq2rcOzayTtUkVUQWSJMGrhER7FuuMR9cJw5a8AOH69XnXrkDPGBMVQmNJOIoMkO4dOzTt6ofUchZxLQA==}
+  '@opensystemslab/map@1.0.0-alpha.15':
+    resolution: {integrity: sha512-Z0feONs1+P6LIn04wxFdwHaKfJkqSpo3bHe0Nr43g50gq2dqnCT2KKxkXCwY4zUKnV6duFYPqAK1KD/kjzSs/w==}
 
   '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb':
     resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb}
@@ -7311,9 +7304,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -7571,12 +7561,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  govuk-frontend@5.14.0:
-    resolution: {integrity: sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==}
-    engines: {node: '>= 4.2.0'}
-
-  govuk-frontend@6.2.0:
-    resolution: {integrity: sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==}
+  govuk-frontend@6.4.0:
+    resolution: {integrity: sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==}
     engines: {node: '>= 4.2.0'}
 
   graceful-fs@4.2.11:
@@ -9184,11 +9170,6 @@ packages:
     peerDependencies:
       ol: '>= 5.3.0'
 
-  ol-mapbox-style@12.6.1:
-    resolution: {integrity: sha512-bpN7ZvqbQX/JZnru0MTQgPIAUBAgPOvYDj/9BoJoqCvFYjHxCpRFDQJEoD10PLw3vGHNJFYBUvY82yfW26otQg==}
-    peerDependencies:
-      ol: '*'
-
   ol-mapbox-style@13.4.1:
     resolution: {integrity: sha512-da4FKZUXoXMzK5ADeRHAXzd3bTeiKg/Y9LBOTB6qNTP62MQm93y6ISrIXzOS9atfGgQMEHJ2pCgP272IMeZCXA==}
     peerDependencies:
@@ -9678,8 +9659,13 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
-  proj4@2.20.8:
-    resolution: {integrity: sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==}
+  proj4@2.21.0:
+    resolution: {integrity: sha512-33HfDftqw8kY+Cl1dcL16SJuqTSzYxmz4re7Nmhk+fs1/N1fFrAkkF579msQTR/4fLeJVSNne8/gpoCz0fk1uw==}
+    peerDependencies:
+      geotiff: '*'
+    peerDependenciesMeta:
+      geotiff:
+        optional: true
 
   promise-all-reject-late@1.0.1:
     resolution: {integrity: sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==}
@@ -9832,9 +9818,6 @@ packages:
 
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
-
-  rambda@10.3.4:
-    resolution: {integrity: sha512-FbqeXxuxV/T1QHbIlh4YSvZ+MbDoaWgbKq0AfxeM+7tAcp2eqWN6jog2Fh2lz1jDmoVSqkiXhtdXGsaWAYYmow==}
 
   rambda@11.2.0:
     resolution: {integrity: sha512-Shzc8LTC+rhgDYddMEaTYhAo/U6kdp25/6dOymrCRyK3R9vVmt4a0Rl6zFtGEzh0dWYxTgrH3uff53RTzn1Rwg==}
@@ -10272,9 +10255,6 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -13740,19 +13720,7 @@ snapshots:
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
-
   '@mapbox/unitbezier@1.0.0': {}
-
-  '@maplibre/maplibre-gl-style-spec@23.3.0':
-    dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/unitbezier': 0.0.1
-      json-stringify-pretty-compact: 4.0.0
-      minimist: 1.2.8
-      quickselect: 3.0.0
-      rw: 1.3.3
-      tinyqueue: 3.0.0
 
   '@maplibre/maplibre-gl-style-spec@24.10.0':
     dependencies:
@@ -14146,42 +14114,24 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opensystemslab/map@1.0.0-alpha.11':
+  '@opensystemslab/map@1.0.0-alpha.15(geotiff@3.0.5)':
     dependencies:
       '@turf/helpers': 7.3.5
       '@turf/union': 7.3.5
       '@types/geojson': 7946.0.16
       accessible-autocomplete: 3.0.1
       file-saver: 2.0.5
-      govuk-frontend: 5.14.0
-      jspdf: 4.2.1
-      lit: 3.3.2
-      ol: 10.9.0
-      ol-ext: 4.0.38(ol@10.9.0)
-      ol-mapbox-style: 12.6.1(ol@10.9.0)
-      postcode: 5.1.0
-      proj4: 2.20.8
-      rambda: 10.3.4
-    transitivePeerDependencies:
-      - preact
-
-  '@opensystemslab/map@1.0.0-alpha.14':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@turf/union': 7.3.5
-      '@types/geojson': 7946.0.16
-      accessible-autocomplete: 3.0.1
-      file-saver: 2.0.5
-      govuk-frontend: 6.2.0
+      govuk-frontend: 6.4.0
       jspdf: 4.2.1
       lit: 3.3.2
       ol: 10.9.0
       ol-ext: 4.0.38(ol@10.9.0)
       ol-mapbox-style: 13.4.1(ol@10.9.0)
       postcode: 5.1.0
-      proj4: 2.20.8
+      proj4: 2.21.0(geotiff@3.0.5)
       rambda: 11.2.0
     transitivePeerDependencies:
+      - geotiff
       - preact
 
   '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -18557,8 +18507,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fflate@0.8.2: {}
-
   fflate@0.8.3: {}
 
   figures@3.2.0:
@@ -18837,9 +18785,7 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  govuk-frontend@5.14.0: {}
-
-  govuk-frontend@6.2.0: {}
+  govuk-frontend@6.4.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -19623,7 +19569,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       fast-png: 6.4.0
-      fflate: 0.8.2
+      fflate: 0.8.3
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
@@ -20781,12 +20727,6 @@ snapshots:
     dependencies:
       ol: 10.9.0
 
-  ol-mapbox-style@12.6.1(ol@10.9.0):
-    dependencies:
-      '@maplibre/maplibre-gl-style-spec': 23.3.0
-      mapbox-to-css-font: 3.2.0
-      ol: 10.9.0
-
   ol-mapbox-style@13.4.1(ol@10.9.0):
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 24.10.0
@@ -21352,10 +21292,12 @@ snapshots:
 
   progress@2.0.3: {}
 
-  proj4@2.20.8:
+  proj4@2.21.0(geotiff@3.0.5):
     dependencies:
       mgrs: 1.0.0
       wkt-parser: 1.5.5
+    optionalDependencies:
+      geotiff: 3.0.5
 
   promise-all-reject-late@1.0.1: {}
 
@@ -21551,8 +21493,6 @@ snapshots:
     dependencies:
       performance-now: 2.1.0
     optional: true
-
-  rambda@10.3.4: {}
 
   rambda@11.2.0: {}
 
@@ -22151,8 +22091,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ packages:
   - scripts/*
 
 catalog:
+  "@opensystemslab/map": 1.0.0-alpha.15
   "@opensystemslab/planx-core": github:theopensystemslab/planx-core#fd0d1c4aa3879f1b73afef7ef7eb27579a0d2acb
   "@types/jsdom": ^28.0.3
   "@types/node": ~24.10.15
@@ -53,5 +54,4 @@ catalogs:
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
-  - dompurify@3.4.11
-  - "@opensystemslab/map@1.0.0-alpha.14"
+  - "@opensystemslab/map@1.0.0-alpha.15"


### PR DESCRIPTION
- Bumps to @opensystemslab/map@1.0.0-alpha.15 to resolve a11y issue
- Moves map to shared pnpm catalog - a11y fix is also needed in LPS