### PR TITLE
fix(a11y): correct header and close button on Planning Constriant modal [DAC_SR_Feedback_08]

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
@@ -161,7 +161,7 @@ export const OverrideEntitiesModal = ({
           aria-label="Close"
           onClick={closeModal}
           data-testid="override-modal-close-button"
-          sx={{ color: "grey.600", marginTop: 2, marginRight: 2 }}
+          sx={{ color: "grey.600", marginTop: 1, marginRight: 2 }}
         >
           <Close />
         </IconButton>

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
@@ -1,3 +1,4 @@
+import Close from "@mui/icons-material/CloseOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -6,6 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import type { Constraint, Metadata } from "@opensystemslab/planx-core/types";
 import omit from "lodash/omit";
@@ -61,7 +63,7 @@ export const OverrideEntitiesModal = ({
   } are inaccurate?`;
 
   const closeModal = (_event: any, reason?: string) => {
-    if (reason && reason == "backdropClick") {
+    if (reason && reason === "backdropClick") {
       return;
     }
 
@@ -139,9 +141,31 @@ export const OverrideEntitiesModal = ({
       maxWidth="xl"
       aria-labelledby="dialog-heading"
     >
-      <DialogTitle variant="h3" component="h1" id="dialog-heading">
-        I don't think this constraint applies to this property
-      </DialogTitle>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 2,
+        }}
+      >
+        <DialogTitle
+          variant="h3"
+          component="h2"
+          id="dialog-heading"
+          sx={{ flex: 1 }}
+        >
+          I don't think this constraint applies to this property
+        </DialogTitle>
+        <IconButton
+          aria-label="Close"
+          onClick={closeModal}
+          data-testid="override-modal-close-button"
+          sx={{ color: "grey.600", marginTop: 2, marginRight: 2 }}
+        >
+          <Close />
+        </IconButton>
+      </Box>
       <DialogContent dividers>
         <Box component="form">
           <Typography variant="body2" gutterBottom>


### PR DESCRIPTION
The report also mentioned "The escape button closed the modal; this was an issue as it meant if I had not finished my task, I was required to re-open the modal. Usually, I would only expect the modal to close either after I have made a selection or I close it manually." - I didn't fix this as it's my understanding that Escape should be expected to close modals (https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) - and perhaps the reviewers issue was that they actually didn't know it was a modal therefore the escape behaviour was unexpected? Keen to hear anyone else's take on this though... 