### PR TITLE
feat[alt notes]: disable old Question/Checklist "no option" notes

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -41,6 +41,27 @@ describe("Checklist editor component", () => {
     expect(screen.getByText("Add option")).toBeInTheDocument();
   });
 
+  it("displays an error if an editor tries to create a pseudo-note", async () => {
+    const { user } = await setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistEditor options={[]} />
+      </DndProvider>,
+    );
+
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Note");
+
+    fireEvent.submit(screen.getByTestId("checklistEditorForm"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Checklists can no longer be used as notes and must have at least one option/,
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it("displays the grouped checklist inputs when the 'expandable' toggle is clicked", async () => {
     const { user } = await setup(
       <DndProvider backend={HTML5Backend}>
@@ -193,6 +214,10 @@ describe("Checklist editor component", () => {
         <ChecklistEditor options={[]} handleSubmit={handleSubmit} />
       </DndProvider>,
     );
+
+    // Set title (required)
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Test");
 
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
     const autocompleteInput = within(autocompleteComponent).getByRole(

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -8,11 +8,9 @@ import type {
 import { generatePayload } from "@planx/components/shared/BaseChecklist/model";
 import type { EditorProps } from "@planx/components/shared/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import type { FormikErrors, FormikValues } from "formik";
 import React from "react";
 
-import type { ChecklistWithOptions } from "./model";
-import type { Checklist } from "./model";
+import type { Checklist, ChecklistWithOptions } from "./model";
 import { parseChecklist, validationSchema } from "./model";
 
 type ExtraProps = FlatOptions<Option> | GroupedOptions<Option>;
@@ -41,13 +39,6 @@ export const ChecklistEditor: React.FC<Props> = (props) => {
               2,
             ),
           );
-        }
-      },
-      validate: ({ options, ...values }) => {
-        const errors: FormikErrors<FormikValues> = {};
-        if (values.text && (!options || !options.length)) {
-          errors.text =
-            "Checklists can no longer be used as notes and must have at least one option";
         }
       },
       validationSchema,

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -33,7 +33,7 @@ describe("Editor validation", () => {
   test("both 'allRequired' and 'exclusiveOr' cannot be toggled on together", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         allRequired: true,
         options: [
           {
@@ -50,7 +50,7 @@ describe("Editor validation", () => {
   test("only one exclusive option is permitted", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         allRequired: false,
         options: [
           {
@@ -71,7 +71,7 @@ describe("Editor validation", () => {
   test("options must set data values if the component does", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         fn: "topLevelFn",
         allRequired: false,
         options: [
@@ -91,7 +91,7 @@ describe("Editor validation", () => {
   test("fn is required for alwaysAutoAnswerBlank", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         alwaysAutoAnswerBlank: true,
         fn: null,
         options: [
@@ -113,7 +113,7 @@ describe("Editor validation", () => {
   test("alwaysAutoAnswerBlank allows only one blank value", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         alwaysAutoAnswerBlank: true,
         fn: "test",
         options: [
@@ -138,6 +138,7 @@ describe("Editor validation", () => {
 
   test("checklists - data fields can be set for each option", async () => {
     const result = validationSchema.validate({
+      text: "Test",
       allRequired: false,
       neverAutoAnswer: false,
       alwaysAutoAnswerBlank: false,
@@ -167,7 +168,6 @@ describe("Editor validation", () => {
           ],
         },
       ],
-      text: "Test",
     });
 
     expect(result).toBeDefined();
@@ -175,7 +175,7 @@ describe("Editor validation", () => {
 
   test("grouped checklists - data fields can be set for each option", async () => {
     const result = validationSchema.validate({
-      title: "Test",
+      text: "Test",
       alwaysAutoAnswerBlank: false,
       fn: "test",
       options: [
@@ -197,7 +197,7 @@ describe("Editor validation", () => {
     test("groups must have unique titles", async () => {
       await expect(() =>
         validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Repeated group name",
@@ -225,7 +225,7 @@ describe("Editor validation", () => {
     test("groups must have unique titles - whitespace is stripped before checks", async () => {
       await expect(() =>
         validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Whitespace   ",
@@ -254,7 +254,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -272,7 +272,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option (inc. whitespace)", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -290,7 +290,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -315,7 +315,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups (inc. whitespace)", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -339,7 +339,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -375,7 +375,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups (inc. whitespace)", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -414,7 +414,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -431,7 +431,7 @@ describe("Editor validation", () => {
 
       test("checklists - repeated data values are allowed", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           options: [
             {
               id: "a",
@@ -450,7 +450,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -474,7 +474,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - data values can be repeated within groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -497,7 +497,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Common property types",
@@ -536,7 +536,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - data values can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -27,6 +27,27 @@ it("displays the options editor when the 'Add option' button is clicked", async 
   expect(optionsEditor).toBeInTheDocument();
 });
 
+it("displays an error if an editor tries to create a pseudo-note", async () => {
+  const { user } = await setup(
+    <DndProvider backend={HTML5Backend}>
+      <Question node={{}} options={[]} />
+    </DndProvider>,
+  );
+
+  await user.click(screen.getByPlaceholderText("Text"));
+  await user.paste("Note");
+
+  fireEvent.submit(screen.getByTestId("question-component-form"));
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(
+        /Questions can no longer be used as notes and must have at least one option/,
+      ),
+    ).toBeInTheDocument(),
+  );
+});
+
 describe("data field", () => {
   it("clears option val fields when the question data field is cleared", async () => {
     const { user } = await setup(

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -36,10 +36,14 @@ export const QuestionComponent: React.FC<Props> = (props) => {
       },
       validate: ({ options, ...values }) => {
         const errors: FormikErrors<FormikValues> = {};
-        // if (values.text && !options.length) {
-        //   errors.text =
-        //     "Questions can no longer be used as notes and must have at least one option";
-        // }
+        if (!options.length) {
+          if (values.text) {
+            errors.text =
+              "Questions can no longer be used as notes and must have at least one option";
+          } else {
+            errors.options = "Add at least one option";
+          }
+        }
         if (values.fn && !options.some((option) => option.data.val)) {
           errors.fn = "At least one option must also set a data field";
         }

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -144,6 +144,10 @@ describe("Responsive Checklist editor component", () => {
       </DndProvider>,
     );
 
+    // Set title (required)
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Test");
+
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
     const autocompleteInput = within(autocompleteComponent).getByRole(
       "combobox",

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.tsx
@@ -1,8 +1,6 @@
 import type { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import type { FormikErrors, FormikValues } from "formik";
-import React from "react";
 
 import type { ConditionalOption } from "../Option/model";
 import { BaseChecklistComponent } from "../shared/BaseChecklist/Editor";
@@ -52,13 +50,6 @@ function ResponsiveChecklistComponent(props: Props) {
               2,
             ),
           );
-        }
-      },
-      validate: ({ options, ...values }) => {
-        const errors: FormikErrors<FormikValues> = {};
-        if (values.text && (!options || !options.length)) {
-          errors.text =
-            "Checklists can no longer be used as notes and must have at least one option";
         }
       },
       validationSchema,

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/model.ts
@@ -233,6 +233,30 @@ const uniqueLabelsTest: TestConfig<AnyChecklist> = {
   },
 };
 
+const atLeastOneOption: TestConfig<AnyChecklist> = {
+  name: "atLeastOneOption",
+  test: function ({ text, options, groupedOptions }) {
+    if (
+      (options && options.length > 0) ||
+      (groupedOptions && groupedOptions.length > 0)
+    )
+      return true;
+
+    if (text) {
+      return this.createError({
+        path: "text",
+        message:
+          "Checklists can no longer be used as notes and must have at least one option",
+      });
+    } else {
+      return this.createError({
+        path: "options",
+        message: "Add at least one option",
+      });
+    }
+  },
+};
+
 const uniqueLabelsWithinGroupsTest: TestConfig<AnyChecklist> = {
   name: "uniqueLabelsWithinGroups",
   test: function ({ groupedOptions }) {
@@ -281,9 +305,9 @@ const uniqueGroupTitlesTest: TestConfig<AnyChecklist> = {
 export const baseChecklistValidationSchema =
   baseNodeDataValidationSchema.concat(
     object({
+      text: string().required(),
       description: richText(),
       fn: string().nullable(),
-      text: string(),
       img: string(),
       categories: array(
         object({
@@ -298,5 +322,6 @@ export const baseChecklistValidationSchema =
       .test(atLeastOneDataFieldTest as TestConfig<unknown>)
       .test(uniqueLabelsTest as TestConfig<unknown>)
       .test(uniqueLabelsWithinGroupsTest as TestConfig<unknown>)
-      .test(uniqueGroupTitlesTest as TestConfig<unknown>),
+      .test(uniqueGroupTitlesTest as TestConfig<unknown>)
+      .test(atLeastOneOption as TestConfig<unknown>),
   );


### PR DESCRIPTION
Disables the old way of adding [Responsive]Questions/Checklists as pseudo "notes" a little more thoroughly than last time with test coverage!

To test: 
- You can't "add" a _new_ [Responsive]Question/Checklist with _only_ a title and no options as a pseudo note
- You can't "update" an _existing_ one, you have to add options to validate or exit/remove. (These will be migrated to new `ComponentType.Note` in near future!)