### PR TITLE
perf(api): Performance improvements for `findParentNode()`

### DIFF
--- a/apps/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
+++ b/apps/api.planx.uk/modules/saveAndReturn/service/validateSession.ts
@@ -113,13 +113,16 @@ async function reconcileSessionData({
     sessionData.breadcrumbs,
   );
 
-  const findParentNode = (nodeId: string): string | undefined => {
-    const [parentId, _] =
-      Object.entries(currentFlow).find(([_, node]) =>
-        node.edges?.includes(nodeId),
-      ) || [];
-    return parentId;
-  };
+  // Build a map of relationships just once to use as a lookup
+  const parentByChildId = new Map<string, string>();
+  for (const [parentId, node] of Object.entries(currentFlow)) {
+    for (const childId of node.edges ?? []) {
+      if (!parentByChildId.has(childId)) parentByChildId.set(childId, parentId);
+    }
+  }
+
+  const findParentNode = (nodeId: string): string | undefined =>
+    parentByChildId.get(nodeId);
 
   const removeAlteredAndAffectedBreadcrumb = (nodeId: string) => {
     const foundParentId = findParentNode(nodeId);


### PR DESCRIPTION
## What's the problem?
The API went down yesterday, and AWS CloudWatch logs point to a `POST /validate-session` request blocking the Node event loop for 244s. Then health checks failed, and the task was killed.

Reconciliation seems like the most likely candidate on this request, so I started taking a closer look at this.

## What's the cause?
Within the reconciliation process the `findParentNode()` helper iterates over the entire flow once per altered node. This means a loop running for alteredNodes × flowSize, rebuilding the whole entries array each call - `Object.entries(currentFlow).find(...)`.

## What's the solution?
If we build a child → parent map once, we can solve this with a single pass through, and just use it as a lookup instead of iterating each time.

Locally I've ran the before / after here with the current method (using `.find()`) and the new method (`Map`) and it's a significant improvement. In particular this has a large effect as the number of altered nodes grows. This is a bit back-of-the envelope and not a really `bench()` test (would love to put some of these in place if we split out graph navigation into a package!).

Altered nodes | Old (`.find()`) | New (`Map` index) | Speedup |
|---|---|---|---|
| 1,000 | 117.8 ms | 0.3 ms | 342× |
| 3,000 | 1.3 s | 0.7 ms | 1,929× |
| 6,000 | 6.4 s | 1.8 ms | 3,660× |
| 12,000 | 29.8 s | 4.4 ms | 6,834× |
| 18,000 | 73.5 s | 8.9 ms | 8,280× |
| 24,000 | 124.7 s | 10.9 ms | 11,446× |

## Next steps...
This was the likely trigger that caused the API to go down. But ideally here we'd scale or manage this more gracefully. The API died at exactly 25% memory each time which makes me think there's an issue here with the resourcing of this Fargate task. Looking at this now!