### PR TITLE
feat: search UI & queries/hooks

### DIFF
--- a/apps/editor.planx.uk/src/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/components/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import { DEFAULT_PRIMARY_COLOR } from "theme";
 
-import type { BadgeProps, BadgeShape, BadgeSize } from "./types";
+import type { BadgeProps, BadgeSize } from "./types";
 import { BadgeVariant } from "./types";
 
 const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
@@ -13,16 +13,13 @@ const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
   compact: { box: 50, borderRadius: 50 },
 };
 
-const SQUARE_BORDER_RADIUS = 6;
-
 const Root = styled(Box, {
-  shouldForwardProp: (prop) => prop !== "size" && prop !== "shape",
-})<{ size: BadgeSize; shape: BadgeShape }>(({ size, shape }) => ({
+  shouldForwardProp: (prop) => prop !== "size",
+})<{ size: BadgeSize }>(({ size }) => ({
   width: DIMENSIONS[size].box,
   height: DIMENSIONS[size].box,
   minWidth: DIMENSIONS[size].box,
-  borderRadius:
-    shape === "square" ? SQUARE_BORDER_RADIUS : DIMENSIONS[size].borderRadius,
+  borderRadius: DIMENSIONS[size].borderRadius,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -44,13 +41,12 @@ const Initial = styled("span", {
 }));
 
 export const Badge: React.FC<BadgeProps> = (props) => {
-  const { size = "default", shape = "circle" } = props;
+  const { size = "default" } = props;
 
   if (props.variant === BadgeVariant.SourceTemplate) {
     return (
       <Root
         size={size}
-        shape={shape}
         sx={{ backgroundColor: "template.light" }}
         role="img"
         aria-label="Source template"
@@ -65,7 +61,6 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        shape={shape}
         sx={{
           backgroundColor: props.backgroundColour,
           color: props.iconColour,
@@ -84,7 +79,6 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
-        shape={shape}
         sx={{ backgroundColor: backgroundColour }}
         role="img"
         aria-label={team.name}
@@ -100,7 +94,6 @@ export const Badge: React.FC<BadgeProps> = (props) => {
   return (
     <Root
       size={size}
-      shape={shape}
       sx={{ backgroundColor: backgroundColour }}
       role="img"
       aria-label={team.name}

--- a/apps/editor.planx.uk/src/components/Badge/Badge.tsx
+++ b/apps/editor.planx.uk/src/components/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { getContrastTextColor } from "styleUtils";
 import { DEFAULT_PRIMARY_COLOR } from "theme";
 
-import type { BadgeProps, BadgeSize } from "./types";
+import type { BadgeProps, BadgeShape, BadgeSize } from "./types";
 import { BadgeVariant } from "./types";
 
 const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
@@ -13,13 +13,16 @@ const DIMENSIONS: Record<BadgeSize, { box: number; borderRadius: number }> = {
   compact: { box: 50, borderRadius: 50 },
 };
 
+const SQUARE_BORDER_RADIUS = 6;
+
 const Root = styled(Box, {
-  shouldForwardProp: (prop) => prop !== "size",
-})<{ size: BadgeSize }>(({ size }) => ({
+  shouldForwardProp: (prop) => prop !== "size" && prop !== "shape",
+})<{ size: BadgeSize; shape: BadgeShape }>(({ size, shape }) => ({
   width: DIMENSIONS[size].box,
   height: DIMENSIONS[size].box,
   minWidth: DIMENSIONS[size].box,
-  borderRadius: DIMENSIONS[size].borderRadius,
+  borderRadius:
+    shape === "square" ? SQUARE_BORDER_RADIUS : DIMENSIONS[size].borderRadius,
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -41,12 +44,13 @@ const Initial = styled("span", {
 }));
 
 export const Badge: React.FC<BadgeProps> = (props) => {
-  const { size = "default" } = props;
+  const { size = "default", shape = "circle" } = props;
 
   if (props.variant === BadgeVariant.SourceTemplate) {
     return (
       <Root
         size={size}
+        shape={shape}
         sx={{ backgroundColor: "template.light" }}
         role="img"
         aria-label="Source template"
@@ -61,6 +65,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
+        shape={shape}
         sx={{
           backgroundColor: props.backgroundColour,
           color: props.iconColour,
@@ -79,6 +84,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
     return (
       <Root
         size={size}
+        shape={shape}
         sx={{ backgroundColor: backgroundColour }}
         role="img"
         aria-label={team.name}
@@ -94,6 +100,7 @@ export const Badge: React.FC<BadgeProps> = (props) => {
   return (
     <Root
       size={size}
+      shape={shape}
       sx={{ backgroundColor: backgroundColour }}
       role="img"
       aria-label={team.name}

--- a/apps/editor.planx.uk/src/components/Badge/types.ts
+++ b/apps/editor.planx.uk/src/components/Badge/types.ts
@@ -12,6 +12,8 @@ export type BadgeVariant = ObjectValues<typeof BadgeVariant>;
 
 export type BadgeSize = "default" | "compact";
 
+export type BadgeShape = "circle" | "square";
+
 interface BadgeTeam {
   name: string;
   theme: {
@@ -22,6 +24,8 @@ interface BadgeTeam {
 
 interface BadgeBaseProps {
   size?: BadgeSize;
+  /** @default "circle" */
+  shape?: BadgeShape;
 }
 
 interface SourceTemplateBadgeProps extends BadgeBaseProps {

--- a/apps/editor.planx.uk/src/components/Badge/types.ts
+++ b/apps/editor.planx.uk/src/components/Badge/types.ts
@@ -12,8 +12,6 @@ export type BadgeVariant = ObjectValues<typeof BadgeVariant>;
 
 export type BadgeSize = "default" | "compact";
 
-export type BadgeShape = "circle" | "square";
-
 interface BadgeTeam {
   name: string;
   theme: {
@@ -24,8 +22,6 @@ interface BadgeTeam {
 
 interface BadgeBaseProps {
   size?: BadgeSize;
-  /** @default "circle" */
-  shape?: BadgeShape;
 }
 
 interface SourceTemplateBadgeProps extends BadgeBaseProps {

--- a/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
@@ -46,7 +46,7 @@ export const FlowDetailsPanel: React.FC<FlowDetailsPanelProps> = ({
     ) : undefined,
     description: flow.summary ?? undefined,
     primaryAction:
-      canCopy && flow.can_create_from_copy
+      canCopy && flow.canCreateFromCopy
         ? {
             label: "Copy to my team",
             onClick: () => copyToTeam(flow),

--- a/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
@@ -1,0 +1,85 @@
+import Box from "@mui/material/Box";
+import { useNavigate } from "@tanstack/react-router";
+import { formatLastEditMessage } from "pages/FlowEditor/utils";
+import React from "react";
+import { cardBoxShadow } from "theme";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType } from "ui/editor/FlowTag/types";
+
+import { Badge } from "../../../components/Badge/Badge";
+import { BadgeVariant } from "../../../components/Badge/types";
+import { SearchListItemDetail } from "./SearchListItemDetail";
+import { SearchListItemDetailActions } from "./SearchListItemDetailActions";
+import type { SearchResult } from "./SearchResult";
+import { useCopyFlowToTeam } from "./useCopyFlowToTeam";
+import type { FlowSearchResult } from "./useSearchFlows";
+
+interface FlowDetailsPanelProps {
+  flow: FlowSearchResult;
+  canCopy: boolean;
+}
+
+export const FlowDetailsPanel: React.FC<FlowDetailsPanelProps> = ({
+  flow,
+  canCopy,
+}) => {
+  const navigate = useNavigate();
+  const { copyToTeam, isPending } = useCopyFlowToTeam();
+
+  const editMessage = flow.operations[0]
+    ? formatLastEditMessage(
+        flow.operations[0].createdAt,
+        flow.operations[0].actor,
+      ).formatted
+    : undefined;
+
+  const hasSendComponent = Boolean(flow.publishedFlows[0]?.hasSendComponent);
+
+  const result: SearchResult = {
+    icon: <Badge variant={BadgeVariant.Team} team={flow.team} size="compact" />,
+    sourceTeam: flow.team.name,
+    statusLabel: flow.status === "online" ? "Online" : undefined,
+    title: flow.name,
+    meta: editMessage,
+    tag: hasSendComponent ? (
+      <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+    ) : undefined,
+    description: flow.summary ?? undefined,
+    primaryAction:
+      canCopy && flow.can_create_from_copy
+        ? {
+            label: "Copy to my team",
+            onClick: () => copyToTeam(flow),
+            disabled: isPending,
+          }
+        : undefined,
+    secondaryAction: {
+      label: "View flow",
+      onClick: () =>
+        navigate({
+          to: "/app/$team/$flow",
+          params: { team: flow.team.slug, flow: flow.slug },
+        }),
+    },
+  };
+
+  return (
+    <Box
+      sx={(theme) => ({
+        border: `1px solid ${theme.palette.border.light}`,
+        borderRadius: "4px",
+        boxShadow: cardBoxShadow,
+        backgroundColor: theme.palette.background.default,
+        overflow: "hidden",
+      })}
+    >
+      <Box sx={{ p: 3 }}>
+        <SearchListItemDetail result={result} />
+      </Box>
+      <SearchListItemDetailActions
+        primaryAction={result.primaryAction}
+        secondaryAction={result.secondaryAction}
+      />
+    </Box>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/RelatedItemsSection.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/RelatedItemsSection.tsx
@@ -1,0 +1,36 @@
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+
+import type { SearchResultRelatedItems } from "./SearchResult";
+
+interface RelatedItemsSectionProps {
+  relatedItems: SearchResultRelatedItems;
+  /** @default true */
+  showDivider?: boolean;
+}
+
+export const RelatedItemsSection: React.FC<RelatedItemsSectionProps> = ({
+  relatedItems,
+  showDivider = true,
+}) => (
+  <>
+    {showDivider && <Divider sx={{ my: 2 }} />}
+    <Typography
+      variant="body1"
+      sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, mb: 1.5 }}
+    >
+      {relatedItems.label}
+    </Typography>
+    <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+      {relatedItems.items.map((item) => (
+        <Tooltip key={item.key} title={item.tooltip}>
+          <span>{item.icon}</span>
+        </Tooltip>
+      ))}
+    </Box>
+  </>
+);

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -1,3 +1,4 @@
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import Box from "@mui/material/Box";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
@@ -11,11 +12,13 @@ import type { SearchResult } from "./SearchResult";
 interface SearchListItemProps {
   result: SearchResult;
   onClick?: () => void;
+  selected?: boolean;
 }
 
 export const SearchListItem: React.FC<SearchListItemProps> = ({
   result: { icon, title, description, statusLabel },
   onClick,
+  selected,
 }) => {
   const content = (
     <>
@@ -57,10 +60,12 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
     return (
       <ListItemButton
         onClick={onClick}
-        alignItems="flex-start"
+        alignItems="center"
+        selected={selected}
         sx={{ px: 2, py: 1.5, gap: 1.5 }}
       >
         {content}
+        <ChevronRightIcon sx={{ ml: "auto", color: "text.secondary" }} />
       </ListItemButton>
     );
   }

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
@@ -1,11 +1,10 @@
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
-import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
 import CheckCircleIcon from "ui/icons/CheckCircle";
 
+import { RelatedItemsSection } from "./RelatedItemsSection";
 import type { SearchResult } from "./SearchResult";
 
 interface SearchListItemDetailProps {
@@ -63,22 +62,7 @@ export const SearchListItemDetail: React.FC<SearchListItemDetailProps> = ({
         </Typography>
       )}
       {relatedItems && relatedItems.items.length > 0 && (
-        <>
-          <Divider sx={{ my: 2 }} />
-          <Typography
-            variant="body1"
-            sx={{ fontWeight: FONT_WEIGHT_SEMI_BOLD, mb: 1.5 }}
-          >
-            {relatedItems.label}
-          </Typography>
-          <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
-            {relatedItems.items.map((item) => (
-              <Tooltip key={item.key} title={item.tooltip}>
-                <span>{item.icon}</span>
-              </Tooltip>
-            ))}
-          </Box>
-        </>
+        <RelatedItemsSection relatedItems={relatedItems} />
       )}
     </>
   );

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
@@ -22,7 +22,7 @@ export const SearchListItemDetailActions: React.FC<
       <DialogActions
         sx={{
           bgcolor: "background.paper",
-          justifyContent: onClose ? "flex-end" : "flex-start",
+          justifyContent: "flex-end",
         }}
       >
         {onClose && (

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
@@ -44,7 +44,8 @@ export const SearchListItemDetailActions: React.FC<
           <Button
             onClick={secondaryAction.onClick}
             disabled={secondaryAction.disabled}
-            sx={{ backgroundColor: "background.default" }}
+            variant="contained"
+            color="secondary"
           >
             {secondaryAction.label}
           </Button>

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetailActions.tsx
@@ -7,18 +7,24 @@ import type { SearchResult } from "./SearchResult";
 
 interface SearchListItemDetailActionsProps {
   primaryAction?: SearchResult["primaryAction"];
+  secondaryAction?: SearchResult["secondaryAction"];
   onClose?: () => void;
 }
 
 export const SearchListItemDetailActions: React.FC<
   SearchListItemDetailActionsProps
-> = ({ primaryAction, onClose }) => {
-  if (!onClose && !primaryAction) return null;
+> = ({ primaryAction, secondaryAction, onClose }) => {
+  if (!onClose && !primaryAction && !secondaryAction) return null;
 
   return (
     <>
       <Divider />
-      <DialogActions>
+      <DialogActions
+        sx={{
+          bgcolor: "background.paper",
+          justifyContent: onClose ? "flex-end" : "flex-start",
+        }}
+      >
         {onClose && (
           <Button variant="contained" color="secondary" onClick={onClose}>
             Close
@@ -32,6 +38,15 @@ export const SearchListItemDetailActions: React.FC<
             disabled={primaryAction.disabled}
           >
             {primaryAction.label}
+          </Button>
+        )}
+        {secondaryAction && (
+          <Button
+            onClick={secondaryAction.onClick}
+            disabled={secondaryAction.disabled}
+            sx={{ backgroundColor: "background.default" }}
+          >
+            {secondaryAction.label}
           </Button>
         )}
       </DialogActions>

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -153,6 +153,10 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                 bgcolor:
                   index === tabIndex ? "text.primary" : "background.default",
                 color: index === tabIndex ? "background.default" : undefined,
+                "&:hover, &:focus, &:focus-visible, &:active": {
+                  bgcolor: index === tabIndex ? "text.primary" : "action.hover",
+                  color: index === tabIndex ? "background.default" : undefined,
+                },
               }}
             />
           ))}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -122,15 +122,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
             <CloseIcon />
           </IconButton>
         </Box>
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            gap: 3,
-            px: 3,
-            pb: 2,
-          }}
-        >
+        <Box sx={{ px: 3, pb: 2 }}>
           <DebouncedSearchInput
             value={search}
             onChange={handleSearchChange}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -207,7 +207,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                       )}
                       <SearchListItem
                         result={{
-                          icon: flow.is_template ? (
+                          icon: flow.isTemplate ? (
                             <Badge
                               variant={BadgeVariant.SourceTemplate}
                               size="compact"
@@ -220,7 +220,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                             />
                           ),
                           title: flow.name,
-                          description: flow.is_template
+                          description: flow.isTemplate
                             ? `Template – ${flow.team.name}`
                             : flow.team.name,
                         }}
@@ -233,7 +233,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
               </Box>
               {selectedFlow && (
                 <Box sx={{ minWidth: 0, height: "100%", overflowY: "auto" }}>
-                  {selectedFlow.is_template ? (
+                  {selectedFlow.isTemplate ? (
                     <TemplateDetailsPanel
                       template={{
                         id: selectedFlow.id,

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -18,30 +18,18 @@ import { BadgeVariant } from "../../../components/Badge/types";
 import { FlowDetailsPanel } from "./FlowDetailsPanel";
 import { SearchListItem } from "./SearchListItem";
 import { TemplateDetailsPanel } from "./TemplateDetailsPanel";
-import type { FlowSearchResult, FlowsWhere } from "./useSearchFlows";
+import type { FlowFilter, FlowSearchResult } from "./useSearchFlows";
 import { useSearchFlows } from "./useSearchFlows";
 
 interface SearchTab {
   label: string;
-  where: FlowsWhere | undefined;
+  filter: FlowFilter;
 }
 
 const TABS: SearchTab[] = [
-  { label: "All flows", where: undefined },
-  {
-    label: "Templates",
-    where: {
-      is_template: { _eq: true },
-      can_create_from_copy: { _eq: true },
-    },
-  },
-  {
-    label: "Flows I can copy",
-    where: {
-      is_template: { _eq: false },
-      can_create_from_copy: { _eq: true },
-    },
-  },
+  { label: "All flows", filter: "all" },
+  { label: "Templates", filter: "templates" },
+  { label: "Flows I can copy", filter: "copyable" },
 ];
 
 interface SearchModalProps {
@@ -63,7 +51,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
 
   const { results, loading, skipped } = useSearchFlows(
     search,
-    TABS[tabIndex].where,
+    TABS[tabIndex].filter,
   );
 
   const canCopy = canUserEditTeam(teamSlug);

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -74,13 +74,13 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
       maxWidth={false}
       slotProps={{
         paper: {
-          sx: {
+          sx: (theme) => ({
             width: "90vw",
-            maxWidth: "90vw",
+            maxWidth: theme.breakpoints.values.contentWide,
             height: "90vh",
             display: "flex",
             flexDirection: "column",
-          },
+          }),
         },
       }}
     >

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -78,8 +78,6 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
     setSelectedFlow(null);
   };
 
-  if (!results) return null;
-
   return (
     <Dialog
       open={open}
@@ -172,7 +170,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
               <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
             </Box>
           )}
-          {!skipped && !loading && Boolean(results?.length) && (
+          {!skipped && !loading && results && results.length > 0 && (
             <Box
               sx={{
                 display: "grid",
@@ -190,7 +188,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                   minWidth: 0,
                   height: "100%",
                   border: `1px solid ${theme.palette.border.light}`,
-                  borderRadius: 1,
+                  borderRadius: "4px",
                   boxShadow: cardBoxShadow,
                   backgroundColor: theme.palette.background.default,
                   overflowY: "auto",

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -1,0 +1,253 @@
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import Typography from "@mui/material/Typography";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { useStore } from "pages/FlowEditor/lib/store";
+import React, { useState } from "react";
+import { cardBoxShadow } from "theme";
+import { DebouncedSearchInput } from "ui/shared/SearchBox/DebouncedSearchInput";
+
+import { Badge } from "../../../components/Badge/Badge";
+import { BadgeVariant } from "../../../components/Badge/types";
+import { FlowDetailsPanel } from "./FlowDetailsPanel";
+import { SearchListItem } from "./SearchListItem";
+import { TemplateDetailsPanel } from "./TemplateDetailsPanel";
+import type { FlowSearchResult, FlowsWhere } from "./useSearchFlows";
+import { useSearchFlows } from "./useSearchFlows";
+
+interface SearchTab {
+  label: string;
+  where: FlowsWhere | undefined;
+}
+
+const TABS: SearchTab[] = [
+  { label: "All flows", where: undefined },
+  {
+    label: "Templates",
+    where: {
+      is_template: { _eq: true },
+      can_create_from_copy: { _eq: true },
+    },
+  },
+  {
+    label: "Flows I can copy",
+    where: {
+      is_template: { _eq: false },
+      can_create_from_copy: { _eq: true },
+    },
+  },
+];
+
+interface SearchModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
+  const [search, setSearch] = useState("");
+  const [tabIndex, setTabIndex] = useState(0);
+  const [selectedFlow, setSelectedFlow] = useState<FlowSearchResult | null>(
+    null,
+  );
+
+  const [teamSlug, canUserEditTeam] = useStore((state) => [
+    state.teamSlug,
+    state.canUserEditTeam,
+  ]);
+
+  const { results, loading, skipped } = useSearchFlows(
+    search,
+    TABS[tabIndex].where,
+  );
+
+  const canCopy = canUserEditTeam(teamSlug);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setSelectedFlow(null);
+  };
+
+  const handleTabChange = (index: number) => {
+    setTabIndex(index);
+    setSelectedFlow(null);
+  };
+
+  if (!results) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth={false}
+      slotProps={{
+        paper: {
+          sx: {
+            width: "90vw",
+            maxWidth: "90vw",
+            height: "90vh",
+            display: "flex",
+            flexDirection: "column",
+          },
+        },
+      }}
+    >
+      <DialogContent
+        sx={{
+          p: 0,
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: 3,
+            pt: 3,
+            pb: 2,
+          }}
+        >
+          <Typography variant="h3" component="h2">
+            Search Plan✕
+          </Typography>
+          <IconButton aria-label="close search" onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 3,
+            px: 3,
+            pb: 2,
+          }}
+        >
+          <DebouncedSearchInput
+            value={search}
+            onChange={handleSearchChange}
+            placeholder="Search flows across Plan✕"
+            fullWidth
+            hideLabel
+          />
+        </Box>
+        <Box sx={{ display: "flex", gap: 1, px: 3, pb: 2 }}>
+          {TABS.map(({ label }, index) => (
+            <Chip
+              key={label}
+              label={label}
+              clickable
+              onClick={() => handleTabChange(index)}
+              color={index === tabIndex ? "default" : undefined}
+              variant={index === tabIndex ? "filled" : "outlined"}
+              sx={{
+                height: 28,
+                bgcolor:
+                  index === tabIndex ? "text.primary" : "background.default",
+                color: index === tabIndex ? "background.default" : undefined,
+              }}
+            />
+          ))}
+        </Box>
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {!skipped && loading && (
+            <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+              <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
+            </Box>
+          )}
+          {!skipped && !loading && Boolean(results?.length) && (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 3,
+                alignItems: "flex-start",
+                px: 3,
+                pb: 3,
+                flex: 1,
+                minHeight: 0,
+              }}
+            >
+              <Box
+                sx={(theme) => ({
+                  minWidth: 0,
+                  height: "100%",
+                  border: `1px solid ${theme.palette.border.light}`,
+                  borderRadius: 1,
+                  boxShadow: cardBoxShadow,
+                  backgroundColor: theme.palette.background.default,
+                  overflowY: "auto",
+                })}
+              >
+                <List disablePadding>
+                  {results.map((flow, index) => (
+                    <React.Fragment key={flow.id}>
+                      {index > 0 && (
+                        <Divider sx={{ borderColor: "border.main" }} />
+                      )}
+                      <SearchListItem
+                        result={{
+                          icon: flow.is_template ? (
+                            <Badge
+                              variant={BadgeVariant.SourceTemplate}
+                              size="compact"
+                            />
+                          ) : (
+                            <Badge
+                              variant={BadgeVariant.Team}
+                              team={flow.team}
+                              size="compact"
+                            />
+                          ),
+                          title: flow.name,
+                          description: flow.is_template
+                            ? `Template – ${flow.team.name}`
+                            : flow.team.name,
+                        }}
+                        onClick={() => setSelectedFlow(flow)}
+                        selected={selectedFlow?.id === flow.id}
+                      />
+                    </React.Fragment>
+                  ))}
+                </List>
+              </Box>
+              {selectedFlow && (
+                <Box sx={{ minWidth: 0, height: "100%", overflowY: "auto" }}>
+                  {selectedFlow.is_template ? (
+                    <TemplateDetailsPanel
+                      template={{
+                        id: selectedFlow.id,
+                        name: selectedFlow.name,
+                        summary: selectedFlow.summary ?? "",
+                        team: { name: selectedFlow.team.name },
+                      }}
+                    />
+                  ) : (
+                    <FlowDetailsPanel flow={selectedFlow} canCopy={canCopy} />
+                  )}
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -174,6 +174,27 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
               <DelayedLoadingIndicator inline msDelayBeforeVisible={300} />
             </Box>
           )}
+          {!skipped && !loading && results && results.length === 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                textAlign: "center",
+                flex: 1,
+                px: 3,
+                pb: 3,
+              }}
+            >
+              <Typography variant="h3" component="p">
+                No results found
+              </Typography>
+              <Typography sx={{ color: "text.secondary", pt: 1 }}>
+                Check your search term and try again
+              </Typography>
+            </Box>
+          )}
           {!skipped && !loading && results && results.length > 0 && (
             <Box
               sx={{

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchResult.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchResult.ts
@@ -27,4 +27,5 @@ export interface SearchResult {
   tag?: React.ReactNode;
   relatedItems?: SearchResultRelatedItems;
   primaryAction?: SearchResultAction;
+  secondaryAction?: SearchResultAction;
 }

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsPanel.tsx
@@ -1,49 +1,51 @@
-import Dialog from "@mui/material/Dialog";
-import DialogContent from "@mui/material/DialogContent";
+import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
 import React from "react";
+import { cardBoxShadow } from "theme";
 
+import { RelatedItemsSection } from "./RelatedItemsSection";
 import { SearchListItemDetail } from "./SearchListItemDetail";
 import { SearchListItemDetailActions } from "./SearchListItemDetailActions";
 import type { Template } from "./types";
 import { useTemplateDetails } from "./useTemplateDetails";
 
-interface TemplateDetailsModalProps {
+interface TemplateDetailsPanelProps {
   template: Template;
-  open: boolean;
-  onClose: () => void;
 }
 
-export const TemplateDetailsModal: React.FC<TemplateDetailsModalProps> = ({
+export const TemplateDetailsPanel: React.FC<TemplateDetailsPanelProps> = ({
   template,
-  open,
-  onClose,
 }) => {
   const { result, isConfirmationOpen, setIsConfirmationOpen, handleAddToTeam } =
-    useTemplateDetails(template, { skip: !open, onAdded: onClose });
+    useTemplateDetails(template);
+
+  const { relatedItems, ...resultWithoutRelatedItems } = result;
 
   return (
     <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        fullWidth
-        maxWidth="formWrap"
-        slotProps={{
-          paper: {
-            sx: (theme) => ({ maxWidth: theme.breakpoints.values.formWrap }),
-          },
-        }}
+      <Box
+        sx={(theme) => ({
+          border: `1px solid ${theme.palette.border.light}`,
+          borderRadius: "4px",
+          boxShadow: cardBoxShadow,
+          backgroundColor: theme.palette.background.default,
+          overflow: "hidden",
+        })}
       >
-        <DialogContent sx={{ backgroundColor: "background.default" }}>
-          <SearchListItemDetail result={result} />
-        </DialogContent>
-        <SearchListItemDetailActions
-          primaryAction={result.primaryAction}
-          onClose={onClose}
-        />
-      </Dialog>
+        <Box sx={{ p: 3 }}>
+          <SearchListItemDetail result={resultWithoutRelatedItems} />
+        </Box>
+        <SearchListItemDetailActions primaryAction={result.primaryAction} />
+        {relatedItems && relatedItems.items.length > 0 && (
+          <Box sx={{ p: 3 }}>
+            <RelatedItemsSection
+              relatedItems={relatedItems}
+              showDivider={false}
+            />
+          </Box>
+        )}
+      </Box>
       <ConfirmationDialog
         open={isConfirmationOpen}
         onClose={(confirmed) => {

--- a/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/TemplateDetailsPanel.tsx
@@ -35,16 +35,11 @@ export const TemplateDetailsPanel: React.FC<TemplateDetailsPanelProps> = ({
       >
         <Box sx={{ p: 3 }}>
           <SearchListItemDetail result={resultWithoutRelatedItems} />
+          {relatedItems && relatedItems.items.length > 0 && (
+            <RelatedItemsSection relatedItems={relatedItems} />
+          )}
         </Box>
         <SearchListItemDetailActions primaryAction={result.primaryAction} />
-        {relatedItems && relatedItems.items.length > 0 && (
-          <Box sx={{ p: 3 }}>
-            <RelatedItemsSection
-              relatedItems={relatedItems}
-              showDivider={false}
-            />
-          </Box>
-        )}
       </Box>
       <ConfirmationDialog
         open={isConfirmationOpen}

--- a/apps/editor.planx.uk/src/pages/Explore/components/useCopyFlowToTeam.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useCopyFlowToTeam.ts
@@ -1,0 +1,67 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useToast } from "hooks/useToast";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
+import { slugify } from "utils";
+
+export const useCopyFlowToTeam = () => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [
+    teamId,
+    teamSlug,
+    showLoading,
+    hideLoading,
+    setLoadingCompleteCallback,
+  ] = useStore((state) => [
+    state.teamId,
+    state.teamSlug,
+    state.showLoading,
+    state.hideLoading,
+    state.setLoadingCompleteCallback,
+  ]);
+
+  const { mutate: createFlow, isPending } = useCreateFlow();
+
+  const copyToTeam = (
+    flow: { id: string; name: string },
+    onDone?: () => void,
+  ) => {
+    const name = `${flow.name} (copy)`;
+
+    setLoadingCompleteCallback(() => {
+      toast.success("Flow created successfully");
+      setLoadingCompleteCallback(undefined);
+    });
+    showLoading("Creating flow...");
+
+    createFlow(
+      {
+        mode: "copy",
+        flow: {
+          sourceId: flow.id,
+          teamId,
+          name,
+          slug: slugify(name),
+        },
+      },
+      {
+        onSuccess: async ({ flow: newFlow }) => {
+          onDone?.();
+          await navigate({
+            to: "/app/$team/$flow",
+            params: { team: teamSlug, flow: newFlow.slug },
+          });
+          hideLoading();
+        },
+        onError: () => {
+          setLoadingCompleteCallback(undefined);
+          hideLoading();
+          toast.error("Failed to add flow to your team");
+        },
+      },
+    );
+  };
+
+  return { copyToTeam, isPending };
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -25,9 +25,9 @@ export interface FlowSearchResult {
   slug: string;
   summary: string | null;
   status: string;
-  is_template: boolean;
-  can_create_from_copy: boolean;
-  templated_from: string | null;
+  isTemplate: boolean;
+  canCreateFromCopy: boolean;
+  templatedFrom: string | null;
   team: {
     id: number;
     name: string;
@@ -58,9 +58,9 @@ const SEARCH_FLOWS = gql`
       slug
       summary
       status
-      is_template
-      can_create_from_copy
-      templated_from
+      isTemplate: is_template
+      canCreateFromCopy: can_create_from_copy
+      templatedFrom: templated_from
       team {
         id
         name

--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -1,0 +1,91 @@
+import { gql, useQuery } from "@apollo/client";
+
+export interface FlowsWhere {
+  is_template?: { _eq: boolean };
+  can_create_from_copy?: { _eq: boolean };
+}
+
+export interface FlowSearchResult {
+  id: string;
+  name: string;
+  slug: string;
+  summary: string | null;
+  status: string;
+  is_template: boolean;
+  can_create_from_copy: boolean;
+  templated_from: string | null;
+  team: {
+    id: number;
+    name: string;
+    slug: string;
+    theme: {
+      primaryColour: string | null;
+      logo: string | null;
+    };
+  };
+  publishedFlows: { hasSendComponent: boolean }[];
+  operations: {
+    createdAt: string;
+    actor?: { firstName: string; lastName: string };
+  }[];
+}
+
+const RESULTS_LIMIT = 50;
+
+const SEARCH_FLOWS = gql`
+  query SearchFlows($search: String!, $where: flows_bool_exp, $limit: Int!) {
+    results: search_flows(
+      args: { search: $search }
+      where: $where
+      limit: $limit
+    ) {
+      id
+      name
+      slug
+      summary
+      status
+      is_template
+      can_create_from_copy
+      templated_from
+      team {
+        id
+        name
+        slug
+        theme {
+          primaryColour: primary_colour
+          logo
+        }
+      }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        hasSendComponent: has_send_component
+      }
+      operations(limit: 1, order_by: { created_at: desc }) {
+        createdAt: created_at
+        actor {
+          firstName: first_name
+          lastName: last_name
+        }
+      }
+    }
+  }
+`;
+
+const MIN_SEARCH_LENGTH = 3;
+
+export const useSearchFlows = (search: string, where?: FlowsWhere) => {
+  // search_flows won't return anything for under 3 characters so don't execute
+  const skip = search.trim().length < MIN_SEARCH_LENGTH;
+
+  const { data, loading } = useQuery<{ results: FlowSearchResult[] }>(
+    SEARCH_FLOWS,
+    {
+      variables: { search, where, limit: RESULTS_LIMIT },
+      skip,
+    },
+  );
+
+  return { results: data?.results, loading, skipped: skip };
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -5,6 +5,20 @@ export interface FlowsWhere {
   can_create_from_copy?: { _eq: boolean };
 }
 
+export type FlowFilter = "all" | "templates" | "copyable";
+
+const FILTER_WHERE: Record<FlowFilter, FlowsWhere | undefined> = {
+  all: undefined,
+  templates: {
+    is_template: { _eq: true },
+    can_create_from_copy: { _eq: true },
+  },
+  copyable: {
+    is_template: { _eq: false },
+    can_create_from_copy: { _eq: true },
+  },
+};
+
 export interface FlowSearchResult {
   id: string;
   name: string;
@@ -75,14 +89,14 @@ const SEARCH_FLOWS = gql`
 
 const MIN_SEARCH_LENGTH = 3;
 
-export const useSearchFlows = (search: string, where?: FlowsWhere) => {
+export const useSearchFlows = (search: string, filter: FlowFilter) => {
   // search_flows won't return anything for under 3 characters so don't execute
   const skip = search.trim().length < MIN_SEARCH_LENGTH;
 
   const { data, loading } = useQuery<{ results: FlowSearchResult[] }>(
     SEARCH_FLOWS,
     {
-      variables: { search, where, limit: RESULTS_LIMIT },
+      variables: { search, where: FILTER_WHERE[filter], limit: RESULTS_LIMIT },
       skip,
     },
   );

--- a/apps/editor.planx.uk/src/pages/Explore/components/useTemplateDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useTemplateDetails.tsx
@@ -1,0 +1,239 @@
+import { gql, useQuery } from "@apollo/client";
+import { useNavigate } from "@tanstack/react-router";
+import { useToast } from "hooks/useToast";
+import { SYSTEM_TEAMS } from "lib/systemTeams";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { formatLastEditMessage } from "pages/FlowEditor/utils";
+import { useCreateFlow } from "pages/Flows/components/AddFlow/hooks/useCreateFlow";
+import { useState } from "react";
+import FlowTag from "ui/editor/FlowTag/FlowTag";
+import { FlowTagType } from "ui/editor/FlowTag/types";
+import { slugify } from "utils";
+
+import { Badge } from "../../../components/Badge/Badge";
+import { BadgeVariant } from "../../../components/Badge/types";
+import type { SearchResult } from "./SearchResult";
+import type { Template } from "./types";
+
+interface TemplateDetails {
+  team: { name: string };
+  operations: {
+    id: number;
+    createdAt: string;
+    actor?: { firstName: string; lastName: string };
+  }[];
+  publishedFlows: { id: number; hasSendComponent: boolean }[];
+  usedByTeams: {
+    id: string;
+    team: {
+      id: number;
+      name: string;
+      theme: {
+        primaryColour?: string | null;
+        logo?: string | null;
+      };
+    };
+  }[];
+}
+
+const GET_TEMPLATE_DETAILS = gql`
+  query GetTemplateDetails($id: uuid!, $systemTeams: [String!]!) {
+    flow: flows_by_pk(id: $id) {
+      id
+      team {
+        name
+      }
+      operations(limit: 1, order_by: { created_at: desc }) {
+        id
+        createdAt: created_at
+        actor {
+          firstName: first_name
+          lastName: last_name
+        }
+      }
+      publishedFlows: published_flows(
+        order_by: { created_at: desc }
+        limit: 1
+      ) {
+        id
+        hasSendComponent: has_send_component
+      }
+      usedByTeams: templated_flows(
+        distinct_on: team_id
+        order_by: [{ team_id: asc }, { created_at: desc }]
+        where: { team: { slug: { _nin: $systemTeams } } }
+      ) {
+        id
+        team {
+          id
+          name
+          theme {
+            primaryColour: primary_colour
+            logo
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface UseTemplateDetailsOptions {
+  skip?: boolean;
+  onAdded?: () => void;
+}
+export const useTemplateDetails = (
+  template: Template,
+  { skip = false, onAdded }: UseTemplateDetailsOptions = {},
+) => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [
+    teamId,
+    teamName,
+    teamSlug,
+    canUserEditTeam,
+    showLoading,
+    hideLoading,
+    setLoadingCompleteCallback,
+  ] = useStore((state) => [
+    state.teamId,
+    state.teamName,
+    state.teamSlug,
+    state.canUserEditTeam,
+    state.showLoading,
+    state.hideLoading,
+    state.setLoadingCompleteCallback,
+  ]);
+
+  const { data } = useQuery<{ flow: TemplateDetails | null }>(
+    GET_TEMPLATE_DETAILS,
+    {
+      variables: { id: template.id, systemTeams: SYSTEM_TEAMS },
+      skip,
+    },
+  );
+
+  const details = data?.flow ?? undefined;
+  const { mutate: createFlow, isPending } = useCreateFlow();
+
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
+
+  const isAlreadySubscribed = Boolean(
+    details?.usedByTeams.some(({ team }) => team.id === teamId),
+  );
+
+  const handleAddToTeam = () => {
+    const name = `${template.name} (templated)`;
+
+    setLoadingCompleteCallback(() => {
+      toast.success("Flow created successfully");
+      setLoadingCompleteCallback(undefined);
+    });
+    showLoading("Creating flow...");
+
+    createFlow(
+      {
+        mode: "template",
+        flow: {
+          sourceId: template.id,
+          teamId,
+          name,
+          slug: slugify(name),
+          isPattern: false,
+          isTemplate: false,
+          isService: false,
+        },
+      },
+      {
+        onSuccess: async ({ flow }) => {
+          onAdded?.();
+          await navigate({
+            to: "/app/$team/$flow",
+            params: { team: teamSlug, flow: flow.slug },
+          });
+          hideLoading();
+        },
+        onError: () => {
+          setLoadingCompleteCallback(undefined);
+          hideLoading();
+          toast.error("Failed to add template to your team");
+        },
+      },
+    );
+  };
+
+  const editMessage = details?.operations[0]
+    ? formatLastEditMessage(
+        details.operations[0].createdAt,
+        details.operations[0].actor,
+      ).formatted
+    : undefined;
+
+  const usedByTeams = [...(details?.usedByTeams ?? [])].sort((a, b) => {
+    if (a.team.id === teamId) return -1;
+    if (b.team.id === teamId) return 1;
+    return 0;
+  });
+
+  const usedByCount = usedByTeams.length;
+
+  const usedByLabel = (() => {
+    if (canUserEditTeam(teamSlug) && isAlreadySubscribed) {
+      const otherTeamsCount = usedByCount - 1;
+      if (otherTeamsCount === 0) return `Used by ${teamName}:`;
+      return `Used by ${teamName} and ${otherTeamsCount} other team${otherTeamsCount === 1 ? "" : "s"}:`;
+    }
+    return `Used by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`;
+  })();
+
+  const result: SearchResult = {
+    icon: <Badge variant={BadgeVariant.SourceTemplate} size="compact" />,
+    sourceTeam: details?.team.name ?? template.team.name,
+    statusLabel:
+      canUserEditTeam(teamSlug) && isAlreadySubscribed
+        ? "Subscribed"
+        : undefined,
+    title: template.name,
+    meta: editMessage,
+    tag: details?.publishedFlows[0]?.hasSendComponent ? (
+      <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+    ) : undefined,
+    description: template.summary,
+    relatedItems:
+      usedByCount > 0
+        ? {
+            label: usedByLabel,
+            items: usedByTeams.map(({ team }) => ({
+              key: team.id,
+              tooltip: team.name,
+              icon: (
+                <Badge
+                  variant={BadgeVariant.Team}
+                  team={team}
+                  size="compact"
+                  shape="square"
+                />
+              ),
+            })),
+          }
+        : undefined,
+    primaryAction: canUserEditTeam(teamSlug)
+      ? {
+          label: "Add to my team",
+          onClick: () =>
+            isAlreadySubscribed
+              ? setIsConfirmationOpen(true)
+              : handleAddToTeam(),
+          disabled: isPending,
+        }
+      : undefined,
+  };
+
+  return {
+    result,
+    isPending,
+    isConfirmationOpen,
+    setIsConfirmationOpen,
+    handleAddToTeam,
+  };
+};

--- a/apps/editor.planx.uk/src/pages/Explore/components/useTemplateDetails.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useTemplateDetails.tsx
@@ -180,10 +180,10 @@ export const useTemplateDetails = (
   const usedByLabel = (() => {
     if (canUserEditTeam(teamSlug) && isAlreadySubscribed) {
       const otherTeamsCount = usedByCount - 1;
-      if (otherTeamsCount === 0) return `Used by ${teamName}:`;
-      return `Used by ${teamName} and ${otherTeamsCount} other team${otherTeamsCount === 1 ? "" : "s"}:`;
+      if (otherTeamsCount === 0) return `Subscribed to by ${teamName}:`;
+      return `Subscribed to by ${teamName} and ${otherTeamsCount} other team${otherTeamsCount === 1 ? "" : "s"}:`;
     }
-    return `Used by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`;
+    return `Subscribed to by ${usedByCount} team${usedByCount === 1 ? "" : "s"}:`;
   })();
 
   const result: SearchResult = {
@@ -207,12 +207,7 @@ export const useTemplateDetails = (
               key: team.id,
               tooltip: team.name,
               icon: (
-                <Badge
-                  variant={BadgeVariant.Team}
-                  team={team}
-                  size="compact"
-                  shape="square"
-                />
+                <Badge variant={BadgeVariant.Team} team={team} size="compact" />
               ),
             })),
           }

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -1,7 +1,8 @@
 import SearchIcon from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
+import ButtonBase from "@mui/material/ButtonBase";
 import Container from "@mui/material/Container";
+import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
@@ -11,8 +12,23 @@ import NumbersWidget from "./components/NumbersWidget";
 import { SearchModal } from "./components/SearchModal";
 import TemplatesWidget from "./components/TemplatesWidget";
 
+const SearchBarButton = styled(ButtonBase)(({ theme }) => ({
+  width: "100%",
+  maxWidth: 360,
+  height: 50,
+  padding: theme.spacing(0, 2),
+  gap: theme.spacing(1),
+  justifyContent: "flex-start",
+  border: `1px solid ${theme.palette.border.main}`,
+  borderRadius: 4,
+  backgroundColor: theme.palette.common.white,
+  color: theme.palette.text.placeholder,
+  "&:hover, &:focus-visible": {
+    borderColor: theme.palette.text.primary,
+  },
+}));
+
 export default function Explore() {
-  const team = useStore((state) => state.getTeam());
   const [searchOpen, setSearchOpen] = useState(false);
 
   return (
@@ -31,12 +47,15 @@ export default function Explore() {
           <Typography variant="h2" component="h1">
             Explore Plan✕
           </Typography>
-          <Button
-            startIcon={<SearchIcon />}
+          <SearchBarButton
             onClick={() => setSearchOpen(true)}
+            aria-label="Search Plan✕"
           >
-            Search Plan✕
-          </Button>
+            <SearchIcon />
+            <Typography variant="body1" sx={{ color: "inherit" }}>
+              Search flows across Plan✕
+            </Typography>
+          </SearchBarButton>
         </Box>
         <Box
           sx={{

--- a/apps/editor.planx.uk/src/pages/Explore/index.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/index.tsx
@@ -1,15 +1,19 @@
+import SearchIcon from "@mui/icons-material/Search";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import { useState } from "react";
 import { DashboardWidget } from "ui/editor/DashboardWidget";
 
 import { useStore } from "../../pages/FlowEditor/lib/store";
 import NumbersWidget from "./components/NumbersWidget";
+import { SearchModal } from "./components/SearchModal";
 import TemplatesWidget from "./components/TemplatesWidget";
 
 export default function Explore() {
   const team = useStore((state) => state.getTeam());
+  const [searchOpen, setSearchOpen] = useState(false);
 
   return (
     <Box sx={{ bgcolor: "background.paper", flexGrow: 1 }}>
@@ -27,8 +31,12 @@ export default function Explore() {
           <Typography variant="h2" component="h1">
             Explore Plan✕
           </Typography>
-          {/* TODO: Style search button */}
-          <Button>Search PlanX</Button>
+          <Button
+            startIcon={<SearchIcon />}
+            onClick={() => setSearchOpen(true)}
+          >
+            Search Plan✕
+          </Button>
         </Box>
         <Box
           sx={{
@@ -46,6 +54,7 @@ export default function Explore() {
           </DashboardWidget>
         </Box>
       </Container>
+      <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />
     </Box>
   );
 }

--- a/apps/editor.planx.uk/src/ui/shared/SearchBox/DebouncedSearchInput.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SearchBox/DebouncedSearchInput.tsx
@@ -13,6 +13,8 @@ interface DebouncedSearchInputProps {
   onChange: (value: string) => void;
   hideLabel?: boolean;
   compact?: boolean;
+  fullWidth?: boolean;
+  placeholder?: string;
   debounceMs?: number;
 }
 
@@ -29,6 +31,8 @@ export const DebouncedSearchInput = ({
   onChange,
   hideLabel = false,
   compact = false,
+  fullWidth = false,
+  placeholder,
   debounceMs = DEFAULT_DEBOUNCE_MS,
 }: DebouncedSearchInputProps) => {
   const [localValue, setLocalValue] = useState(value);
@@ -78,6 +82,8 @@ export const DebouncedSearchInput = ({
       isSearching={isSearching}
       hideLabel={hideLabel}
       compact={compact}
+      fullWidth={fullWidth}
+      placeholder={placeholder}
     />
   );
 };


### PR DESCRIPTION
### What's in this PR?
- Hooks & gql snippets for executing search queries
- New UI components for rendering search results
- Move template details logic to `useTemplateDetails` so it can be re-used in the new `TemplateDetailsPanel` as well as the existing `TemplateDetailsModal`


### To note
- Noticed a bug with the DB search implementation where e.g. 'app' matches results but 'appl' does not, due to the stem matching approach. Will fix this in a separate PR
- This is a fairly large PR, so I'd be happy to split it out if preferred. Could split it either as hooks vs UI components, or as initial results vs DetailsPanels  - also worth nothing that a good ~200+ lines of this is just a hook refactor into a separate file. Give me a shout for preferred review approach or if this is fine already!