### PR TITLE
refactor: CloseButton as reusable component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -1,31 +1,26 @@
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import MoreInfoFeedbackComponent from "components/Feedback/MoreInfoFeedback/MoreInfoFeedback";
 import React from "react";
+import { CloseButton } from "ui/shared/CloseButton";
 
 const DrawerContent = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2.5, 4, 2, 0),
   fontSize: "1rem",
   lineHeight: "1.5",
   [theme.breakpoints.up("sm")]: {
-    padding: theme.spacing(6, 4, 4, 1),
+    padding: theme.spacing(3, 4, 3, 1),
   },
 }));
 
-const CloseButton = styled(Box)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "flex-end",
+const CloseButtonWrapper = styled(Box)(({ theme }) => ({
   position: "fixed",
   top: theme.spacing(1),
   right: theme.spacing(1),
-  color: theme.palette.text.primary,
   zIndex: theme.zIndex.drawer + 1,
 }));
 
@@ -41,18 +36,13 @@ const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
     open={open}
     onClose={() => handleClose()}
   >
-    <CloseButton>
-      <IconButton
+    <CloseButtonWrapper>
+      <CloseButton
         onClick={() => handleClose()}
-        role="button"
         title="Close panel"
-        aria-label="Close panel"
-        size="large"
         color="inherit"
-      >
-        <CloseIcon />
-      </IconButton>
-    </CloseButton>
+      />
+    </CloseButtonWrapper>
     <Container maxWidth={false} sx={{ bgcolor: "white" }}>
       <Typography variant="h1" sx={visuallyHidden}>
         More information

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -1,12 +1,10 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CloseIcon from "@mui/icons-material/Close";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import Dialog, { dialogClasses } from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -14,6 +12,7 @@ import ButtonBase from "@planx/components/shared/Buttons/ButtonBase";
 import React, { useState } from "react";
 import { useLocation } from "react-use";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { CloseButton } from "ui/shared/CloseButton";
 
 export interface Environment {
   name: string;
@@ -53,14 +52,18 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
   },
 }));
 
-const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
-  border: "none",
+const DialogHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
   padding: theme.spacing(1),
   backgroundColor: theme.palette.background.dark,
   color: theme.palette.common.white,
+}));
+
+const StyledDialogTitle = styled(DialogTitle)(() => ({
+  border: "none",
+  padding: 0,
 }));
 
 const StyledCard = styled(Card)<{ selected?: boolean }>(() => ({
@@ -150,8 +153,8 @@ export const EnvironmentSelect: React.FC = () => {
           },
         }}
       >
-        <StyledDialogTitle>
-          <Box>
+        <DialogHeader>
+          <StyledDialogTitle>
             <Typography
               variant="subtitle1"
               component="span"
@@ -162,15 +165,14 @@ export const EnvironmentSelect: React.FC = () => {
             <Typography variant="body2" component="span">
               environments
             </Typography>
-          </Box>
-          <IconButton
-            aria-label="close"
+          </StyledDialogTitle>
+          <CloseButton
+            size="small"
             onClick={handleClose}
-            sx={{ color: "#ffffff", padding: 0 }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </StyledDialogTitle>
+            title="Close panel"
+            sx={{ padding: 0 }}
+          />
+        </DialogHeader>
         <Stack
           sx={{
             p: 1,

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
@@ -1,8 +1,6 @@
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Fade from "@mui/material/Fade";
-import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import Typography from "@mui/material/Typography";
 import {
@@ -14,6 +12,7 @@ import {
 import { useMemo, useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import SettingsDescription from "ui/editor/SettingsDescription";
+import { CloseButton } from "ui/shared/CloseButton";
 import { Switch } from "ui/shared/Switch";
 
 interface Props {
@@ -94,9 +93,7 @@ const FeatureFlagsPanel = ({ anchorEl, onClose }: Props) => {
         }}
       >
         <Typography variant="h4">Feature flags</Typography>
-        <IconButton aria-label="close" onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
+        <CloseButton size="small" onClick={onClose} sx={{ marginRight: -1 }} />
       </Box>
       <Box sx={{ px: 1.5, py: 1, flex: 1 }}>
         <SettingsDescription>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -1,11 +1,9 @@
-import CloseIcon from "@mui/icons-material/Close";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Fade from "@mui/material/Fade";
-import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
@@ -18,6 +16,7 @@ import { partitionBySuperseded } from "pages/FlowEditor/components/Notifications
 import { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import StyledTab from "ui/editor/StyledTab";
+import { CloseButton } from "ui/shared/CloseButton";
 
 interface Props {
   anchorEl: HTMLElement | null;
@@ -106,9 +105,7 @@ const NotificationsPanel = ({
         }}
       >
         <Typography variant="h4">Notifications</Typography>
-        <IconButton aria-label="close" onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
+        <CloseButton size="small" onClick={onClose} sx={{ marginRight: -1 }} />
       </Box>
       <TabList>
         <Tabs

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -1,11 +1,9 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CloseIcon from "@mui/icons-material/Close";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -15,6 +13,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import type { TeamSummary } from "pages/FlowEditor/lib/store/team";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { cardBoxShadow, focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { CloseButton } from "ui/shared/CloseButton";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
 const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
@@ -33,8 +32,7 @@ const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
   }),
 );
 
-const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
-  border: "none",
+const DialogHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
@@ -43,6 +41,11 @@ const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
   top: 0,
   backgroundColor: theme.palette.background.paper,
   zIndex: 1,
+}));
+
+const StyledDialogTitle = styled(DialogTitle)(() => ({
+  border: "none",
+  padding: 0,
 }));
 
 const StyledCard = styled(Card)<{ selected?: boolean; teamcolor?: string }>(
@@ -193,16 +196,15 @@ export const TeamSelect: React.FC<Props> = ({
           },
         }}
       >
-        <StyledDialogTitle>
-          <Box>
-            <Typography variant="h4" component="span">
-              Select a team
-            </Typography>
-          </Box>
-          <IconButton aria-label="close" onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </StyledDialogTitle>
+        <DialogHeader>
+          <StyledDialogTitle variant="h4">Select a team</StyledDialogTitle>
+          <CloseButton
+            onClick={handleClose}
+            size="small"
+            title="Close panel"
+            sx={{ marginRight: -0.5, marginTop: -0.5 }}
+          />
+        </DialogHeader>
         <Box sx={{ p: 1, pb: 1.5, pt: 0 }}>
           <SearchBox
             records={teams}

--- a/apps/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/index.tsx
@@ -1,5 +1,4 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import CloseIcon from "@mui/icons-material/Close";
 import LightbulbIcon from "@mui/icons-material/Lightbulb";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import RuleIcon from "@mui/icons-material/Rule";
@@ -7,7 +6,6 @@ import WarningIcon from "@mui/icons-material/Warning";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import {
   getInternalFeedbackMetadata,
@@ -16,8 +14,8 @@ import {
 import { BackButton } from "pages/Preview/Questions";
 import React, { useState } from "react";
 import { usePrevious } from "react-use";
-import { CloseButton } from "ui/icons/CloseButton";
 import FeedbackOption from "ui/public/FeedbackOption";
+import { CloseButton } from "ui/shared/CloseButton";
 
 import FeedbackForm from "./FeedbackForm/FeedbackForm";
 import FeedbackPhaseBanner from "./FeedbackPhaseBanner";
@@ -93,17 +91,10 @@ const Feedback: React.FC = () => {
           <ArrowBackIcon fontSize="small" />
           Back
         </BackButton>
-        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
-          <IconButton
-            role="button"
-            title="Close panel"
-            aria-label="Close panel"
-            size="large"
-            color="inherit"
-          >
-            <CloseIcon />
-          </IconButton>
-        </CloseButton>
+        <CloseButton
+          title="Close panel"
+          onClick={() => handleFeedbackViewClick("close")}
+        />
       </FeedbackHeader>
     );
   }
@@ -117,17 +108,11 @@ const Feedback: React.FC = () => {
             {props.title}
           </Typography>
         </FeedbackTitle>
-        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
-          <IconButton
-            role="button"
-            title="Close panel"
-            aria-label="Close panel"
-            size="large"
-            color="inherit"
-          >
-            <CloseIcon />
-          </IconButton>
-        </CloseButton>
+        <CloseButton
+          title="Close panel"
+          color="inherit"
+          onClick={() => handleFeedbackViewClick("close")}
+        />
       </FeedbackHeader>
     );
   }

--- a/apps/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/index.tsx
@@ -87,7 +87,10 @@ const Feedback: React.FC = () => {
   function BackAndCloseFeedbackHeader(): FCReturn {
     return (
       <FeedbackHeader>
-        <BackButton onClick={() => handleFeedbackViewClick("back")}>
+        <BackButton
+          onClick={() => handleFeedbackViewClick("back")}
+          variant="link"
+        >
           <ArrowBackIcon fontSize="small" />
           Back
         </BackButton>
@@ -110,7 +113,6 @@ const Feedback: React.FC = () => {
         </FeedbackTitle>
         <CloseButton
           title="Close panel"
-          color="inherit"
           onClick={() => handleFeedbackViewClick("close")}
         />
       </FeedbackHeader>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -103,11 +103,7 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
             Note
           </Typography>
         </DialogTitle>
-        <CloseButton
-          onClick={onClose}
-          title="Close panel"
-          sx={{ color: "grey.600" }}
-        />
+        <CloseButton onClick={onClose} title="Close panel" />
       </Box>
       <Box component="form" onSubmit={formik.handleSubmit}>
         <DialogContent dividers sx={{ px: 4, py: 3 }}>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -1,4 +1,3 @@
-import Close from "@mui/icons-material/CloseOutlined";
 import DeleteIcon from "@mui/icons-material/Delete";
 import StickyNote2Icon from "@mui/icons-material/StickyNote2";
 import Box from "@mui/material/Box";
@@ -7,13 +6,13 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import type { FlowNote, FlowNoteTarget } from "hooks/data/useFlowNotes";
 import { useToast } from "hooks/useToast";
 import { formatLastEditMessage } from "pages/FlowEditor/utils";
 import React from "react";
+import { CloseButton } from "ui/shared/CloseButton";
 import Input from "ui/shared/Input/Input";
 import { object, string } from "yup";
 
@@ -81,7 +80,7 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
 
   return (
     <Dialog open fullWidth onClose={onClose}>
-      <DialogTitle
+      <Box
         sx={{
           py: 1,
           px: 2.5,
@@ -90,21 +89,26 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
           justifyContent: "space-between",
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <DialogTitle
+          sx={{
+            p: 0,
+            border: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
           <StickyNote2Icon sx={{ color: "text.primary", fontSize: "1.6rem" }} />
-          <Typography variant="h3" component="h1">
+          <Typography variant="h3" component="span">
             Note
           </Typography>
-        </Box>
-        <IconButton
-          aria-label="close"
+        </DialogTitle>
+        <CloseButton
           onClick={onClose}
-          size="large"
+          title="Close panel"
           sx={{ color: "grey.600" }}
-        >
-          <Close />
-        </IconButton>
-      </DialogTitle>
+        />
+      </Box>
       <Box component="form" onSubmit={formik.handleSubmit}>
         <DialogContent dividers sx={{ px: 4, py: 3 }}>
           <Input

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,5 +1,4 @@
 import { gql, useQuery } from "@apollo/client";
-import Close from "@mui/icons-material/CloseOutlined";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -10,7 +9,7 @@ import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedL
 import { addDays, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 
 import type { Submission } from "../types";
 import { SubmissionDetails } from "./SubmissionDetails";
@@ -71,14 +70,7 @@ const SubmissionModalWrapper = ({
         }}
       >
         <DialogTitle variant="h2">Submission details</DialogTitle>
-        <CloseButton
-          aria-label="close"
-          onClick={handleClose}
-          size="large"
-          sx={{ paddingTop: 2.5 }}
-        >
-          <Close />
-        </CloseButton>
+        <CloseButton onClick={handleClose} sx={{ paddingTop: 2.5 }} />
       </Box>
 
       <DialogContent children={children} />

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -1,5 +1,4 @@
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
-import Close from "@mui/icons-material/CloseOutlined";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -19,7 +18,7 @@ import {
 } from "pages/FlowEditor/utils";
 import React, { useMemo, useState } from "react";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 import { Switch } from "ui/shared/Switch";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
@@ -268,9 +267,7 @@ const FormModal: React.FC<FormModalProps> = ({
             canChange={!handleDelete}
           />
 
-          <CloseButton aria-label="close" onClick={handleClose} size="large">
-            <Close />
-          </CloseButton>
+          <CloseButton onClick={handleClose} />
         </DialogTitle>
         <DialogContent dividers sx={{ p: 0, position: "relative" }}>
           {!handleDelete && (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -267,7 +267,7 @@ const FormModal: React.FC<FormModalProps> = ({
             canChange={!handleDelete}
           />
 
-          <CloseButton onClick={handleClose} />
+          <CloseButton onClick={handleClose} sx={{ marginRight: -1 }} />
         </DialogTitle>
         <DialogContent dividers sx={{ p: 0, position: "relative" }}>
           {!handleDelete && (

--- a/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
@@ -1,12 +1,11 @@
-import Close from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { notFound, useLocation, useNavigate } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
 import { FOOTER_ITEMS } from "types";
+import { CloseButton } from "ui/shared/CloseButton";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 const Root = styled(Box)(({ theme }) => ({
@@ -19,12 +18,6 @@ const Root = styled(Box)(({ theme }) => ({
   paddingBottom: theme.spacing(10),
 }));
 
-const CloseIconButton = styled(IconButton)(() => ({
-  position: "absolute",
-  right: 20,
-  top: 20,
-}));
-
 function Layout(props: {
   heading?: string;
   content?: string;
@@ -33,9 +26,10 @@ function Layout(props: {
 }) {
   return (
     <Root>
-      <CloseIconButton onClick={props.onClose} size="medium" aria-label="Close">
-        <Close />
-      </CloseIconButton>
+      <CloseButton
+        onClick={props.onClose}
+        sx={{ position: "absolute", right: 20, top: 20 }}
+      />
       <Container maxWidth="md">
         <Typography variant="h1">{props.heading}</Typography>
         <ReactMarkdownOrHtml

--- a/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
@@ -1,11 +1,12 @@
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { notFound, useLocation, useNavigate } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { BackButton } from "pages/Preview/Questions";
 import { FOOTER_ITEMS } from "types";
-import { CloseButton } from "ui/shared/CloseButton";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
 const Root = styled(Box)(({ theme }) => ({
@@ -14,8 +15,6 @@ const Root = styled(Box)(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  paddingTop: theme.spacing(2),
-  paddingBottom: theme.spacing(10),
 }));
 
 function Layout(props: {
@@ -26,16 +25,23 @@ function Layout(props: {
 }) {
   return (
     <Root>
-      <CloseButton
-        onClick={props.onClose}
-        sx={{ position: "absolute", right: 20, top: 20 }}
-      />
-      <Container maxWidth="md">
-        <Typography variant="h1">{props.heading}</Typography>
-        <ReactMarkdownOrHtml
-          source={props.content}
-          openLinksOnNewTab={props.openLinksOnNewTab}
-        />
+      <Container maxWidth="contentWrap" sx={{ position: "relative" }}>
+        <BackButton onClick={props.onClose} variant="link">
+          <ArrowBackIcon fontSize="small" />
+          Back
+        </BackButton>
+        <Container
+          maxWidth="formWrap"
+          sx={{ margin: 0, padding: "0 !important" }}
+        >
+          <Typography variant="h2" component="h1">
+            {props.heading}
+          </Typography>
+          <ReactMarkdownOrHtml
+            source={props.content}
+            openLinksOnNewTab={props.openLinksOnNewTab}
+          />
+        </Container>
       </Container>
     </Root>
   );

--- a/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
+++ b/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
@@ -1,8 +1,0 @@
-import IconButton from "@mui/material/IconButton";
-import { styled } from "@mui/material/styles";
-
-export const CloseButton = styled(IconButton)(({ theme }) => ({
-  margin: "0 0 0 auto",
-  padding: theme.spacing(1),
-  color: theme.palette.grey[600],
-}));

--- a/apps/editor.planx.uk/src/ui/shared/CloseButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/CloseButton.tsx
@@ -1,0 +1,31 @@
+import CloseIcon from "@mui/icons-material/Close";
+import IconButton, { type IconButtonProps } from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import React from "react";
+
+const StyledIconButton = styled(IconButton)(({ theme, size }) => ({
+  margin: "0 0 0 auto",
+  padding: size === "small" ? theme.spacing(0.75) : theme.spacing(1),
+  color: "inherit",
+}));
+
+export interface CloseButtonProps extends Omit<
+  IconButtonProps,
+  "title" | "aria-label" | "children" | "size"
+> {
+  /** Used as both the button title and the accessible name */
+  title?: string;
+  size?: "small" | "medium";
+}
+
+export const CloseButton: React.FC<CloseButtonProps> = ({
+  title = "Close",
+  size,
+  ...props
+}) => (
+  <StyledIconButton title={title} aria-label={title} size={size} {...props}>
+    <CloseIcon
+      sx={{ opacity: 0.8, fontSize: size === "small" ? "1.5rem" : "1.75rem" }}
+    />
+  </StyledIconButton>
+);

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
@@ -1,11 +1,10 @@
-import Close from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";
 import React from "react";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 
 interface DataTableModalProps {
   open: boolean;
@@ -37,9 +36,7 @@ export const DataTableModal: React.FC<DataTableModalProps> = ({
     <Dialog open={open} fullWidth onClose={onClose}>
       <ModalHeader>
         <Typography variant="h4">{title}</Typography>
-        <CloseButton aria-label="close" onClick={onClose} size="large">
-          <Close />
-        </CloseButton>
+        <CloseButton onClick={onClose} />
       </ModalHeader>
       <ModalBody>{children}</ModalBody>
     </Dialog>

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -117,7 +117,7 @@ test.describe("Templates", () => {
       await page.getByLabel("Require edits").click();
 
       // Close modal without saving
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("button", { name: "Discard changes" }).click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 
@@ -394,7 +394,7 @@ test.describe("Templates", () => {
       await expect(
         page.getByText(REQUIRED_NODE_INSTRUCTIONS).first(),
       ).toBeVisible();
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
     });
 
@@ -447,7 +447,7 @@ test.describe("Templates", () => {
         page.locator('button[form="modal"][type="submit"]'),
       ).toBeDisabled();
 
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
     });
 


### PR DESCRIPTION
## What does this PR do?

`CloseButton` has recently been created as a reusable `IconButton` with styling only, meaning that when using it with a properly marked up `IconButton` as a child, two `<button>` elements are nested together:

<img width="570" height="90" alt="image" src="https://github.com/user-attachments/assets/51af2970-8d15-45d1-b4df-6e660ea35f16" />

As there are numerous uses of the close button across both the editor and public interfaces, it's worth going the whole way to making this a reusable component, meaning that:
- Button is marked up with correct `title` and `aria-label`
- Size/padding can be standardised with an optional `small` size
- Button inherits colour of parent


### Components updated

**Editor:**
- Component modal (`FormModal`)
- `NoteEditorDialog` 
- `EnvironmentSelect`
- `TeamSelect`
- `NotificationsPanel`
- `FeatureFlagsPanel`

**Public:**
- `MoreInfo` (help text)
- Feedback panel

### Also fixes

- Content page (public) to have correct `back` button rather than close icon (which is currently incorrectly placed in the header
 
**Current:**

<img width="1162" height="375" alt="image" src="https://github.com/user-attachments/assets/3a2a0196-f213-451a-a88e-3b3ba1252181" />

**Fixed:**

<img width="1162" height="375" alt="image" src="https://github.com/user-attachments/assets/ddab45ae-f87d-4672-b3b0-a8bc221db316" />

