### PR TITLE
chore(editor): Tidy up leftover onSubmit function

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -43,12 +43,6 @@ const Component: React.FC<Props> = (props: Props) => {
     props.formikRef,
   );
 
-  const onSubmit = (newValues: Pay) => {
-    if (props.handleSubmit) {
-      props.handleSubmit({ type: TYPES.Pay, data: newValues });
-    }
-  };
-
   return (
     <FormikProvider value={formik}>
       <form id="modal" name="modal" onSubmit={formik.handleSubmit}>


### PR DESCRIPTION
Spotted when working on #7252

This looks like a leftover from the following refactor - https://github.com/theopensystemslab/planx-new/pull/3987

This function is not called or referenced elsewhere, `onSubmit()` is hend within the `formik` instance directly.

<img width="578" height="334" alt="image" src="https://github.com/user-attachments/assets/2f0b20c9-6473-45bb-8e94-9dcdfa7c272f" />
