### PR TITLE
chore: update tree sketch plan schemas

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionCA.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionCA.ts
@@ -23,7 +23,15 @@ export const TreeDescriptionCA: Schema = {
     },
     {
       type: "text",
-      required: false,
+      data: {
+        title: "Tree description",
+        description: "For example 'rear garden, mature (80cm diameter)'.",
+        fn: "description",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
       data: {
         title: "Proposed work",
         fn: "work",

--- a/apps/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionTPO.ts
+++ b/apps/editor.planx.uk/src/@planx/components/List/schemas/TreeDescriptionTPO.ts
@@ -23,7 +23,15 @@ export const TreeDescriptionTPO: Schema = {
     },
     {
       type: "text",
-      required: false,
+      data: {
+        title: "Tree description",
+        description: "For example 'rear garden, mature (80cm diameter)'.",
+        fn: "description",
+        type: TextInputType.Short,
+      },
+    },
+    {
+      type: "text",
       data: {
         title: "Proposed work",
         fn: "work",
@@ -32,7 +40,6 @@ export const TreeDescriptionTPO: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Reasons for the proposed work",
         fn: "reason",

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/SketchPlanFullDescriptionCA.ts
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/SketchPlanFullDescriptionCA.ts
@@ -14,7 +14,6 @@ export const SketchPlanFullDescriptionCA: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Tree description",
         description: "For example 'rear garden, mature (80cm diameter)'.",
@@ -24,7 +23,6 @@ export const SketchPlanFullDescriptionCA: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Proposed work",
         fn: "work",

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/SketchPlanFullDescriptionTPO.ts
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/schemas/SketchPlanFullDescriptionTPO.ts
@@ -25,7 +25,6 @@ export const SketchPlanFullDescriptionTPO: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Tree description",
         description: "For example 'rear garden, mature (80cm diameter)'.",
@@ -35,7 +34,6 @@ export const SketchPlanFullDescriptionTPO: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Proposed work",
         fn: "work",
@@ -44,7 +42,6 @@ export const SketchPlanFullDescriptionTPO: Schema = {
     },
     {
       type: "text",
-      required: false,
       data: {
         title: "Reasons for the proposed work",
         fn: "reason",


### PR DESCRIPTION
Based on repeated feedback from Barnet, this changes tree sketch plan schemas to require descriptions rather than optionally request them.