### PR TITLE
fix(ci): Fix Docker collisions on Vultr

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,10 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
+concurrency:
+  group: pull-request-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Check file changes

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
 set -o errexit -o pipefail
 
-# run from project root
+# Run from project root
 cd "$(dirname $0)/../.."
 
 echo "root:$SSH_PASSWORD" | chpasswd
 
-# check if swap space is available - see link for more on updating swap:
+# Check if swap space is available - see link for more on updating swap:
 # https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-22-04
 swapon --show
 
-# caddy runs up against kernel buffer limits of host OS, so we increase them
-# see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+# Caddy runs up against kernel buffer limits of host OS, so we increase them
+# See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 sysctl -w net.core.rmem_max=7500000
 sysctl -w net.core.wmem_max=7500000
 
-# ensure docker does not pull caddy image via ipv6 (no subnet configured, it will fail)
+# Ensure docker does not pull caddy image via ipv6 (no subnet configured, it will fail)
 sysctl -w net.ipv6.conf.all.disable_ipv6=1
 sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
-# set env for this shell
+# Set env for this shell
 set -o allexport
 source .env.pizza
 DOCKER_BUILDKIT=1
 set +o allexport
 
-# fallback to building caddy image if pull fails
+# Fallback to building caddy image if pull fails
 PIZZA_FAILOVER=""
 if docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
   echo "Caddy image pulled successfully"
@@ -34,9 +34,22 @@ else
   PIZZA_FAILOVER="-f docker-compose.pizza.failover.yml"
 fi
 
-# start services
-docker compose \
-  -f docker-compose.yml \
-  -f docker-compose.pizza.yml $PIZZA_FAILOVER \
-  -f docker-compose.seed.yml \
-  up --build --wait
+function compose() {
+  docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.pizza.yml $PIZZA_FAILOVER \
+    -f docker-compose.seed.yml \
+    "$@"
+}
+
+# Build outside the lock. Images don't collide, so this keeps the lock short-lived
+compose build
+
+# Use a lock to ensure overlapping runs of this script (pushes to GH in short succession) can't collide
+exec 9>/tmp/pizza-deploy.lock
+flock 9
+
+# Drop any leftover containers/network from an interrupted run before starting
+compose down --remove-orphans
+
+compose up --no-build --wait

--- a/scripts/pullrequest/create.sh
+++ b/scripts/pullrequest/create.sh
@@ -42,12 +42,11 @@ function compose() {
     "$@"
 }
 
-# Build outside the lock. Images don't collide, so this keeps the lock short-lived
-compose build
-
 # Use a lock to ensure overlapping runs of this script (pushes to GH in short succession) can't collide
 exec 9>/tmp/pizza-deploy.lock
-flock 9
+flock -w 900 9
+
+compose build
 
 # Drop any leftover containers/network from an interrupted run before starting
 compose down --remove-orphans

--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -36,12 +36,11 @@ function compose() {
     "$@"
 }
 
-# Build outside the lock. Images don't collide, so this keeps the lock short-lived
-compose build
-
 # Use a lock to ensure overlapping runs of this script (pushes to GH in short succession) can't collide
 exec 9>/tmp/pizza-deploy.lock
-flock 9
+flock -w 900 9
+
+compose build
 
 # Explicitly drop containers in case provenance of caddy container is changed
 compose down --remove-orphans

--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit -o pipefail
 
-# run from project root
+# Run from project root
 cd "$(dirname $0)/../.."
 
 # caddy runs up against kernel buffer limits of host OS, so we increase them
@@ -19,7 +19,7 @@ source .env.pizza
 DOCKER_BUILDKIT=1
 set +o allexport
 
-# fallback to building caddy image if pull fails
+# Fallback to building caddy image if pull fails
 PIZZA_FAILOVER=""
 if docker pull "$VULTR_CR_URN/caddy-vultr:latest"; then
   echo "Caddy image pulled successfully"
@@ -28,15 +28,22 @@ else
   PIZZA_FAILOVER="-f docker-compose.pizza.failover.yml"
 fi
 
-# explicitly drop containers in case provenance of caddy container is changed
-docker compose \
-  -f docker-compose.yml \
-  -f docker-compose.pizza.yml $PIZZA_FAILOVER \
-  -f docker-compose.seed.yml \
-  down --remove-orphans
+function compose() {
+  docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.pizza.yml $PIZZA_FAILOVER \
+    -f docker-compose.seed.yml \
+    "$@"
+}
 
-docker compose \
-  -f docker-compose.yml \
-  -f docker-compose.pizza.yml $PIZZA_FAILOVER \
-  -f docker-compose.seed.yml \
-  up --build --renew-anon-volumes --force-recreate --wait
+# Build outside the lock. Images don't collide, so this keeps the lock short-lived
+compose build
+
+# Use a lock to ensure overlapping runs of this script (pushes to GH in short succession) can't collide
+exec 9>/tmp/pizza-deploy.lock
+flock 9
+
+# Explicitly drop containers in case provenance of caddy container is changed
+compose down --remove-orphans
+
+compose up --no-build --renew-anon-volumes --force-recreate --wait


### PR DESCRIPTION
## What's the problem?
This aims to resolve a pretty common CI failure - 

```sh
Container storybook Error response from daemon: Conflict. The container name "/storybook" is already in use by container "c7d78faf781cdd582ff4a8af56a95a1e412b6139bfb74d567780187daca0ecda". You have to remove (or rename) that container to be able to reuse that name. 
Error response from daemon: Conflict. The container name "/storybook" is already in use by container "c7d78faf781cdd582ff4a8af56a95a1e412b6139bfb74d567780187daca0ecda". You have to remove (or rename) that container to be able to reuse that name.
2026/08/31 09:47:59 Process exited with status 1
```

## What's the cause?
We get this when there's two pushes within relatively short succession (second push starts before 1st CI run completes). 

Each PR runs on a single Vultr machine, with fixed container and network names. Two pushes within one ~9-min build window leads to two runs that both run `down → build → up` on the same host. This race condition is what leads to the error - two instances running at once, but trying to share container and network names.

```mermaid
sequenceDiagram
    participant Dev as PR pushes
    participant D1 as Deploy 1
    participant D2 as Deploy 2
    participant H as Pizza

    Dev->>D1: Push 1
    activate D1
    Note over D1: Build 1
    Dev->>D2: Push 2 (shortly after)
    activate D2
    Note over D2: Build 2
    D1->>H: ✅ Creates network + Storybook, Caddy etc
    deactivate D1
    D2->>H: ❌ "Container /storybook already in use"
    deactivate D2
 ```

## What's the solution?
Two parts here - 
 1. Add concurrency to the GHA - a second push should kill the first run, there's no need to proceed with tests, builds etc. This doesn't stop `create.sh` / `update.sh` scripts from running on the Vultr machine though, it just drops the SSH connection.
 
 2. Use a lock to make sure subsequent runs of the script can't collide and overlap. We just need to wait for the previous (short) `docker compose` command to finish before starting on the next one.