### PR TITLE
fix(ci): Update dependabot to run correctly for new monorepo setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,14 @@ updates:
       sharedb:
         patterns: ["sharedb", "@types/sharedb"]
     ignore:
-      # Node version is managed manually, only allow patches
-      - dependency-name: "@types/node"
+      # Majors only across the workspace so we don't fall too far behind
+      # Security updates bypass this and still raise PRs for CVEs
+      - dependency-name: "*"
         update-types:
-          ["version-update:semver-major", "version-update:semver-minor"]
+          ["version-update:semver-patch", "version-update:semver-minor"]
+      # Node version is managed manually - also ignore major versions
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     # Matches pnpm's `minimumReleaseAge` in pnpm-workspace.yaml
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,84 +2,28 @@
 # fixes for vulnerabilities/CVEs (i.e. security updates) are handled automatically as per repo settings
 version: 2
 
-# TODO: increase use of groups to collect version upgrades in logical fashion and reduce PRs
-multi-ecosystem-groups:
-  # Sync versions of ShareDB between the Editor and ShareDB service
-  sharedb-sync:
-    schedule:
-      interval: "monthly"
-    labels: ["sharedb", "pnpm"]
-
 updates:
-  # Root
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     labels: ["pnpm"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # Editor
-  - package-ecosystem: "npm"
-    directory: "/apps/editor.planx.uk"
-    schedule:
-      interval: "monthly"
-    labels: ["editor", "pnpm"]
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-      - dependency-name: "sharedb" # Ignore sharedb here, handled by sharedb-sync group
+    open-pull-requests-limit: 10
     groups:
       tiptap:
         patterns: ["@tiptap/*"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # Editor - sharedb-sync group
-  - package-ecosystem: "npm"
-    directory: "/apps/editor.planx.uk"
-    patterns: ["sharedb"]
-    multi-ecosystem-group: "sharedb-sync"
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # localplanning.services
-  - package-ecosystem: "npm"
-    directory: "/apps/localplanning.services"
-    schedule:
-      interval: "monthly"
-    labels: ["lps", "pnpm"]
+      pulumi:
+        patterns: ["@pulumi/*"]
+      vitest:
+        patterns: ["vitest", "@vitest/*"]
+      sharedb:
+        patterns: ["sharedb", "@types/sharedb"]
     ignore:
-      - dependency-name: "*"
+      # Node version is managed manually, only allow patches
+      - dependency-name: "@types/node"
         update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # Hasura
-  - package-ecosystem: "npm"
-    directory: "/apps/hasura.planx.uk"
-    schedule:
-      interval: "monthly"
-    labels: ["hasura", "pnpm"]
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
+          ["version-update:semver-major", "version-update:semver-minor"]
+    # Matches pnpm's `minimumReleaseAge` in pnpm-workspace.yaml
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -100,51 +44,6 @@ updates:
     labels: ["hasura", "caddy", "docker"]
     open-pull-requests-limit: 1
 
-  - package-ecosystem: "npm"
-    directory: "/apps/hasura.planx.uk/tests"
-    schedule:
-      interval: "monthly"
-    labels: ["hasura", "tests", "pnpm"]
-    commit-message:
-      prefix: "[skip pizza] "
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # ShareDB
-  - package-ecosystem: "npm"
-    directory: "/apps/sharedb.planx.uk"
-    schedule:
-      interval: "monthly"
-    labels: ["sharedb", "pnpm"]
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-      - dependency-name: "sharedb" # Ignore sharedb here, handled by sharedb-sync group
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # ShareDB - sharedb-sync group
-  - package-ecosystem: "npm"
-    directory: "/apps/sharedb.planx.uk"
-    patterns: ["sharedb"]
-    multi-ecosystem-group: "sharedb-sync"
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
   - package-ecosystem: "docker"
     directory: "/apps/sharedb.planx.uk"
     schedule:
@@ -152,49 +51,12 @@ updates:
     labels: ["sharedb", "docker"]
     open-pull-requests-limit: 1
 
-  # API
-  - package-ecosystem: "npm"
-    directory: "/apps/api.planx.uk"
-    schedule:
-      interval: "monthly"
-    labels: ["api", "pnpm"]
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-    groups:
-      vitest:
-        patterns: ["vitest", "@vitest/coverage-istanbul", "@vitest/ui"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
   - package-ecosystem: "docker"
     directory: "/apps/api.planx.uk"
     schedule:
       interval: "monthly"
     labels: ["api", "docker"]
     open-pull-requests-limit: 1
-
-  # E2E tests
-  - package-ecosystem: "npm"
-    directory: "/e2e"
-    schedule:
-      interval: "monthly"
-    labels: ["e2e", "tests", "pnpm"]
-    commit-message:
-      prefix: "[skip pizza] "
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
 
   # Caddy container (reverse proxy for pizzas)
   - package-ecosystem: "docker"
@@ -212,29 +74,6 @@ updates:
     labels: ["ci", "postgres", "docker"]
     open-pull-requests-limit: 1
 
-  # Infrastructure (pnpm workspace so we only reference the root)
-  # NB. this config may serve as a useful reference when we push monorepo setup at project root
-  - package-ecosystem: "npm"
-    directory: "/infrastructure"
-    schedule:
-      interval: "monthly"
-    labels: ["infra", "pnpm"]
-    groups:
-      # group pulumi updates together to reduce noise
-      pulumi:
-        patterns: ["@pulumi/*"]
-    # handle all @types/node bumps (bar patches) manually, to keep alignment with node version (see .nvmrc)
-    ignore:
-      - dependency-name: "@types/node"
-        update-types:
-          ["version-update:semver-major", "version-update:semver-minor"]
-    cooldown:
-      default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-
-  # GitHub actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What's the problem?
Dependabot has not been reliably picking up packages since we moved to the monorepo. We can see error logs as follows for each app - 

```sh
Dependabot could not run pnpm to update your dependencies due to a configuration error
Please review your pnpm setup. Dependabot encountered the following error when running it:

Updating workspaces from inside a workspace subdirectory is not supported. Both `pnpm-lock.yaml` and `pnpm-workspace.yaml` exist in a parent directory. Dependabot should only update from the root workspace.
```

Source: https://github.com/theopensystemslab/planx-new/network/updates/1544330629

Some PRs do succeed to open, but most of the outstanding dependabot issues show the following - 

<img width="979" height="195" alt="image" src="https://github.com/user-attachments/assets/f47486a0-dec1-4719-8cff-dc0613ab070e" />

## What's the cause?
We're now using a single pnpm workspace (one root `pnpm-lock.yaml` and one `pnpm-workspace.yaml`), and Dependabot cannot update `npm` from a subdirectory. This means every per-app job was erroring with as above.

## What's the solution?
Collapse the per-app setup in favour of a single root `npm` configuration, pointing at the root `pnpm-workspace.yaml`.