### PR TITLE
feat(editor): Dummy payment menu for submission modal

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/InitiateRefundDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/InitiateRefundDialog.tsx
@@ -1,0 +1,33 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import React from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export const InitiateRefundDialog = ({ open, onClose }: Props) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle variant="h3" component="h1">
+        Initiate refund
+      </DialogTitle>
+      <DialogContent dividers>
+        <DialogContentText>
+          Refunds are managed centrally by the PlanX team. To refund this
+          payment, please contact the team.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained" color="primary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/PaymentMenuGrouped.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/PaymentMenuGrouped.stories.tsx
@@ -1,0 +1,42 @@
+import Box from "@mui/material/Box";
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+
+import type { Submission } from "../types";
+import { PaymentMenuGrouped } from "./PaymentMenuGrouped";
+
+const mockSucceededPayment: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "126ec0c4-12f2-1209-aa09-11294ec3ee12",
+  eventId: "c8uu7c6a-7ea9-412d-9c4d-8f08039e1212",
+  eventType: "Pay",
+  status: "Success",
+  retry: false,
+  response: {},
+  createdAt: "2024-01-12T12:17:42.275655+00:00",
+  flowName: "Apply for a lawful development certificate",
+  address: "1, AMERSHAM ROAD, BEACONSFIELD, BUCKINGHAMSHIRE, HP9 2HA",
+};
+
+const meta = {
+  // TODO: Match Ollie's paths
+  title: "Editor Components/Submissions/Details Modal/Payment menu",
+  component: PaymentMenuGrouped,
+  decorators: [
+    (Story) => (
+      <Box sx={{ p: 2 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof PaymentMenuGrouped>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    sessionId: mockSucceededPayment.sessionId,
+    paymentEvent: mockSucceededPayment,
+  },
+} satisfies Story;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/PaymentMenuGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/PaymentMenuGrouped.tsx
@@ -1,0 +1,72 @@
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import PaymentIcon from "@mui/icons-material/Payment";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { useState } from "react";
+
+import type { Submission } from "../types";
+import { InitiateRefundDialog } from "./InitiateRefundDialog";
+
+type Props = {
+  sessionId: string;
+  paymentEvent: Submission;
+};
+
+/**
+ * Groups payment-related actions behind a single "Payment" dropdown
+ */
+export const PaymentMenuGrouped = ({ sessionId, paymentEvent }: Props) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [isRefundDialogOpen, setIsRefundDialogOpen] = useState(false);
+  const isMenuOpen = Boolean(anchorEl);
+
+  const handleCloseMenu = () => setAnchorEl(null);
+
+  /**
+   * TODO: Wire up refund workflow
+   */
+  const handleInitiateRefund = () => {
+    console.log("Initiate refund", { sessionId, paymentEvent });
+    setIsRefundDialogOpen(true);
+    handleCloseMenu();
+  };
+
+  /**
+   * TODO: Wire up download invoice workflow
+   */
+  const handleDownloadInvoice = () => {
+    console.log("Download invoice", { sessionId, paymentEvent });
+    handleCloseMenu();
+  };
+
+  return (
+    <>
+      <Button
+        color="primary"
+        variant="contained"
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        startIcon={<PaymentIcon />}
+        endIcon={<KeyboardArrowDown />}
+        aria-haspopup="menu"
+        aria-controls={isMenuOpen ? "payment-menu" : undefined}
+        aria-expanded={isMenuOpen ? "true" : undefined}
+      >
+        Payment
+      </Button>
+      <Menu
+        id="payment-menu"
+        anchorEl={anchorEl}
+        open={isMenuOpen}
+        onClose={handleCloseMenu}
+      >
+        <MenuItem onClick={handleInitiateRefund}>Initiate refund</MenuItem>
+        <MenuItem onClick={handleDownloadInvoice}>Download invoice</MenuItem>
+      </Menu>
+      <InitiateRefundDialog
+        open={isRefundDialogOpen}
+        onClose={() => setIsRefundDialogOpen(false)}
+      />
+    </>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -13,6 +13,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import { CloseButton } from "ui/icons/CloseButton";
 
 import type { Submission } from "../types";
+import { getSucceededPayment } from "../utils";
 import { SubmissionDetails } from "./SubmissionDetails";
 import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
 
@@ -121,6 +122,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
   const events = data?.submissions || [];
   const latestEvent = events[0];
   const submittedAt = getSubmittedAt(events);
+  const succeededPayment = getSucceededPayment(events);
 
   const submissionExpirationDate = submittedAt
     ? addDays(new Date(submittedAt), DAYS_UNTIL_EXPIRY)
@@ -156,6 +158,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
             teamSlug={teamSlug}
             submittedAt={submittedAt}
             isSubmissionAvailable={isSubmissionAvailable}
+            succeededPayment={succeededPayment}
           />
         </Grid>
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetails.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import { hasFeatureFlag } from "lib/featureFlags";
 import type { DescriptionListItem } from "ui/public/DescriptionList";
 import { DescriptionList } from "ui/public/DescriptionList";
 
@@ -8,6 +9,7 @@ import { BadgeVariant } from "../../../../../components/Badge/types";
 import { useTeamLogo } from "../hooks";
 import type { Submission } from "../types";
 import { DownloadSubmissionButtonGrouped } from "./DownloadSubmissionButtonGrouped";
+import { PaymentMenuGrouped } from "./PaymentMenuGrouped";
 import { ViewSubmissionButtonGrouped } from "./ViewSubmissionButtonGrouped";
 
 type SubmissionDetailsProps = {
@@ -16,6 +18,7 @@ type SubmissionDetailsProps = {
   teamSlug: string;
   submittedAt?: string;
   isSubmissionAvailable: boolean;
+  succeededPayment?: Submission;
 };
 
 export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
@@ -46,6 +49,11 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
   const teamName = themeData?.teams[0].name;
   const teamColour = themeData?.teams[0].theme.primaryColour;
 
+  const showSubmissionActions =
+    Boolean(props.submittedAt) && props.isSubmissionAvailable;
+  const showPaymentActions =
+    hasFeatureFlag("STRIPE_MIGRATION") && Boolean(props.succeededPayment);
+
   return (
     <Box
       sx={{
@@ -75,7 +83,7 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
         <DescriptionList data={submissionData} />
       </Box>
 
-      {props.submittedAt && props.isSubmissionAvailable && (
+      {(showSubmissionActions || showPaymentActions) && (
         <Box
           sx={{
             display: "flex",
@@ -87,14 +95,24 @@ export const SubmissionDetails: React.FC<SubmissionDetailsProps> = (props) => {
             borderColor: "border.main",
           }}
         >
-          <ViewSubmissionButtonGrouped
-            sessionId={props.sessionId}
-            submittedAt={props.submittedAt}
-          />
-          <DownloadSubmissionButtonGrouped
-            sessionId={props.sessionId}
-            submittedAt={props.submittedAt}
-          />
+          {showSubmissionActions && props.submittedAt && (
+            <>
+              <ViewSubmissionButtonGrouped
+                sessionId={props.sessionId}
+                submittedAt={props.submittedAt}
+              />
+              <DownloadSubmissionButtonGrouped
+                sessionId={props.sessionId}
+                submittedAt={props.submittedAt}
+              />
+            </>
+          )}
+          {showPaymentActions && props.succeededPayment && (
+            <PaymentMenuGrouped
+              sessionId={props.sessionId}
+              paymentEvent={props.succeededPayment}
+            />
+          )}
         </Box>
       )}
     </Box>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/utils.ts
@@ -20,6 +20,13 @@ export const getConsolidatedStatus = (
   }
 };
 
+export const getSucceededPayment = (
+  events: Submission[],
+): Submission | undefined =>
+  events.find(
+    (event) => event.eventType === "Pay" && event.status === "Success",
+  );
+
 const NON_RESUBMITTABLE_EVENT_TYPES = [
   "Pay",
   "Invited to pay",


### PR DESCRIPTION
## What does this PR do?
Adds a "Payment" dropdown to the submission detail modal, which groups upcoming payment actions.

This is part of the Stripe migration work, tickets here - 
 - https://github.com/orgs/theopensystemslab/projects/11/views/1?pane=issue&itemId=223947681
 - https://github.com/orgs/theopensystemslab/projects/11/views/1?pane=issue&itemId=223995025
 
 This is currently behind the `STRIPE_MIGRATION` feature flag, and totally non-functional. Clicking either option leads to a `console.log()` being fired only.
 
 ## Testing
Currently, this isn't that easy to directly test on the Pizza. You need to toggle off `STRIPE_MIGRATION` to make a submission w/ payment, then toggle it back on alongside `GROUPED_SUBMISSIONS`.

Here's a submission where I've already done this - TODO (blocked by Resend issues, please see https://github.com/theopensystemslab/planx-new/pull/7293)

Once the full Storybook is up for the submissions modal, we'll have coverage of all permutations here I think.

Storybook here - https://storybook.7290.planx.pizza/?path=/docs/editor-components-submissions-details-modal-payment-menu--docs

<img width="839" height="366" alt="image" src="https://github.com/user-attachments/assets/77395491-c89d-4544-b29c-d54ddc210e7e" />
