### PR TITLE
feat: explain sanitised addresses in submissions log

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.test.tsx
@@ -41,6 +41,27 @@ describe("Checklist editor component", () => {
     expect(screen.getByText("Add option")).toBeInTheDocument();
   });
 
+  it("displays an error if an editor tries to create a pseudo-note", async () => {
+    const { user } = await setup(
+      <DndProvider backend={HTML5Backend}>
+        <ChecklistEditor options={[]} />
+      </DndProvider>,
+    );
+
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Note");
+
+    fireEvent.submit(screen.getByTestId("checklistEditorForm"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Checklists can no longer be used as notes and must have at least one option/,
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it("displays the grouped checklist inputs when the 'expandable' toggle is clicked", async () => {
     const { user } = await setup(
       <DndProvider backend={HTML5Backend}>
@@ -193,6 +214,10 @@ describe("Checklist editor component", () => {
         <ChecklistEditor options={[]} handleSubmit={handleSubmit} />
       </DndProvider>,
     );
+
+    // Set title (required)
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Test");
 
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
     const autocompleteInput = within(autocompleteComponent).getByRole(

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/Editor.tsx
@@ -8,11 +8,9 @@ import type {
 import { generatePayload } from "@planx/components/shared/BaseChecklist/model";
 import type { EditorProps } from "@planx/components/shared/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import type { FormikErrors, FormikValues } from "formik";
 import React from "react";
 
-import type { ChecklistWithOptions } from "./model";
-import type { Checklist } from "./model";
+import type { Checklist, ChecklistWithOptions } from "./model";
 import { parseChecklist, validationSchema } from "./model";
 
 type ExtraProps = FlatOptions<Option> | GroupedOptions<Option>;
@@ -41,13 +39,6 @@ export const ChecklistEditor: React.FC<Props> = (props) => {
               2,
             ),
           );
-        }
-      },
-      validate: ({ options, ...values }) => {
-        const errors: FormikErrors<FormikValues> = {};
-        if (values.text && (!options || !options.length)) {
-          errors.text =
-            "Checklists can no longer be used as notes and must have at least one option";
         }
       },
       validationSchema,

--- a/apps/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
+++ b/apps/editor.planx.uk/src/@planx/components/Checklist/model.test.ts
@@ -33,7 +33,7 @@ describe("Editor validation", () => {
   test("both 'allRequired' and 'exclusiveOr' cannot be toggled on together", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         allRequired: true,
         options: [
           {
@@ -50,7 +50,7 @@ describe("Editor validation", () => {
   test("only one exclusive option is permitted", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         allRequired: false,
         options: [
           {
@@ -71,7 +71,7 @@ describe("Editor validation", () => {
   test("options must set data values if the component does", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         fn: "topLevelFn",
         allRequired: false,
         options: [
@@ -91,7 +91,7 @@ describe("Editor validation", () => {
   test("fn is required for alwaysAutoAnswerBlank", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         alwaysAutoAnswerBlank: true,
         fn: null,
         options: [
@@ -113,7 +113,7 @@ describe("Editor validation", () => {
   test("alwaysAutoAnswerBlank allows only one blank value", async () => {
     await expect(() =>
       validationSchema.validate({
-        title: "Test",
+        text: "Test",
         alwaysAutoAnswerBlank: true,
         fn: "test",
         options: [
@@ -138,6 +138,7 @@ describe("Editor validation", () => {
 
   test("checklists - data fields can be set for each option", async () => {
     const result = validationSchema.validate({
+      text: "Test",
       allRequired: false,
       neverAutoAnswer: false,
       alwaysAutoAnswerBlank: false,
@@ -167,7 +168,6 @@ describe("Editor validation", () => {
           ],
         },
       ],
-      text: "Test",
     });
 
     expect(result).toBeDefined();
@@ -175,7 +175,7 @@ describe("Editor validation", () => {
 
   test("grouped checklists - data fields can be set for each option", async () => {
     const result = validationSchema.validate({
-      title: "Test",
+      text: "Test",
       alwaysAutoAnswerBlank: false,
       fn: "test",
       options: [
@@ -197,7 +197,7 @@ describe("Editor validation", () => {
     test("groups must have unique titles", async () => {
       await expect(() =>
         validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Repeated group name",
@@ -225,7 +225,7 @@ describe("Editor validation", () => {
     test("groups must have unique titles - whitespace is stripped before checks", async () => {
       await expect(() =>
         validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Whitespace   ",
@@ -254,7 +254,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -272,7 +272,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option (inc. whitespace)", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -290,7 +290,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -315,7 +315,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups (inc. whitespace)", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -339,7 +339,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -375,7 +375,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups (inc. whitespace)", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -414,7 +414,7 @@ describe("Editor validation", () => {
       test("checklists - unique labels must be used for each option", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             options: [
               {
                 id: "a",
@@ -431,7 +431,7 @@ describe("Editor validation", () => {
 
       test("checklists - repeated data values are allowed", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           options: [
             {
               id: "a",
@@ -450,7 +450,7 @@ describe("Editor validation", () => {
       test("grouped checklists - labels must be unique within groups", async () => {
         await expect(() =>
           validationSchema.validate({
-            title: "Test",
+            text: "Test",
             groupedOptions: [
               {
                 title: "Section 1",
@@ -474,7 +474,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - data values can be repeated within groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",
@@ -497,7 +497,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - labels can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Common property types",
@@ -536,7 +536,7 @@ describe("Editor validation", () => {
 
       test("grouped checklists - data values can be repeated across groups", async () => {
         const result = validationSchema.validate({
-          title: "Test",
+          text: "Test",
           groupedOptions: [
             {
               title: "Section 1",

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -16,6 +16,7 @@ import type { EnhancedTextInput } from "../types";
 import type { FormValues } from "./types";
 
 const HEADING_ID = "confirm-project-description-heading";
+const NOT_CHECKED_HINT_ID = "confirm-project-description-not-checked-hint";
 
 const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
   const { values, errors, setFieldValue } = useFormikContext<FormValues>();
@@ -25,14 +26,27 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
   };
 
   const showError = Boolean(errors.userInput);
+  const isWritingNew = values.selectedOption === "new";
 
   return (
     <Box sx={{ mb: 2 }}>
       <Typography variant="h2" component="h1" id={HEADING_ID} sx={{ mb: 1 }}>
-        Confirm your project description
+        {isWritingNew
+          ? "Enter your new description"
+          : "Confirm your project description"}
       </Typography>
-      <Typography variant="subtitle1" component="p" sx={{ mb: 2 }}>
-        Edit the description below, or continue to submit it as shown.
+      {!isWritingNew && (
+        <Typography variant="subtitle1" component="p" sx={{ mb: 1 }}>
+          Edit the description below, or continue to submit it as shown.
+        </Typography>
+      )}
+      <Typography
+        variant="subtitle1"
+        component="p"
+        id={NOT_CHECKED_HINT_ID}
+        sx={{ mb: 2 }}
+      >
+        This will not be checked for suggested improvements.
       </Typography>
       <InputRow>
         <Box sx={{ width: "100%" }}>
@@ -50,6 +64,7 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
               "aria-labelledby": HEADING_ID,
               "aria-describedby": [
                 props.description ? DESCRIPTION_TEXT : "",
+                NOT_CHECKED_HINT_ID,
                 "character-hint",
                 showError ? `${ERROR_MESSAGE}-${props.id}` : "",
               ]

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescription.test.tsx
@@ -171,23 +171,25 @@ describe("Passport generation", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // Select "Write a new description" and type a custom value
+    // Select "Write a new description" and advance to modification step
     await user.click(
       screen.getByRole("radio", { name: /Write a new description/i }),
     );
-    const customInput = screen.getByRole("textbox", {
-      name: /Enter your project description/i,
-    });
-    await user.type(customInput, "my custom description");
-
-    // Continuing submits directly without a modification step
     await user.click(screen.getByTestId("continue-button"));
+
+    // Modification step: field starts blank, ready for a new description
     expect(
-      screen.queryByRole("heading", {
-        name: /Confirm your project description/i,
+      screen.getByRole("heading", {
+        name: /Enter your new description/i,
         level: 1,
       }),
-    ).not.toBeInTheDocument();
+    ).toBeVisible();
+    const textarea = screen.getByRole("textbox", {
+      name: /Enter your new description/i,
+    });
+    expect(textarea).toHaveValue("");
+    await user.type(textarea, "my custom description");
+    await user.click(screen.getByTestId("continue-button"));
 
     // Breadcrumb formatted as expected
     expect(handleSubmit).toHaveBeenCalledWith(
@@ -238,7 +240,7 @@ describe("Passport generation", () => {
 
     // Modification step: clear pre-filled text and enter a custom description
     const textarea = screen.getByRole("textbox", {
-      name: /Project description/i,
+      name: /Confirm your project description/i,
     });
     expect(textarea).toHaveValue(ENHANCED);
     await user.clear(textarea);
@@ -577,11 +579,13 @@ describe("basic layout and behaviour", () => {
       }),
     ).toBeVisible();
     expect(
-      screen.getByRole("textbox", { name: /Project description/i }),
+      screen.getByRole("textbox", {
+        name: /Confirm your project description/i,
+      }),
     ).toHaveValue(ORIGINAL);
   });
 
-  it("selecting 'Write a new description' reveals a text input", async () => {
+  it("selecting 'Write a new description' advances to a blank modification step", async () => {
     const { user } = await setup(
       <EnhancedTextInputComponent
         id="testId"
@@ -600,22 +604,28 @@ describe("basic layout and behaviour", () => {
       await screen.findByText(taskDefaults.projectDescription.revisionTitle),
     ).toBeVisible();
 
-    // No text input visible before selecting the option
-    expect(
-      screen.queryByRole("textbox", {
-        name: /Enter your project description/i,
-      }),
-    ).not.toBeInTheDocument();
-
-    // Selecting the option reveals the text input
+    // Selecting the option and continuing takes the user to the modification step
+    // consistent with the other two options, with the field left blank
     await user.click(
       screen.getByRole("radio", { name: /Write a new description/i }),
     );
+    await user.click(screen.getByTestId("continue-button"));
     expect(
-      screen.getByRole("textbox", {
-        name: /Enter your project description/i,
+      screen.getByRole("heading", {
+        name: /Enter your new description/i,
+        level: 1,
       }),
     ).toBeVisible();
+    expect(
+      screen.getByRole("textbox", {
+        name: /Enter your new description/i,
+      }),
+    ).toHaveValue("");
+
+    // The "edit below, or continue" copy doesn't make sense against a blank field
+    expect(
+      screen.queryByText(/Edit the description below/i),
+    ).not.toBeInTheDocument();
   });
 
   it("displays additional information to the user on the 'task' step", async () => {
@@ -720,6 +730,9 @@ describe("basic layout and behaviour", () => {
     expect(
       screen.getByRole("radio", { name: /Use suggested description/i }),
     ).toBeInTheDocument();
+
+    // Returning to the selection step should not re-trigger the API as the input hasn't changed
+    expect(requestSpy).toHaveBeenCalledTimes(1);
   });
 
   test("users can navigate 'back' to the input step", async () => {
@@ -796,8 +809,7 @@ describe("basic layout and behaviour", () => {
     );
   });
 
-  // Revisit this with new UI which doesn't contain a textinput natively on the second step
-  test.skip("navigating 'back' does not re-trigger the API when the input does not change", async () => {
+  test("navigating 'back' does not re-trigger the API when the input does not change", async () => {
     const { user } = await setup(
       <EnhancedTextInputComponent
         id="testId"

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ProjectDescriptions.error.test.tsx
@@ -65,7 +65,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /This doesn't look like a planning project description/,
       }),
     ).toBeVisible();
@@ -97,7 +97,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /Service unavailable/,
       }),
     ).toBeVisible();
@@ -129,7 +129,7 @@ describe("error handling", () => {
     // Error status displayed to user
     expect(
       await screen.findByRole("heading", {
-        level: 2,
+        level: 1,
         name: /Rate limit exceeded/,
       }),
     ).toBeVisible();

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ErrorCard.tsx
@@ -1,6 +1,6 @@
 import Typography from "@mui/material/Typography";
 import { ErrorSummaryContainer } from "@planx/components/shared/Preview/ErrorSummaryContainer";
-import React, { type PropsWithChildren } from "react";
+import React, { type PropsWithChildren, useEffect, useRef } from "react";
 
 interface Props {
   title: string;
@@ -11,26 +11,42 @@ const ErrorCard: React.FC<PropsWithChildren<Props>> = ({
   title,
   description,
   children,
-}) => (
-  <ErrorSummaryContainer role="status">
-    <Typography variant="h3" component="h2" sx={{ mb: 2 }}>
-      {title}
-    </Typography>
-    {Array.isArray(description) ? (
-      description.map((paragraph, index) => (
-        <Typography
-          key={index}
-          variant="body1"
-          gutterBottom={index < description.length - 1}
-        >
-          {paragraph}
-        </Typography>
-      ))
-    ) : (
-      <Typography variant="body1">{description}</Typography>
-    )}
-    {children}
-  </ErrorSummaryContainer>
-);
+}) => {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  // This replaces the previous step's heading, so move focus here to give
+  // screen reader users a clear change of context to the new content
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <ErrorSummaryContainer role="status">
+      <Typography
+        ref={headingRef}
+        tabIndex={-1}
+        variant="h3"
+        component="h1"
+        sx={{ mb: 2 }}
+      >
+        {title}
+      </Typography>
+      {Array.isArray(description) ? (
+        description.map((paragraph, index) => (
+          <Typography
+            key={index}
+            variant="body1"
+            gutterBottom={index < description.length - 1}
+          >
+            {paragraph}
+          </Typography>
+        ))
+      ) : (
+        <Typography variant="body1">{description}</Typography>
+      )}
+      {children}
+    </ErrorSummaryContainer>
+  );
+};
 
 export default ErrorCard;

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -6,7 +6,6 @@ import Typography from "@mui/material/Typography";
 import { HelpButton } from "@planx/components/shared/Preview/CardHeader/styled";
 import MoreInfo from "@planx/components/shared/Preview/MoreInfo";
 import MoreInfoSection from "@planx/components/shared/Preview/MoreInfoSection";
-import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
 import { useQuery } from "@tanstack/react-query";
 import { useFormikContext } from "formik";
 import { enhanceProjectDescription } from "lib/api/ai/requests";
@@ -15,11 +14,7 @@ import type { APIError } from "lib/api/client";
 import { useStore } from "pages/FlowEditor/lib/store";
 import React, { type ComponentProps, useEffect, useRef, useState } from "react";
 import { ApplicationPath } from "types";
-import InputLabel from "ui/public/InputLabel";
-import { CharacterCounter } from "ui/shared/CharacterCounter";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
-import Input from "ui/shared/Input/Input";
-import InputRow from "ui/shared/InputRow";
 import ProgressiveLoading from "ui/shared/ProgressiveLoading";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
@@ -32,7 +27,6 @@ import {
   QuoteDescription,
   QuotedText,
   RecommendedTag,
-  RevealedContent,
   StyledFormLabel,
 } from "./styles";
 
@@ -111,16 +105,7 @@ const ProjectDescription: React.FC<Props> = (props) => {
     useFormikContext<FormValues>();
   const [open, setOpen] = useState(false);
 
-  const initialValueRef = useRef(
-    (() => {
-      if (values.status !== "success") return values.userInput;
-      // If userInput matches a previously-processed value, use the cached original
-      const isPreviouslyProcessed =
-        values.userInput === values.original ||
-        values.userInput === values.enhanced;
-      return isPreviouslyProcessed ? values.original : values.userInput;
-    })(),
-  );
+  const initialValueRef = useRef(props.queryInput);
 
   const { isPending, data, error, isSuccess } = useQuery<
     EnhanceResponse,
@@ -154,7 +139,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
         enhanced: data.enhanced,
         error: null,
         selectedOption: null,
-        customDescription: "",
       });
     }
   }, [isSuccess, data, setValues]);
@@ -168,7 +152,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
         error: error.data.error,
         userInput: initialValueRef.current,
         selectedOption: null,
-        customDescription: "",
       });
     }
   }, [error, setValues]);
@@ -186,17 +169,10 @@ const ProjectDescription: React.FC<Props> = (props) => {
           setFieldValue("userInput", data.original);
           break;
         case "new":
-          setFieldValue("userInput", values.customDescription);
+          setFieldValue("userInput", "");
           break;
       }
     }
-  };
-
-  const handleCustomDescriptionChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setFieldValue("customDescription", event.target.value);
-    setFieldValue("userInput", event.target.value);
   };
 
   const showRadioError = !values.selectedOption && Boolean(errors.userInput);
@@ -307,33 +283,6 @@ const ProjectDescription: React.FC<Props> = (props) => {
               />
             </RadioGroup>
           </ErrorWrapper>
-
-          {values.selectedOption === "new" && (
-            <RevealedContent>
-              <InputRow>
-                <InputLabel
-                  label="Enter your project description. This will not be checked for suggested improvements."
-                  htmlFor={props.id}
-                >
-                  <Input
-                    type="text"
-                    multiline
-                    rows={5}
-                    name="customDescription"
-                    value={values.customDescription}
-                    bordered
-                    onChange={handleCustomDescriptionChange}
-                    id={props.id}
-                  />
-                  <CharacterCounter
-                    limit={TEXT_LIMITS[TextInputType.Long]}
-                    count={values.customDescription.length}
-                    error={false}
-                  />
-                </InputLabel>
-              </InputRow>
-            </RevealedContent>
-          )}
         </Box>
       )}
 

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/styles.ts
@@ -44,13 +44,6 @@ export const QuoteDescription = styled(Typography)(({ theme }) => ({
   position: "relative",
 })) as typeof Typography;
 
-export const RevealedContent = styled(Box)(({ theme }) => ({
-  borderLeft: `4px solid ${theme.palette.border.main}`,
-  paddingLeft: theme.spacing(3.45),
-  marginLeft: theme.spacing(3.2),
-  paddingTop: theme.spacing(1),
-}));
-
 export const QuotedText = styled(Typography)(({ theme }) => ({
   marginTop: theme.spacing(2),
   paddingLeft: theme.spacing(1.5),

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/index.tsx
@@ -9,7 +9,7 @@ import type { TaskComponentMap } from "../types";
 import InitialUserInput from "./InitialUserInput";
 import ModifyUserInput from "./ModifyUserInput";
 import ProjectDescription from "./Tasks/ProjectDescription";
-import type { FormValues, Props } from "./types";
+import type { FormValues, Props, Step } from "./types";
 import { getValidationSchema, makeBreadcrumb } from "./utils";
 
 const taskComponents: TaskComponentMap = {
@@ -18,9 +18,8 @@ const taskComponents: TaskComponentMap = {
 
 const EnhancedTextInputComponent = (props: Props) => {
   const previous = getPreviouslySubmittedData(props);
-  const [step, setStep] = useState<"input" | "selection" | "modification">(
-    "input",
-  );
+  const [step, setStep] = useState<Step>("input");
+  const [queryInput, setQueryInput] = useState("");
   const isRunningTask = useIsFetching({ queryKey: [props.task] });
 
   const initialValues: FormValues = previous
@@ -33,7 +32,6 @@ const EnhancedTextInputComponent = (props: Props) => {
           props.previouslySubmittedData?.data?._enhancements[props.fn].enhanced,
         error: null,
         selectedOption: null,
-        customDescription: "",
       }
     : {
         userInput: "",
@@ -41,7 +39,6 @@ const EnhancedTextInputComponent = (props: Props) => {
         enhanced: null,
         error: null,
         selectedOption: null,
-        customDescription: "",
       };
 
   const nextStep = (values: FormValues) => {
@@ -51,12 +48,12 @@ const EnhancedTextInputComponent = (props: Props) => {
       return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
     }
 
-    if (step === "input") return setStep("selection");
-
-    if (step === "selection") {
-      if (values.selectedOption !== "new") return setStep("modification");
-      return props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
+    if (step === "input") {
+      setQueryInput(values.userInput);
+      return setStep("selection");
     }
+
+    if (step === "selection") return setStep("modification");
 
     if (step === "modification") {
       props.handleSubmit?.({ data: makeBreadcrumb(props.fn, values) });
@@ -66,7 +63,7 @@ const EnhancedTextInputComponent = (props: Props) => {
   const TaskComponent = taskComponents[props.task];
   if (!TaskComponent) return null;
 
-  const validationSchema = getValidationSchema(props);
+  const validationSchema = getValidationSchema(props, step);
 
   return (
     <Formik<FormValues>
@@ -80,7 +77,7 @@ const EnhancedTextInputComponent = (props: Props) => {
       {({ submitForm, values, setFieldValue }) => {
         const showCardHeader =
           step === "input" ||
-          values.status !== "success" ||
+          values.status === "idle" ||
           Boolean(isRunningTask);
 
         const handleBack = (() => {
@@ -88,9 +85,7 @@ const EnhancedTextInputComponent = (props: Props) => {
           // Repopulate field with user's original input
           if (step === "selection" && !isRunningTask)
             return () => {
-              if (values.status === "success") {
-                setFieldValue("userInput", values.original);
-              }
+              setFieldValue("userInput", queryInput);
               setStep("input");
             };
           return undefined;
@@ -115,7 +110,9 @@ const EnhancedTextInputComponent = (props: Props) => {
             )}
             {step === "input" && <InitialUserInput {...props} />}
             {step === "modification" && <ModifyUserInput {...props} />}
-            {step === "selection" && <TaskComponent {...props} />}
+            {step === "selection" && (
+              <TaskComponent {...props} queryInput={queryInput} />
+            )}
           </Card>
         );
       }}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/types.tsx
@@ -4,10 +4,11 @@ import type { EnhancedTextInput, TaskAction } from "../types";
 
 export type Props = PublicProps<EnhancedTextInput>;
 
+export type Step = "input" | "selection" | "modification";
+
 interface FormValuesBase {
   userInput: string;
   selectedOption: TaskAction | null;
-  customDescription: string;
 }
 
 interface FormValuesIdle extends FormValuesBase {

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/utils.ts
@@ -6,7 +6,7 @@ import { object, string } from "yup";
 
 import type { BreadcrumbData, TaskActionDescription } from "../types";
 import { TaskActionMap } from "./../types";
-import type { FormValues, Props } from "./types";
+import type { FormValues, Props, Step } from "./types";
 
 export const getAction = (values: FormValues): TaskActionDescription => {
   if (values.status === "idle")
@@ -48,12 +48,17 @@ export const makeBreadcrumb = (
   } as BreadcrumbData;
 };
 
-export const getValidationSchema = (props: Props) =>
+export const getValidationSchema = (props: Props, step: Step) =>
   object({
     status: string().oneOf(["idle", "success", "error"]).required(),
     userInput: textInputValidationSchema({
       data: { ...props, type: TextInputType.Long },
       required: true,
+    }).when("selectedOption", {
+      // initial input is not required if we are coming from the 'enter a new description' option
+      is: (selectedOption: string | null) =>
+        step === "selection" && selectedOption === "new",
+      then: (schema) => schema.notRequired(),
     }),
     original: string().when("status", {
       is: (status: string) => status === "success" || status === "error",

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/types.ts
@@ -102,6 +102,6 @@ export type TaskDefaults = { [K in Task]: TaskRegistry[K]["editorProps"] };
  */
 export type TaskComponentMap = {
   [K in Task]: React.ComponentType<
-    PublicProps<EnhancedTextInputForTask<K>>
+    PublicProps<EnhancedTextInputForTask<K>> & { queryInput: string }
   > | null;
 };

--- a/apps/editor.planx.uk/src/@planx/components/Option/model.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Option/model.tsx
@@ -19,6 +19,7 @@ export interface Option {
     text: string;
     val?: string;
     exclusive?: true;
+    notes?: string;
   };
 }
 
@@ -43,6 +44,7 @@ export const optionValidationSchema = object({
     text: string().required().trim(),
     val: string(),
     exclusive: mixed().oneOf([true, undefined]),
+    notes: string(),
     // TODO: Validate rules?
   }),
 });

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Public/Modal.tsx
@@ -1,3 +1,4 @@
+import Close from "@mui/icons-material/CloseOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -6,6 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import type { Constraint, Metadata } from "@opensystemslab/planx-core/types";
 import omit from "lodash/omit";
@@ -61,7 +63,7 @@ export const OverrideEntitiesModal = ({
   } are inaccurate?`;
 
   const closeModal = (_event: any, reason?: string) => {
-    if (reason && reason == "backdropClick") {
+    if (reason && reason === "backdropClick") {
       return;
     }
 
@@ -139,9 +141,31 @@ export const OverrideEntitiesModal = ({
       maxWidth="xl"
       aria-labelledby="dialog-heading"
     >
-      <DialogTitle variant="h3" component="h1" id="dialog-heading">
-        I don't think this constraint applies to this property
-      </DialogTitle>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: 2,
+        }}
+      >
+        <DialogTitle
+          variant="h3"
+          component="h2"
+          id="dialog-heading"
+          sx={{ flex: 1 }}
+        >
+          I don't think this constraint applies to this property
+        </DialogTitle>
+        <IconButton
+          aria-label="Close"
+          onClick={closeModal}
+          data-testid="override-modal-close-button"
+          sx={{ color: "grey.600", marginTop: 1, marginRight: 2 }}
+        >
+          <Close />
+        </IconButton>
+      </Box>
       <DialogContent dividers>
         <Box component="form">
           <Typography variant="body2" gutterBottom>

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.test.tsx
@@ -27,6 +27,27 @@ it("displays the options editor when the 'Add option' button is clicked", async 
   expect(optionsEditor).toBeInTheDocument();
 });
 
+it("displays an error if an editor tries to create a pseudo-note", async () => {
+  const { user } = await setup(
+    <DndProvider backend={HTML5Backend}>
+      <Question node={{}} options={[]} />
+    </DndProvider>,
+  );
+
+  await user.click(screen.getByPlaceholderText("Text"));
+  await user.paste("Note");
+
+  fireEvent.submit(screen.getByTestId("question-component-form"));
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(
+        /Questions can no longer be used as notes and must have at least one option/,
+      ),
+    ).toBeInTheDocument(),
+  );
+});
+
 describe("data field", () => {
   it("clears option val fields when the question data field is cleared", async () => {
     const { user } = await setup(

--- a/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Question/Editor.tsx
@@ -36,10 +36,14 @@ export const QuestionComponent: React.FC<Props> = (props) => {
       },
       validate: ({ options, ...values }) => {
         const errors: FormikErrors<FormikValues> = {};
-        // if (values.text && !options.length) {
-        //   errors.text =
-        //     "Questions can no longer be used as notes and must have at least one option";
-        // }
+        if (!options.length) {
+          if (values.text) {
+            errors.text =
+              "Questions can no longer be used as notes and must have at least one option";
+          } else {
+            errors.options = "Add at least one option";
+          }
+        }
         if (values.fn && !options.some((option) => option.data.val)) {
           errors.fn = "At least one option must also set a data field";
         }

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.test.tsx
@@ -144,6 +144,10 @@ describe("Responsive Checklist editor component", () => {
       </DndProvider>,
     );
 
+    // Set title (required)
+    await user.click(screen.getByPlaceholderText("Text"));
+    await user.paste("Test");
+
     const autocompleteComponent = screen.getByTestId("checklist-data-field");
     const autocompleteInput = within(autocompleteComponent).getByRole(
       "combobox",

--- a/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ResponsiveChecklist/Editor.tsx
@@ -1,8 +1,6 @@
 import type { ComponentType as TYPES } from "@opensystemslab/planx-core/types";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
-import type { FormikErrors, FormikValues } from "formik";
-import React from "react";
 
 import type { ConditionalOption } from "../Option/model";
 import { BaseChecklistComponent } from "../shared/BaseChecklist/Editor";
@@ -52,13 +50,6 @@ function ResponsiveChecklistComponent(props: Props) {
               2,
             ),
           );
-        }
-      },
-      validate: ({ options, ...values }) => {
-        const errors: FormikErrors<FormikValues> = {};
-        if (values.text && (!options || !options.length)) {
-          errors.text =
-            "Checklists can no longer be used as notes and must have at least one option";
         }
       },
       validationSchema,

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/model.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/model.ts
@@ -233,6 +233,30 @@ const uniqueLabelsTest: TestConfig<AnyChecklist> = {
   },
 };
 
+const atLeastOneOption: TestConfig<AnyChecklist> = {
+  name: "atLeastOneOption",
+  test: function ({ text, options, groupedOptions }) {
+    if (
+      (options && options.length > 0) ||
+      (groupedOptions && groupedOptions.length > 0)
+    )
+      return true;
+
+    if (text) {
+      return this.createError({
+        path: "text",
+        message:
+          "Checklists can no longer be used as notes and must have at least one option",
+      });
+    } else {
+      return this.createError({
+        path: "options",
+        message: "Add at least one option",
+      });
+    }
+  },
+};
+
 const uniqueLabelsWithinGroupsTest: TestConfig<AnyChecklist> = {
   name: "uniqueLabelsWithinGroups",
   test: function ({ groupedOptions }) {
@@ -281,9 +305,9 @@ const uniqueGroupTitlesTest: TestConfig<AnyChecklist> = {
 export const baseChecklistValidationSchema =
   baseNodeDataValidationSchema.concat(
     object({
+      text: string().required(),
       description: richText(),
       fn: string().nullable(),
-      text: string(),
       img: string(),
       categories: array(
         object({
@@ -298,5 +322,6 @@ export const baseChecklistValidationSchema =
       .test(atLeastOneDataFieldTest as TestConfig<unknown>)
       .test(uniqueLabelsTest as TestConfig<unknown>)
       .test(uniqueLabelsWithinGroupsTest as TestConfig<unknown>)
-      .test(uniqueGroupTitlesTest as TestConfig<unknown>),
+      .test(uniqueGroupTitlesTest as TestConfig<unknown>)
+      .test(atLeastOneOption as TestConfig<unknown>),
   );

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
@@ -105,6 +105,17 @@ export const BaseOptionsEditor: React.FC<Props> = (props) => {
           disabled={props.disabled}
           onChange={(ev) => updateSharedField("flags", ev)}
         />
+        {
+          <InputRow>
+            <Input
+              value={props.value.data.notes || ""}
+              placeholder="Note"
+              multiline
+              disabled={props.disabled}
+              onChange={(ev) => updateSharedField("notes", ev.target.value)}
+            />
+          </InputRow>
+        }
         {showRuleBuilder && (
           <RuleBuilder
             labels={{

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/MoreInfo.tsx
@@ -1,31 +1,26 @@
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import MoreInfoFeedbackComponent from "components/Feedback/MoreInfoFeedback/MoreInfoFeedback";
 import React from "react";
+import { CloseButton } from "ui/shared/CloseButton";
 
 const DrawerContent = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2.5, 4, 2, 0),
   fontSize: "1rem",
   lineHeight: "1.5",
   [theme.breakpoints.up("sm")]: {
-    padding: theme.spacing(6, 4, 4, 1),
+    padding: theme.spacing(3, 4, 3, 1),
   },
 }));
 
-const CloseButton = styled(Box)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "flex-end",
+const CloseButtonWrapper = styled(Box)(({ theme }) => ({
   position: "fixed",
   top: theme.spacing(1),
   right: theme.spacing(1),
-  color: theme.palette.text.primary,
   zIndex: theme.zIndex.drawer + 1,
 }));
 
@@ -41,18 +36,13 @@ const MoreInfo: React.FC<IMoreInfo> = ({ open, children, handleClose }) => (
     open={open}
     onClose={() => handleClose()}
   >
-    <CloseButton>
-      <IconButton
+    <CloseButtonWrapper>
+      <CloseButton
         onClick={() => handleClose()}
-        role="button"
         title="Close panel"
-        aria-label="Close panel"
-        size="large"
         color="inherit"
-      >
-        <CloseIcon />
-      </IconButton>
-    </CloseButton>
+      />
+    </CloseButtonWrapper>
     <Container maxWidth={false} sx={{ bgcolor: "white" }}>
       <Typography variant="h1" sx={visuallyHidden}>
         More information

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/EnvironmentSelect.tsx
@@ -1,12 +1,10 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CloseIcon from "@mui/icons-material/Close";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardActionArea from "@mui/material/CardActionArea";
 import Dialog, { dialogClasses } from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -14,6 +12,7 @@ import ButtonBase from "@planx/components/shared/Buttons/ButtonBase";
 import React, { useState } from "react";
 import { useLocation } from "react-use";
 import { FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { CloseButton } from "ui/shared/CloseButton";
 
 export interface Environment {
   name: string;
@@ -53,14 +52,18 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
   },
 }));
 
-const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
-  border: "none",
+const DialogHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
   padding: theme.spacing(1),
   backgroundColor: theme.palette.background.dark,
   color: theme.palette.common.white,
+}));
+
+const StyledDialogTitle = styled(DialogTitle)(() => ({
+  border: "none",
+  padding: 0,
 }));
 
 const StyledCard = styled(Card)<{ selected?: boolean }>(() => ({
@@ -150,8 +153,8 @@ export const EnvironmentSelect: React.FC = () => {
           },
         }}
       >
-        <StyledDialogTitle>
-          <Box>
+        <DialogHeader>
+          <StyledDialogTitle>
             <Typography
               variant="subtitle1"
               component="span"
@@ -162,15 +165,14 @@ export const EnvironmentSelect: React.FC = () => {
             <Typography variant="body2" component="span">
               environments
             </Typography>
-          </Box>
-          <IconButton
-            aria-label="close"
+          </StyledDialogTitle>
+          <CloseButton
+            size="small"
             onClick={handleClose}
-            sx={{ color: "#ffffff", padding: 0 }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </StyledDialogTitle>
+            title="Close panel"
+            sx={{ padding: 0 }}
+          />
+        </DialogHeader>
         <Stack
           sx={{
             p: 1,

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/FeatureFlagsPanel.tsx
@@ -1,8 +1,6 @@
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Fade from "@mui/material/Fade";
-import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import Typography from "@mui/material/Typography";
 import {
@@ -14,6 +12,7 @@ import {
 import { useMemo, useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import SettingsDescription from "ui/editor/SettingsDescription";
+import { CloseButton } from "ui/shared/CloseButton";
 import { Switch } from "ui/shared/Switch";
 
 interface Props {
@@ -94,9 +93,7 @@ const FeatureFlagsPanel = ({ anchorEl, onClose }: Props) => {
         }}
       >
         <Typography variant="h4">Feature flags</Typography>
-        <IconButton aria-label="close" onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
+        <CloseButton size="small" onClick={onClose} sx={{ marginRight: -1 }} />
       </Box>
       <Box sx={{ px: 1.5, py: 1, flex: 1 }}>
         <SettingsDescription>

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/NotificationsPanel.tsx
@@ -1,11 +1,9 @@
-import CloseIcon from "@mui/icons-material/Close";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Fade from "@mui/material/Fade";
-import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
@@ -18,6 +16,7 @@ import { partitionBySuperseded } from "pages/FlowEditor/components/Notifications
 import { useState } from "react";
 import { EmptyState } from "ui/editor/EmptyState";
 import StyledTab from "ui/editor/StyledTab";
+import { CloseButton } from "ui/shared/CloseButton";
 
 interface Props {
   anchorEl: HTMLElement | null;
@@ -106,9 +105,7 @@ const NotificationsPanel = ({
         }}
       >
         <Typography variant="h4">Notifications</Typography>
-        <IconButton aria-label="close" onClick={onClose}>
-          <CloseIcon />
-        </IconButton>
+        <CloseButton size="small" onClick={onClose} sx={{ marginRight: -1 }} />
       </Box>
       <TabList>
         <Tabs

--- a/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
+++ b/apps/editor.planx.uk/src/components/EditorNavMenu/components/TeamSelect.tsx
@@ -1,11 +1,9 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CloseIcon from "@mui/icons-material/Close";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -15,6 +13,7 @@ import { useStore } from "pages/FlowEditor/lib/store";
 import type { TeamSummary } from "pages/FlowEditor/lib/store/team";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { cardBoxShadow, focusStyle, FONT_WEIGHT_SEMI_BOLD } from "theme";
+import { CloseButton } from "ui/shared/CloseButton";
 import { SearchBox } from "ui/shared/SearchBox/SearchBox";
 
 const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
@@ -33,8 +32,7 @@ const StyledButtonBase = styled(ButtonBase)<{ teamcolor?: string }>(
   }),
 );
 
-const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
-  border: "none",
+const DialogHeader = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
@@ -43,6 +41,11 @@ const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
   top: 0,
   backgroundColor: theme.palette.background.paper,
   zIndex: 1,
+}));
+
+const StyledDialogTitle = styled(DialogTitle)(() => ({
+  border: "none",
+  padding: 0,
 }));
 
 const StyledCard = styled(Card)<{ selected?: boolean; teamcolor?: string }>(
@@ -193,16 +196,15 @@ export const TeamSelect: React.FC<Props> = ({
           },
         }}
       >
-        <StyledDialogTitle>
-          <Box>
-            <Typography variant="h4" component="span">
-              Select a team
-            </Typography>
-          </Box>
-          <IconButton aria-label="close" onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </StyledDialogTitle>
+        <DialogHeader>
+          <StyledDialogTitle variant="h4">Select a team</StyledDialogTitle>
+          <CloseButton
+            onClick={handleClose}
+            size="small"
+            title="Close panel"
+            sx={{ marginRight: -0.5, marginTop: -0.5 }}
+          />
+        </DialogHeader>
         <Box sx={{ p: 1, pb: 1.5, pt: 0 }}>
           <SearchBox
             records={teams}

--- a/apps/editor.planx.uk/src/components/Feedback/index.tsx
+++ b/apps/editor.planx.uk/src/components/Feedback/index.tsx
@@ -1,5 +1,4 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import CloseIcon from "@mui/icons-material/Close";
 import LightbulbIcon from "@mui/icons-material/Lightbulb";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import RuleIcon from "@mui/icons-material/Rule";
@@ -7,7 +6,6 @@ import WarningIcon from "@mui/icons-material/Warning";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Drawer from "@mui/material/Drawer";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import {
   getInternalFeedbackMetadata,
@@ -16,8 +14,8 @@ import {
 import { BackButton } from "pages/Preview/Questions";
 import React, { useState } from "react";
 import { usePrevious } from "react-use";
-import { CloseButton } from "ui/icons/CloseButton";
 import FeedbackOption from "ui/public/FeedbackOption";
+import { CloseButton } from "ui/shared/CloseButton";
 
 import FeedbackForm from "./FeedbackForm/FeedbackForm";
 import FeedbackPhaseBanner from "./FeedbackPhaseBanner";
@@ -89,21 +87,17 @@ const Feedback: React.FC = () => {
   function BackAndCloseFeedbackHeader(): FCReturn {
     return (
       <FeedbackHeader>
-        <BackButton onClick={() => handleFeedbackViewClick("back")}>
+        <BackButton
+          onClick={() => handleFeedbackViewClick("back")}
+          variant="link"
+        >
           <ArrowBackIcon fontSize="small" />
           Back
         </BackButton>
-        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
-          <IconButton
-            role="button"
-            title="Close panel"
-            aria-label="Close panel"
-            size="large"
-            color="inherit"
-          >
-            <CloseIcon />
-          </IconButton>
-        </CloseButton>
+        <CloseButton
+          title="Close panel"
+          onClick={() => handleFeedbackViewClick("close")}
+        />
       </FeedbackHeader>
     );
   }
@@ -117,17 +111,10 @@ const Feedback: React.FC = () => {
             {props.title}
           </Typography>
         </FeedbackTitle>
-        <CloseButton onClick={() => handleFeedbackViewClick("close")}>
-          <IconButton
-            role="button"
-            title="Close panel"
-            aria-label="Close panel"
-            size="large"
-            color="inherit"
-          >
-            <CloseIcon />
-          </IconButton>
-        </CloseButton>
+        <CloseButton
+          title="Close panel"
+          onClick={() => handleFeedbackViewClick("close")}
+        />
       </FeedbackHeader>
     );
   }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/AttachedNote.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/AttachedNote.tsx
@@ -4,7 +4,8 @@ import React from "react";
 
 export const AttachedNote: React.FC<{
   note: string;
-}> = ({ note }) => {
+  variant?: "option";
+}> = ({ note, variant }) => {
   const showNotes = useStore((state) => state.showNotes);
 
   // TODO also return null if templated flow and *not* attached to a templated node?
@@ -14,7 +15,7 @@ export const AttachedNote: React.FC<{
     <Box
       className="card-attached-note"
       sx={() => ({
-        borderWidth: "0 1px 1px 1px",
+        borderWidth: variant === "option" ? "1px 0 0 0" : "0 1px 1px 1px",
         borderStyle: "solid",
         width: "100%",
         p: 0.5,

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
+import { AttachedNote } from "./AttachedNote";
 import { DataField } from "./DataField";
 import { FlagBand, NoFlagBand } from "./FlagBand";
 import Hanger from "./Hanger";
@@ -87,6 +88,9 @@ const Option: React.FC<any> = (props) => {
           <div className="text">{props.data.text}</div>
           {props.data?.val && (
             <DataField value={props.data.val} variant="child" />
+          )}
+          {props.data?.notes && (
+            <AttachedNote note={props.data.notes} variant="option" />
           )}
         </Link>
       </div>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/notes/NoteEditorDialog.tsx
@@ -1,4 +1,3 @@
-import Close from "@mui/icons-material/CloseOutlined";
 import DeleteIcon from "@mui/icons-material/Delete";
 import StickyNote2Icon from "@mui/icons-material/StickyNote2";
 import Box from "@mui/material/Box";
@@ -7,13 +6,13 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { useFormik } from "formik";
 import type { FlowNote, FlowNoteTarget } from "hooks/data/useFlowNotes";
 import { useToast } from "hooks/useToast";
 import { formatLastEditMessage } from "pages/FlowEditor/utils";
 import React from "react";
+import { CloseButton } from "ui/shared/CloseButton";
 import Input from "ui/shared/Input/Input";
 import { object, string } from "yup";
 
@@ -81,7 +80,7 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
 
   return (
     <Dialog open fullWidth onClose={onClose}>
-      <DialogTitle
+      <Box
         sx={{
           py: 1,
           px: 2.5,
@@ -90,21 +89,22 @@ export const NoteEditorDialog: React.FC<NoteEditorDialogProps> = (props) => {
           justifyContent: "space-between",
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <DialogTitle
+          sx={{
+            p: 0,
+            border: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
           <StickyNote2Icon sx={{ color: "text.primary", fontSize: "1.6rem" }} />
-          <Typography variant="h3" component="h1">
+          <Typography variant="h3" component="span">
             Note
           </Typography>
-        </Box>
-        <IconButton
-          aria-label="close"
-          onClick={onClose}
-          size="large"
-          sx={{ color: "grey.600" }}
-        >
-          <Close />
-        </IconButton>
-      </DialogTitle>
+        </DialogTitle>
+        <CloseButton onClick={onClose} title="Close panel" />
+      </Box>
       <Box component="form" onSubmit={formik.handleSubmit}>
         <DialogContent dividers sx={{ px: 4, py: 3 }}>
           <Input

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.tsx
@@ -91,9 +91,6 @@ const EventsLogGrouped: React.FC<EventsLogGroupedProps> = ({
       field: "address",
       headerName: "Address",
       width: 350,
-      columnOptions: {
-        valueFormatter: (value: string | null) => value || "Sanitised",
-      },
     },
     {
       field: "consolidatedStatus",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,5 +1,4 @@
 import { gql, useQuery } from "@apollo/client";
-import Close from "@mui/icons-material/CloseOutlined";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -10,7 +9,7 @@ import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedL
 import { addDays, isBefore } from "date-fns";
 import { DAYS_UNTIL_EXPIRY } from "lib/pay";
 import { useStore } from "pages/FlowEditor/lib/store";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 
 import type { Submission } from "../types";
 import { hasBeenSanitised } from "../utils";
@@ -72,14 +71,7 @@ const SubmissionModalWrapper = ({
         }}
       >
         <DialogTitle variant="h2">Submission details</DialogTitle>
-        <CloseButton
-          aria-label="close"
-          onClick={handleClose}
-          size="large"
-          sx={{ paddingTop: 2.5 }}
-        >
-          <Close />
-        </CloseButton>
+        <CloseButton onClick={handleClose} sx={{ paddingTop: 2.5 }} />
       </Box>
 
       <DialogContent children={children} />

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/FormModal/index.tsx
@@ -1,5 +1,4 @@
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
-import Close from "@mui/icons-material/CloseOutlined";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -19,7 +18,7 @@ import {
 } from "pages/FlowEditor/utils";
 import React, { useMemo, useState } from "react";
 import type { NodeSearchParams } from "routes/_authenticated/app/$team/$flow/_flowEditor/nodes/route";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 import { Switch } from "ui/shared/Switch";
 import { getNodeRoute } from "utils/routeUtils/utils";
 
@@ -268,9 +267,7 @@ const FormModal: React.FC<FormModalProps> = ({
             canChange={!handleDelete}
           />
 
-          <CloseButton aria-label="close" onClick={handleClose} size="large">
-            <Close />
-          </CloseButton>
+          <CloseButton onClick={handleClose} sx={{ marginRight: -1 }} />
         </DialogTitle>
         <DialogContent dividers sx={{ p: 0, position: "relative" }}>
           {!handleDelete && (

--- a/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
+++ b/apps/editor.planx.uk/src/pages/Preview/ContentPage.tsx
@@ -1,11 +1,11 @@
-import Close from "@mui/icons-material/Close";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { notFound, useLocation, useNavigate } from "@tanstack/react-router";
 import { useStore } from "pages/FlowEditor/lib/store";
+import { BackButton } from "pages/Preview/Questions";
 import { FOOTER_ITEMS } from "types";
 import ReactMarkdownOrHtml from "ui/shared/ReactMarkdownOrHtml/ReactMarkdownOrHtml";
 
@@ -15,14 +15,6 @@ const Root = styled(Box)(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  paddingTop: theme.spacing(2),
-  paddingBottom: theme.spacing(10),
-}));
-
-const CloseIconButton = styled(IconButton)(() => ({
-  position: "absolute",
-  right: 20,
-  top: 20,
 }));
 
 function Layout(props: {
@@ -33,15 +25,23 @@ function Layout(props: {
 }) {
   return (
     <Root>
-      <CloseIconButton onClick={props.onClose} size="medium" aria-label="Close">
-        <Close />
-      </CloseIconButton>
-      <Container maxWidth="md">
-        <Typography variant="h1">{props.heading}</Typography>
-        <ReactMarkdownOrHtml
-          source={props.content}
-          openLinksOnNewTab={props.openLinksOnNewTab}
-        />
+      <Container maxWidth="contentWrap" sx={{ position: "relative" }}>
+        <BackButton onClick={props.onClose} variant="link">
+          <ArrowBackIcon fontSize="small" />
+          Back
+        </BackButton>
+        <Container
+          maxWidth="formWrap"
+          sx={{ margin: 0, padding: "0 !important" }}
+        >
+          <Typography variant="h2" component="h1">
+            {props.heading}
+          </Typography>
+          <ReactMarkdownOrHtml
+            source={props.content}
+            openLinksOnNewTab={props.openLinksOnNewTab}
+          />
+        </Container>
       </Container>
     </Root>
   );

--- a/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
+++ b/apps/editor.planx.uk/src/ui/icons/CloseButton.tsx
@@ -1,8 +1,0 @@
-import IconButton from "@mui/material/IconButton";
-import { styled } from "@mui/material/styles";
-
-export const CloseButton = styled(IconButton)(({ theme }) => ({
-  margin: "0 0 0 auto",
-  padding: theme.spacing(1),
-  color: theme.palette.grey[600],
-}));

--- a/apps/editor.planx.uk/src/ui/shared/CloseButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/CloseButton.tsx
@@ -1,0 +1,31 @@
+import CloseIcon from "@mui/icons-material/Close";
+import IconButton, { type IconButtonProps } from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import React from "react";
+
+const StyledIconButton = styled(IconButton)(({ theme, size }) => ({
+  margin: "0 0 0 auto",
+  padding: size === "small" ? theme.spacing(0.75) : theme.spacing(1),
+  color: "inherit",
+}));
+
+export interface CloseButtonProps extends Omit<
+  IconButtonProps,
+  "title" | "aria-label" | "children" | "size"
+> {
+  /** Used as both the button title and the accessible name */
+  title?: string;
+  size?: "small" | "medium";
+}
+
+export const CloseButton: React.FC<CloseButtonProps> = ({
+  title = "Close",
+  size,
+  ...props
+}) => (
+  <StyledIconButton title={title} aria-label={title} size={size} {...props}>
+    <CloseIcon
+      sx={{ opacity: 0.8, fontSize: size === "small" ? "1.5rem" : "1.75rem" }}
+    />
+  </StyledIconButton>
+);

--- a/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/DataTable/components/DataTableModal.tsx
@@ -1,11 +1,10 @@
-import Close from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";
 import React from "react";
-import { CloseButton } from "ui/icons/CloseButton";
+import { CloseButton } from "ui/shared/CloseButton";
 
 interface DataTableModalProps {
   open: boolean;
@@ -37,9 +36,7 @@ export const DataTableModal: React.FC<DataTableModalProps> = ({
     <Dialog open={open} fullWidth onClose={onClose}>
       <ModalHeader>
         <Typography variant="h4">{title}</Typography>
-        <CloseButton aria-label="close" onClick={onClose} size="large">
-          <Close />
-        </CloseButton>
+        <CloseButton onClick={onClose} />
       </ModalHeader>
       <ModalBody>{children}</ModalBody>
     </Dialog>

--- a/apps/hasura.planx.uk/migrations/default/1788270607778_explain_sanitised_address_in_submissions_grouped/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1788270607778_explain_sanitised_address_in_submissions_grouped/down.sql
@@ -1,0 +1,170 @@
+CREATE
+OR REPLACE VIEW "public"."submissions_grouped" AS WITH payments AS (
+  SELECT
+    ps.session_id,
+    'Pay' :: text AS event_type,
+    initcap(ps.status) AS status,
+    ps.created_at
+  FROM
+    (
+      payment_status ps
+      LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status))
+    )
+  WHERE
+    (
+      (ps.status <> 'created' :: text)
+      AND (
+        ps.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+    )
+),
+invitations_to_pay AS (
+  SELECT
+    pr.session_id,
+    'Invite to pay' :: text AS event_type,
+    CASE
+      WHEN (pr.paid_at IS NULL) THEN 'Invited to pay' :: text
+      ELSE 'Paid' :: text
+    END AS status,
+    pr.created_at
+  FROM
+    payment_requests pr
+),
+submissions AS (
+  SELECT
+    (
+      (
+        (
+          (seil.request -> 'payload' :: text) -> 'payload' :: text
+        ) ->> 'sessionId' :: text
+      )
+    ) :: uuid AS session_id,
+    CASE
+      WHEN ((se.webhook_conf) :: text ~~ '%bops%' :: text) THEN 'Submit to BOPS' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%uniform%' :: text) THEN 'Submit to Uniform' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+      ) THEN 'Send to email' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+      ) THEN 'Upload to AWS S3 (no notification)' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+      ) THEN 'Upload to AWS S3' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%idox%' :: text) THEN 'Submit to Idox Nexus' :: text
+      ELSE (se.webhook_conf) :: text
+    END AS event_type,
+    CASE
+      WHEN (seil.status = 200) THEN 'Success' :: text
+      ELSE format('Failed (%s)' :: text, seil.status)
+    END AS status,
+    seil.created_at
+  FROM
+    (
+      hdb_catalog.hdb_scheduled_events se
+      LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id))
+    )
+  WHERE
+    (
+      (
+        seil.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (
+        ((se.webhook_conf) :: text ~~ '%bops%' :: text)
+        OR ((se.webhook_conf) :: text ~~ '%uniform%' :: text)
+        OR (
+          (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+        )
+        OR ((se.webhook_conf) :: text ~~ '%idox%' :: text)
+      )
+    )
+),
+all_events AS (
+  SELECT
+    payments.session_id,
+    payments.event_type,
+    payments.status,
+    payments.created_at
+  FROM
+    payments
+  UNION ALL
+  SELECT
+    invitations_to_pay.session_id,
+    invitations_to_pay.event_type,
+    invitations_to_pay.status,
+    invitations_to_pay.created_at
+  FROM
+    invitations_to_pay
+  UNION ALL
+  SELECT
+    submissions.session_id,
+    submissions.event_type,
+    submissions.status,
+    submissions.created_at
+  FROM
+    submissions
+),
+latest_per_event_type AS (
+  SELECT
+    DISTINCT ON (all_events.session_id, all_events.event_type) all_events.session_id,
+    all_events.event_type,
+    all_events.status,
+    all_events.created_at
+  FROM
+    all_events
+  ORDER BY
+    all_events.session_id,
+    all_events.event_type,
+    all_events.created_at DESC
+),
+representative_event AS (
+  SELECT
+    DISTINCT ON (latest_per_event_type.session_id) latest_per_event_type.session_id,
+    latest_per_event_type.event_type,
+    latest_per_event_type.status,
+    latest_per_event_type.created_at
+  FROM
+    latest_per_event_type
+  ORDER BY
+    latest_per_event_type.session_id,
+    (latest_per_event_type.status ~~ 'Failed%' :: text) DESC,
+    latest_per_event_type.created_at DESC
+)
+SELECT
+  f.id AS flow_id,
+  re.session_id,
+  re.event_type,
+  re.status,
+  re.created_at,
+  f.team_id,
+  f.name AS flow_name,
+  COALESCE(
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'single_line_address' :: text
+    ),
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'title' :: text
+    )
+  ) AS address
+FROM
+  (
+    (
+      representative_event re
+      LEFT JOIN lowcal_sessions ls ON ((ls.id = re.session_id))
+    )
+    LEFT JOIN flows f ON ((f.id = ls.flow_id))
+  )
+WHERE
+  (ls.flow_id IS NOT NULL)
+ORDER BY
+  re.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1788270607778_explain_sanitised_address_in_submissions_grouped/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1788270607778_explain_sanitised_address_in_submissions_grouped/up.sql
@@ -1,0 +1,174 @@
+CREATE
+OR REPLACE VIEW "public"."submissions_grouped" AS WITH payments AS (
+  SELECT
+    ps.session_id,
+    'Pay' :: text AS event_type,
+    initcap(ps.status) AS status,
+    ps.created_at
+  FROM
+    (
+      payment_status ps
+      LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status))
+    )
+  WHERE
+    (
+      (ps.status <> 'created' :: text)
+      AND (
+        ps.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+    )
+),
+invitations_to_pay AS (
+  SELECT
+    pr.session_id,
+    'Invite to pay' :: text AS event_type,
+    CASE
+      WHEN (pr.paid_at IS NULL) THEN 'Invited to pay' :: text
+      ELSE 'Paid' :: text
+    END AS status,
+    pr.created_at
+  FROM
+    payment_requests pr
+),
+submissions AS (
+  SELECT
+    (
+      (
+        (
+          (seil.request -> 'payload' :: text) -> 'payload' :: text
+        ) ->> 'sessionId' :: text
+      )
+    ) :: uuid AS session_id,
+    CASE
+      WHEN ((se.webhook_conf) :: text ~~ '%bops%' :: text) THEN 'Submit to BOPS' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%uniform%' :: text) THEN 'Submit to Uniform' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+      ) THEN 'Send to email' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+      ) THEN 'Upload to AWS S3 (no notification)' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+      ) THEN 'Upload to AWS S3' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%idox%' :: text) THEN 'Submit to Idox Nexus' :: text
+      ELSE (se.webhook_conf) :: text
+    END AS event_type,
+    CASE
+      WHEN (seil.status = 200) THEN 'Success' :: text
+      ELSE format('Failed (%s)' :: text, seil.status)
+    END AS status,
+    seil.created_at
+  FROM
+    (
+      hdb_catalog.hdb_scheduled_events se
+      LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id))
+    )
+  WHERE
+    (
+      (
+        seil.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (
+        ((se.webhook_conf) :: text ~~ '%bops%' :: text)
+        OR ((se.webhook_conf) :: text ~~ '%uniform%' :: text)
+        OR (
+          (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+        )
+        OR ((se.webhook_conf) :: text ~~ '%idox%' :: text)
+      )
+    )
+),
+all_events AS (
+  SELECT
+    payments.session_id,
+    payments.event_type,
+    payments.status,
+    payments.created_at
+  FROM
+    payments
+  UNION ALL
+  SELECT
+    invitations_to_pay.session_id,
+    invitations_to_pay.event_type,
+    invitations_to_pay.status,
+    invitations_to_pay.created_at
+  FROM
+    invitations_to_pay
+  UNION ALL
+  SELECT
+    submissions.session_id,
+    submissions.event_type,
+    submissions.status,
+    submissions.created_at
+  FROM
+    submissions
+),
+latest_per_event_type AS (
+  SELECT
+    DISTINCT ON (all_events.session_id, all_events.event_type) all_events.session_id,
+    all_events.event_type,
+    all_events.status,
+    all_events.created_at
+  FROM
+    all_events
+  ORDER BY
+    all_events.session_id,
+    all_events.event_type,
+    all_events.created_at DESC
+),
+representative_event AS (
+  SELECT
+    DISTINCT ON (latest_per_event_type.session_id) latest_per_event_type.session_id,
+    latest_per_event_type.event_type,
+    latest_per_event_type.status,
+    latest_per_event_type.created_at
+  FROM
+    latest_per_event_type
+  ORDER BY
+    latest_per_event_type.session_id,
+    (latest_per_event_type.status ~~ 'Failed%' :: text) DESC,
+    latest_per_event_type.created_at DESC
+)
+SELECT
+  f.id AS flow_id,
+  re.session_id,
+  re.event_type,
+  re.status,
+  re.created_at,
+  f.team_id,
+  f.name AS flow_name,
+  CASE
+    WHEN ls.submitted_at < (now() - interval '6 months') THEN 'No longer retained' :: text
+    ELSE COALESCE(
+      (
+        (
+          ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+        ) ->> 'single_line_address' :: text
+      ),
+      (
+        (
+          ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+        ) ->> 'title' :: text
+      ),
+      'Not applicable'
+    )
+  END AS address
+FROM
+  (
+    (
+      representative_event re
+      LEFT JOIN lowcal_sessions ls ON ((ls.id = re.session_id))
+    )
+    LEFT JOIN flows f ON ((f.id = ls.flow_id))
+  )
+WHERE
+  (ls.flow_id IS NOT NULL)
+ORDER BY
+  re.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1788270994493_explain_sanitised_address_in_submission_services_log/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1788270994493_explain_sanitised_address_in_submission_services_log/down.sql
@@ -1,0 +1,247 @@
+CREATE
+OR REPLACE VIEW "public"."submission_services_log" AS WITH payments AS (
+  SELECT
+    ps.session_id,
+    ps.payment_id AS event_id,
+    'Pay' :: text AS event_type,
+    initcap(ps.status) AS status,
+    jsonb_build_object(
+      'status',
+      ps.status,
+      'description',
+      pse.comment,
+      'govuk_pay_reference',
+      ps.payment_id,
+      'govuk_pay_metadata',
+      ps.gov_pay_metadata
+    ) AS response,
+    ps.created_at,
+    false AS retry
+  FROM
+    (
+      payment_status ps
+      LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status))
+    )
+  WHERE
+    (
+      (ps.status <> 'created' :: text)
+      AND (
+        ps.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+    )
+),
+retries AS (
+  SELECT
+    hdb_scheduled_event_invocation_logs.id
+  FROM
+    hdb_catalog.hdb_scheduled_event_invocation_logs
+  WHERE
+    (
+      (
+        hdb_scheduled_event_invocation_logs.event_id,
+        hdb_scheduled_event_invocation_logs.created_at
+      ) IN (
+        SELECT
+          seil.event_id,
+          max(seil.created_at) AS max
+        FROM
+          (
+            hdb_catalog.hdb_scheduled_event_invocation_logs seil
+            LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id))
+          )
+        WHERE
+          (se.tries > 1)
+        GROUP BY
+          seil.event_id
+      )
+    )
+),
+submissions AS (
+  SELECT
+    (
+      (
+        (
+          (seil.request -> 'payload' :: text) -> 'payload' :: text
+        ) ->> 'sessionId' :: text
+      )
+    ) :: uuid AS session_id,
+    se.id AS event_id,
+    CASE
+      WHEN ((se.webhook_conf) :: text ~~ '%bops%' :: text) THEN 'Submit to BOPS' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%uniform%' :: text) THEN 'Submit to Uniform' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+      ) THEN 'Send to email' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+      ) THEN 'Upload to AWS S3 (no notification)' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+      ) THEN 'Upload to AWS S3' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%idox%' :: text) THEN 'Submit to Idox Nexus' :: text
+      ELSE (se.webhook_conf) :: text
+    END AS event_type,
+    CASE
+      WHEN (seil.status = 200) THEN 'Success' :: text
+      ELSE format('Failed (%s)' :: text, seil.status)
+    END AS status,
+    (seil.response) :: jsonb AS response,
+    seil.created_at,
+    (
+      EXISTS (
+        SELECT
+          1
+        FROM
+          retries r
+        WHERE
+          (r.id = seil.id)
+      )
+    ) AS retry
+  FROM
+    (
+      hdb_catalog.hdb_scheduled_events se
+      LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id))
+    )
+  WHERE
+    (
+      (
+        seil.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (
+        ((se.webhook_conf) :: text ~~ '%bops%' :: text)
+        OR ((se.webhook_conf) :: text ~~ '%uniform%' :: text)
+        OR (
+          (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+        )
+        OR ((se.webhook_conf) :: text ~~ '%idox%' :: text)
+      )
+    )
+),
+session_starts AS (
+  SELECT
+    ls_1.id AS session_id,
+    (ls_1.id) :: text AS event_id,
+    'Started session' :: text AS event_type,
+    'Success' :: text AS status,
+    NULL :: jsonb AS response,
+    ls_1.created_at,
+    false AS retry
+  FROM
+    lowcal_sessions ls_1
+  WHERE
+    (
+      (
+        ls_1.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (ls_1.created_at IS NOT NULL)
+    )
+),
+payment_invites AS (
+  SELECT
+    pr.session_id,
+    (pr.id) :: text AS event_id,
+    'Invited to pay' :: text AS event_type,
+    'Success' :: text AS status,
+    jsonb_build_object(
+      'payee_email',
+      pr.payee_email,
+      'payee_name',
+      pr.payee_name,
+      'paid_at',
+      pr.paid_at
+    ) AS response,
+    pr.created_at,
+    false AS retry
+  FROM
+    payment_requests pr
+  WHERE
+    (
+      pr.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+    )
+),
+all_events AS (
+  SELECT
+    payments.session_id,
+    payments.event_id,
+    payments.event_type,
+    payments.status,
+    payments.response,
+    payments.created_at,
+    payments.retry
+  FROM
+    payments
+  UNION ALL
+  SELECT
+    submissions.session_id,
+    submissions.event_id,
+    submissions.event_type,
+    submissions.status,
+    submissions.response,
+    submissions.created_at,
+    submissions.retry
+  FROM
+    submissions
+  UNION ALL
+  SELECT
+    session_starts.session_id,
+    session_starts.event_id,
+    session_starts.event_type,
+    session_starts.status,
+    session_starts.response,
+    session_starts.created_at,
+    session_starts.retry
+  FROM
+    session_starts
+  UNION ALL
+  SELECT
+    payment_invites.session_id,
+    payment_invites.event_id,
+    payment_invites.event_type,
+    payment_invites.status,
+    payment_invites.response,
+    payment_invites.created_at,
+    payment_invites.retry
+  FROM
+    payment_invites
+)
+SELECT
+  ls.flow_id,
+  ae.session_id,
+  ae.event_id,
+  ae.event_type,
+  ae.status,
+  ae.response,
+  ae.created_at,
+  ae.retry,
+  f.team_id,
+  f.name AS flow_name,
+  COALESCE(
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'single_line_address' :: text
+    ),
+    (
+      (
+        ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+      ) ->> 'title' :: text
+    )
+  ) AS address
+FROM
+  (
+    (
+      all_events ae
+      LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id))
+    )
+    LEFT JOIN flows f ON ((f.id = ls.flow_id))
+  )
+WHERE
+  (ls.flow_id IS NOT NULL)
+ORDER BY
+  ae.created_at DESC;

--- a/apps/hasura.planx.uk/migrations/default/1788270994493_explain_sanitised_address_in_submission_services_log/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1788270994493_explain_sanitised_address_in_submission_services_log/up.sql
@@ -1,0 +1,251 @@
+CREATE
+OR REPLACE VIEW "public"."submission_services_log" AS WITH payments AS (
+  SELECT
+    ps.session_id,
+    ps.payment_id AS event_id,
+    'Pay' :: text AS event_type,
+    initcap(ps.status) AS status,
+    jsonb_build_object(
+      'status',
+      ps.status,
+      'description',
+      pse.comment,
+      'govuk_pay_reference',
+      ps.payment_id,
+      'govuk_pay_metadata',
+      ps.gov_pay_metadata
+    ) AS response,
+    ps.created_at,
+    false AS retry
+  FROM
+    (
+      payment_status ps
+      LEFT JOIN payment_status_enum pse ON ((pse.value = ps.status))
+    )
+  WHERE
+    (
+      (ps.status <> 'created' :: text)
+      AND (
+        ps.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+    )
+),
+retries AS (
+  SELECT
+    hdb_scheduled_event_invocation_logs.id
+  FROM
+    hdb_catalog.hdb_scheduled_event_invocation_logs
+  WHERE
+    (
+      (
+        hdb_scheduled_event_invocation_logs.event_id,
+        hdb_scheduled_event_invocation_logs.created_at
+      ) IN (
+        SELECT
+          seil.event_id,
+          max(seil.created_at) AS max
+        FROM
+          (
+            hdb_catalog.hdb_scheduled_event_invocation_logs seil
+            LEFT JOIN hdb_catalog.hdb_scheduled_events se ON ((se.id = seil.event_id))
+          )
+        WHERE
+          (se.tries > 1)
+        GROUP BY
+          seil.event_id
+      )
+    )
+),
+submissions AS (
+  SELECT
+    (
+      (
+        (
+          (seil.request -> 'payload' :: text) -> 'payload' :: text
+        ) ->> 'sessionId' :: text
+      )
+    ) :: uuid AS session_id,
+    se.id AS event_id,
+    CASE
+      WHEN ((se.webhook_conf) :: text ~~ '%bops%' :: text) THEN 'Submit to BOPS' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%uniform%' :: text) THEN 'Submit to Uniform' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+      ) THEN 'Send to email' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+      ) THEN 'Upload to AWS S3 (no notification)' :: text
+      WHEN (
+        (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+      ) THEN 'Upload to AWS S3' :: text
+      WHEN ((se.webhook_conf) :: text ~~ '%idox%' :: text) THEN 'Submit to Idox Nexus' :: text
+      ELSE (se.webhook_conf) :: text
+    END AS event_type,
+    CASE
+      WHEN (seil.status = 200) THEN 'Success' :: text
+      ELSE format('Failed (%s)' :: text, seil.status)
+    END AS status,
+    (seil.response) :: jsonb AS response,
+    seil.created_at,
+    (
+      EXISTS (
+        SELECT
+          1
+        FROM
+          retries r
+        WHERE
+          (r.id = seil.id)
+      )
+    ) AS retry
+  FROM
+    (
+      hdb_catalog.hdb_scheduled_events se
+      LEFT JOIN hdb_catalog.hdb_scheduled_event_invocation_logs seil ON ((seil.event_id = se.id))
+    )
+  WHERE
+    (
+      (
+        seil.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (
+        ((se.webhook_conf) :: text ~~ '%bops%' :: text)
+        OR ((se.webhook_conf) :: text ~~ '%uniform%' :: text)
+        OR (
+          (se.webhook_conf) :: text ~~ '%email-submission%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%?notify=false%' :: text
+        )
+        OR (
+          (se.webhook_conf) :: text ~~ '%upload-submission%' :: text
+        )
+        OR ((se.webhook_conf) :: text ~~ '%idox%' :: text)
+      )
+    )
+),
+session_starts AS (
+  SELECT
+    ls_1.id AS session_id,
+    (ls_1.id) :: text AS event_id,
+    'Started session' :: text AS event_type,
+    'Success' :: text AS status,
+    NULL :: jsonb AS response,
+    ls_1.created_at,
+    false AS retry
+  FROM
+    lowcal_sessions ls_1
+  WHERE
+    (
+      (
+        ls_1.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+      )
+      AND (ls_1.created_at IS NOT NULL)
+    )
+),
+payment_invites AS (
+  SELECT
+    pr.session_id,
+    (pr.id) :: text AS event_id,
+    'Invited to pay' :: text AS event_type,
+    'Success' :: text AS status,
+    jsonb_build_object(
+      'payee_email',
+      pr.payee_email,
+      'payee_name',
+      pr.payee_name,
+      'paid_at',
+      pr.paid_at
+    ) AS response,
+    pr.created_at,
+    false AS retry
+  FROM
+    payment_requests pr
+  WHERE
+    (
+      pr.created_at >= '2024-01-01 00:00:00+00' :: timestamp with time zone
+    )
+),
+all_events AS (
+  SELECT
+    payments.session_id,
+    payments.event_id,
+    payments.event_type,
+    payments.status,
+    payments.response,
+    payments.created_at,
+    payments.retry
+  FROM
+    payments
+  UNION ALL
+  SELECT
+    submissions.session_id,
+    submissions.event_id,
+    submissions.event_type,
+    submissions.status,
+    submissions.response,
+    submissions.created_at,
+    submissions.retry
+  FROM
+    submissions
+  UNION ALL
+  SELECT
+    session_starts.session_id,
+    session_starts.event_id,
+    session_starts.event_type,
+    session_starts.status,
+    session_starts.response,
+    session_starts.created_at,
+    session_starts.retry
+  FROM
+    session_starts
+  UNION ALL
+  SELECT
+    payment_invites.session_id,
+    payment_invites.event_id,
+    payment_invites.event_type,
+    payment_invites.status,
+    payment_invites.response,
+    payment_invites.created_at,
+    payment_invites.retry
+  FROM
+    payment_invites
+)
+SELECT
+  ls.flow_id,
+  ae.session_id,
+  ae.event_id,
+  ae.event_type,
+  ae.status,
+  ae.response,
+  ae.created_at,
+  ae.retry,
+  f.team_id,
+  f.name AS flow_name,
+  CASE
+    WHEN ls.submitted_at < (now() - interval '6 months') THEN 'No longer retained' :: text
+    ELSE COALESCE(
+      (
+        (
+          ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+        ) ->> 'single_line_address' :: text
+      ),
+      (
+        (
+          ((ls.data -> 'passport' :: text) -> 'data' :: text) -> '_address' :: text
+        ) ->> 'title' :: text
+      ),
+      'Not applicable'
+    )
+  END AS address
+FROM
+  (
+    (
+      all_events ae
+      LEFT JOIN lowcal_sessions ls ON ((ls.id = ae.session_id))
+    )
+    LEFT JOIN flows f ON ((f.id = ls.flow_id))
+  )
+WHERE
+  (ls.flow_id IS NOT NULL)
+ORDER BY
+  ae.created_at DESC;

--- a/e2e/tests/ui-driven/src/helpers/addComponent.ts
+++ b/e2e/tests/ui-driven/src/helpers/addComponent.ts
@@ -440,6 +440,8 @@ async function createComponentOptions(
 
   await page.getByPlaceholder("Flags (up to one per category)").nth(1).click();
   await page.getByRole("option", { name: selectedFlag, exact: true }).click();
+  // Close the 'flags' autocomplete
+  await page.keyboard.press("Escape");
 }
 
 async function createComponentOptionsWithDataValues(
@@ -453,6 +455,8 @@ async function createComponentOptionsWithDataValues(
     await page
       .getByRole("option", { name: option.dataValue, exact: true })
       .click();
+    // Close the 'data field' autocomplete
+    await page.keyboard.press("Escape");
   }
 }
 

--- a/e2e/tests/ui-driven/src/templates.spec.ts
+++ b/e2e/tests/ui-driven/src/templates.spec.ts
@@ -117,7 +117,7 @@ test.describe("Templates", () => {
       await page.getByLabel("Require edits").click();
 
       // Close modal without saving
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("button", { name: "Discard changes" }).click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
 
@@ -394,7 +394,7 @@ test.describe("Templates", () => {
       await expect(
         page.getByText(REQUIRED_NODE_INSTRUCTIONS).first(),
       ).toBeVisible();
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
     });
 
@@ -447,7 +447,7 @@ test.describe("Templates", () => {
         page.locator('button[form="modal"][type="submit"]'),
       ).toBeDisabled();
 
-      await page.locator('button[aria-label="close"]').click();
+      await page.locator('button[aria-label="Close"]').click();
       await page.getByRole("dialog").waitFor({ state: "detached" });
     });
 


### PR DESCRIPTION
Alters db views `submissions_grouped` and `submission_services_log` to show 'No longer retained' when applications >6mo old. (As Daf suggested [in comment](https://github.com/theopensystemslab/planx-new/pull/7291#discussion_r3881680525))

This gives us 3 options for displaying addresses:
1. Address
2. Empty (eg for services that don't have addresses, such as "Register to attend Public Inquiry")
3. "No longer retained" for older applications

Copy suggestions welcome--this felt like a middle ground between succinct and technical "Sanitised" and verbose "Submission is older than 6months". 