### PR TITLE
fix(a11y): focus on main-content on load [DAC_SR_Feedback_07]

### DIFF
--- a/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/Questions.tsx
@@ -175,15 +175,11 @@ const Questions = ({ previewEnvironment }: QuestionsProps) => {
 
   // manage focus on form step changes
   useEffect(() => {
-    const contentEl = document.querySelector('[data-testid="document-start"]');
+    const contentEl = document.getElementById("main-content");
     if (!contentEl) return;
 
-    if (contentEl instanceof HTMLElement) {
-      contentEl.setAttribute("tabindex", "-1");
-
-      if (!isInitialLoad.current) {
-        contentEl.focus();
-      }
+    if (!isInitialLoad.current) {
+      contentEl.focus();
     }
     isInitialLoad.current = false;
   }, [node?.id]);

--- a/e2e/tests/ui-driven/src/a11y-flows/focus-navigation.spec.ts
+++ b/e2e/tests/ui-driven/src/a11y-flows/focus-navigation.spec.ts
@@ -42,30 +42,22 @@ test.describe("Focus navigation accessibility", () => {
     await tearDownTestContext();
   });
 
-  test("skip link works consistently across multiple form steps", async ({
+  test("focus moves to main content consistently across multiple form steps", async ({
     page,
   }) => {
+    const mainContent = page.locator("#main-content");
+
     await fillInEmail({ page, context });
     await clickContinue({ page, waitForResponse: true });
 
     await answerQuestion({ page, title: "Question 1", answer: "A" });
     await clickContinue({ page, waitForLogEvent: true });
 
-    await page.keyboard.press("Tab");
-
-    const skipLink = page.getByRole("link", { name: "Skip to main content" });
-    await expect(skipLink).toBeFocused();
-
-    await skipLink.click();
+    await expect(mainContent).toBeFocused();
 
     await answerQuestion({ page, title: "Question 2", answer: "One" });
     await clickContinue({ page, waitForLogEvent: true });
 
-    await page.keyboard.press("Tab");
-
-    const skipLinkAgain = page.getByRole("link", {
-      name: "Skip to main content",
-    });
-    await expect(skipLinkAgain).toBeFocused();
+    await expect(mainContent).toBeFocused();
   });
 });


### PR DESCRIPTION
You can verify this by opening browser console and running:
`document.addEventListener('focusin', e => console.log('focus →', e.target))`,

then stepping through the flow, on each new page you should see: 
`focus → <main id=​"main-content" tabindex=​"-1" class=​"css-ddl2xc">​…​</main>​`
