### PR TITLE
fix: pass description property to exclusive-or-option checklist items

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/ExclusiveChecklistItem.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/ExclusiveChecklistItem.tsx
@@ -52,6 +52,7 @@ export const ExclusiveChecklistItem = ({
             <ChecklistItem
               onChange={changeCheckbox(exclusiveOrOption.id)}
               label={exclusiveOrOption.data.text}
+              description={exclusiveOrOption.data.description}
               id={exclusiveOrOption.id}
               checked={formik.values.checked.includes(exclusiveOrOption.id)}
               inputProps={{

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/GroupedChecklist.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Public/components/GroupedChecklist.tsx
@@ -163,6 +163,9 @@ const GroupedChecklistComponent: React.FC<PublicProps<GroupedChecklist>> = (
                         exclusiveOrOptionGroup.children[0].id,
                       )}
                       label={exclusiveOrOptionGroup.children[0].data.text}
+                      description={
+                        exclusiveOrOptionGroup.children[0].data.description
+                      }
                       id={exclusiveOrOptionGroup.children[0].id}
                       checked={formik.values.checked.includes(
                         exclusiveOrOptionGroup.children[0].id,


### PR DESCRIPTION
Spotted by George [here](https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1787749722392559): exclusive 'or' options were missing the description property.