### PR TITLE
fix(a11y): Enhanced Text Input - DAC_Labels_not_Programmatically_Associated_01

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -57,36 +57,47 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
 }) => {
   const radioGroupState = useRadioGroup();
   const isSelected = radioGroupState?.value === id;
+  const recommendedTagId = `${id}-recommended`;
 
   return (
-    <StyledFormLabel
-      focused={false}
-      isSelected={isSelected}
-      showBorder={recommended}
-    >
-      {recommended && <RecommendedTag>Recommended</RecommendedTag>}
-      <Radio
-        value={id}
-        onChange={onChange}
-        slotProps={{ input: { "aria-label": title } }}
-      />
-      <Box sx={{ position: "relative" }}>
-        <Typography
-          variant="body1"
-          sx={{
-            color: "text.primary",
-            pt: 0.95,
+    <Box sx={{ position: "relative" }}>
+      {recommended && (
+        <RecommendedTag id={recommendedTagId}>Recommended</RecommendedTag>
+      )}
+      <StyledFormLabel
+        htmlFor={id}
+        focused={false}
+        isSelected={isSelected}
+        showBorder={recommended}
+      >
+        <Radio
+          id={id}
+          value={id}
+          onChange={onChange}
+          slotProps={{
+            input: {
+              "aria-describedby": recommended ? recommendedTagId : undefined,
+            },
           }}
-        >
-          {title}
-        </Typography>
-        {description && (
-          <QuoteDescription variant="subtitle1" component="blockquote">
-            {description}
-          </QuoteDescription>
-        )}
-      </Box>
-    </StyledFormLabel>
+        />
+        <Box sx={{ position: "relative" }}>
+          <Typography
+            variant="body1"
+            sx={{
+              color: "text.primary",
+              pt: 0.95,
+            }}
+          >
+            {title}
+          </Typography>
+          {description && (
+            <QuoteDescription variant="subtitle1" component="blockquote">
+              {description}
+            </QuoteDescription>
+          )}
+        </Box>
+      </StyledFormLabel>
+    </Box>
   );
 };
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
@@ -27,7 +27,8 @@ export const StyledFormLabel = styled(FormLabel, {
 
 export const RecommendedTag = styled(Box)(({ theme }) => ({
   position: "absolute",
-  top: 0,
+  // Matches StyledFormLabel's marginTop so the tag overlaps its border rather than sitting above it
+  top: theme.spacing(1),
   left: 0,
   width: "100%",
   backgroundColor: theme.palette.secondary.dark,


### PR DESCRIPTION
From page 18 in the revised report - basically the labels were not properly associated with the inputs. 

[DAC Accessibility Audit Report WCAG 2.2 AA for Lambeth Plan X v2.0 Final Aug 26.pdf](https://github.com/user-attachments/files/31406507/DAC.Accessibility.Audit.Report.WCAG.2.2.AA.for.Lambeth.Plan.X.v2.0.Final.Aug.26.pdf)
