### PR TITLE
fix: Ensure error boundary always has access to the component call stack

### DIFF
--- a/apps/editor.planx.uk/eslint.config.mjs
+++ b/apps/editor.planx.uk/eslint.config.mjs
@@ -75,6 +75,12 @@ export default [
               message:
                 "Please import shared Switch component from 'ui/shared/Switch' instead of the MUI Switch component directly",
             },
+            {
+              name: "react-error-boundary",
+              importNames: ["ErrorBoundary"],
+              message:
+                "Please use AppErrorBoundary from 'components/Error/AppErrorBoundary' instead — it reports caught errors to Airbrake with a component stack.",
+            },
           ],
           patterns: ["@mui/*/*/*"],
         },

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.govPay.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.govPay.test.tsx
@@ -3,11 +3,10 @@ import { PaymentStatus } from "@opensystemslab/planx-core/types";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { act, screen, waitFor } from "@testing-library/react";
 import { logger } from "airbrake";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { http, HttpResponse } from "msw";
 import type { FullStore, Store } from "pages/FlowEditor/lib/store";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { ErrorBoundary } from "react-error-boundary";
 import server from "test/mockServer";
 import { setup } from "test/utils";
 import type { Breadcrumbs } from "types";
@@ -137,14 +136,14 @@ describe("Pay component when fee is undefined or £0", () => {
     });
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     // handleSubmit has NOT been called (not skipped), Pay shows error instead
@@ -164,14 +163,14 @@ describe("Pay component when fee is undefined or £0", () => {
     });
 
     const { getByTestId, user, getByRole } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     // Node is not auto-answered
@@ -208,14 +207,14 @@ describe("Pay component when fee is undefined or £0", () => {
     });
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -327,14 +326,14 @@ describe("Pay component when returning from payment provider", () => {
     const { handleSubmit } = setUpPayComponent(inFlightPayment);
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(await screen.findByText("Check payment status")).toBeInTheDocument();
@@ -371,14 +370,14 @@ describe("Pay component when returning from payment provider", () => {
     const { handleSubmit } = setUpPayComponent(inFlightPayment);
 
     const { user } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     await user.click(await screen.findByText("Check payment status"));
@@ -399,14 +398,14 @@ describe("Pay component when returning from payment provider", () => {
     });
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(await screen.findByText("Check payment status")).toBeInTheDocument();
@@ -429,14 +428,14 @@ describe("Pay component when returning from payment provider", () => {
     const { handleSubmit } = setUpPayComponent(inFlightPayment);
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     await waitFor(() => expect(handleSubmit).toHaveBeenCalled());

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stripe.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Public/Pay.stripe.test.tsx
@@ -1,9 +1,8 @@
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { act, screen, waitFor } from "@testing-library/react";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import type { FullStore, Store } from "pages/FlowEditor/lib/store";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { ErrorBoundary } from "react-error-boundary";
 import { setup } from "test/utils";
 import type { Breadcrumbs } from "types";
 import { vi } from "vitest";
@@ -75,14 +74,14 @@ describe("Pay component with Stripe provider (feature flag on)", () => {
     );
 
     const { user } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     await user.click(await screen.findByText("Pay now"));
@@ -108,14 +107,14 @@ describe("Pay component with Stripe provider (feature flag on)", () => {
     );
 
     const { user } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(await screen.findByText("Pay now")).toBeInTheDocument();
@@ -138,7 +137,7 @@ describe("Pay component with Stripe provider (feature flag on)", () => {
     );
 
     const { user } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
@@ -146,7 +145,7 @@ describe("Pay component with Stripe provider (feature flag on)", () => {
           hidePay={true}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     await user.click(await screen.findByText("Continue"));
@@ -165,14 +164,14 @@ describe("Pay component with Stripe provider (feature flag on)", () => {
     );
 
     await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <Pay
           title="Pay"
           fn="application.fee.payable"
           handleSubmit={handleSubmit}
           govPayMetadata={[]}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(await screen.findByText("Pay now")).toBeInTheDocument();

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/index.test.tsx
@@ -1,9 +1,7 @@
 import { act } from "@testing-library/react";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { http, HttpResponse } from "msw";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import server from "test/mockServer";
 import { setup } from "test/utils";
 import { vi } from "vitest";
@@ -43,7 +41,7 @@ beforeEach(() => {
 describe("error state", () => {
   it("renders an error if no address is present in the passport", async () => {
     const { getByRole, getByTestId } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <PlanningConstraints
           title="Planning constraints"
           description="Things that might affect your project"
@@ -52,7 +50,7 @@ describe("error state", () => {
           handleSubmit={vi.fn()}
           dataValues={availableDataValues}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
 
     expect(getByTestId("error-summary-invalid-graph")).toBeInTheDocument();
@@ -61,7 +59,7 @@ describe("error state", () => {
 
   it("should not have any accessibility violations", async () => {
     const { container } = await setup(
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <PlanningConstraints
           title="Planning constraints"
           description="Things that might affect your project"
@@ -69,7 +67,7 @@ describe("error state", () => {
           disclaimer="This page does not include information about historic planning conditions that may apply to this property."
           dataValues={availableDataValues}
         />
-      </ErrorBoundary>,
+      </AppErrorBoundary>,
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Public.test.tsx
@@ -1,7 +1,5 @@
 import { screen } from "@testing-library/react";
-import ErrorFallback from "components/Error/ErrorFallback";
-import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { setup } from "test/utils";
 import { vi } from "vitest";
 
@@ -16,12 +14,12 @@ const defaultPresentationalProps: PresentationalProps = {
 
 test("renders a warning for editors if address data is not in state", async () => {
   await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <PropertyInformation
         title="About the property"
         description="This is the information we currently have about the property"
       />
-    </ErrorBoundary>,
+    </AppErrorBoundary>,
   );
 
   expect(screen.getByTestId("error-summary-invalid-graph")).toBeInTheDocument();

--- a/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.test.tsx
+++ b/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.test.tsx
@@ -1,0 +1,92 @@
+import { logger } from "airbrake";
+import React from "react";
+import { setup } from "test/utils";
+import { vi } from "vitest";
+
+import { AppErrorBoundary } from "./AppErrorBoundary";
+import { GraphError } from "./GraphError";
+
+vi.mock("airbrake", () => ({
+  logger: {
+    notify: vi.fn(),
+  },
+}));
+
+const ThrowError: React.FC = () => {
+  throw new Error("Something broke");
+};
+
+const ThrowGraphError: React.FC = () => {
+  throw new GraphError("nodeMustFollowFindProperty");
+};
+
+describe("AppErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders children when nothing throws", async () => {
+    const { getByText } = await setup(
+      <AppErrorBoundary>
+        <h1>All good</h1>
+      </AppErrorBoundary>,
+    );
+
+    expect(getByText("All good")).toBeInTheDocument();
+    expect(logger.notify).not.toHaveBeenCalled();
+  });
+
+  it("renders ErrorFallback and reports to Airbrake with a component stack", async () => {
+    const { getByText } = await setup(
+      <AppErrorBoundary>
+        <ThrowError />
+      </AppErrorBoundary>,
+    );
+
+    expect(getByText(/Something went wrong/)).toBeInTheDocument();
+    expect(logger.notify).toHaveBeenCalledTimes(1);
+    expect(logger.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        params: expect.objectContaining({
+          componentStack: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("skips reporting when disableReporting is set (but still renders the fallback)", async () => {
+    const { getByText } = await setup(
+      <AppErrorBoundary
+        disableReporting
+        FallbackComponent={() => <p>Soft failure</p>}
+      >
+        <ThrowError />
+      </AppErrorBoundary>,
+    );
+
+    expect(getByText("Soft failure")).toBeInTheDocument();
+    expect(logger.notify).not.toHaveBeenCalled();
+  });
+
+  it("displays a custom FallbackComponent", async () => {
+    const { getByText } = await setup(
+      <AppErrorBoundary FallbackComponent={() => <p>Custom fallback</p>}>
+        <ThrowError />
+      </AppErrorBoundary>,
+    );
+
+    expect(getByText("Custom fallback")).toBeInTheDocument();
+  });
+
+  it("does not report GraphErrors", async () => {
+    const { getByRole } = await setup(
+      <AppErrorBoundary>
+        <ThrowGraphError />
+      </AppErrorBoundary>,
+    );
+
+    expect(getByRole("heading", { name: /Invalid graph/ })).toBeInTheDocument();
+    expect(logger.notify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.tsx
+++ b/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.tsx
@@ -1,10 +1,11 @@
 import React, { type ComponentType, type PropsWithChildren } from "react";
-import {
-  ErrorBoundary,
-  type ErrorBoundaryProps,
-  type FallbackProps,
-  type OnErrorCallback,
+import type {
+  ErrorBoundaryProps,
+  FallbackProps,
+  OnErrorCallback,
 } from "react-error-boundary";
+// eslint-disable-next-line no-restricted-imports
+import { ErrorBoundary } from "react-error-boundary";
 
 import ErrorFallback from "./ErrorFallback";
 import { logError } from "./logError";

--- a/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.tsx
+++ b/apps/editor.planx.uk/src/components/Error/AppErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import React, { type ComponentType, type PropsWithChildren } from "react";
+import {
+  ErrorBoundary,
+  type ErrorBoundaryProps,
+  type FallbackProps,
+  type OnErrorCallback,
+} from "react-error-boundary";
+
+import ErrorFallback from "./ErrorFallback";
+import { logError } from "./logError";
+
+type AppErrorBoundaryProps = PropsWithChildren<{
+  FallbackComponent?: ComponentType<FallbackProps>;
+  disableReporting?: boolean;
+  onError?: OnErrorCallback;
+  onReset?: ErrorBoundaryProps["onReset"];
+  resetKeys?: ErrorBoundaryProps["resetKeys"];
+}>;
+
+/**
+ * Wraps `react-error-boundary` so that every caught error is reported
+ * to Airbrake with its React component stack via logError()
+ */
+export const AppErrorBoundary: React.FC<AppErrorBoundaryProps> = ({
+  children,
+  FallbackComponent = ErrorFallback,
+  disableReporting = false,
+  onError,
+  ...props
+}) => (
+  <ErrorBoundary
+    FallbackComponent={FallbackComponent}
+    onError={(error, info) => {
+      if (!disableReporting) logError(error, info);
+      onError?.(error, info);
+    }}
+    {...props}
+  >
+    {children}
+  </ErrorBoundary>
+);

--- a/apps/editor.planx.uk/src/components/Error/ErrorFallback.tsx
+++ b/apps/editor.planx.uk/src/components/Error/ErrorFallback.tsx
@@ -1,7 +1,6 @@
 import Typography from "@mui/material/Typography";
 import Card from "@planx/components/shared/Preview/Card";
 import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
-import { logger } from "airbrake";
 import React from "react";
 import type { FallbackProps } from "react-error-boundary";
 
@@ -9,8 +8,6 @@ import { GraphErrorComponent, isGraphError } from "./GraphError";
 
 const ErrorFallback: React.FC<FallbackProps> = ({ error }) => {
   if (isGraphError(error)) return <GraphErrorComponent error={error} />;
-
-  logger.notify(error);
 
   return (
     <Card>

--- a/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
+++ b/apps/editor.planx.uk/src/components/Error/GraphError.test.tsx
@@ -1,11 +1,9 @@
-import { logger } from "airbrake";
-import ErrorFallback from "components/Error/ErrorFallback";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import { setup } from "test/utils";
 import { vi } from "vitest";
 import { axe } from "vitest-axe";
 
+import { AppErrorBoundary } from "./AppErrorBoundary";
 import { GraphError } from "./GraphError";
 
 vi.mock("airbrake", () => ({
@@ -24,9 +22,9 @@ const ThrowGraphError: React.FC = () => {
 
 it("does not render if a child does not throw an error", async () => {
   const { queryByRole } = await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <h1>No error</h1>
-    </ErrorBoundary>,
+    </AppErrorBoundary>,
   );
   expect(
     queryByRole("heading", { name: /Invalid graph/ }),
@@ -35,9 +33,9 @@ it("does not render if a child does not throw an error", async () => {
 
 it("does not render if a child throws a non-Graph error", async () => {
   const { queryByRole, getByText } = await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <ThrowError />
-    </ErrorBoundary>,
+    </AppErrorBoundary>,
   );
   // ErrorFallback displays...
   expect(getByText(/Something went wrong/)).toBeInTheDocument();
@@ -49,32 +47,20 @@ it("does not render if a child throws a non-Graph error", async () => {
 
 it("renders if a child throws an error", async () => {
   const { queryByText, getByRole } = await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <ThrowGraphError />
-    </ErrorBoundary>,
+    </AppErrorBoundary>,
   );
 
   expect(queryByText(/Something went wrong/)).not.toBeInTheDocument();
   expect(getByRole("heading", { name: /Invalid graph/ })).toBeInTheDocument();
 });
 
-it("does not call Airbrake", async () => {
-  const loggerSpy = vi.spyOn(logger, "notify");
-
-  await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <ThrowGraphError />
-    </ErrorBoundary>,
-  );
-
-  expect(loggerSpy).not.toHaveBeenCalled();
-});
-
 it("should not have accessability violations", async () => {
   const { container } = await setup(
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <ThrowGraphError />
-    </ErrorBoundary>,
+    </AppErrorBoundary>,
   );
   const results = await axe(container);
   expect(results).toHaveNoViolations();

--- a/apps/editor.planx.uk/src/components/Error/logError.test.ts
+++ b/apps/editor.planx.uk/src/components/Error/logError.test.ts
@@ -1,0 +1,50 @@
+import { logger } from "airbrake";
+import type { ErrorInfo } from "react";
+import { vi } from "vitest";
+
+import { GraphError } from "./GraphError";
+import { logError } from "./logError";
+
+vi.mock("airbrake", () => ({
+  logger: {
+    notify: vi.fn(),
+  },
+}));
+
+const info: ErrorInfo = {
+  componentStack: "\n    at Widget\n    at Dashboard",
+};
+
+describe("logError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports non-Graph errors to Airbrake with the component stack", () => {
+    const error = new Error("Something broke");
+
+    logError(error, info);
+
+    expect(logger.notify).toHaveBeenCalledTimes(1);
+    expect(logger.notify).toHaveBeenCalledWith({
+      error,
+      params: { componentStack: info.componentStack },
+    });
+  });
+
+  it("reports non-Error thrown values (so they are no longer silently 'undefined')", () => {
+    logError(undefined, info);
+
+    expect(logger.notify).toHaveBeenCalledTimes(1);
+    expect(logger.notify).toHaveBeenCalledWith({
+      error: undefined,
+      params: { componentStack: info.componentStack },
+    });
+  });
+
+  it("does not report GraphErrors (shown to the user via GraphErrorComponent)", () => {
+    logError(new GraphError("nodeMustFollowFindProperty"), info);
+
+    expect(logger.notify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor.planx.uk/src/components/Error/logError.ts
+++ b/apps/editor.planx.uk/src/components/Error/logError.ts
@@ -1,0 +1,10 @@
+import { logger } from "airbrake";
+import type { ErrorInfo } from "react";
+
+import { isGraphError } from "./GraphError";
+
+export const logError = (error: unknown, info: ErrorInfo): void => {
+  if (isGraphError(error)) return;
+
+  logger.notify({ error, params: { componentStack: info.componentStack } });
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -4,8 +4,8 @@ import {
 } from "@opensystemslab/planx-core/types";
 import { TASKS } from "@planx/components/EnhancedTextInput/model";
 import type { Task } from "@planx/components/EnhancedTextInput/types";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import { exhaustiveCheck } from "utils";
 
 import type { Store } from "../../../lib/store";
@@ -193,7 +193,7 @@ const getSetValueText = ({ operation, fn, val }: Store.Node["data"] = {}) => {
 
 export default function SafeNode(props: any) {
   return (
-    <ErrorBoundary
+    <AppErrorBoundary
       FallbackComponent={() => (
         <Question
           hasFailed
@@ -206,6 +206,6 @@ export default function SafeNode(props: any) {
       )}
     >
       <Node {...props} />
-    </ErrorBoundary>
+    </AppErrorBoundary>
   );
 }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Settings/Team/Integrations/SubmissionEmails/EmailsTable.tsx
@@ -8,10 +8,9 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { useState } from "react";
 import { AddButton } from "ui/editor/AddButton";
 
 import { StyledTableRow } from "../../../../Team/styles";
@@ -193,7 +192,7 @@ const EmailsTableContent = () => {
 };
 
 export const EmailsTable = () => (
-  <ErrorBoundary FallbackComponent={ErrorFallback}>
+  <AppErrorBoundary>
     <EmailsTableContent />
-  </ErrorBoundary>
+  </AppErrorBoundary>
 );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLog.tsx
@@ -1,10 +1,9 @@
 import BarChartIcon from "@mui/icons-material/BarChart";
 import type { GridFilterItem } from "@mui/x-data-grid";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import { EmptyState } from "ui/editor/EmptyState";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import type { ColumnConfig } from "ui/shared/DataTable/types";
@@ -183,9 +182,9 @@ const EventsLog: React.FC<EventsLogProps> = ({
   }
 
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <DataTable columns={columns} rows={rowData} />
-    </ErrorBoundary>
+    </AppErrorBoundary>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -1,12 +1,11 @@
 import BarChartIcon from "@mui/icons-material/BarChart";
-import type { GridFilterItem, GridRowParams } from "@mui/x-data-grid";
+import type { GridRowParams } from "@mui/x-data-grid";
 import { useNavigate } from "@tanstack/react-router";
 import { useParams } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useMemo, useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import React, { useMemo } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import { DataTable } from "ui/shared/DataTable/DataTable";
 import type { ColumnConfig } from "ui/shared/DataTable/types";
@@ -14,11 +13,7 @@ import { ColumnFilterType } from "ui/shared/DataTable/types";
 import { dateFormatter } from "ui/shared/DataTable/utils";
 
 import { submissionStatusGroupedOptions } from "../submissionFilterOptions";
-import type {
-  EventsLogGroupedProps,
-  Submission,
-  SubmissionSummary,
-} from "../types";
+import type { EventsLogGroupedProps, SubmissionSummary } from "../types";
 import { getConsolidatedStatus } from "../utils";
 import { StatusChipGrouped } from "./StatusChipGrouped";
 
@@ -119,13 +114,13 @@ const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
     { field: "id", headerName: "Session ID", width: 400 },
   ];
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <DataTable
         columns={columns}
         rows={submissionsWithConsolidatedStatus}
         onRowClick={handleRowClick}
       />
-    </ErrorBoundary>
+    </AppErrorBoundary>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/FormattedResponse.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/FormattedResponse.tsx
@@ -1,7 +1,7 @@
 import ReactJson from "@microlink/react-json-view";
 import { styled } from "@mui/material/styles";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 
 const Root = styled("pre")(({ theme }) => ({
   padding: theme.spacing(2.5, 2),
@@ -35,7 +35,7 @@ export const FormattedResponse: React.FC<FormattedResponseProps> = ({
 
   return (
     <Root>
-      <ErrorBoundary FallbackComponent={InvalidJSONError}>
+      <AppErrorBoundary FallbackComponent={InvalidJSONError} disableReporting>
         <ReactJson
           src={parsedResponse}
           theme="monokai"
@@ -45,7 +45,7 @@ export const FormattedResponse: React.FC<FormattedResponseProps> = ({
           style={{ background: "transparent" }}
           enableClipboard={false}
         />
-      </ErrorBoundary>
+      </AppErrorBoundary>
     </Root>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -7,19 +7,17 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { type BaseNodeData, parseFormValues } from "@planx/components/shared";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import type { FormikProps } from "formik";
 import {
   nodeIsChildOfTemplatedInternalPortal,
   nodeIsTemplatedInternalPortal,
 } from "pages/FlowEditor/utils";
 import React, { useMemo, useState } from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { CloseButton } from "ui/icons/CloseButton";
 import { Switch } from "ui/shared/Switch";
@@ -278,7 +276,7 @@ const FormModal: React.FC<FormModalProps> = ({
           {!handleDelete && (
             <TextInputToggle type={type} parent={parent} before={before} />
           )}
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <AppErrorBoundary>
             <Component
               formikRef={formikRef}
               node={node}
@@ -323,7 +321,7 @@ const FormModal: React.FC<FormModalProps> = ({
                 });
               }}
             />
-          </ErrorBoundary>
+          </AppErrorBoundary>
         </DialogContent>
         <DialogActions
           disableSpacing

--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -9,18 +9,11 @@ import { getLocalFlowIdb, setLocalFlowIdb } from "lib/local.idb";
 import * as NEW from "lib/local.new";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";
 import type { PreviewEnvironment } from "pages/FlowEditor/lib/store/shared";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Session } from "types";
 import { ApplicationPath } from "types";
 
-import ErrorFallback from "../../components/Error/ErrorFallback";
+import { AppErrorBoundary } from "../../components/Error/AppErrorBoundary";
 import OpenInEditorButton from "../../components/OpenInEditorButton";
 import { useStore } from "../FlowEditor/lib/store";
 import type { HandleSubmit } from "./Node";
@@ -255,13 +248,13 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
       {node && (
         <>
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <AppErrorBoundary>
             <Node
               node={node}
               key={node.id}
               handleSubmit={handleSubmit(node.id!)}
             />
-          </ErrorBoundary>
+          </AppErrorBoundary>
         </>
       )}
       {isDraft && <OpenInEditorButton />}

--- a/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/layout/AuthenticatedLayout.tsx
@@ -4,14 +4,13 @@ import { styled } from "@mui/material/styles";
 import { useRouter } from "@tanstack/react-router";
 import Breadcrumbs from "components/Breadcrumbs";
 import EditorNavMenu from "components/EditorNavMenu/EditorNavMenu";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import LoadingOverlay from "components/LoadingOverlay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import type { PropsWithChildren } from "react";
 import React, { useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { ErrorBoundary } from "react-error-boundary";
 import WatermarkBackground from "ui/shared/WatermarkBackground";
 
 import Header from "../../components/Header/Header";
@@ -60,10 +59,10 @@ const Layout: React.FC<PropsWithChildren> = ({ children }) => {
         <EditorNavMenu />
         <DashboardContainer>
           <Breadcrumbs />
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <AppErrorBoundary>
             <WatermarkBackground variant="dark" opacity={0.05} />
             <DndProvider backend={HTML5Backend}>{children}</DndProvider>
-          </ErrorBoundary>
+          </AppErrorBoundary>
         </DashboardContainer>
       </DashboardWrap>
     </>

--- a/apps/editor.planx.uk/src/pages/layout/PublicLayout.tsx
+++ b/apps/editor.planx.uk/src/pages/layout/PublicLayout.tsx
@@ -6,12 +6,11 @@ import {
   ThemeProvider,
 } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import Feedback from "components/Feedback";
 import { useStore } from "pages/FlowEditor/lib/store";
 import type { PropsWithChildren } from "react";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import { generateTeamTheme } from "theme";
 import Logo from "ui/images/OGLLogo.svg";
 import Main from "ui/shared/Main";
@@ -109,9 +108,7 @@ const PublicLayout: React.FC<PropsWithChildren> = ({ children }) => {
         <RootContainer data-testid="document-start">
           <Header />
           <MainContainer>
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-              {children}
-            </ErrorBoundary>
+            <AppErrorBoundary>{children}</AppErrorBoundary>
           </MainContainer>
           <PublicFooter />
         </RootContainer>

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/_flowEditor/route.tsx
@@ -1,11 +1,10 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import { hasFeatureFlag } from "lib/featureFlags";
 import FlowEditor from "pages/FlowEditor";
 import { FlowNotesProvider } from "pages/FlowEditor/components/Flow/notes/FlowNotesContext";
 import { RecentFlowsProvider } from "pages/FlowEditor/components/RecentFlows/RecentFlowsContext";
 import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 
 export const Route = createFileRoute(
   "/_authenticated/app/$team/$flow/_flowEditor",
@@ -25,12 +24,12 @@ function FlowEditorLayout() {
 
   return (
     <RecentFlowsProvider>
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <AppErrorBoundary>
         <NotesWrapper>
           <FlowEditor />
           <Outlet />
         </NotesWrapper>
-      </ErrorBoundary>
+      </AppErrorBoundary>
     </RecentFlowsProvider>
   );
 }

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
@@ -4,9 +4,8 @@ import {
   stripSearchParams,
 } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import FlowSkeleton from "pages/FlowEditor/FlowSkeleton";
-import { ErrorBoundary } from "react-error-boundary";
 import { CatchAllComponent } from "routes/$";
 
 import { flowsSearchSchema } from "../flows";
@@ -40,8 +39,8 @@ export const Route = createFileRoute("/_authenticated/app/$team/$flow")({
 
 function RouteComponent() {
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <AppErrorBoundary>
       <Outlet />
-    </ErrorBoundary>
+    </AppErrorBoundary>
   );
 }

--- a/apps/editor.planx.uk/src/ui/editor/NewSettingsSection.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/NewSettingsSection.tsx
@@ -2,10 +2,8 @@ import type { BoxProps } from "@mui/material/Box";
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import type { ReactNode } from "react";
-import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 
 const Root = styled(Box)(({ theme }) => ({
   display: "block",
@@ -34,9 +32,7 @@ export default function NewSettingsSection(
 ) {
   return (
     <Root {...props}>
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
-        {props.children}
-      </ErrorBoundary>
+      <AppErrorBoundary>{props.children}</AppErrorBoundary>
     </Root>
   );
 }

--- a/apps/editor.planx.uk/src/ui/editor/SettingsSection.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/SettingsSection.tsx
@@ -2,10 +2,8 @@ import type { BoxProps } from "@mui/material/Box";
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import { contentFlowSpacing } from "@planx/components/shared/Preview/Card";
-import ErrorFallback from "components/Error/ErrorFallback";
+import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
 import type { ReactNode } from "react";
-import React from "react";
-import { ErrorBoundary } from "react-error-boundary";
 
 const Root = styled(Box, {
   shouldForwardProp: (prop) => prop !== "background",
@@ -40,9 +38,7 @@ export default function SettingsSection(
 ) {
   return (
     <Root {...props}>
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
-        {props.children}
-      </ErrorBoundary>
+      <AppErrorBoundary>{props.children}</AppErrorBoundary>
     </Root>
   );
 }


### PR DESCRIPTION
## What's the problem?
One of the largest open issues on Airbrake (59 occurrences) is just `Error: undefined`. This is essentially unactionable as there's no associated call stack we can dig into. We can't understand the root cause - it could be one issue, or many disparate issues. Please see occurrences here - https://planx.airbrake.io/projects/329753/groups/4345444345772610066

## What's the cause?
This is happening because `logger.notify(error)` is getting called in the body of `<ErrorFallback/>`, which doesn't have access to the call stack unless an existing `Error` object was passed in (but we can see it just receives and `undefined). The [react-error-boundary docs](https://github.com/bvaughn/react-error-boundary#logging-errors) show that we should report from the boundary component's `onError(error, info)` callback prop, where `info.componentStack` is available, not from the `<ErrorFallback/>` UI.

## What's the solution?
I've made a basic wrapper (`AppErrorBoundary` - better names welcome!) which enforces this pattern - we always call `logError()` to hit Airbrake with the full information.

All instances of `<ErrorBoundary/>` have now been swapped out for the new `<AppErrorBoundary/>`,  and some imports tidied up in these files.

## Next steps...
So the `undefined` errors will continue to throw at the same rate! But now each time there will be a proper call stack in place allowing us to actually diagnose and fix these issues.