### PR TITLE
chore(api): Log cause of payment parsing error to Airbrake

### DIFF
--- a/apps/api.planx.uk/modules/pay/helpers.ts
+++ b/apps/api.planx.uk/modules/pay/helpers.ts
@@ -71,7 +71,10 @@ export async function logPaymentStatus({
     } catch (e) {
       reportError({
         error: `Failed to insert a payment status: ${e}`,
-        context: { govUkResponse },
+        context: {
+          govUkResponse,
+          ...(e instanceof Error && { cause: e.cause }),
+        },
       });
     }
   }


### PR DESCRIPTION
Aiming to get more information on this category of error - https://planx.airbrake.io/projects/329753/groups/4355606157377770771?tab=notice-detail

Logging the `cause` directly to Airbrake should allow us to pick up the Zod error originating here - 

https://github.com/theopensystemslab/planx-core/blob/2a081237d30d242087ba95b74140626f9f08ee11/src/utils/feeBreakdown.ts#L184-L188
