### PR TITLE
fix: make submission availability a condition of resubmit button

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -7,6 +7,8 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import { useNavigate } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { addDays, isBefore } from "date-fns";
+import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { CloseButton } from "ui/icons/CloseButton";
 
@@ -120,6 +122,14 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   const latestEvent = events[0];
   const submittedAt = getSubmittedAt(events);
 
+  const submissionExpirationDate = submittedAt
+    ? addDays(new Date(submittedAt), DAYS_UNTIL_EXPIRY)
+    : null;
+
+  const isSubmissionAvailable = submissionExpirationDate
+    ? isBefore(new Date(), submissionExpirationDate)
+    : false;
+
   if (loading) {
     return (
       <SubmissionModalWrapper handleClose={handleClose}>
@@ -145,11 +155,15 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
             latestEvent={latestEvent}
             teamSlug={teamSlug}
             submittedAt={submittedAt}
+            isSubmissionAvailable={isSubmissionAvailable}
           />
         </Grid>
 
         <Grid size={{ xs: 12, md: 6 }}>
-          <SubmissionEventsHistory events={events} />
+          <SubmissionEventsHistory
+            events={events}
+            isSubmissionAvailable={isSubmissionAvailable}
+          />
         </Grid>
       </Grid>
     </SubmissionModalWrapper>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,7 +1,5 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import { addDays, isBefore } from "date-fns";
-import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import type { DescriptionListItem } from "ui/public/DescriptionList";
 import { DescriptionList } from "ui/public/DescriptionList";
 
@@ -17,6 +15,7 @@ type SubmissionDetailsProps = {
   latestEvent: Submission;
   teamSlug: string;
   submittedAt?: string;
+  isSubmissionAvailable: boolean;
 };
 
 export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
@@ -47,13 +46,6 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
   const teamName = themeData?.teams[0].name;
   const teamColour = themeData?.teams[0].theme.primaryColour;
 
-  const submissionExpirationDate = props.submittedAt
-    ? addDays(new Date(props.submittedAt), DAYS_UNTIL_EXPIRY)
-    : null;
-
-  const isSubmissionAvailable =
-    submissionExpirationDate && isBefore(new Date(), submissionExpirationDate);
-
   return (
     <Box
       sx={{
@@ -83,7 +75,7 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         <DescriptionList data={submissionData} />
       </Box>
 
-      {props.submittedAt && isSubmissionAvailable && (
+      {props.submittedAt && props.isSubmissionAvailable && (
         <Box
           sx={{
             display: "flex",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionEventsHistory.tsx
@@ -63,9 +63,10 @@ const getMostRecentEventId = (groupedEvents: GroupedEvent[]): Set<string> => {
   );
 };
 
-export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
-  events,
-}) => {
+export const SubmissionEventsHistory: React.FC<{
+  events: Submission[];
+  isSubmissionAvailable: boolean;
+}> = ({ events, isSubmissionAvailable }) => {
   const groupedEvents = groupEvents(events);
   const mostRecentIds = getMostRecentEventId(groupedEvents);
 
@@ -93,6 +94,7 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
             key={groupedEvent.eventId}
             groupedEvent={groupedEvent}
             isMostRecent={mostRecentIds.has(groupedEvent.eventId)}
+            isSubmissionAvailable={isSubmissionAvailable}
           />
         ))}
       </Box>
@@ -103,7 +105,12 @@ export const SubmissionEventsHistory: React.FC<{ events: Submission[] }> = ({
 const SubmissionEvent: React.FC<{
   groupedEvent: GroupedEvent;
   isMostRecent: boolean;
-}> = ({ groupedEvent: { sessionId, events: attempts }, isMostRecent }) => {
+  isSubmissionAvailable: boolean;
+}> = ({
+  groupedEvent: { sessionId, events: attempts },
+  isMostRecent,
+  isSubmissionAvailable,
+}) => {
   const { eventType, createdAt, status } = attempts[0];
   const hideResponse =
     eventType === "Invited to pay" || eventType === "Started session";
@@ -133,7 +140,12 @@ const SubmissionEvent: React.FC<{
         <Typography sx={{ fontWeight: "bold" }}>{eventType}</Typography>
 
         <Permission.IsPlatformAdmin>
-          {canResubmit(isMostRecent, status, eventType) && (
+          {canResubmit(
+            isMostRecent,
+            status,
+            eventType,
+            isSubmissionAvailable,
+          ) && (
             <ResubmitButtonGrouped
               sessionId={sessionId}
               eventType={eventType}

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
@@ -30,8 +30,10 @@ export const canResubmit = (
   isMostRecent: boolean,
   status: string | undefined,
   eventType: Submission["eventType"] | SessionEvent,
+  isSubmissionAvailable: boolean,
 ): eventType is Submission["eventType"] => {
   return (
+    isSubmissionAvailable &&
     isMostRecent &&
     status !== "Success" &&
     !NON_RESUBMITTABLE_EVENT_TYPES.includes(eventType)


### PR DESCRIPTION
Testing on staging with older data is surfacing various cases I wasn't able to test locally... Previously only checked for `isPlatformAdmin` and not `isSubmissionAvailable` also! Pulls logic up into parent component because the boolean value is used for conditional rendering in various places. 