### PR TITLE
chore: Reinstate `useSendEmailAuth()` middleware for consistency

### DIFF
--- a/apps/api.planx.uk/modules/sendEmail/routes.ts
+++ b/apps/api.planx.uk/modules/sendEmail/routes.ts
@@ -37,7 +37,7 @@ router.post(
 
 router.post(
   "/send-email/welcome",
-  useHasuraAuth,
+  useSendEmailAuth,
   useWelcomeEmailGuard,
   validate(resendEmailSchema),
   resendEmailController,

--- a/apps/api.planx.uk/modules/sendEmail/routes.ts
+++ b/apps/api.planx.uk/modules/sendEmail/routes.ts
@@ -36,7 +36,7 @@ router.post(
 );
 
 router.post(
-  "/send-email/welcome",
+  "/send-email/:template(welcome)",
   useSendEmailAuth,
   useWelcomeEmailGuard,
   validate(resendEmailSchema),


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-new/pull/7293/changes#r3893721226 - I hit "merge" before properly reading this comment sorry!

Non-functional change, just more consistent and clear.