### PR TITLE
[api] upgrade AI SDK + enforce `disallowPromptTraining`

### DIFF
--- a/apps/api.planx.uk/modules/ai/constants.ts
+++ b/apps/api.planx.uk/modules/ai/constants.ts
@@ -1,1 +1,2 @@
+// NB. we maintain an account-level allowlist which includes only the below model
 export const DEFAULT_MODEL_ID = "google/gemini-3.1-pro-preview" as const;

--- a/apps/api.planx.uk/modules/ai/projectDescription/service.test.ts
+++ b/apps/api.planx.uk/modules/ai/projectDescription/service.test.ts
@@ -1,0 +1,203 @@
+import { APICallError } from "ai";
+// see: https://ai-sdk.dev/docs/ai-sdk-core/testing
+import { MockLanguageModelV4 } from "ai/test";
+
+import { DEFAULT_MODEL_ID } from "../constants.js";
+import { GATEWAY_STATUS } from "../types.js";
+import { enhanceProjectDescription } from "./service.js";
+
+const mockLogAiGatewayExchange = vi.fn();
+const mockGetModel = vi.fn();
+
+vi.mock("../logs.js", () => ({
+  logAiGatewayExchange: (args: unknown) => mockLogAiGatewayExchange(args),
+}));
+
+vi.mock("../utils.js", () => ({
+  getModel: () => mockGetModel(),
+}));
+
+const mockFlowId = "123e4567-e89b-12d3-a456-426614174000";
+const endpoint = "/ai/project-description/enhance";
+
+/** Captures the options `generateText` passes down to the model. */
+let modelCallOptions: Record<string, unknown> | undefined;
+
+// a model returning a schema-compliant object, plus the gateway metadata the audit log reads
+const stubModel = (
+  overrides: {
+    enhancedDescription?: string;
+    status?: string;
+  } = {},
+) =>
+  new MockLanguageModelV4({
+    doGenerate: async (options) => {
+      modelCallOptions = options as unknown as Record<string, unknown>;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              enhancedDescription:
+                overrides.enhancedDescription ??
+                "Construction of a single-storey rear extension to an existing dwelling",
+              status: overrides.status ?? GATEWAY_STATUS.ENHANCED,
+            }),
+          },
+        ],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: {
+            total: 120,
+            noCache: 120,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: { total: 30, text: 30, reasoning: 0 },
+        },
+        providerMetadata: {
+          gateway: { cost: "0.00042", generationId: "gen_abc123" },
+        },
+        response: { modelId: DEFAULT_MODEL_ID },
+        warnings: [],
+      };
+    },
+  });
+
+const enhance = () =>
+  enhanceProjectDescription(
+    "small rear extension",
+    endpoint,
+    mockFlowId,
+    undefined,
+  );
+
+describe("enhanceProjectDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    modelCallOptions = undefined;
+  });
+
+  describe("request options sent to the gateway", () => {
+    it("enforces disallowPromptTraining nested under the gateway provider key", async () => {
+      // guard against providerOptions being dropped, leaving disallowPromptTraining unenforced
+      mockGetModel.mockReturnValueOnce(stubModel());
+
+      await enhance();
+
+      expect(modelCallOptions?.providerOptions).toMatchObject({
+        gateway: { disallowPromptTraining: true },
+      });
+    });
+
+    it("sends the loaded system prompt as a system message", async () => {
+      // v7 renamed the top-level option from `system` to `instructions`; either way it should reach
+      // the model as a system message, with the status placeholders in system.md already substituted
+      mockGetModel.mockReturnValueOnce(stubModel());
+
+      await enhance();
+
+      expect(modelCallOptions?.prompt).toMatchObject([
+        {
+          role: "system",
+          content: expect.stringContaining(GATEWAY_STATUS.ENHANCED),
+        },
+        { role: "user" },
+      ]);
+    });
+  });
+
+  describe("successful enhancement", () => {
+    it("returns the enhanced description", async () => {
+      mockGetModel.mockReturnValueOnce(stubModel());
+
+      await expect(enhance()).resolves.toEqual({
+        ok: true,
+        value:
+          "Construction of a single-storey rear extension to an existing dwelling",
+      });
+    });
+
+    it("records the exchange against the final step", async () => {
+      mockGetModel.mockReturnValueOnce(stubModel());
+
+      await enhance();
+
+      expect(mockLogAiGatewayExchange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint,
+          flowId: mockFlowId,
+          modelId: DEFAULT_MODEL_ID,
+          gatewayStatus: GATEWAY_STATUS.ENHANCED,
+          tokenUsage: 150,
+          costUsd: 0.00042,
+          vercelGenerationId: "gen_abc123",
+        }),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("reports a description the model judged unrelated to planning", async () => {
+      mockGetModel.mockReturnValueOnce(
+        stubModel({ status: GATEWAY_STATUS.INVALID }),
+      );
+
+      await expect(enhance()).resolves.toEqual({
+        ok: false,
+        error: GATEWAY_STATUS.INVALID,
+      });
+    });
+
+    it("names the reason when no provider satisfies the request constraints", async () => {
+      // the gateway rejects an unroutable request with a 400
+      // `invalid_request_error`, naming the cause in `error.param.name`
+      const message =
+        "No provider for google/gemini-3.1-pro-preview supports the requested inference region.";
+      const body = {
+        error: {
+          message,
+          type: "invalid_request_error",
+          param: { name: "NoInferenceEndpointProvidersError" },
+        },
+      };
+      const unroutable = Object.assign(new Error(message), {
+        type: "invalid_request_error",
+        statusCode: 400,
+        cause: new APICallError({
+          message,
+          url: "https://ai-gateway.vercel.sh/v4/ai/language-model",
+          requestBodyValues: {},
+          statusCode: 400,
+          responseBody: JSON.stringify(body),
+          data: body,
+          isRetryable: false,
+        }),
+      });
+
+      mockGetModel.mockReturnValueOnce(
+        new MockLanguageModelV4({
+          doGenerate: async () => {
+            throw unroutable;
+          },
+        }),
+      );
+
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      await expect(enhance()).resolves.toEqual({
+        ok: false,
+        error: GATEWAY_STATUS.ERROR,
+      });
+
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("NoInferenceEndpointProvidersError"),
+        expect.anything(),
+      );
+
+      consoleError.mockRestore();
+    });
+  });
+});

--- a/apps/api.planx.uk/modules/ai/projectDescription/service.test.ts
+++ b/apps/api.planx.uk/modules/ai/projectDescription/service.test.ts
@@ -1,3 +1,4 @@
+import { GatewayInvalidRequestError } from "@ai-sdk/gateway";
 import { APICallError } from "ai";
 // see: https://ai-sdk.dev/docs/ai-sdk-core/testing
 import { MockLanguageModelV4 } from "ai/test";
@@ -161,8 +162,8 @@ describe("enhanceProjectDescription", () => {
           param: { name: "NoInferenceEndpointProvidersError" },
         },
       };
-      const unroutable = Object.assign(new Error(message), {
-        type: "invalid_request_error",
+      const unroutable = new GatewayInvalidRequestError({
+        message,
         statusCode: 400,
         cause: new APICallError({
           message,
@@ -194,6 +195,34 @@ describe("enhanceProjectDescription", () => {
 
       expect(consoleError).toHaveBeenCalledWith(
         expect.stringContaining("NoInferenceEndpointProvidersError"),
+        expect.anything(),
+      );
+
+      consoleError.mockRestore();
+    });
+
+    it("falls back to 'reason unknown' when the rejection carries no APICallError cause", async () => {
+      mockGetModel.mockReturnValueOnce(
+        new MockLanguageModelV4({
+          doGenerate: async () => {
+            throw new GatewayInvalidRequestError({
+              message: "Invalid request",
+            });
+          },
+        }),
+      );
+
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      await expect(enhance()).resolves.toEqual({
+        ok: false,
+        error: GATEWAY_STATUS.ERROR,
+      });
+
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("reason unknown"),
         expect.anything(),
       );
 

--- a/apps/api.planx.uk/modules/ai/projectDescription/service.ts
+++ b/apps/api.planx.uk/modules/ai/projectDescription/service.ts
@@ -1,8 +1,10 @@
 import {
+  APICallError,
   generateText,
   InvalidPromptError,
   NoContentGeneratedError,
   NoObjectGeneratedError,
+  NoOutputGeneratedError,
   Output,
 } from "ai";
 import { readFileSync } from "fs";
@@ -37,37 +39,39 @@ export const enhanceProjectDescription = async (
 ): Promise<GatewayResult> => {
   try {
     const startTime = Date.now();
-    const result = getModel(DEFAULT_MODEL_ID);
-    if (!result.ok) {
-      return { ok: false, error: result.error };
-    }
-    if (!result.model) {
-      return { ok: false, error: GATEWAY_STATUS.ERROR };
-    }
+    const model = getModel(DEFAULT_MODEL_ID);
     const prompt = `<user_input>${original_description}</user_input>`;
     const res = await generateText({
-      model: result.model,
+      model,
       output: Output.object({
         schema: projectDescriptionOutputSchema,
       }),
-      system: loadSystemPrompt(),
+      instructions: loadSystemPrompt(),
       prompt,
+      // XXX: we enforce only routing to providers which don't train on prompt data
+      // we want to upgrade to ZDR + in-EU inference in future (depending on model availability)
+      providerOptions: {
+        gateway: {
+          disallowPromptTraining: true,
+        },
+      },
     });
     const responseTimeMs = Date.now() - startTime;
 
     // log the exchange w/ Vercel AI Gateway to the audit table in db
     await logAiGatewayExchange({
       endpoint,
-      modelId: res.response?.modelId || DEFAULT_MODEL_ID,
+      modelId: res.finalStep.response.modelId || DEFAULT_MODEL_ID,
       prompt,
       response: res.output.enhancedDescription ?? undefined,
       gatewayStatus: res.output.status || undefined,
       tokenUsage: res.usage?.totalTokens,
-      costUsd: res.providerMetadata?.gateway?.cost
-        ? parseFloat(res.providerMetadata.gateway.cost as string)
+      costUsd: res.finalStep.providerMetadata?.gateway?.cost
+        ? parseFloat(res.finalStep.providerMetadata.gateway.cost as string)
         : undefined,
       vercelGenerationId:
-        (res.providerMetadata?.gateway?.generationId as string) || undefined,
+        (res.finalStep.providerMetadata?.gateway?.generationId as string) ||
+        undefined,
       responseTimeMs,
       flowId,
       sessionId,
@@ -79,6 +83,7 @@ export const enhanceProjectDescription = async (
       ? { ok: false, error: output.status }
       : { ok: true, value: output.enhancedDescription };
   } catch (error) {
+    // full list of AI SDK errors: https://ai-sdk.dev/docs/reference/ai-sdk-errors
     if (InvalidPromptError.isInstance(error)) {
       console.error(
         "Prompt provided to model was determined to be invalid",
@@ -92,6 +97,15 @@ export const enhanceProjectDescription = async (
         "Model failed to return an output compliant with given schema",
         error,
       );
+    } else if (NoOutputGeneratedError.isInstance(error)) {
+      console.error("Model failed to return any output whatsoever", error);
+    } else if (isUnroutableRequestError(error)) {
+      console.error(
+        `No AI Gateway provider for '${DEFAULT_MODEL_ID}' meets the requirements in request (and/or in account-wide settings) - ${
+          getGatewayRejectionName(error) ?? "reason unknown"
+        }`,
+        error,
+      );
     } else {
       console.error(
         "Unexpected error with request to Vercel AI Gateway",
@@ -100,4 +114,32 @@ export const enhanceProjectDescription = async (
     }
     return { ok: false, error: GATEWAY_STATUS.ERROR };
   }
+};
+
+/**
+ * The Gateway rejects a request with 400 invalid_request_error when no provider can
+ * satisfy the requested constraints, e.g. inference region, ZDR, etc. It names the
+ * specific reason in `error.param.name`, e.g. NoInferenceEndpointProvidersError.
+ */
+const isUnroutableRequestError = (error: unknown): boolean =>
+  error instanceof Error &&
+  "type" in error &&
+  error.type === "invalid_request_error" &&
+  "statusCode" in error &&
+  error.statusCode === 400;
+
+/**
+ * The Gateway*Error classes from `@ai-sdk/gateway` aren't re-exported from `ai` package,
+ * so we catch this error by duck-type, as above. Its `cause` is an APICallError,
+ * which *is* exported and carries the parsed response body on `data`.
+ */
+const getGatewayRejectionName = (error: unknown): string | undefined => {
+  const cause = error instanceof Error ? error.cause : undefined;
+  if (!APICallError.isInstance(cause)) return undefined;
+
+  const body = cause.data as
+    { error?: { param?: { name?: unknown } } } | undefined;
+  const name = body?.error?.param?.name;
+
+  return typeof name === "string" ? name : undefined;
 };

--- a/apps/api.planx.uk/modules/ai/projectDescription/service.ts
+++ b/apps/api.planx.uk/modules/ai/projectDescription/service.ts
@@ -1,3 +1,4 @@
+import { GatewayInvalidRequestError } from "@ai-sdk/gateway";
 import {
   APICallError,
   generateText,
@@ -84,60 +85,54 @@ export const enhanceProjectDescription = async (
       : { ok: true, value: output.enhancedDescription };
   } catch (error) {
     // full list of AI SDK errors: https://ai-sdk.dev/docs/reference/ai-sdk-errors
-    if (InvalidPromptError.isInstance(error)) {
-      console.error(
-        "Prompt provided to model was determined to be invalid",
-        error,
-      );
-      return { ok: false, error: GATEWAY_STATUS.INVALID };
-    } else if (NoContentGeneratedError.isInstance(error)) {
-      console.error("Model failed to generate any content", error);
-    } else if (NoObjectGeneratedError.isInstance(error)) {
-      console.error(
-        "Model failed to return an output compliant with given schema",
-        error,
-      );
-    } else if (NoOutputGeneratedError.isInstance(error)) {
-      console.error("Model failed to return any output whatsoever", error);
-    } else if (isUnroutableRequestError(error)) {
-      console.error(
-        `No AI Gateway provider for '${DEFAULT_MODEL_ID}' meets the requirements in request (and/or in account-wide settings) - ${
-          getGatewayRejectionName(error) ?? "reason unknown"
-        }`,
-        error,
-      );
-    } else {
-      console.error(
-        "Unexpected error with request to Vercel AI Gateway",
-        error,
-      );
+    switch (true) {
+      case InvalidPromptError.isInstance(error):
+        console.error(
+          "Prompt provided to model was determined to be invalid",
+          error,
+        );
+        return { ok: false, error: GATEWAY_STATUS.INVALID };
+      case NoContentGeneratedError.isInstance(error):
+        console.error("Model failed to generate any content", error);
+        break;
+      case NoObjectGeneratedError.isInstance(error):
+        console.error(
+          "Model failed to return an output compliant with given schema",
+          error,
+        );
+        break;
+      case NoOutputGeneratedError.isInstance(error):
+        console.error("Model failed to return any output whatsoever", error);
+        break;
+      case GatewayInvalidRequestError.isInstance(error):
+        console.error(
+          `No AI Gateway provider for '${DEFAULT_MODEL_ID}' meets the requirements in request (and/or in account-wide settings) - ${
+            getGatewayRejectionName(error) ?? "reason unknown"
+          }`,
+          error,
+        );
+        break;
+      default:
+        console.error(
+          "Unexpected error with request to Vercel AI Gateway",
+          error,
+        );
     }
     return { ok: false, error: GATEWAY_STATUS.ERROR };
   }
 };
 
 /**
- * The Gateway rejects a request with 400 invalid_request_error when no provider can
- * satisfy the requested constraints, e.g. inference region, ZDR, etc. It names the
- * specific reason in `error.param.name`, e.g. NoInferenceEndpointProvidersError.
+ * The Gateway rejects a request with a 400 `invalid_request_error` when no provider can satisfy
+ * the requested constraints, e.g. inference region/ZDR. We burrow into its `cause`, which is an
+ * APICallError, to find the reason in `error.param.name` e.g. NoInferenceEndpointProvidersError.
  */
-const isUnroutableRequestError = (error: unknown): boolean =>
-  error instanceof Error &&
-  "type" in error &&
-  error.type === "invalid_request_error" &&
-  "statusCode" in error &&
-  error.statusCode === 400;
+const getGatewayRejectionName = (
+  error: GatewayInvalidRequestError,
+): string | undefined => {
+  if (!APICallError.isInstance(error.cause)) return undefined;
 
-/**
- * The Gateway*Error classes from `@ai-sdk/gateway` aren't re-exported from `ai` package,
- * so we catch this error by duck-type, as above. Its `cause` is an APICallError,
- * which *is* exported and carries the parsed response body on `data`.
- */
-const getGatewayRejectionName = (error: unknown): string | undefined => {
-  const cause = error instanceof Error ? error.cause : undefined;
-  if (!APICallError.isInstance(cause)) return undefined;
-
-  const body = cause.data as
+  const body = error.cause.data as
     { error?: { param?: { name?: unknown } } } | undefined;
   const name = body?.error?.param?.name;
 

--- a/apps/api.planx.uk/modules/ai/types.ts
+++ b/apps/api.planx.uk/modules/ai/types.ts
@@ -1,5 +1,3 @@
-import type { LanguageModel } from "ai";
-
 // we use plain objects w/ const assertion in place of problematic TS enums
 export const GATEWAY_STATUS = {
   ENHANCED: "ENHANCED",
@@ -27,7 +25,6 @@ export type GatewayFailureStatus = (typeof GATEWAY_FAILURE_STATUSES)[number];
 type GatewaySuccess = {
   ok: true;
   value?: string;
-  model?: LanguageModel;
 };
 
 type GatewayFailure = {

--- a/apps/api.planx.uk/modules/ai/utils.test.ts
+++ b/apps/api.planx.uk/modules/ai/utils.test.ts
@@ -1,10 +1,68 @@
-import { describe, vi } from "vitest";
+import { DEFAULT_MODEL_ID } from "./constants.js";
+import { getModel } from "./utils.js";
 
-vi.mock("ai", () => ({
-  createGateway: vi.fn(),
-  NoSuchModelError: {
-    isInstance: vi.fn(),
-  },
-}));
+describe("getModel", () => {
+  beforeEach(() => {
+    vi.stubEnv("AI_GATEWAY_API_KEY", "test-api-key");
+  });
 
-describe.todo("getModel - unit tests");
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves a gateway-backed model for the requested ID", () => {
+    const model = getModel("google/gemini-3.7-flash");
+
+    expect(model).toMatchObject({
+      modelId: "google/gemini-3.7-flash",
+      provider: "gateway",
+      specificationVersion: "v4",
+    });
+  });
+
+  it("resolves the default model", () => {
+    expect(getModel(DEFAULT_MODEL_ID)).toMatchObject({
+      modelId: DEFAULT_MODEL_ID,
+      provider: "gateway",
+    });
+  });
+
+  it("returns a model that can be called", () => {
+    // the model is a lazy handle, not a live connection
+    expect(getModel(DEFAULT_MODEL_ID)).toHaveProperty(
+      "doGenerate",
+      expect.any(Function),
+    );
+  });
+
+  it("does not validate the model ID", () => {
+    // the gateway resolves any slug, rejecting unknown models server-side when
+    // the request is made - so a bad ID surfaces from `generateText`, not here
+    expect(() => getModel("not-a-real/model-xyz")).not.toThrow();
+    expect(getModel("not-a-real/model-xyz")).toMatchObject({
+      modelId: "not-a-real/model-xyz",
+    });
+  });
+
+  it("authenticates with the gateway API key from the environment", async () => {
+    vi.stubEnv("AI_GATEWAY_API_KEY", "sentinel-key");
+
+    // reaching into the provider's own config is the only way to observe this
+    // wiring, since the key is otherwise used only when a request is made
+    const { config } = getModel(DEFAULT_MODEL_ID) as unknown as {
+      config: { headers: () => Record<string, string> };
+    };
+
+    await expect(config.headers()).resolves.toMatchObject({
+      authorization: "Bearer sentinel-key",
+    });
+  });
+
+  it("does not require an API key to be set", () => {
+    // likewise deferred: a missing key surfaces when the request is made.
+    // `projectDescriptionController` is what guards this case up front
+    vi.stubEnv("AI_GATEWAY_API_KEY", undefined);
+
+    expect(() => getModel(DEFAULT_MODEL_ID)).not.toThrow();
+  });
+});

--- a/apps/api.planx.uk/modules/ai/utils.ts
+++ b/apps/api.planx.uk/modules/ai/utils.ts
@@ -1,22 +1,11 @@
-import { createGateway, NoSuchModelError } from "ai";
+import { createGateway, type LanguageModel } from "ai";
 
-import { GATEWAY_STATUS, type GatewayResult } from "./types.js";
-
-export const getModel = (modelId: string): GatewayResult => {
-  try {
-    const gateway = createGateway({
-      apiKey: process.env.AI_GATEWAY_API_KEY,
-    });
-    return { ok: true, model: gateway(modelId) };
-  } catch (error) {
-    if (NoSuchModelError.isInstance(error)) {
-      console.error(
-        `Model '${modelId}' not available in Vercel AI Gateway. Please check the model ID.`,
-        error,
-      );
-    } else {
-      console.error(`Failed to instantiate model '${modelId}'`, error);
-    }
-    return { ok: false, error: GATEWAY_STATUS.ERROR };
-  }
-};
+/**
+ * Resolves a model through the Vercel AI Gateway.
+ *
+ * Nothing is validated here - the gateway builds the model lazily, so an
+ * unknown model ID or a missing API key only surfaces when the request is
+ * actually made, as an error from `generateText`.
+ */
+export const getModel = (modelId: string): LanguageModel =>
+  createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY })(modelId);

--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -11,6 +11,7 @@
     "dist"
   ],
   "dependencies": {
+    "@ai-sdk/gateway": "^4.0.72",
     "@airbrake/node": "^2.1.9",
     "@aws-sdk/client-s3": "^3.1120.0",
     "@aws-sdk/s3-request-presigner": "^3.1120.0",

--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -19,7 +19,7 @@
     "@types/geojson": "^7946.0.16",
     "@types/isomorphic-fetch": "^0.0.36",
     "adm-zip": "^0.6.0",
-    "ai": "^6.0.271",
+    "ai": "^7.0.79",
     "axios": "catalog:",
     "body-parser": "^2.3.0",
     "cookie-parser": "^1.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
 
   apps/api.planx.uk:
     dependencies:
+      '@ai-sdk/gateway':
+        specifier: ^4.0.72
+        version: 4.0.73(zod@3.25.76)
       '@airbrake/node':
         specifier: ^2.1.9
         version: 2.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0
       ai:
-        specifier: ^6.0.271
-        version: 6.0.271(zod@3.25.76)
+        specifier: ^7.0.79
+        version: 7.0.91(zod@3.25.76)
       axios:
         specifier: 'catalog:'
         version: 1.20.0
@@ -1398,21 +1398,21 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/gateway@3.0.184':
-    resolution: {integrity: sha512-7SuKsT4RS9lm6ShODj0vzS+S1ZKw5GukA7x3gg3t/gVwk0bu7l3XXC3sdEdBsBlTP97KklMYdZHmjcJoOVt67Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.73':
+    resolution: {integrity: sha512-1Gp6QtVHfegKoMcf1pjk4fpgDg1cUdK5NnrEiUsYhLWa6owDMmF7kP+qL7ZgQNDYKTOijT+5cTeHrL281kUiiQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.49':
-    resolution: {integrity: sha512-8e7pd+82bobqrFOaD5dG/PiEuvLYr5olaE3I56ch0jipR0H7sGD6ohwTUynv6k8O8QidWiyIbEsZCtr/2dyXIA==}
-    engines: {node: '>=18.17'}
+  '@ai-sdk/provider-utils@5.0.36':
+    resolution: {integrity: sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.15':
-    resolution: {integrity: sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.10':
+    resolution: {integrity: sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==}
+    engines: {node: '>=22'}
 
   '@airbrake/browser@2.1.9':
     resolution: {integrity: sha512-BMCT1gEzvaucQFyLSwPwHqg6KbN7dLW97R83M+2OPEKl23r0KatitiC/bj/7BeztH0PPidGXaFoM5A5ofIUjoQ==}
@@ -5566,6 +5566,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@wry/caches@1.0.1':
     resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
     engines: {node: '>=8'}
@@ -5633,9 +5636,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.271:
-    resolution: {integrity: sha512-8eS5Lhf5JT/ncw8+puVOa2cH+H6uKnHoORLqm6Ei3elwcoGIROrIh0VWhrKgbYLGpuz2pOTXW54nAJzPssQzAw==}
-    engines: {node: '>=18'}
+  ai@7.0.91:
+    resolution: {integrity: sha512-Hn0iIQY1FXow2wd+DxzdA/4ijY+6TP9CREqpN3aIs01wnBW9119yHW0Dvn53sTQzkk7+rSVXaXlDAYM5hhMJZA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -9963,21 +9966,11 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  seroval-plugins@1.6.4:
-    resolution: {integrity: sha512-R0f1U9hmn38+dFMz6b6ab8lwucmw4AtiY7St+JPWudy1dm+Bs3g884nyrsH9Cy6rKpZKLYayXuMda9GZ/fl8JQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
   seroval-plugins@1.6.7:
     resolution: {integrity: sha512-4Nk35ttD3DTDJW4hgw5StsVAPeU6qnDFnULAouw6tQ7oLTV/ICXrWpsXo2EE52eSP2joUMazbVf52mFEcADqRw==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
-
-  seroval@1.6.4:
-    resolution: {integrity: sha512-LErWMNS2RRFdu2RMA5u/PA59/IWs0XsikyEXGQ2/36iEWFrdG0ABmg17E17cikrv76891kOAMq3TkTFXpwAHXw==}
-    engines: {node: '>=10'}
 
   seroval@1.6.7:
     resolution: {integrity: sha512-AeDcLh0yO2SFm9W71essgnSzLV9DI8ZH0x0knXn2DMnUZj728mpLbxjlbB6IqKCmqh8JA3cEqRyGoNkt584JcQ==}
@@ -11559,22 +11552,23 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/gateway@3.0.184(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.73(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.49(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.49(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.36(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider': 4.0.10
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.1
-      undici: 6.28.0
+      undici: 7.29.0
       zod: 3.25.76
 
-  '@ai-sdk/provider@3.0.15':
+  '@ai-sdk/provider@4.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -15876,6 +15870,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@workflow/serde@4.1.0': {}
+
   '@wry/caches@1.0.1':
     dependencies:
       tslib: 2.8.1
@@ -15930,12 +15926,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.271(zod@3.25.76):
+  ai@7.0.91(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.184(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.15
-      '@ai-sdk/provider-utils': 4.0.49(zod@3.25.76)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.73(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@3.25.76)
       zod: 3.25.76
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
@@ -21044,15 +21039,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.6.4(seroval@1.6.4):
-    dependencies:
-      seroval: 1.6.4
-
   seroval-plugins@1.6.7(seroval@1.6.7):
     dependencies:
       seroval: 1.6.7
-
-  seroval@1.6.4: {}
 
   seroval@1.6.7: {}
 


### PR DESCRIPTION
As per title. See [Slack thread](https://opensystemslab.slack.com/archives/C0ARCE260LF/p1786457050736379) for motivation.

In passing through we also expand caught errors (so that changes in account-level settings which invalidate hardcoded model choice will be clear to see), simplify the `getModel` util (which doesn't throw), and add tests for full coverage on `api.planx.uk/modules/ai/`.

Vercel migration guide: https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0