### PR TITLE
fix(editor): Resolve Tanstack Router warning for `CatchAllComponent`

### DIFF
--- a/apps/editor.planx.uk/src/pages/ErrorPage/CatchAllComponent.tsx
+++ b/apps/editor.planx.uk/src/pages/ErrorPage/CatchAllComponent.tsx
@@ -1,0 +1,11 @@
+import ErrorPage from "pages/ErrorPage/ErrorPage";
+import React from "react";
+
+export function CatchAllComponent() {
+  return (
+    <ErrorPage title="Page not found">
+      The page you're looking for doesn't exist. Please check the URL or go back
+      to the homepage.
+    </ErrorPage>
+  );
+}

--- a/apps/editor.planx.uk/src/routes/$.tsx
+++ b/apps/editor.planx.uk/src/routes/$.tsx
@@ -1,17 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import ErrorPage from "pages/ErrorPage/ErrorPage";
-import React from "react";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 
 export const Route = createFileRoute("/$")({
   component: CatchAllComponent,
 });
-
-// TODO: export from elsewhere (and import here) to avoid code-split warning
-export function CatchAllComponent() {
-  return (
-    <ErrorPage title="Page not found">
-      The page you're looking for doesn't exist. Please check the URL or go back
-      to the homepage.
-    </ErrorPage>
-  );
-}

--- a/apps/editor.planx.uk/src/routes/__root.tsx
+++ b/apps/editor.planx.uk/src/routes/__root.tsx
@@ -6,12 +6,11 @@ import {
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { zodValidator } from "@tanstack/zod-adapter";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 import ErrorPage from "pages/ErrorPage/ErrorPage";
 import React from "react";
 import { createPortal } from "react-dom";
 import { z } from "zod";
-
-import { CatchAllComponent } from "./$";
 
 // Search params schema for error handling and redirects
 const rootSearchSchema = z.object({

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/$flow/route.tsx
@@ -5,8 +5,8 @@ import {
 } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { AppErrorBoundary } from "components/Error/AppErrorBoundary";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 import FlowSkeleton from "pages/FlowEditor/FlowSkeleton";
-import { CatchAllComponent } from "routes/$";
 
 import { flowsSearchSchema } from "../flows";
 import { connectToFlowRoute } from "./-route.utils";

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -3,8 +3,8 @@ import { createFileRoute, notFound, Outlet } from "@tanstack/react-router";
 import RouteLoadingIndicator from "components/RouteLoadingIndicator";
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 import React from "react";
-import { CatchAllComponent } from "routes/$";
 
 import { useStore } from "../../../../pages/FlowEditor/lib/store";
 

--- a/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import gql from "graphql-tag";
-import { CatchAllComponent } from "routes/$";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 
 import { useStore } from "../../../pages/FlowEditor/lib/store";
 import type { TeamSummary } from "../../../pages/FlowEditor/lib/store/team";

--- a/apps/editor.planx.uk/src/test/utils.tsx
+++ b/apps/editor.planx.uk/src/test/utils.tsx
@@ -22,8 +22,8 @@ import userEvent, {
   PointerEventsCheckLevel,
 } from "@testing-library/user-event";
 import { ToastContextProvider } from "contexts/ToastContext";
+import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
 import React from "react";
-import { CatchAllComponent } from "routes/$";
 
 import { defaultTheme } from "../theme";
 


### PR DESCRIPTION
Resolves the following warning shown when running the Editor - 

```sh
[tanstack-router] These exports from "/Users/dafyddllyr/Code/planx-new/apps/editor.planx.uk/src/routes/$.tsx" will not be code-split and will increase your bundle size:
- CatchAllComponent
For the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.
```

<img width="569" height="103" alt="image" src="https://github.com/user-attachments/assets/107efe0f-0a19-4b37-a145-cc42a0d9316f" />

The solution is not to export a component from a Route file elsewhere, but just to create the component as standalone and import it as a pure component, not from within a route file.