### PR TITLE
feat: group event history by type

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -117,7 +117,14 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
       <DialogTitle variant="h2">Submission details</DialogTitle>
       <DialogContent>
         <Grid container>
-          <Grid size={6}>
+          <Grid
+            size={6}
+            sx={{
+              position: "sticky",
+              top: 0,
+              alignSelf: "flex-start",
+            }}
+          >
             <SubmissionDetails
               sessionId={sessionId}
               latestEvent={latestEvent}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -13,37 +13,30 @@ import { StatusIcon } from "./StatusIcon";
 const groupEvents = (submissions: Submission[]): GroupedEvent[] => {
   if (submissions.length === 0) return [];
 
-  const result: GroupedEvent[] = [];
-  let currentGroup: GroupedEvent | null = null;
+  const eventsMap = new Map<string, Submission[]>();
 
   for (const submission of submissions) {
-    if (
-      !currentGroup ||
-      currentGroup.events[0].eventType !== submission.eventType
-    ) {
-      currentGroup = {
-        sessionId: submission.sessionId,
-        eventId: submission.eventId,
-        events: [
-          {
-            eventType: submission.eventType,
-            createdAt: submission.createdAt,
-            retry: submission.retry,
-            response: submission.response,
-            status: submission.status,
-          },
-        ],
-      };
-      result.push(currentGroup);
-    } else {
-      currentGroup.events.push({
-        eventType: submission.eventType,
-        createdAt: submission.createdAt,
-        retry: submission.retry,
-        response: submission.response,
-        status: submission.status,
-      });
-    }
+    const events = eventsMap.get(submission.eventType) || [];
+    events.push(submission);
+    eventsMap.set(submission.eventType, events);
+  }
+
+  const result: GroupedEvent[] = [];
+
+  for (const [eventType, events] of eventsMap.entries()) {
+    const groupedEvent: GroupedEvent = {
+      sessionId: events[0].sessionId,
+      eventId: events[0].eventId,
+      events: events.map((event) => ({
+        eventType: event.eventType,
+        createdAt: event.createdAt,
+        retry: event.retry,
+        response: event.response,
+        status: event.status,
+      })),
+    };
+
+    result.push(groupedEvent);
   }
 
   return result;


### PR DESCRIPTION
Rewrites the `groupEvents` function to group at the highest level by event type and not time. The query returns the events sorted by time desc so no further sorting required. 

Some of the event histories are still quite long, so made the `SubmissionDetails` panel sticky while I was at it. 