### PR TITLE
fix(editor): Additional validation for Stripe metadata

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.test.ts
@@ -96,6 +96,39 @@ describe("Payment Metadata Schema", () => {
     expect(result).toEqual(input);
   });
 
+  test("static values cannot contain square brackets", async () => {
+    const input = [
+      ...defaults,
+      { key: "myKey", value: "value[0]", type: "static" },
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(
+      /Static values cannot contain \[ or \] characters/,
+    );
+  });
+
+  test("static values reject lone opening bracket", async () => {
+    const input = [
+      ...defaults,
+      { key: "myKey", value: "value[with", type: "static" },
+    ];
+    const errors = await validate(input);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(
+      /Static values cannot contain \[ or \] characters/,
+    );
+  });
+
+  test("dynamic values can contain square brackets", async () => {
+    const input = [
+      ...defaults,
+      { key: "myKey", value: "passport.var[0]", type: "data" },
+    ];
+    const result = await validate(input);
+    expect(result).toEqual(input);
+  });
+
   test("keys must be unique", async () => {
     const input = [
       ...defaults,

--- a/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/model.ts
@@ -84,8 +84,15 @@ export const REQUIRED_PAYMENT_METADATA = [
   "paidViaInviteToPay",
 ];
 
-// Validation must match requirements set out here -
-// https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39
+/**
+ * Validation rules for both GovPay and Stripe metadata
+ *
+ * Rules set out here -
+ * GovPay - https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39
+ * Stripe - https://docs.stripe.com/metadata
+ *
+ * @TODO Once migration to Stripe is completed, we can loosen these rules to only validate against Stripe requirements
+ */
 export const paymentMetadataSchema = array(
   object({
     key: string()
@@ -103,6 +110,16 @@ export const paymentMetadataSchema = array(
           if (type === "data") return true;
           // Static strings must be 100 characters or less
           return value.length <= 100;
+        },
+      })
+      .test({
+        name: "no-brackets",
+        message: "Static values cannot contain [ or ] characters",
+        test: (value, context) => {
+          if (!value) return true;
+          const type = context.parent.type;
+          if (type !== "static") return true;
+          return !/[[\]]/.test(value);
         },
       }),
     type: mixed()


### PR DESCRIPTION
## What does this PR do?
This PR adds an additional check for payment metadata to conform to Stripe requirements. All other requirements are looser than GovPay, we can come back and expand this later.

Docs - https://docs.stripe.com/metadata

## Testing
I've checked this is safe to roll out, and that no existing metadata contains `[` or `]` with the following check -

```sql
SELECT
  f.id AS flow_id,
  f.slug AS flow_slug,
  t.name AS team_name,
  node_id,
  m.value ->> 'key' AS metadata_key,
  m.value ->> 'value' AS metadata_value
FROM flows f
JOIN teams t ON t.id = f.team_id,
LATERAL jsonb_each(f.data) AS nodes(node_id, node_data),
LATERAL jsonb_array_elements(node_data -> 'data' -> 'govPayMetadata') AS m(value)
WHERE node_data -> 'data' ? 'govPayMetadata'
  AND m.value ->> 'type' = 'static'
  AND (m.value ->> 'value' LIKE '%[%' OR m.value ->> 'value' LIKE '%]%');
```

Would appreciate a second pair of eyes here to make sure this query doesn't miss anything. Dropping the final clause gives me the expected results - a list of all fields.