### PR TITLE
feat[alt notes]: new `Note` component type and sanitise function on flatten

### DIFF
--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -426,7 +426,7 @@ const draftParentFlow: FlowGraph = {
   n0t3: {
     type: ComponentType.Note,
     data: {
-      note: "This is a sticky note",
+      text: "This is a sticky note",
       tags: ["toReview"],
     },
   },

--- a/apps/api.planx.uk/shared/dataMerged.test.ts
+++ b/apps/api.planx.uk/shared/dataMerged.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@opensystemslab/planx-core/types";
 
 import { queryMock } from "../tests/graphqlQueryMock.js";
-import { dataMerged } from "./dataMerged.js";
+import { dataMerged, sanitiseNotes } from "./dataMerged.js";
 
 describe("dataMerged() function", () => {
   beforeEach(() => {
@@ -307,18 +307,39 @@ describe("dataMerged() function", () => {
   });
 });
 
+describe("sanitiseNotes() function", () => {
+  it("removes all data associated with Note component types but preserves their position", () => {
+    const sanitisedFlow = sanitiseNotes(draftParentFlow);
+
+    expect(sanitisedFlow["n0t3"]).not.toHaveProperty("data");
+    expect(sanitisedFlow["_root"].edges).toContain("n0t3");
+    expect(sanitisedFlow["n0t3"]).toEqual({ type: ComponentType.Note });
+  });
+
+  it("removes internal notes prop from any component type which sets it", () => {
+    const sanitisedFlow = sanitiseNotes(draftParentFlow);
+
+    expect(sanitisedFlow["45vie6vizK"]).toHaveProperty("data");
+    expect(sanitisedFlow["45vie6vizK"]).not.toHaveProperty("notes");
+
+    expect(sanitisedFlow["DQRnJfTvkq"]).toHaveProperty("data");
+    expect(sanitisedFlow["DQRnJfTvkq"]).not.toHaveProperty("notes");
+  });
+});
+
 /**
  * Draft parent flow data which includes 3 nested flow nodes (2 unique flows) and 1 folder
  */
 const draftParentFlow: FlowGraph = {
   _root: {
-    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU", "n0t3"],
   },
   "45vie6vizK": {
     data: {
       content: "<h1>Folder</h1><p>This is content in a folder</p>",
       resetButton: false,
       tags: [],
+      notes: "Remember to internally review this content",
     },
     type: ComponentType.Content,
   },
@@ -328,6 +349,7 @@ const draftParentFlow: FlowGraph = {
       text: "Which branch?",
       neverAutoAnswer: false,
       alwaysAutoAnswerBlank: false,
+      notes: "Remember to internally review this question",
     },
     type: ComponentType.Question,
     edges: ["jTi25P1WkE", "xwVz9s9ZVQ", "f6zoaYuboI"],
@@ -401,6 +423,13 @@ const draftParentFlow: FlowGraph = {
       areTemplatedNodeInstructionsRequired: false,
     },
   },
+  n0t3: {
+    type: ComponentType.Note,
+    data: {
+      note: "This is a sticky note",
+      tags: ["toReview"],
+    },
+  },
 };
 
 /**
@@ -411,7 +440,7 @@ const draftParentFlow: FlowGraph = {
  */
 const flattenedParentFlow: FlowGraph = {
   _root: {
-    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU", "n0t3"],
   },
   "0ND9E0ov0D": {
     type: ComponentType.InternalPortal,
@@ -525,6 +554,9 @@ const flattenedParentFlow: FlowGraph = {
     type: ComponentType.Answer,
     edges: ["UZWjLKDsBv"],
   },
+  n0t3: {
+    type: ComponentType.Note,
+  },
 };
 
 /**
@@ -533,7 +565,7 @@ const flattenedParentFlow: FlowGraph = {
  */
 const flattenedParentFlowDraftOnly: FlowGraph = {
   _root: {
-    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU"],
+    edges: ["DQRnJfTvkq", "JtWhixLQQD", "r6ZeA1GFpU", "n0t3"],
   },
   "0ND9E0ov0D": {
     type: ComponentType.InternalPortal,
@@ -641,6 +673,9 @@ const flattenedParentFlowDraftOnly: FlowGraph = {
     type: ComponentType.Answer,
     edges: ["UZWjLKDsBv"],
   },
+  n0t3: {
+    type: ComponentType.Note,
+  },
 };
 
 const draftNestedFlowA: FlowGraph = {
@@ -680,6 +715,7 @@ const draftNestedFlowB: FlowGraph = {
       content:
         "<h1>Nested B</h1><p>This is UNPUBLISHED nested flow content</p><p></p>",
       resetButton: false,
+      notes: "This is an un-sanitised internal note",
     },
   },
 };

--- a/apps/api.planx.uk/shared/dataMerged.ts
+++ b/apps/api.planx.uk/shared/dataMerged.ts
@@ -1,5 +1,6 @@
 import type { FlowGraph } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
+import cloneDeep from "lodash/cloneDeep.js";
 
 import { getFlowData, getMostRecentPublishedFlowVersion } from "../helpers.js";
 import type { Node } from "../types.js";
@@ -51,7 +52,25 @@ export const dataMerged = async (
     }
   }
 
-  return mergedGraph as FlowGraph;
+  return redactNotesFromFlow(mergedGraph) as FlowGraph;
+};
+
+const redactNotesFromFlow = (flow: MergedGraph): MergedGraph => {
+  const redactedFlow = cloneDeep(flow);
+
+  for (const [nodeId, node] of Object.entries(redactedFlow)) {
+    // Leave "Note" components in place in the graph, but fully delete their data/content
+    if (node?.type === ComponentType.Note) {
+      delete redactedFlow[nodeId]?.["data"];
+      continue;
+    }
+    // For any component type that has "internal notes", remove only this prop
+    if (node?.data?.notes) {
+      delete redactedFlow[nodeId]?.["data"]?.["notes"];
+    }
+  }
+
+  return redactedFlow;
 };
 
 const fetchAndMergeStack = async (

--- a/apps/api.planx.uk/shared/dataMerged.ts
+++ b/apps/api.planx.uk/shared/dataMerged.ts
@@ -52,10 +52,10 @@ export const dataMerged = async (
     }
   }
 
-  return redactNotesFromFlow(mergedGraph) as FlowGraph;
+  return sanitiseNotes(mergedGraph) as FlowGraph;
 };
 
-const redactNotesFromFlow = (flow: MergedGraph): MergedGraph => {
+export const sanitiseNotes = (flow: MergedGraph): MergedGraph => {
   const redactedFlow = cloneDeep(flow);
 
   for (const [nodeId, node] of Object.entries(redactedFlow)) {

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -36,12 +36,12 @@ function NoteComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              name="note"
+              name="text"
               format="large"
               minRows={4}
               multiline={true}
               placeholder="Note"
-              value={formik.values.note}
+              value={formik.values.text}
               onChange={formik.handleChange}
               disabled={props.disabled}
             />

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -7,7 +7,7 @@ import Input from "ui/shared/Input/Input";
 import InputRow from "ui/shared/InputRow";
 
 import type { EditorProps } from "../shared/types";
-import type { Note} from "./model";
+import type { Note } from "./model";
 import { parseContent, validationSchema } from "./model";
 
 type Props = EditorProps<ComponentType.Note, Note>;

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -1,0 +1,60 @@
+import { ComponentType } from "@opensystemslab/planx-core/types";
+import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
+import { ModalFooter } from "ui/editor/ModalFooter";
+import ModalSection from "ui/editor/ModalSection";
+import ModalSectionContent from "ui/editor/ModalSectionContent";
+import Input from "ui/shared/Input/Input";
+import InputRow from "ui/shared/InputRow";
+
+import type { EditorProps } from "../shared/types";
+import type { Note} from "./model";
+import { parseContent, validationSchema } from "./model";
+
+type Props = EditorProps<ComponentType.Note, Note>;
+
+export default NoteComponent;
+
+function NoteComponent(props: Props) {
+  const formik = useFormikWithRef(
+    {
+      initialValues: parseContent(props.node?.data),
+      onSubmit: (newValues) => {
+        props.handleSubmit?.({
+          type: ComponentType.Note,
+          data: newValues,
+        });
+      },
+      validationSchema,
+    },
+    props.formikRef,
+  );
+
+  // Notes will never be "templated", therefore no template fields here
+  return (
+    <form onSubmit={formik.handleSubmit} id="modal">
+      <ModalSection>
+        <ModalSectionContent>
+          <InputRow>
+            <Input
+              name="note"
+              format="large"
+              minRows={4}
+              multiline={true}
+              placeholder="Note"
+              value={formik.values.note}
+              onChange={formik.handleChange}
+              disabled={props.disabled}
+            />
+          </InputRow>
+        </ModalSectionContent>
+      </ModalSection>
+      <ModalFooter
+        formik={formik}
+        disabled={props.disabled}
+        showTags={true}
+        showInternalNotes={false}
+        showMoreInformation={false}
+      />
+    </form>
+  );
+}

--- a/apps/editor.planx.uk/src/@planx/components/Note/Public.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Public.tsx
@@ -1,0 +1,17 @@
+import type { PublicProps } from "@planx/components/shared/types";
+import { useEffect } from "react";
+
+import type { Note } from "./model";
+
+export type Props = PublicProps<Note>;
+
+// Notes are never seen by users and always auto-answered
+export default function Component(props: Props) {
+  useEffect(() => {
+    props.handleSubmit?.({
+      auto: true,
+    });
+  }, []);
+
+  return null;
+}

--- a/apps/editor.planx.uk/src/@planx/components/Note/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Note/model.ts
@@ -5,18 +5,17 @@ import type { BaseNodeData } from "../shared";
 import { baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface Note extends BaseNodeData {
-  note: string;
+  text: string;
 }
 
 export const parseContent = (data: Record<string, any> | undefined): Note => ({
-  note: data?.note || "",
+  text: data?.text || "",
   ...parseBaseNodeData(data),
 });
 
-// TODO determine if use of "required" here will interfere later with flattened graph where `note` has been stripped out?
 export const validationSchema: SchemaOf<Note> =
   baseNodeDataValidationSchema.concat(
     object({
-      note: string().required(),
+      text: string().required(),
     }),
   );

--- a/apps/editor.planx.uk/src/@planx/components/Note/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Note/model.ts
@@ -1,12 +1,8 @@
-import type { SchemaOf} from "yup";
+import type { SchemaOf } from "yup";
 import { object, string } from "yup";
 
-import type {
-  BaseNodeData} from "../shared";
-import {
-  baseNodeDataValidationSchema,
-  parseBaseNodeData,
-} from "../shared";
+import type { BaseNodeData } from "../shared";
+import { baseNodeDataValidationSchema, parseBaseNodeData } from "../shared";
 
 export interface Note extends BaseNodeData {
   note: string;

--- a/apps/editor.planx.uk/src/@planx/components/Note/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Note/model.ts
@@ -1,0 +1,26 @@
+import type { SchemaOf} from "yup";
+import { object, string } from "yup";
+
+import type {
+  BaseNodeData} from "../shared";
+import {
+  baseNodeDataValidationSchema,
+  parseBaseNodeData,
+} from "../shared";
+
+export interface Note extends BaseNodeData {
+  note: string;
+}
+
+export const parseContent = (data: Record<string, any> | undefined): Note => ({
+  note: data?.note || "",
+  ...parseBaseNodeData(data),
+});
+
+// TODO determine if use of "required" here will interfere later with flattened graph where `note` has been stripped out?
+export const validationSchema: SchemaOf<Note> =
+  baseNodeDataValidationSchema.concat(
+    object({
+      note: string().required(),
+    }),
+  );

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -120,6 +120,7 @@ const presentationalComponents: {
   [TYPES.List]: List,
   [TYPES.MapAndLabel]: MapAndLabel,
   [TYPES.NextSteps]: undefined,
+  [TYPES.Note]: undefined,
   [TYPES.Notice]: undefined,
   [TYPES.NumberInput]: NumberInput,
   [TYPES.Page]: Page,

--- a/apps/editor.planx.uk/src/@planx/components/shared/componentTitles.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/componentTitles.ts
@@ -20,6 +20,7 @@ export const COMPONENT_TITLES: Partial<Record<ComponentType, string>> = {
   [ComponentType.List]: "List",
   [ComponentType.MapAndLabel]: "Map and label",
   [ComponentType.NextSteps]: "Next steps",
+  [ComponentType.Note]: "Note",
   [ComponentType.Notice]: "Notice",
   [ComponentType.NumberInput]: "Number input",
   [ComponentType.Page]: "Page",

--- a/apps/editor.planx.uk/src/@planx/components/shared/icons.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/icons.tsx
@@ -28,6 +28,7 @@ import SearchOutlined from "@mui/icons-material/SearchOutlined";
 import Send from "@mui/icons-material/Send";
 import ShapeLine from "@mui/icons-material/ShapeLine";
 import SquareFoot from "@mui/icons-material/SquareFoot";
+import StickyNote2Icon from "@mui/icons-material/StickyNote2";
 import TextFields from "@mui/icons-material/TextFields";
 import type { OverridableComponent } from "@mui/material/OverridableComponent";
 import type { SvgIconProps, SvgIconTypeMap } from "@mui/material/SvgIcon";
@@ -66,6 +67,7 @@ export const ICONS: {
   [TYPES.List]: ListAlt,
   [TYPES.MapAndLabel]: ShapeLine,
   [TYPES.NextSteps]: ArrowForwardIcon,
+  [TYPES.Note]: StickyNote2Icon,
   [TYPES.Notice]: ReportProblemOutlined,
   [TYPES.NumberInput]: Pin,
   [TYPES.Page]: Article,

--- a/apps/editor.planx.uk/src/lib/featureFlags.ts
+++ b/apps/editor.planx.uk/src/lib/featureFlags.ts
@@ -3,6 +3,7 @@ export const AVAILABLE_FEATURE_FLAGS = [
   "EXPLORE",
   "GROUPED_SUBMISSIONS",
   "NOTES",
+  "NOTES_V2",
   "STRIPE_MIGRATION",
 ] as const;
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -100,7 +100,7 @@ const Node: React.FC<any> = (props) => {
     case TYPES.Note:
       // TODO also "hide" notes if templated flow; always hide notes that come from source versus show notes if inside templated folder i can edit?
       return showNotes ? (
-        <Question {...allProps} text={node?.data?.note ?? "Note"} />
+        <Question {...allProps} text={node?.data?.text ?? "Note"} />
       ) : null;
     case TYPES.Notice:
       return <Question {...allProps} text={node?.data?.title ?? "Notice"} />;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -19,9 +19,10 @@ import Portal from "./Portal";
 import Question from "./Question";
 
 const Node: React.FC<any> = (props) => {
-  const [node, wasVisited] = useStore((state) => [
+  const [node, wasVisited, showNotes] = useStore((state) => [
     state.flow[props.id],
     state.wasVisited(props.id),
+    state.showNotes,
   ]);
 
   const allProps = {
@@ -96,6 +97,11 @@ const Node: React.FC<any> = (props) => {
       );
     case TYPES.NextSteps:
       return <Question {...allProps} text="Next steps" />;
+    case TYPES.Note:
+      // TODO also "hide" notes if templated flow; always hide notes that come from source versus show notes if inside templated folder i can edit?
+      return showNotes ? (
+        <Question {...allProps} text={node?.data?.note ?? "Note"} />
+      ) : null;
     case TYPES.Notice:
       return <Question {...allProps} text={node?.data?.title ?? "Notice"} />;
     case TYPES.NumberInput:

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -80,9 +80,11 @@ const Question: React.FC<Props> = React.memo((props) => {
           "card",
           "decision",
           "type-" + TYPES[props.type as TYPES],
+          `${props.type === TYPES.Note ? "question" : ""}`,
           {
             isDragging,
             isClone: isCloneValue,
+            isNote: props.type === TYPES.Note,
             wasVisited: props.wasVisited,
             hasFailed: props.hasFailed,
           },

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/allFacets.test.ts
@@ -12,6 +12,7 @@ import {
   mockFindPropertyResult,
   mockFlow,
   mockNextStepsOptionResult,
+  mockNoteResult,
   mockNumberInputResult,
   mockPayResult,
   mockPlanningConstraintsResult,
@@ -157,6 +158,20 @@ describe("checklist fields", () => {
       componentType: "Checklist",
       title: ".",
       headline: "Duck",
+    });
+  });
+});
+
+describe("note component fields", () => {
+  it("renders data.text", () => {
+    const output = getDisplayDetailsForResult(mockNoteResult);
+
+    expect(output).toStrictEqual<Output>({
+      key: "Title",
+      iconKey: ComponentType.Note,
+      componentType: "Note",
+      title: "Yellow sticky note",
+      headline: "Yellow",
     });
   });
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
@@ -34,8 +34,8 @@ const keyFormatters: KeyMap = {
         ? "Option (description)"
         : "Description",
   },
-  "data.note": {
-    getDisplayKey: () => "Note",
+  "data.text": {
+    getDisplayKey: () => "Note", // Standalone component type
   },
   "data.notes": {
     getDisplayKey: () => "Internal notes", // TODO rename here and in-modals?

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
@@ -34,9 +34,6 @@ const keyFormatters: KeyMap = {
         ? "Option (description)"
         : "Description",
   },
-  "data.text": {
-    getDisplayKey: () => "Note", // Standalone component type
-  },
   "data.notes": {
     getDisplayKey: () => "Internal notes", // TODO rename here and in-modals?
   },

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/SearchResultCard/getDisplayDetailsForResult.tsx
@@ -34,8 +34,11 @@ const keyFormatters: KeyMap = {
         ? "Option (description)"
         : "Description",
   },
+  "data.note": {
+    getDisplayKey: () => "Note",
+  },
   "data.notes": {
-    getDisplayKey: () => "Internal notes",
+    getDisplayKey: () => "Internal notes", // TODO rename here and in-modals?
   },
   "data.howMeasured": {
     getDisplayKey: () => "How is it defined",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -154,7 +154,7 @@ const feedback: SearchFacets = [
   richTextField("data.disclaimer"),
 ];
 
-const note: SearchFacets = ["data.note"];
+const note: SearchFacets = ["data.text"];
 
 export const ALL_FACETS: SearchFacets = [
   ...basicFields,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/facets.ts
@@ -154,6 +154,8 @@ const feedback: SearchFacets = [
   richTextField("data.disclaimer"),
 ];
 
+const note: SearchFacets = ["data.note"];
+
 export const ALL_FACETS: SearchFacets = [
   ...basicFields,
   ...moreInformation,
@@ -171,6 +173,7 @@ export const ALL_FACETS: SearchFacets = [
   ...planningConstraints,
   ...pay,
   ...feedback,
+  ...note,
   ...DATA_FACETS,
 ];
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Search/mocks/allFacetFlow.ts
@@ -24,6 +24,7 @@ export const mockFlow: FlowGraph = {
       "G6L9c8Sllg",
       "gyyVEMm9Yb",
       "ZVZx9UDPqb",
+      "n0t3",
     ],
   },
   "6rgnMh94zu": {
@@ -285,6 +286,28 @@ export const mockFlow: FlowGraph = {
     },
     type: 900,
   },
+  n0t3: {
+    type: 999,
+    data: {
+      text: "Yellow sticky note",
+    },
+  },
+};
+
+export const mockNoteResult: SearchResult<IndexedNode> = {
+  item: {
+    id: "n0t3",
+    parentId: "_root",
+    type: 999,
+    data: {
+      text: "Yellow sticky note",
+    },
+  },
+  key: "data.text",
+  matchIndices: [[0, 5]],
+  refIndex: 0,
+  score: 0,
+  matchValue: "Yellow",
 };
 
 export const mockQuestionResult: SearchResult<IndexedNode> = {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
@@ -1,5 +1,6 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { COMPONENT_TITLES } from "@planx/components/shared/componentTitles";
+import { hasFeatureFlag } from "lib/featureFlags";
 
 export interface ComponentItem {
   type: TYPES;
@@ -17,17 +18,21 @@ export interface Category {
 const title = (type: TYPES): string => COMPONENT_TITLES[type] ?? String(type);
 
 export const ALL_CATEGORIES: Category[] = [
-  {
-    label: "",
-    items: [
-      {
-        type: TYPES.Note,
-        slug: "note",
-        title: title(TYPES.Note),
-        description: "Add a sticky note visible to editors only",
-      },
-    ],
-  },
+  ...(hasFeatureFlag("NOTES_V2")
+    ? [
+        {
+          label: "",
+          items: [
+            {
+              type: TYPES.Note,
+              slug: "note",
+              title: title(TYPES.Note),
+              description: "Add a sticky note visible to editors only",
+            },
+          ],
+        },
+      ]
+    : []),
   {
     label: "Structure",
     items: [

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
@@ -21,13 +21,13 @@ export const ALL_CATEGORIES: Category[] = [
   ...(hasFeatureFlag("NOTES_V2")
     ? [
         {
-          label: "",
+          label: "", // Notes intentionally not categorised, TODO revisit styling?
           items: [
             {
               type: TYPES.Note,
               slug: "note",
               title: title(TYPES.Note),
-              description: "Add a sticky note visible to editors only",
+              description: "Add a sticky note visible to Editors only",
             },
           ],
         },

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/componentData.ts
@@ -18,6 +18,17 @@ const title = (type: TYPES): string => COMPONENT_TITLES[type] ?? String(type);
 
 export const ALL_CATEGORIES: Category[] = [
   {
+    label: "",
+    items: [
+      {
+        type: TYPES.Note,
+        slug: "note",
+        title: title(TYPES.Note),
+        description: "Add a sticky note visible to editors only",
+      },
+    ],
+  },
+  {
     label: "Structure",
     items: [
       {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/index.ts
@@ -18,6 +18,7 @@ import InternalPortal from "@planx/components/InternalPortal/Editor";
 import List from "@planx/components/List/Editor";
 import MapAndLabel from "@planx/components/MapAndLabel/Editor";
 import NextSteps from "@planx/components/NextSteps/Editor";
+import Note from "@planx/components/Note/Editor";
 import Notice from "@planx/components/Notice/Editor";
 import NumberInput from "@planx/components/NumberInput/Editor";
 import Page from "@planx/components/Page/Editor";
@@ -64,6 +65,7 @@ const components: {
   list: List,
   "map-and-label": MapAndLabel,
   "next-steps": NextSteps,
+  note: Note,
   notice: Notice,
   "number-input": NumberInput,
   page: Page,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/data/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/data/types.ts
@@ -23,6 +23,7 @@ export const SLUGS: {
   [TYPES.List]: "list",
   [TYPES.MapAndLabel]: "map-and-label",
   [TYPES.NextSteps]: "next-steps",
+  [TYPES.Note]: "note",
   [TYPES.Notice]: "notice",
   [TYPES.NumberInput]: "number-input",
   [TYPES.Page]: "page",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -834,6 +834,7 @@ $fontMonospace: "Source Code Pro", monospace;
   }
   align-items: center;
 
+  // TODO retire `.question.` prefix
   &.question.isNote {
     a {
       background: #fffdb0 !important;

--- a/apps/editor.planx.uk/src/pages/Preview/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Node.tsx
@@ -36,6 +36,8 @@ import type { MapAndLabel } from "@planx/components/MapAndLabel/model";
 import MapAndLabelComponent from "@planx/components/MapAndLabel/Public";
 import type { NextSteps } from "@planx/components/NextSteps/model";
 import NextStepsComponent from "@planx/components/NextSteps/Public";
+import type { Note } from "@planx/components/Note/model";
+import NoteComponent from "@planx/components/Note/Public";
 import type { Notice } from "@planx/components/Notice/model";
 import NoticeComponent from "@planx/components/Notice/Public";
 import type { NumberInput } from "@planx/components/NumberInput/model";
@@ -237,6 +239,9 @@ const Node: React.FC<Props> = (props) => {
 
     case TYPES.NextSteps:
       return <NextStepsComponent {...getComponentProps<NextSteps>()} />;
+
+    case TYPES.Note:
+      return <NoteComponent {...getComponentProps<Note>()} />;
 
     case TYPES.Notice:
       return <NoticeComponent {...getComponentProps<Notice>()} />;

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route.tsx
@@ -21,6 +21,7 @@ const nodeSearchSchema = z.object({
       "map-and-label",
       "feedback",
       "task-list",
+      "note",
       "notice",
       "result",
       "content",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ catalogs:
       specifier: 1.0.0-alpha.15
       version: 1.0.0-alpha.15
     '@opensystemslab/planx-core':
-      specifier: github:theopensystemslab/planx-core#2fce56a
+      specifier: github:theopensystemslab/planx-core#2a08123
       version: 1.0.0
     '@types/jsdom':
       specifier: ^28.0.3
@@ -161,7 +161,7 @@ importers:
         version: 3.1076.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@planx/file-upload':
         specifier: workspace:*
         version: link:../../packages/file-upload
@@ -468,7 +468,7 @@ importers:
         version: 1.0.0-alpha.15(geotiff@3.0.5)
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@planx/file-upload':
         specifier: workspace:*
         version: link:../../packages/file-upload
@@ -999,7 +999,7 @@ importers:
         version: 12.9.0
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1042,7 +1042,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       axios:
         specifier: 'catalog:'
         version: 1.18.1
@@ -1406,7 +1406,7 @@ importers:
     dependencies:
       '@opensystemslab/planx-core':
         specifier: 'catalog:'
-        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3351,8 +3351,8 @@ packages:
   '@opensystemslab/map@1.0.0-alpha.15':
     resolution: {integrity: sha512-Z0feONs1+P6LIn04wxFdwHaKfJkqSpo3bHe0Nr43g50gq2dqnCT2KKxkXCwY4zUKnV6duFYPqAK1KD/kjzSs/w==}
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3':
-    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3}
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11':
+    resolution: {tarball: https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11}
     version: 1.0.0
     peerDependencies:
       '@emotion/react': ^11.14.0
@@ -7216,8 +7216,8 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.10.1:
-    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+  fast-xml-parser@5.11.0:
+    resolution: {integrity: sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==}
     hasBin: true
 
   fastest-stable-stringify@2.0.2:
@@ -8507,8 +8507,8 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
-  marked@18.0.9:
-    resolution: {integrity: sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==}
+  marked@18.0.10:
+    resolution: {integrity: sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -10560,8 +10560,8 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  strnum@2.4.1:
-    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -11219,6 +11219,10 @@ packages:
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  uuid@14.0.2:
+    resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -13919,7 +13923,7 @@ snapshots:
       - geotiff
       - preact
 
-  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2fce56acedd2b657bc5557540578d25cb810a4c3(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@opensystemslab/planx-core@https://codeload.github.com/theopensystemslab/planx-core/tar.gz/2a081237d30d242087ba95b74140626f9f08ee11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
@@ -13928,15 +13932,15 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       cheerio: 1.2.0
-      fast-xml-parser: 5.10.1
+      fast-xml-parser: 5.11.0
       graphql: 16.14.2
       graphql-request: 6.1.0(graphql@16.14.2)
       lodash-es: 4.18.1
-      marked: 18.0.9
+      marked: 18.0.10
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       type-fest: 4.41.0
-      uuid: 14.0.1
+      uuid: 14.0.2
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -18188,13 +18192,13 @@ snapshots:
       path-expression-matcher: 1.6.2
       xml-naming: 0.1.0
 
-  fast-xml-parser@5.10.1:
+  fast-xml-parser@5.11.0:
     dependencies:
       '@nodable/entities': 3.0.0
       fast-xml-builder: 1.2.0
       is-unsafe: 2.0.0
       path-expression-matcher: 1.6.2
-      strnum: 2.4.1
+      strnum: 2.4.2
       xml-naming: 0.3.0
 
   fastest-stable-stringify@2.0.2: {}
@@ -19558,7 +19562,7 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  marked@18.0.9: {}
+  marked@18.0.10: {}
 
   material-colors@1.2.6: {}
 
@@ -22140,7 +22144,7 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  strnum@2.4.1:
+  strnum@2.4.2:
     dependencies:
       anynum: 1.0.1
 
@@ -22770,6 +22774,8 @@ snapshots:
     optional: true
 
   uuid@14.0.1: {}
+
+  uuid@14.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ packages:
 
 catalog:
   "@opensystemslab/map": 1.0.0-alpha.15
-  "@opensystemslab/planx-core": github:theopensystemslab/planx-core#2fce56a
+  "@opensystemslab/planx-core": github:theopensystemslab/planx-core#2a08123
   "@types/jsdom": ^28.0.3
   "@types/node": ~24.10.15
   "@vitest/eslint-plugin": ^1.6.20


### PR DESCRIPTION
- Adds a `Notes v2` feature flag to separate this work from original implementation
- Adds a new compent type `Note` (`{"type": 999}`) which relies on https://github.com/theopensystemslab/planx-core
  - This means standalone notes are _always_ in the graph and tracked by ShareDB operations
  - The "Show notes" graph toggle determines if they are visible or not; even when hidden, ShareDB still accounts for their position in all nearby operations
- Incorporates new component type into "Search"
- Adds a `sanitiseNotes` step to `dataMerged` function which runs when flattening flows (when checking for changes to publish, and on load of `/preview` & `/draft` routes)

**Not yet handled:** 
- Attached notes https://github.com/theopensystemslab/planx-new/pull/7265
- "Visibility" rules for templates and source templates https://github.com/theopensystemslab/planx-new/pull/7271
- DB-level permissions for `flows.data` (eg `getFlowData` API helper still relies on `$public` client; this is the _only_ questionable use of `$public` client, the rest are all querying published flows which will be "sanitised" on next publish) - see discussion here https://opensystemslab.slack.com/archives/C5Q59R3HB/p1787759810242429
- Disabling and migrating "old" ways of creating standalone notes

**To test:**
- Turn on the feature flag
- Confirm you see the new "Note" option in the component select modal
- Create a "Note" component, maybe a few!
- Create other component types and populate "Internal notes"
- Load a `/draft`, `/preview` or `/published` route and inspect flow data (eg `window.api.getState().flow`)
  - For a given `Note` component type, confirm it doesn't have `data: { note: "xx" }`
  - For any other component type with an internal notes, confirm that `data` no longer includes `notes` prop
  - When you compare to the same flow inspection in the editor graph page, you'll see full note _content_