### PR TITLE
fix(editor): Populate required `orderedFlow` before loading source templates

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.test.tsx
@@ -1,0 +1,77 @@
+import type { OrderedFlow } from "@opensystemslab/planx-core/types";
+import { ComponentType } from "@opensystemslab/planx-core/types";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { setup } from "test/utils";
+
+import Customisations from ".";
+
+const { setState } = useStore;
+
+describe("Customisations tab", () => {
+  it("renders no customisable nodes, and does not throw, when orderedFlow is unavailable", async () => {
+    setState({
+      id: "test-flow-id",
+      orderedFlow: undefined,
+      isTemplatedFrom: false,
+      isTemplate: true,
+    });
+
+    const { getByText, queryAllByRole } = await setup(<Customisations />);
+
+    // Renders (no crash) but lists nothing
+    expect(getByText("Nodes set to 'Allow edits'")).toBeInTheDocument();
+    expect(queryAllByRole("listitem")).toHaveLength(0);
+  });
+
+  it("lists only templated nodes, in orderedFlow order", async () => {
+    const node = (
+      id: string,
+      isTemplatedNode: boolean,
+    ): OrderedFlow[number] => ({
+      id,
+      parentId: "_root",
+      type: ComponentType.Question,
+      data: {
+        isTemplatedNode,
+        templatedNodeInstructions: `instructions for ${id}`,
+      },
+    });
+
+    const orderedFlow: OrderedFlow = [
+      node("alpha", true),
+      node("skip1", false),
+      node("bravo", true),
+      node("skip2", false),
+      node("charlie", true),
+    ];
+
+    const flow = Object.fromEntries(
+      orderedFlow.map(({ id, type, data }) => [id, { type, data }]),
+    );
+
+    setState({
+      id: "test-flow-id",
+      orderedFlow,
+      flow: { _root: { edges: [] }, ...flow },
+      isTemplatedFrom: false,
+      isTemplate: true,
+    });
+
+    const { getAllByRole, queryByText } = await setup(<Customisations />);
+
+    const renderedInstructions = getAllByRole("listitem").map(
+      (li) => li.textContent,
+    );
+
+    // Exactly the three templated nodes, in orderedFlow order
+    expect(renderedInstructions).toEqual([
+      expect.stringContaining("instructions for alpha"),
+      expect.stringContaining("instructions for bravo"),
+      expect.stringContaining("instructions for charlie"),
+    ]);
+
+    // Non-templated nodes are excluded
+    expect(queryByText("instructions for skip1")).not.toBeInTheDocument();
+    expect(queryByText("instructions for skip2")).not.toBeInTheDocument();
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Sidebar/Customisations/index.tsx
@@ -2,37 +2,26 @@ import { gql, useSubscription } from "@apollo/client";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import Typography from "@mui/material/Typography";
-import { sortIdsDepthFirst } from "@planx/graph";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useEffect } from "react";
 
 import { CustomisationCard } from "./CustomisationCard";
 import type { FlowEdits } from "./types";
 
 const Customisations = () => {
-  const [flowId, flow, isTemplatedFrom, isTemplate, setOrderedFlow] = useStore(
+  const [flowId, isTemplatedFrom, isTemplate, orderedFlow] = useStore(
     (state) => [
       state.id,
-      state.flow,
       state.isTemplatedFrom,
       state.isTemplate,
-      state.setOrderedFlow,
+      state.orderedFlow,
     ],
   );
 
-  useEffect(() => {
-    if (flow) setOrderedFlow();
-  }, [flow, setOrderedFlow]);
-
   // Get the nodes within this flow that are customisable and sort them top-down to match graph
-  const customisableNodeIds = new Set(
-    Object.entries(flow)
-      .filter(([_nodeId, nodeData]) => Boolean(nodeData.data?.isTemplatedNode))
-      .map((entry) => entry[0]),
-  );
-  const sortedCustomisableNodeIds =
-    sortIdsDepthFirst(flow)(customisableNodeIds);
+  const sortedCustomisableNodeIds = (orderedFlow ?? [])
+    .filter((node) => Boolean(node.data?.isTemplatedNode))
+    .map((node) => node.id);
 
   // Subscribe to edits in order to mark customisable nodes "done"
   const { data, loading, error } = useSubscription<{

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.test.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.test.tsx
@@ -22,6 +22,7 @@ vi.mock("utils/routeUtils/queryUtils", () => ({
 const mockDisconnectFromFlow = vi.fn();
 const mockConnectToFlow = vi.fn().mockResolvedValue(undefined);
 const mockGetFlowInformation = vi.fn();
+const mockSetOrderedFlow = vi.fn();
 
 const makeStore = (overrides: Partial<FullStore> = {}): FullStore =>
   ({
@@ -29,7 +30,7 @@ const makeStore = (overrides: Partial<FullStore> = {}): FullStore =>
     disconnectFromFlow: mockDisconnectFromFlow,
     connectToFlow: mockConnectToFlow,
     getFlowInformation: mockGetFlowInformation,
-    setOrderedFlow: vi.fn(),
+    setOrderedFlow: mockSetOrderedFlow,
     ...overrides,
   }) as unknown as FullStore;
 
@@ -120,5 +121,67 @@ describe("connectToFlowRoute (ShareDB connection guard)", () => {
 
     expect(mockDisconnectFromFlow).toHaveBeenCalledOnce();
     expect(mockConnectToFlow).toHaveBeenCalledWith("lambeth-flow-b-uuid");
+  });
+
+  // The Customise panel (source templates, and templates) requires `orderedFlow`
+  describe("preparing orderedFlow for the Customise panel", () => {
+    beforeEach(() => {
+      vi.mocked(useStore.getState).mockReturnValue(makeStore({ id: "" }));
+      vi.mocked(getBasicFlowData).mockResolvedValue({
+        id: "flow-uuid",
+        name: "Some Flow",
+      });
+    });
+
+    it("sets the ordered flow for a templated-from (child) flow", async () => {
+      vi.mocked(getFlowEditorData).mockResolvedValue({
+        id: "flow-uuid",
+        flowStatus: "online",
+        isFlowPublished: false,
+        isTemplate: false,
+        isService: true,
+        templatedFrom: "template-uuid",
+        template: undefined,
+        isPattern: false,
+      });
+
+      await connectToFlowRoute("lambeth", "someFlow");
+
+      expect(mockSetOrderedFlow).toHaveBeenCalledOnce();
+    });
+
+    it("sets the ordered flow for a source template", async () => {
+      vi.mocked(getFlowEditorData).mockResolvedValue({
+        id: "flow-uuid",
+        flowStatus: "online",
+        isFlowPublished: false,
+        isTemplate: true,
+        isService: false,
+        templatedFrom: "",
+        template: undefined,
+        isPattern: false,
+      });
+
+      await connectToFlowRoute("lambeth", "someTemplate");
+
+      expect(mockSetOrderedFlow).toHaveBeenCalledOnce();
+    });
+
+    it("does not set the ordered flow for a plain flow", async () => {
+      vi.mocked(getFlowEditorData).mockResolvedValue({
+        id: "flow-uuid",
+        flowStatus: "online",
+        isFlowPublished: false,
+        isTemplate: false,
+        isService: true,
+        templatedFrom: "",
+        template: undefined,
+        isPattern: false,
+      });
+
+      await connectToFlowRoute("lambeth", "someFlow");
+
+      expect(mockSetOrderedFlow).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.utils.ts
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/-route.utils.ts
@@ -36,7 +36,9 @@ export async function connectToFlowRoute(teamSlug: string, rootFlow: string) {
       isPattern: flowEditorData.isPattern,
     });
 
-    if (flowEditorData.templatedFrom) {
+    // Both templated flows and source templates render the <Customise/> panel by default
+    // This requires `orderedFlow` - prepare it once here
+    if (flowEditorData.templatedFrom || flowEditorData.isTemplate) {
       store.setOrderedFlow();
     }
 


### PR DESCRIPTION
## What's the problem?
Airbrake has been reporting a recurring `TypeError: Cannot read properties of undefined (reading 'edges')` error for about a month. Error tracked here - https://planx.airbrake.io/projects/329753/groups/4381666065751580350

## What's the cause?
I believe this regression was introduced in #7003 . This set the `<Customise/>` tab as default for source templates but did not update the route files to also set `orderedFlow` before the page loaded, or manage loading states for a missing `flow`.

## What's the solution?
Calculate `orderedFlow` once upstream, and compute it before loading either source templates or templated flows. This means by the time the `<Customise/>` panel loads it always has data ready.

I've also updated this component to directly read from `orderedFlow` instead of re-sorting the `flow` in order to show customised nodes.