### PR TITLE
fix(a11y): Enhanced Text Input - DAC_Labels_or_Instructions_01/02

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -16,6 +16,7 @@ import type { EnhancedTextInput } from "../types";
 import type { FormValues } from "./types";
 
 const HEADING_ID = "confirm-project-description-heading";
+const NOT_CHECKED_HINT_ID = "confirm-project-description-not-checked-hint";
 
 const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
   const { values, errors, setFieldValue } = useFormikContext<FormValues>();
@@ -31,8 +32,16 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
       <Typography variant="h2" component="h1" id={HEADING_ID} sx={{ mb: 1 }}>
         Confirm your project description
       </Typography>
-      <Typography variant="subtitle1" component="p" sx={{ mb: 2 }}>
+      <Typography variant="subtitle1" component="p" sx={{ mb: 1 }}>
         Edit the description below, or continue to submit it as shown.
+      </Typography>
+      <Typography
+        variant="subtitle1"
+        component="p"
+        id={NOT_CHECKED_HINT_ID}
+        sx={{ mb: 2 }}
+      >
+        This will not be checked for suggested improvements.
       </Typography>
       <InputRow>
         <Box sx={{ width: "100%" }}>
@@ -50,6 +59,7 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
               "aria-labelledby": HEADING_ID,
               "aria-describedby": [
                 props.description ? DESCRIPTION_TEXT : "",
+                NOT_CHECKED_HINT_ID,
                 "character-hint",
                 showError ? `${ERROR_MESSAGE}-${props.id}` : "",
               ]

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -26,15 +26,20 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
   };
 
   const showError = Boolean(errors.userInput);
+  const isWritingNew = values.selectedOption === "new";
 
   return (
     <Box sx={{ mb: 2 }}>
       <Typography variant="h2" component="h1" id={HEADING_ID} sx={{ mb: 1 }}>
-        Confirm your project description
+        {isWritingNew
+          ? "Enter your new description"
+          : "Confirm your project description"}
       </Typography>
-      <Typography variant="subtitle1" component="p" sx={{ mb: 1 }}>
-        Edit the description below, or continue to submit it as shown.
-      </Typography>
+      {!isWritingNew && (
+        <Typography variant="subtitle1" component="p" sx={{ mb: 1 }}>
+          Edit the description below, or continue to submit it as shown.
+        </Typography>
+      )}
       <Typography
         variant="subtitle1"
         component="p"

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -178,8 +178,14 @@ describe("Passport generation", () => {
     await user.click(screen.getByTestId("continue-button"));
 
     // Modification step: field starts blank, ready for a new description
+    expect(
+      screen.getByRole("heading", {
+        name: /Enter your new description/i,
+        level: 1,
+      }),
+    ).toBeVisible();
     const textarea = screen.getByRole("textbox", {
-      name: /Confirm your project description/i,
+      name: /Enter your new description/i,
     });
     expect(textarea).toHaveValue("");
     await user.type(textarea, "my custom description");
@@ -606,15 +612,20 @@ describe("basic layout and behaviour", () => {
     await user.click(screen.getByTestId("continue-button"));
     expect(
       screen.getByRole("heading", {
-        name: /Confirm your project description/i,
+        name: /Enter your new description/i,
         level: 1,
       }),
     ).toBeVisible();
     expect(
       screen.getByRole("textbox", {
-        name: /Confirm your project description/i,
+        name: /Enter your new description/i,
       }),
     ).toHaveValue("");
+
+    // The "edit below, or continue" copy doesn't make sense against a blank field
+    expect(
+      screen.queryByText(/Edit the description below/i),
+    ).not.toBeInTheDocument();
   });
 
   it("displays additional information to the user on the 'task' step", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -719,6 +719,9 @@ describe("basic layout and behaviour", () => {
     expect(
       screen.getByRole("radio", { name: /Use suggested description/i }),
     ).toBeInTheDocument();
+
+    // Returning to the selection step should not re-trigger the API as the input hasn't changed
+    expect(requestSpy).toHaveBeenCalledTimes(1);
   });
 
   test("users can navigate 'back' to the input step", async () => {
@@ -795,8 +798,7 @@ describe("basic layout and behaviour", () => {
     );
   });
 
-  // Revisit this with new UI which doesn't contain a textinput natively on the second step
-  test.skip("navigating 'back' does not re-trigger the API when the input does not change", async () => {
+  test("navigating 'back' does not re-trigger the API when the input does not change", async () => {
     const { user } = await setup(
       <EnhancedTextInputComponent
         id="testId"

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -171,23 +171,19 @@ describe("Passport generation", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select "Write a new description" and type a custom value
+    // Select "Write a new description" and advance to modification step
     await user.click(
       screen.getByRole("radio", { name: /Write a new description/i }),
     );
-    const customInput = screen.getByRole("textbox", {
-      name: /Enter your project description/i,
-    });
-    await user.type(customInput, "my custom description");
-
-    // Continuing submits directly without a modification step
     await user.click(screen.getByTestId("continue-button"));
-    expect(
-      screen.queryByRole("heading", {
-        name: /Confirm your project description/i,
-        level: 1,
-      }),
-    ).not.toBeInTheDocument();
+
+    // Modification step: field starts blank, ready for a new description
+    const textarea = screen.getByRole("textbox", {
+      name: /Confirm your project description/i,
+    });
+    expect(textarea).toHaveValue("");
+    await user.type(textarea, "my custom description");
+    await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
     expect(handleSubmit).toHaveBeenCalledWith(
@@ -238,7 +234,7 @@ describe("Passport generation", () => {
 
     // Modification step: clear pre-filled text and enter a custom description
     const textarea = screen.getByRole("textbox", {
-      name: /Project description/i,
+      name: /Confirm your project description/i,
     });
     expect(textarea).toHaveValue(ENHANCED);
     await user.clear(textarea);
@@ -577,11 +573,13 @@ describe("basic layout and behaviour", () => {
       }),
     ).toBeVisible();
     expect(
-      screen.getByRole("textbox", { name: /Project description/i }),
+      screen.getByRole("textbox", {
+        name: /Confirm your project description/i,
+      }),
     ).toHaveValue(ORIGINAL);
   });
 
-  it("selecting 'Write a new description' reveals a text input", async () => {
+  it("selecting 'Write a new description' advances to a blank modification step", async () => {
     const { user } = await setup(
       <EnhancedTextInputComponent
         id="testId"
@@ -600,22 +598,23 @@ describe("basic layout and behaviour", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // No text input visible before selecting the option
-    expect(
-      screen.queryByRole("textbox", {
-        name: /Enter your project description/i,
-      }),
-    ).not.toBeInTheDocument();
-
-    // Selecting the option reveals the text input
+    // Selecting the option and continuing takes the user to the modification step
+    // consistent with the other two options, with the field left blank
     await user.click(
       screen.getByRole("radio", { name: /Write a new description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
     expect(
-      screen.getByRole("textbox", {
-        name: /Enter your project description/i,
+      screen.getByRole("heading", {
+        name: /Confirm your project description/i,
+        level: 1,
       }),
     ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: /Confirm your project description/i,
+      }),
+    ).toHaveValue("");
   });
 
   it("displays additional information to the user on the 'task' step", async () => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
@@ -65,7 +65,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /This doesn't look like a planning project description/,
       }),
     ).toBeVisible();
@@ -97,7 +97,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /Service unavailable/,
       }),
     ).toBeVisible();
@@ -129,7 +129,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /Rate limit exceeded/,
       }),
     ).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
@@ -1,6 +1,6 @@
 import Typography from "@mui/material/Typography";
 import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
-import React, { type PropsWithChildren } from "react";
+import React, { type PropsWithChildren, useEffect, useRef } from "react";
 
 interface Props {
   title: string;
@@ -11,26 +11,42 @@ const ErrorCard: React.FC<PropsWithChildren<Props>> = ({
   title,
   description,
   children,
-}) => (
-  <ErrorSummaryContainer role="status">
-    <Typography variant="h3" component="h2" sx={{ mb: 2 }}>
-      {title}
-    </Typography>
-    {Array.isArray(description) ? (
-      description.map((paragraph, index) => (
-        <Typography
-          key={index}
-          variant="body1"
-          gutterBottom={index < description.length - 1}
-        >
-          {paragraph}
-        </Typography>
-      ))
-    ) : (
-      <Typography variant="body1">{description}</Typography>
-    )}
-    {children}
-  </ErrorSummaryContainer>
-);
+}) => {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  // This replaces the previous step's heading, so move focus here to give
+  // screen reader users a clear change of context to the new content
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <ErrorSummaryContainer role="status">
+      <Typography
+        ref={headingRef}
+        tabIndex={-1}
+        variant="h3"
+        component="h1"
+        sx={{ mb: 2 }}
+      >
+        {title}
+      </Typography>
+      {Array.isArray(description) ? (
+        description.map((paragraph, index) => (
+          <Typography
+            key={index}
+            variant="body1"
+            gutterBottom={index < description.length - 1}
+          >
+            {paragraph}
+          </Typography>
+        ))
+      ) : (
+        <Typography variant="body1">{description}</Typography>
+      )}
+      {children}
+    </ErrorSummaryContainer>
+  );
+};
 
 export default ErrorCard;

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -6,7 +6,6 @@ import Typography from "@mui/material/Typography";
 import { HelpButton } from "@planx/components/shared/Preview/CardHeader/styled";
 import MoreInfo from "@planx/components/shared/Preview/MoreInfo";
 import MoreInfoSection from "@planx/components/shared/Preview/MoreInfoSection";
-import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
 import { useQuery } from "@tanstack/react-query";
 import { useFormikContext } from "formik";
 import { enhanceProjectDescription } from "lib/api/ai/requests";
@@ -15,11 +14,7 @@ import type { APIError } from "lib/api/client";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { type ComponentProps, useEffect, useRef, useState } from "react";
 import { ApplicationPath } from "types";
-import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter } from "ui/shared/CharacterCounter";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
-import Input from "ui/shared/Input/Input";
-import InputRow from "ui/shared/InputRow";
 import ProgressiveLoading from "ui/shared/ProgressiveLoading";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
@@ -32,7 +27,6 @@ import {
   QuoteDescription,
   QuotedText,
   RecommendedTag,
-  RevealedContent,
   StyledFormLabel,
 } from "./styles";
 
@@ -154,7 +148,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
         enhanced: data.enhanced,
         error: null,
         selectedOption: null,
-        customDescription: "",
       });
     }
   }, [isSuccess, data, setValues]);
@@ -168,7 +161,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
         error: error.data.error,
         userInput: initialValueRef.current,
         selectedOption: null,
-        customDescription: "",
       });
     }
   }, [error, setValues]);
@@ -186,17 +178,10 @@ const ProjectDescription: React.FC<Props> = (props) => {
           setFieldValue("userInput", data.original);
           break;
         case "new":
-          setFieldValue("userInput", values.customDescription);
+          setFieldValue("userInput", "");
           break;
       }
     }
-  };
-
-  const handleCustomDescriptionChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setFieldValue("customDescription", event.target.value);
-    setFieldValue("userInput", event.target.value);
   };
 
   const showRadioError = !values.selectedOption && Boolean(errors.userInput);
@@ -307,33 +292,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
               />
             </RadioGroup>
           </ErrorWrapper>
-
-          {values.selectedOption === "new" && (
-            <RevealedContent>
-              <InputRow>
-                <InputLabel
-                  label="Enter your project description. This will not be checked for suggested improvements."
-                  htmlFor={props.id}
-                >
-                  <Input
-                    type="text"
-                    multiline
-                    rows={5}
-                    name="customDescription"
-                    value={values.customDescription}
-                    bordered
-                    onChange={handleCustomDescriptionChange}
-                    id={props.id}
-                  />
-                  <CharacterCounter
-                    limit={TEXT_LIMITS[TextInputType.Long]}
-                    count={values.customDescription.length}
-                    error={false}
-                  />
-                </InputLabel>
-              </InputRow>
-            </RevealedContent>
-          )}
         </Box>
       )}
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -105,16 +105,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
     useFormikContext<FormValues>();
   const [open, setOpen] = useState(false);
 
-  const initialValueRef = useRef(
-    (() => {
-      if (values.status !== "success") return values.userInput;
-      // If userInput matches a previously-processed value, use the cached original
-      const isPreviouslyProcessed =
-        values.userInput === values.original ||
-        values.userInput === values.enhanced;
-      return isPreviouslyProcessed ? values.original : values.userInput;
-    })(),
-  );
+  const initialValueRef = useRef(props.queryInput);
 
   const { isPending, data, error, isSuccess } = useQuery<
     EnhanceResponse,

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
@@ -44,13 +44,6 @@ export const QuoteDescription = styled(Typography)(({ theme }) => ({
   position: "relative",
 })) as typeof Typography;
 
-export const RevealedContent = styled(Box)(({ theme }) => ({
-  borderLeft: `4px solid ${theme.palette.border.main}`,
-  paddingLeft: theme.spacing(3.45),
-  marginLeft: theme.spacing(3.2),
-  paddingTop: theme.spacing(1),
-}));
-
 export const QuotedText = styled(Typography)(({ theme }) => ({
   marginTop: theme.spacing(2),
   paddingLeft: theme.spacing(1.5),

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -73,7 +73,7 @@ const EnhancedTextInputComponent = (props: Props) => {
       {({ submitForm, values, setFieldValue }) => {
         const showCardHeader =
           step === "input" ||
-          values.status !== "success" ||
+          values.status === "idle" ||
           Boolean(isRunningTask);
 
         const handleBack = (() => {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -9,7 +9,7 @@ import type { TaskComponentMap } from "../types";
 import InitialUserInput from "./InitialUserInput";
 import ModifyUserInput from "./ModifyUserInput";
 import ProjectDescription from "./Tasks/ProjectDescription";
-import type { FormValues, Props } from "./types";
+import type { FormValues, Props, Step } from "./types";
 import { getValidationSchema, makeBreadcrumb } from "./utils";
 
 const taskComponents: TaskComponentMap = {
@@ -18,9 +18,7 @@ const taskComponents: TaskComponentMap = {
 
 const EnhancedTextInputComponent = (props: Props) => {
   const previous = getPreviouslySubmittedData(props);
-  const [step, setStep] = useState<"input" | "selection" | "modification">(
-    "input",
-  );
+  const [step, setStep] = useState<Step>("input");
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
   const initialValues: FormValues = previous
@@ -33,7 +31,6 @@ const EnhancedTextInputComponent = (props: Props) => {
           props.previouslySubmittedData?.data?._enhancements[props.fn].enhanced,
         error: null,
         selectedOption: null,
-        customDescription: "",
       }
     : {
         userInput: "",
@@ -41,7 +38,6 @@ const EnhancedTextInputComponent = (props: Props) => {
         enhanced: null,
         error: null,
         selectedOption: null,
-        customDescription: "",
       };
 
   const nextStep = (values: FormValues) => {
@@ -53,10 +49,7 @@ const EnhancedTextInputComponent = (props: Props) => {
 
     if (step === "input") return setStep("selection");
 
-    if (step === "selection") {
-      if (values.selectedOption !== "new") return setStep("modification");
-      return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
-    }
+    if (step === "selection") return setStep("modification");
 
     if (step === "modification") {
       props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
@@ -66,7 +59,7 @@ const EnhancedTextInputComponent = (props: Props) => {
   const TaskComponent = taskComponents[props.task];
   if (!TaskComponent) return null;
 
-  const validationSchema = getValidationSchema(props);
+  const validationSchema = getValidationSchema(props, step);
 
   return (
     <Formik<FormValues>

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -19,6 +19,7 @@ const taskComponents: TaskComponentMap = {
 const EnhancedTextInputComponent = (props: Props) => {
   const previous = getPreviouslySubmittedData(props);
   const [step, setStep] = useState<Step>("input");
+  const [queryInput, setQueryInput] = useState("");
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
   const initialValues: FormValues = previous
@@ -47,7 +48,10 @@ const EnhancedTextInputComponent = (props: Props) => {
       return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
     }
 
-    if (step === "input") return setStep("selection");
+    if (step === "input") {
+      setQueryInput(values.userInput);
+      return setStep("selection");
+    }
 
     if (step === "selection") return setStep("modification");
 
@@ -81,9 +85,7 @@ const EnhancedTextInputComponent = (props: Props) => {
           // Repopulate field with user's original input
           if (step === "selection" && !isRunningTask)
             return () => {
-              if (values.status === "success") {
-                setFieldValue("userInput", values.original);
-              }
+              setFieldValue("userInput", queryInput);
               setStep("input");
             };
           return undefined;
@@ -108,7 +110,9 @@ const EnhancedTextInputComponent = (props: Props) => {
             )}
             {step === "input" && <InitialUserInput {...props} />}
             {step === "modification" && <ModifyUserInput {...props} />}
-            {step === "selection" && <TaskComponent {...props} />}
+            {step === "selection" && (
+              <TaskComponent {...props} queryInput={queryInput} />
+            )}
           </Card>
         );
       }}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
@@ -4,10 +4,11 @@ import type { EnhancedTextInput, TaskAction } from "../types";
 
 export type Props = PublicProps<EnhancedTextInput>;
 
+export type Step = "input" | "selection" | "modification";
+
 interface FormValuesBase {
   userInput: string;
   selectedOption: TaskAction | null;
-  customDescription: string;
 }
 
 interface FormValuesIdle extends FormValuesBase {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
@@ -6,7 +6,7 @@ import { object, string } from "yup";
 
 import type { BreadcrumbData, TaskActionDescription } from "../types";
 import { TaskActionMap } from "./../types";
-import type { FormValues, Props } from "./types";
+import type { FormValues, Props, Step } from "./types";
 
 export const getAction = (values: FormValues): TaskActionDescription => {
   if (values.status === "idle")
@@ -48,12 +48,17 @@ export const makeBreadcrumb = (
   } as BreadcrumbData;
 };
 
-export const getValidationSchema = (props: Props) =>
+export const getValidationSchema = (props: Props, step: Step) =>
   object({
     status: string().oneOf(["idle", "success", "error"]).required(),
     userInput: textInputValidationSchema({
       data: { ...props, type: TextInputType.Long },
       required: true,
+    }).when("selectedOption", {
+      // initial input is not required if we are coming from the 'enter a new description' option
+      is: (selectedOption: string | null) =>
+        step === "selection" && selectedOption === "new",
+      then: (schema) => schema.notRequired(),
     }),
     original: string().when("status", {
       is: (status: string) => status === "success" || status === "error",

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
@@ -102,6 +102,6 @@ export type TaskDefaults = { [K in Task]: TaskRegistry[K]["editorProps"] };
  */
 export type TaskComponentMap = {
   [K in Task]: React.ComponentType<
-    PublicProps<EnhancedTextInputForTask<K>>
+    PublicProps<EnhancedTextInputForTask<K>> & { queryInput: string }
   > | null;
 };


### PR DESCRIPTION
From page 23 in the revised review.

This one was a little bit more involved, more to do with the UX flow when writing a new description, and how the inline text box presents a different UX compared to the other two options which take the user to a new page. So this PR changes the flow so that all three options take the user to the same page, and the text box is optionally pre-filled depending on which option they chose, and the warning about the input not being re-checked is shown consistently.