### PR TITLE
fix(editor): Fixed height for patterns popover to solve async issues

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/ComponentsTab/index.tsx
@@ -12,13 +12,14 @@ import { ComponentRow } from "./ComponentRow";
 import { NoteRow } from "./NoteRow";
 
 export const COMPONENT_LIST_WIDTH = 300;
+export const COMPONENT_LIST_HEIGHT = 480;
 
 /**
  * Shared frame for the component list wherever it's rendered (both popovers + Story)
  */
 export const componentListFrameSx = {
   width: COMPONENT_LIST_WIDTH,
-  maxHeight: "min(480px, 85vh)",
+  maxHeight: `min(${COMPONENT_LIST_HEIGHT}px, 85vh)`,
   display: "flex",
   flexDirection: "column",
   overflow: "hidden",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/index.tsx
@@ -7,7 +7,11 @@ import React, { useCallback, useState } from "react";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
-import { COMPONENT_LIST_WIDTH, componentListFrameSx } from "./ComponentsTab";
+import {
+  COMPONENT_LIST_HEIGHT,
+  COMPONENT_LIST_WIDTH,
+  componentListFrameSx,
+} from "./ComponentsTab";
 import type { ModalTab } from "./ModalTabs";
 import { ModalTabs } from "./ModalTabs";
 import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
@@ -64,7 +68,8 @@ const AddComponentModal: React.FC<Props> = ({
 
   // Flip the popover above the hanger when there isn't room below it
   const rect = anchorEl?.getBoundingClientRect();
-  const showBelow = !rect || window.innerHeight - rect.bottom >= 450;
+  const showBelow =
+    !rect || window.innerHeight - rect.bottom >= COMPONENT_LIST_HEIGHT;
 
   return (
     <Popover
@@ -86,6 +91,7 @@ const AddComponentModal: React.FC<Props> = ({
           sx: {
             ...componentListFrameSx,
             width: popoverWidth,
+            height: `min(${COMPONENT_LIST_HEIGHT}px, 85vh)`,
             mt: showBelow ? "4px" : "-4px",
           },
         },


### PR DESCRIPTION
## What's the problem?
The "Patterns" tab of the `<AddComponentModal/>` does not re-orientate itself on open, it's always top down. Opening the popover on a hanger close to the bottom of the screen makes in un-navigable.

Thread here with video (OSL Slack) - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1787734171912219

## What's the cause?
The contents of the patterns tab are loaded asynchronously and then it never re-adjusts it's position.

## What's the solution?
I've just set a fixed `height` here instead of a dynamic height + max. This means it's always 480px, which is really only an issue until we have a few additional patterns (where we would have hit this point anyway). I think even if it did re-adjust on load, it would feel quite janky, and only be a short-lived solution.

Another option (previously discussed) would be pre-warming the cache with the required patterns but this feels like overkill..!

<img width="677" height="570" alt="image" src="https://github.com/user-attachments/assets/5d03fc9e-d259-446c-97f6-05b712e27399" />
