### PR TITLE
chore(editor): Rename GovPay variables and components

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -22,8 +22,8 @@ import InputRow from "ui/shared/InputRow";
 import { Switch } from "ui/shared/Switch";
 
 import type { EditorProps } from "../../shared/types";
-import { GovPayMetadataSection } from "./GovPayMetadataSection";
 import { InviteToPaySection } from "./InviteToPaySection";
+import { PaymentMetadataSection } from "./PaymentMetadataSection";
 
 export type Props = EditorProps<TYPES.Pay, Pay>;
 
@@ -131,7 +131,7 @@ const Component: React.FC<Props> = (props: Props) => {
           </ModalSectionContent>
         </ModalSection>
         <InviteToPaySection disabled={props.disabled} />
-        <GovPayMetadataSection disabled={props.disabled} />
+        <PaymentMetadataSection disabled={props.disabled} />
         <MoreInformation formik={formik} disabled={props.disabled} />
         <InternalNotes
           name="notes"

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/PaymentMetadataSection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/PaymentMetadataSection.tsx
@@ -25,14 +25,14 @@ const GOVPAY_DOCS_URL =
 
 const STRIPE_DOCS_URL = "https://docs.stripe.com/metadata";
 
-export type FormikGovPayMetadata =
+export type FormikPaymentMetadata =
   Record<keyof GovPayMetadata, string>[] | string | undefined;
 
-interface GovPayMetadataSectionProps {
+interface PaymentMetadataSectionProps {
   disabled?: boolean;
 }
 
-function GovPayMetadataEditor(
+function PaymentMetadataEditor(
   props: ListManagerEditorProps<GovPayMetadata> & {
     isFieldDisabled: (key: string, index: number) => boolean;
     disabled?: boolean;
@@ -43,11 +43,11 @@ function GovPayMetadataEditor(
   const { errors, touched } = useFormikContext<Pay>();
 
   const error = parseError(
-    errors.govPayMetadata as FormikGovPayMetadata,
+    errors.govPayMetadata as FormikPaymentMetadata,
     props.index,
   );
   const isTouched = parseTouched(
-    touched.govPayMetadata as FormikGovPayMetadata,
+    touched.govPayMetadata as FormikPaymentMetadata,
     props.index,
   );
 
@@ -142,7 +142,7 @@ const Headers: React.FC<{ title: string }> = ({ title }) => (
   </>
 );
 
-export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
+export const PaymentMetadataSection: React.FC<PaymentMetadataSectionProps> = ({
   disabled,
 }) => {
   const provider = usePaymentProvider();
@@ -152,7 +152,7 @@ export const GovPayMetadataSection: React.FC<GovPayMetadataSectionProps> = ({
   const EditorComponent = useCallback(
     (editorProps: ListManagerEditorProps<GovPayMetadata>) => (
       // @ts-expect-error "variant" prop is passed in via editorProps, but type inference won't pick this up
-      <GovPayMetadataEditor
+      <PaymentMetadataEditor
         {...editorProps}
         isFieldDisabled={(key, index) =>
           disabled || isFieldDisabled(key, index)

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/helpers.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/helpers.ts
@@ -1,5 +1,5 @@
-import { REQUIRED_GOVPAY_METADATA } from "../model";
-import type { FormikGovPayMetadata } from "./GovPayMetadataSection";
+import { REQUIRED_PAYMENT_METADATA } from "../model";
+import type { FormikPaymentMetadata } from "./PaymentMetadataSection";
 
 /**
  * Helper method to handle Formik errors in arrays
@@ -7,7 +7,7 @@ import type { FormikGovPayMetadata } from "./GovPayMetadataSection";
  * Docs: https://formik.org/docs/api/fieldarray#fieldarray-validation-gotchas
  */
 export const parseError = (
-  errors: FormikGovPayMetadata,
+  errors: FormikPaymentMetadata,
   index: number,
 ): string | undefined => {
   // No errors
@@ -28,7 +28,7 @@ export const parseError = (
  * Please see parseError() for additional context
  */
 export const parseTouched = (
-  touched: string | undefined | FormikGovPayMetadata,
+  touched: string | undefined | FormikPaymentMetadata,
   index: number,
 ): string | undefined => {
   // No errors
@@ -49,5 +49,5 @@ export const parseTouched = (
  * Only disable first instance, otherwise any field beginning with a required field will be disabled, and user will not be able to fix their mistake as the delete icon is also disabled
  */
 export const isFieldDisabled = (key: string, index: number) =>
-  REQUIRED_GOVPAY_METADATA.includes(key) &&
-  index === REQUIRED_GOVPAY_METADATA.indexOf(key);
+  REQUIRED_PAYMENT_METADATA.includes(key) &&
+  index === REQUIRED_PAYMENT_METADATA.indexOf(key);

--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
@@ -1,8 +1,8 @@
-import { govPayMetadataSchema, parsePay } from "./model";
+import { parsePay, paymentMetadataSchema } from "./model";
 
-describe("GovPayMetadata Schema", () => {
+describe("Payment Metadata Schema", () => {
   const validate = async (payload: unknown) =>
-    await govPayMetadataSchema.validate(payload).catch((err) => err.errors);
+    await paymentMetadataSchema.validate(payload).catch((err) => err.errors);
 
   const defaults = [
     { key: "flow", value: "flowName", type: "static" },
@@ -141,7 +141,7 @@ describe("GovPayMetadata Schema", () => {
 });
 
 describe("parsePay() helper function", () => {
-  describe("govPayMetadata mapping", () => {
+  describe("payment metadata mapping", () => {
     it("handles new nodes", () => {
       const result = parsePay();
 

--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -78,7 +78,7 @@ const getReturnURL = (sessionId: string): string => {
 
 export const GOV_UK_PAY_URL = `${import.meta.env.VITE_APP_API_URL}/pay`;
 
-export const REQUIRED_GOVPAY_METADATA = [
+export const REQUIRED_PAYMENT_METADATA = [
   "flow",
   "source",
   "paidViaInviteToPay",
@@ -86,7 +86,7 @@ export const REQUIRED_GOVPAY_METADATA = [
 
 // Validation must match requirements set out here -
 // https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39
-export const govPayMetadataSchema = array(
+export const paymentMetadataSchema = array(
   object({
     key: string()
       .required("Key is a required field")
@@ -129,12 +129,12 @@ export const govPayMetadataSchema = array(
     message: `Keys ${new Intl.ListFormat("en-GB", {
       style: "long",
       type: "conjunction",
-    }).format(REQUIRED_GOVPAY_METADATA)} must be present`,
+    }).format(REQUIRED_PAYMENT_METADATA)} must be present`,
     test: (metadata) => {
       if (!metadata) return false;
 
       const keys = metadata.map((item) => item.key);
-      const allRequiredKeysPresent = REQUIRED_GOVPAY_METADATA.every(
+      const allRequiredKeysPresent = REQUIRED_PAYMENT_METADATA.every(
         (requiredKey) => keys.includes(requiredKey),
       );
       return allRequiredKeysPresent;
@@ -170,7 +170,7 @@ export const validationSchema = object({
     is: true,
     then: string().required(),
   }),
-  govPayMetadata: govPayMetadataSchema,
+  govPayMetadata: paymentMetadataSchema,
 });
 
 export const getDefaultContent = (): Pay => ({


### PR DESCRIPTION
Minor housekeeping, follow up to https://github.com/theopensystemslab/planx-new/pull/7211

This PR rename GovPay-specific variables and components to provider-agnostic names. 

A few notable exceptions - 
- `govPayMetadata` data property / Formik field name - maps to stored flow data in the DB
- `GovPayMetadata` type - defined in `planx-core`
- `GOV_UK_PAY_URL` - I think we want this to stay as a GovPay-specific endpoint, Stripe will get its own alongside (maybe `/pay/stripe` which we can eventually consolidate)