### PR TITLE
[fix] revert postinstall script, prefer turbo

### DIFF
--- a/apps/api.planx.uk/Dockerfile
+++ b/apps/api.planx.uk/Dockerfile
@@ -20,10 +20,7 @@ RUN npm install -g pnpm@10.30.2
 # unless the API's dependencies change (not on every monorepo source change).
 COPY --from=pruner /app/out/json/ ./
 RUN pnpm fetch
-# `--ignore-scripts` skips the root `postinstall` (which builds `packages/*`) - no
-# source has been copied into this layer yet, so it would fail with TS18003. The
-# workspace deps are built below instead, once the full source is present.
-RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+RUN pnpm install --frozen-lockfile --prefer-offline
 
 # Build from the pruned full source
 COPY --from=pruner /app/out/full/ ./

--- a/apps/sharedb.planx.uk/Dockerfile
+++ b/apps/sharedb.planx.uk/Dockerfile
@@ -12,9 +12,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 RUN pnpm fetch
 
 COPY . .
-# `--ignore-scripts` skips the root `postinstall` (which builds `packages/*`) - ShareDB
-# does not rely on any workspace dependencies, so there's nothing here for it to build
-RUN pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+RUN pnpm install --frozen-lockfile --prefer-offline
 # `pnpm deploy` refuses to run unless `inject-workspace-packages=true`, failing with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE
 # It's not exposed as a CLI flag, so we set it via npm's `npm_config_<key>` env-var convention
 RUN npm_config_inject_workspace_packages=true pnpm --filter sharedb.planx.uk deploy --prod --prefer-offline /deploy/sharedb

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "analytics": "docker compose -f ./docker-compose.yml -f ./docker-compose.local.yml --profile mock-services --profile analytics  up -d --quiet-pull",
     "logs": "docker compose logs --tail 30 -f",
     "prepare": "husky",
-    "postinstall": "turbo run build --filter='./packages/*'",
     "prebuild": "./scripts/check-containers.sh dev",
     "pretest": "./scripts/check-containers.sh e2e",
     "typecheck": "turbo run typecheck",

--- a/turbo.json
+++ b/turbo.json
@@ -11,10 +11,17 @@
     ".prettierignore"
   ],
   "tasks": {
-    "typecheck": {},
+    // compiled workspace packages resolve via dist/, so consumers reading types or importing at
+    // runtime (including tests) must build any such dependencies first (`pnpm install` only symlinks)
+    // workspace packages - it never builds them.
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
     "lint": {},
     "lint:fix": {},
-    "test": {},
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**"]


### PR DESCRIPTION
#7259 added a `postinstall` hook, but this broke staging deploy at the `pnpm install --frozen-lockfile --filter "@planx/infrastructure-application..."` line.

Here we revert that and instead rely on turbo to rebuild any workspace `packages/` as needed for typechecking etc. Again, all cached so v minimal speed penalties.