### PR TITLE
fix: submission details date and button rendering

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/DownloadSubmissionButtonGrouped.tsx
@@ -1,7 +1,5 @@
 import CloudDownload from "@mui/icons-material/CloudDownload";
 import Button from "@mui/material/Button";
-import { addDays, isBefore } from "date-fns";
-import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import React from "react";
 
 type Props = {
@@ -10,14 +8,6 @@ type Props = {
 };
 
 export const DownloadSubmissionButtonGrouped = (props: Props) => {
-  const submissionDataExpirationDate = addDays(
-    new Date(props.submittedAt),
-    DAYS_UNTIL_EXPIRY,
-  );
-  const showDownloadButton = isBefore(new Date(), submissionDataExpirationDate);
-
-  if (!showDownloadButton) return;
-
   const zipUrl = `${import.meta.env.VITE_APP_API_URL}/submission/${props.sessionId}/zip`;
 
   return (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButton.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButton.tsx
@@ -14,7 +14,10 @@ import type { RenderCellParams } from "ui/shared/DataTable/types";
 
 import type { Submission } from "../types";
 
-type ResubmitEventType = Exclude<Submission["eventType"], "Pay">;
+type ResubmitEventType = Exclude<
+  Submission["eventType"],
+  "Pay" | "Started session" | "Invited to pay"
+>;
 
 export const ResubmitButton = (params: RenderCellParams) => {
   const teamSlug = useStore((state) => state.teamSlug);

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ResubmitButtonGrouped.tsx
@@ -11,7 +11,10 @@ import React, { useState } from "react";
 
 import type { Submission } from "../types";
 
-type ResubmitEventType = Exclude<Submission["eventType"], "Pay">;
+type ResubmitEventType = Exclude<
+  Submission["eventType"],
+  "Pay" | "Started session" | "Invited to pay"
+>;
 
 type Props = {
   sessionId: string;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -89,6 +89,7 @@ const getSubmittedAt = (events: Submission[]): string | undefined => {
     (event) =>
       event.eventType !== "Pay" &&
       event.eventType !== "Started session" &&
+      event.eventType !== "Invited to pay" &&
       event.status === "Success",
   );
 
@@ -118,6 +119,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   const events = data?.submissions || [];
   const latestEvent = events[0];
   const submittedAt = getSubmittedAt(events);
+  console.log({ submittedAt });
 
   if (loading) {
     return (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -86,7 +86,10 @@ const SubmissionModalWrapper = ({
 
 const getSubmittedAt = (events: Submission[]): string | undefined => {
   const successfulSend = events.find(
-    (event) => event.eventType !== "Pay" && event.status === "Success",
+    (event) =>
+      event.eventType !== "Pay" &&
+      event.eventType !== "Started session" &&
+      event.status === "Success",
   );
 
   return successfulSend?.createdAt ?? undefined;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -119,7 +119,6 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   const events = data?.submissions || [];
   const latestEvent = events[0];
   const submittedAt = getSubmittedAt(events);
-  console.log({ submittedAt });
 
   if (loading) {
     return (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -83,7 +83,7 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         <DescriptionList data={submissionData} />
       </Box>
 
-      {props.submittedAt && !isSubmissionAvailable && (
+      {props.submittedAt && isSubmissionAvailable && (
         <Box
           sx={{
             display: "flex",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,5 +1,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import { addDays, isBefore } from "date-fns";
+import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import type { DescriptionListItem } from "ui/public/DescriptionList";
 import { DescriptionList } from "ui/public/DescriptionList";
 
@@ -45,6 +47,13 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
   const teamName = themeData?.teams[0].name;
   const teamColour = themeData?.teams[0].theme.primaryColour;
 
+  const submissionExpirationDate = props.submittedAt
+    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
+    : null;
+
+  const isSubmissionAvailable =
+    submissionExpirationDate && isBefore(new Date(), submissionExpirationDate);
+
   return (
     <Box
       sx={{
@@ -74,7 +83,7 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         <DescriptionList data={submissionData} />
       </Box>
 
-      {props.submittedAt ? (
+      {props.submittedAt && !isSubmissionAvailable && (
         <Box
           sx={{
             display: "flex",
@@ -95,8 +104,6 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
             submittedAt={props.submittedAt}
           />
         </Box>
-      ) : (
-        <></>
       )}
     </Box>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/ViewSubmissionButtonGrouped.tsx
@@ -2,8 +2,6 @@ import PreviewIcon from "@mui/icons-material/Preview";
 import Button from "@mui/material/Button";
 import { useNavigate } from "@tanstack/react-router";
 import { useParams } from "@tanstack/react-router";
-import { addDays, isBefore } from "date-fns";
-import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React from "react";
 
@@ -13,15 +11,7 @@ type Props = {
 };
 
 export const ViewSubmissionButtonGrouped = (props: Props) => {
-  const submissionDataExpirationDate = props.submittedAt
-    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
-    : null;
-
   const teamSlug = useStore((state) => state.teamSlug);
-
-  const showViewButton = submissionDataExpirationDate
-    ? isBefore(new Date(), submissionDataExpirationDate)
-    : false;
 
   const navigate = useNavigate();
   const params = useParams({ strict: false });
@@ -48,8 +38,6 @@ export const ViewSubmissionButtonGrouped = (props: Props) => {
       });
     }
   };
-
-  if (!showViewButton) return;
 
   return (
     <Button

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/types.ts
@@ -9,7 +9,9 @@ export interface Submission {
     | "Send to email"
     | "Upload to AWS S3"
     | "Upload to AWS S3 (no notification)"
-    | "Submit to Idox Nexus";
+    | "Submit to Idox Nexus"
+    | "Started session"
+    | "Invited to pay";
   status?:
     | "Success"
     | "Failed (500)" // Hasura scheduled event status codes


### PR DESCRIPTION
Two quick fixes to submissions log:

1. Calculate `submissionExpirationDate` and `isSubmissionAvailable` in `SubmissionDetail` so as to conditionally render the parent of `ViewSubmissionButtonGrouped` and `DownloadSubmissionButtonGrouped` (to avoid empty box)

<img width="470" height="116" alt="Screenshot 2026-08-28 102012" src="https://github.com/user-attachments/assets/12175448-cf48-4838-a08b-25a73642cd94" />


2. Ensure that a successful `Started session` event does not populate the "Submitted at" field in `SubmissionDetails` (`submission_services_log` includes "Started session" and "Invited to pay" event types as of #7234