### PR TITLE
feat(stripe): add DB columns and permissions for Stripe account IDs

### DIFF
--- a/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_integrations.yaml
+++ b/apps/hasura.planx.uk/metadata/databases/default/tables/public_team_integrations.yaml
@@ -17,11 +17,13 @@ insert_permissions:
         - production_file_api_key
         - production_govpay_secret
         - production_power_automate_api_key
+        - production_stripe_account_id
         - staging_bops_secret
         - staging_bops_submission_url
         - staging_file_api_key
         - staging_govpay_secret
         - staging_power_automate_api_key
+        - staging_stripe_account_id
         - team_id
     comment: ""
 select_permissions:
@@ -42,11 +44,13 @@ select_permissions:
         - production_file_api_key
         - production_govpay_secret
         - production_power_automate_api_key
+        - production_stripe_account_id
         - staging_bops_secret
         - staging_bops_submission_url
         - staging_file_api_key
         - staging_govpay_secret
         - staging_power_automate_api_key
+        - staging_stripe_account_id
         - team_id
       filter: {}
   - role: platformAdmin
@@ -71,6 +75,14 @@ select_permissions:
       filter: {}
     comment: ""
 update_permissions:
+  - role: api
+    permission:
+      columns:
+        - production_stripe_account_id
+        - staging_stripe_account_id
+      filter: {}
+      check: null
+    comment: "Team membership is enforced in the API layer (requireTeamMembership) before this role writes a connected Stripe account id"
   - role: platformAdmin
     permission:
       columns:

--- a/apps/hasura.planx.uk/migrations/default/1787649549216_alter_table_public_team_integrations_add_stripe_account_id/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787649549216_alter_table_public_team_integrations_add_stripe_account_id/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."team_integrations" drop column "production_stripe_account_id";
+alter table "public"."team_integrations" drop column "staging_stripe_account_id";

--- a/apps/hasura.planx.uk/migrations/default/1787649549216_alter_table_public_team_integrations_add_stripe_account_id/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1787649549216_alter_table_public_team_integrations_add_stripe_account_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."team_integrations" add column "production_stripe_account_id" text;
+alter table "public"."team_integrations" add column "staging_stripe_account_id" text;
+
+comment on column "public"."team_integrations"."production_stripe_account_id" is E'Stripe Connect account id (acct_...) linked via OAuth for production payments';
+comment on column "public"."team_integrations"."staging_stripe_account_id" is E'Stripe Connect account id (acct_...) linked via OAuth for staging payments';

--- a/apps/hasura.planx.uk/tests/team_integrations.test.js
+++ b/apps/hasura.planx.uk/tests/team_integrations.test.js
@@ -87,8 +87,10 @@ describe("team_integrations", () => {
       expect(i.queries).toContain("team_integrations");
     });
 
-    test("cannot create, update, or delete team_integrations", () => {
-      expect(i).toHaveNoMutationsFor("team_integrations");
+    test("can update (e.g. Stripe account id), but cannot create or delete team_integrations", () => {
+      expect(i.mutations).toContain("update_team_integrations");
+      expect(i.mutations).not.toContain("insert_team_integrations");
+      expect(i.mutations).not.toContain("delete_team_integrations");
     });
   });
 });


### PR DESCRIPTION
- add column `team_integrations.production_stripe_account_id`
- add column `team_integrations.staging_stripe_account_id`
- Allows `api` hasura role to update these - actual user permissions will need to be checked at the API layer
- This field will be written as part of the OAuth callback handler, after successful Stripe account connect