### PR TITLE
[editor] fix Dropzone max file size string to reflect var

### DIFF
--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -20,7 +20,10 @@ RUN npm install -g pnpm@10.30.2
 # unless the API's dependencies change (not on every monorepo source change).
 COPY --from=pruner /app/out/json/ ./
 RUN pnpm fetch
-RUN pnpm install --frozen-lockfile --prefer-offline
+# `--ignore-scripts` skips the root `postinstall` (which builds `packages/*`) - no
+# source has been copied into this layer yet, so it would fail with TS18003. The
+# workspace deps are built below instead, once the full source is present.
+RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
 # Build from the pruned full source
 COPY --from=pruner /app/out/full/ ./

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -9,6 +9,7 @@ import handleRejectedUpload from "@planx/components/shared/handleRejectedUpload"
 import {
   ALLOWED_EXTENSIONS_BY_MIME_TYPE,
   MAX_UPLOAD_SIZE_BYTES,
+  MAX_UPLOAD_SIZE_MB,
 } from "@planx/file-upload";
 import { uploadPrivateFile } from "lib/api/fileUpload/requests";
 import { nanoid } from "nanoid";
@@ -226,7 +227,7 @@ export function Dropzone<T extends FileUploadSlot>({
             pt: 1,
           }}
         >
-          Max size per file 30MB
+          Max size per file {MAX_UPLOAD_SIZE_MB}MB
         </Typography>
       </Box>
     </Root>

--- a/apps/sharedb.planx.uk/Dockerfile
+++ b/apps/sharedb.planx.uk/Dockerfile
@@ -12,7 +12,9 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
 COPY . .
-RUN pnpm install --frozen-lockfile --prefer-offline
+# `--ignore-scripts` skips the root `postinstall` (which builds `packages/*`) - ShareDB
+# does not rely on any workspace dependencies, so there's nothing here for it to build
+RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE
 # It's not exposed as a CLI flag, so we set it via npm's `npm_config_<key>` env-var convention
 RUN npm_config_inject_workspace_packages=true pnpm --filter sharedb.planx.uk deploy --prod --prefer-offline /deploy/sharedb

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",
     "logs": "docker compose logs --tail 30 -f",
     "prepare": "husky",
+    "postinstall": "turbo run build --filter='./packages/*'",
     "prebuild": "./scripts/check-containers.sh dev",
     "pretest": "./scripts/check-containers.sh e2e",
     "typecheck": "turbo run typecheck",

--- a/packages/file-upload/maxUploadSize.ts
+++ b/packages/file-upload/maxUploadSize.ts
@@ -1,6 +1,6 @@
 /**
  * Single source of truth for the max upload size of any file
  */
-const MAX_UPLOAD_SIZE_MB = 30;
+export const MAX_UPLOAD_SIZE_MB = 30;
 
 export const MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MB * 1e6;


### PR DESCRIPTION
As per title, another drive-by I came across when varying `MAX_UPLOAD_SIZE_MB` in `file-upload` package for purposes of checking out Docker DX stuff ([Slack](https://opensystemslab.slack.com/archives/C01E3AC0C03/p1787673732830539?thread_ts=1787661499.936989&cid=C01E3AC0C03)).

Also adds a `postinstall` npm hook so any `pnpm i` will also build dependencies in `packages/` (this is cached by turbo so adds milliseconds to any such run).