### PR TITLE
test: grouped submissions log

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.test.tsx
@@ -6,11 +6,13 @@ import { setup } from "test/utils";
 import { it } from "vitest";
 
 import EventsLogGrouped from "./components/EventsLogGrouped";
-import { mockSubmissionsGrouped } from "./mockSubmissionsGrouped";
+import { mockSubmissionsGroupedAllStatuses } from "./mockSubmissionsGrouped";
 
 const handlers = [
   graphql.query("GetSubmissions", () =>
-    HttpResponse.json({ data: { submissions: mockSubmissionsGrouped } }),
+    HttpResponse.json({
+      data: { submissions: mockSubmissionsGroupedAllStatuses },
+    }),
   ),
 ];
 
@@ -19,46 +21,91 @@ beforeEach(() => {
 });
 
 describe("When the submissions log renders", () => {
-  it("shows the expected headers and rows without an error", async () => {
+  beforeEach(async () => {
     await setup(
       <EventsLogGrouped
-        submissions={mockSubmissionsGrouped}
+        submissions={mockSubmissionsGroupedAllStatuses}
         error={undefined}
         loading={false}
       />,
     );
+  });
+
+  it("shows the expected headers", () => {
     const headers = ["Service", "Address", "Status", "Date", "Session ID"];
     headers.map((header) =>
       expect(
         screen.getByRole("columnheader", { name: header }),
       ).toBeInTheDocument(),
     );
+  }, 20_000);
 
-    // test for a selection of row values
-    expect(
-      screen.getAllByRole("gridcell", { name: "Invited to pay" }),
-    ).toHaveLength(1);
+  it("renders the expected session IDs", () => {
+    const expectedSessionIds = [
+      "126ec0c4-12f2-1209-aa09-11294ec3ee12", // sendToEmailSuccessSummary
+      "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5", // invitedToPaySummary
+      "1a2b3c4d-1111-4aaa-8aaa-111111111111", // paymentInProgressSummary
+      "1a2b3c4d-2222-4aaa-8aaa-222222222222", // sendingSummary
+      "556ec0c4-55f2-7709-aa09-15599ec3ee99", // sendToBOPSFailureSummary
+      "1a2b3c4d-3333-4aaa-8aaa-333333333333", // sendToUniformFailureSummary
+      "1a2b3c4d-4444-4aaa-8aaa-444444444444", // sendToEmailFailureSummary
+      "1a2b3c4d-5555-4aaa-8aaa-555555555555", // uploadToAWSFailureSummary
+      "1a2b3c4d-6666-4aaa-8aaa-666666666666", // submitToIdoxFailureSummary
+      "1a2b3c4d-7777-4aaa-8aaa-777777777777", // sanitisedApplicationSummary
+      "aaaaaaaa-4444-4aaa-8aaa-444444444444", // noAddressSendToEmailSummary
+    ];
 
+    expectedSessionIds.forEach((sessionId) => {
+      expect(screen.getByRole("gridcell", { name: sessionId })).toBeVisible();
+    });
+  }, 20_000);
+
+  it("correctly renders statuses", () => {
+    const expectedStatusCounts = {
+      Success: 3, // sendToEmailSuccessSummary, noAddressSendToEmailSummary, sanitisedApplicationSummary
+      "Invited to pay": 1,
+      "Payment in progress": 1,
+      Sending: 1,
+      "Submit to BOPS failed": 1,
+      "Submit to Uniform failed": 1,
+      "Send to email failed": 1,
+      "Upload to AWS S3 failed": 1,
+      "Submit to Idox Nexus failed": 1,
+    };
+
+    Object.entries(expectedStatusCounts).forEach(([status, count]) => {
+      expect(screen.getAllByRole("gridcell", { name: status })).toHaveLength(
+        count,
+      );
+    });
+  }, 20_000);
+
+  it("correctly renders flow names", () => {
+    const expectedFlowNameCounts: Record<string, number> = {
+      "Dsn impact metrics": 1,
+      "Apply for planning permission": 4, // invitedToPay, paymentInProgress, sending, sanitised
+      "Apply for a lawful development certificate": 3, // BOPS, AWS, Idox failures
+      "Report a breach": 2, // Uniform + email failures
+      "Attend a Public Inquiry": 1,
+    };
+
+    Object.entries(expectedFlowNameCounts).forEach(([flowName, count]) => {
+      expect(screen.getAllByText(flowName)).toHaveLength(count);
+    });
+  }, 20_000);
+
+  it("correctly renders addresses", () => {
+    // including "Not applicable" and "No longer retained" cases
     expect(
       screen.getByRole("gridcell", {
-        name: "126ec0c4-12f2-1209-aa09-11294ec3ee12",
+        name: "1, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
       }),
     ).toBeVisible();
-
     expect(
-      screen.getAllByRole("gridcell", {
-        name: "Submit to BOPS failed",
-      }),
-    ).toHaveLength(1);
-
-    expect(screen.getAllByRole("gridcell", { name: "Success" })).toHaveLength(
-      1,
-    );
-
-    expect(screen.getAllByText("Dsn impact metrics")).toHaveLength(1);
-    expect(screen.getAllByText("Report a breach")).toHaveLength(1);
+      screen.getByRole("gridcell", { name: "Not applicable" }),
+    ).toBeVisible();
     expect(
-      screen.getAllByText("Apply for a lawful development certificate"),
-    ).toHaveLength(1);
+      screen.getByRole("gridcell", { name: "No longer retained" }),
+    ).toBeVisible();
   }, 20_000);
 });

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/SubmissionsGrouped.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from "@testing-library/react";
+import { graphql, HttpResponse } from "msw";
+import React from "react";
+import server from "test/mockServer";
+import { setup } from "test/utils";
+import { it } from "vitest";
+
+import EventsLogGrouped from "./components/EventsLogGrouped";
+import { mockSubmissionsGrouped } from "./mockSubmissionsGrouped";
+
+const handlers = [
+  graphql.query("GetSubmissions", () =>
+    HttpResponse.json({ data: { submissions: mockSubmissionsGrouped } }),
+  ),
+];
+
+beforeEach(() => {
+  server.use(...handlers);
+});
+
+describe("When the submissions log renders", () => {
+  it("shows the expected headers and rows without an error", async () => {
+    await setup(
+      <EventsLogGrouped
+        submissions={mockSubmissionsGrouped}
+        error={undefined}
+        loading={false}
+      />,
+    );
+    const headers = ["Service", "Address", "Status", "Date", "Session ID"];
+    headers.map((header) =>
+      expect(
+        screen.getByRole("columnheader", { name: header }),
+      ).toBeInTheDocument(),
+    );
+
+    // test for a selection of row values
+    expect(
+      screen.getAllByRole("gridcell", { name: "Invited to pay" }),
+    ).toHaveLength(1);
+
+    expect(
+      screen.getByRole("gridcell", {
+        name: "126ec0c4-12f2-1209-aa09-11294ec3ee12",
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getAllByRole("gridcell", {
+        name: "Submit to BOPS failed",
+      }),
+    ).toHaveLength(1);
+
+    expect(screen.getAllByRole("gridcell", { name: "Success" })).toHaveLength(
+      1,
+    );
+
+    expect(screen.getAllByText("Dsn impact metrics")).toHaveLength(1);
+    expect(screen.getAllByText("Report a breach")).toHaveLength(1);
+    expect(
+      screen.getAllByText("Apply for a lawful development certificate"),
+    ).toHaveLength(1);
+  }, 20_000);
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.stories.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
 
-import { mockSubmissionsGrouped } from "../mockSubmissionsGrouped";
+import { mockSubmissionsGroupedAllStatuses } from "../mockSubmissionsGrouped";
 import EventsLogGrouped from "./EventsLogGrouped";
 
 const meta = {
@@ -23,7 +23,7 @@ export default meta;
 export const Basic = {
   args: {
     loading: false,
-    submissions: mockSubmissionsGrouped,
+    submissions: mockSubmissionsGroupedAllStatuses,
     error: undefined,
   },
 } satisfies Story;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/EventsLogGrouped.stories.tsx
@@ -1,0 +1,29 @@
+import Box from "@mui/material/Box";
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+
+import { mockSubmissionsGrouped } from "../mockSubmissionsGrouped";
+import EventsLogGrouped from "./EventsLogGrouped";
+
+const meta = {
+  title: "Editor Components/Submissions/Events log grouped",
+  component: EventsLogGrouped,
+  decorators: [
+    (Story) => (
+      <Box sx={{ height: "500px" }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof EventsLogGrouped>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    loading: false,
+    submissions: mockSubmissionsGrouped,
+    error: undefined,
+  },
+} satisfies Story;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
@@ -92,6 +92,12 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
+export const Basic = {
+  args: {
+    sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  },
+};
+
 export const InvitedToPay = {
   args: {
     sessionId: "invited-to-pay-0000-0000-000000000000",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
@@ -3,7 +3,13 @@ import Box from "@mui/material/Box";
 import type { Meta, StoryObj } from "@storybook/tanstack-react";
 
 import { useStore } from "../../../lib/store";
-import { mockSubmissionEvents, teamData } from "../mockSubmissionsGrouped";
+import {
+  mockInvitedToPayEvents,
+  mockSanitisedSuccessEvents,
+  mockSubmissionEvents,
+  mockUnresolvedFailureEvents,
+  teamData,
+} from "../mockSubmissionsGrouped";
 import { GET_TEAM_LOGO } from "../queries";
 import SubmissionDetailContent from "./SubmissionDetailContent";
 import { GET_SUBMISSION_EVENTS } from "./SubmissionDetailContent";
@@ -27,6 +33,39 @@ const mocks = [
     },
     result: {
       data: teamData,
+    },
+  },
+  {
+    request: {
+      query: GET_SUBMISSION_EVENTS,
+      variables: { sessionId: "invited-to-pay-0000-0000-000000000000" },
+    },
+    result: {
+      data: {
+        submissions: mockInvitedToPayEvents,
+      },
+    },
+  },
+  {
+    request: {
+      query: GET_SUBMISSION_EVENTS,
+      variables: { sessionId: "unresolved-failure-0000-0000-00000000" },
+    },
+    result: {
+      data: {
+        submissions: mockUnresolvedFailureEvents,
+      },
+    },
+  },
+  {
+    request: {
+      query: GET_SUBMISSION_EVENTS,
+      variables: { sessionId: "sanitised-success-0000-0000-0000000" },
+    },
+    result: {
+      data: {
+        submissions: mockSanitisedSuccessEvents,
+      },
     },
   },
 ];
@@ -53,8 +92,20 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
-export const Basic = {
+export const InvitedToPay = {
   args: {
-    sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+    sessionId: "invited-to-pay-0000-0000-000000000000",
+  },
+} satisfies Story;
+
+export const UnresolvedFailure = {
+  args: {
+    sessionId: "unresolved-failure-0000-0000-00000000",
+  },
+} satisfies Story;
+
+export const SanitisedSuccess = {
+  args: {
+    sessionId: "sanitised-success-0000-0000-0000000",
   },
 } satisfies Story;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
@@ -1,0 +1,60 @@
+import { MockedProvider } from "@apollo/client/testing";
+import Box from "@mui/material/Box";
+import type { Meta, StoryObj } from "@storybook/tanstack-react";
+
+import { useStore } from "../../../lib/store";
+import { mockSubmissionEvents, teamData } from "../mockSubmissionsGrouped";
+import { GET_TEAM_LOGO } from "../queries";
+import SubmissionDetailContent from "./SubmissionDetailContent";
+import { GET_SUBMISSION_EVENTS } from "./SubmissionDetailContent";
+
+const mocks = [
+  {
+    request: {
+      query: GET_SUBMISSION_EVENTS,
+      variables: { sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" },
+    },
+    result: {
+      data: {
+        submissions: mockSubmissionEvents,
+      },
+    },
+  },
+  {
+    request: {
+      query: GET_TEAM_LOGO,
+      variables: { teamSlug: "test-council" },
+    },
+    result: {
+      data: teamData,
+    },
+  },
+];
+
+const meta = {
+  title: "Editor Components/Submissions/Submission detail content",
+  component: SubmissionDetailContent,
+  decorators: [
+    (Story) => {
+      useStore.setState({ teamSlug: "test-council" });
+
+      return (
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Box>
+            <Story />
+          </Box>
+        </MockedProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof SubmissionDetailContent>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const Basic = {
+  args: {
+    sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  },
+} satisfies Story;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.stories.tsx
@@ -71,7 +71,7 @@ const mocks = [
 ];
 
 const meta = {
-  title: "Editor Components/Submissions/Submission detail content",
+  title: "Editor Components/Submissions/Details Modal/Content",
   component: SubmissionDetailContent,
   decorators: [
     (Story) => {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.tsx
@@ -1,4 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
+import DialogContent from "@mui/material/DialogContent";
 import Grid from "@mui/material/Grid";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { addDays, isBefore } from "date-fns";
@@ -80,33 +81,35 @@ export const SubmissionDetailContent: React.FC<
     : false;
 
   return (
-    <Grid container>
-      <Grid
-        size={{ xs: 12, md: 6 }}
-        sx={{
-          position: { md: "sticky" },
-          top: 0,
-          alignSelf: "flex-start",
-        }}
-      >
-        <SubmissionDetails
-          sessionId={sessionId}
-          latestEvent={latestEvent}
-          teamSlug={teamSlug}
-          submittedAt={submittedAt}
-          isSubmissionAvailable={isSubmissionAvailable}
-          isSanitised={isSanitised}
-          succeededPayment={succeededPayment}
-        />
-      </Grid>
+    <DialogContent>
+      <Grid container>
+        <Grid
+          size={{ xs: 12, md: 6 }}
+          sx={{
+            position: { md: "sticky" },
+            top: 0,
+            alignSelf: "flex-start",
+          }}
+        >
+          <SubmissionDetails
+            sessionId={sessionId}
+            latestEvent={latestEvent}
+            teamSlug={teamSlug}
+            submittedAt={submittedAt}
+            isSubmissionAvailable={isSubmissionAvailable}
+            isSanitised={isSanitised}
+            succeededPayment={succeededPayment}
+          />
+        </Grid>
 
-      <Grid size={{ xs: 12, md: 6 }}>
-        <SubmissionEventsHistory
-          events={events}
-          isSubmissionAvailable={isSubmissionAvailable}
-        />
+        <Grid size={{ xs: 12, md: 6 }}>
+          <SubmissionEventsHistory
+            events={events}
+            isSubmissionAvailable={isSubmissionAvailable}
+          />
+        </Grid>
       </Grid>
-    </Grid>
+    </DialogContent>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailContent.tsx
@@ -1,0 +1,113 @@
+import { gql, useQuery } from "@apollo/client";
+import Grid from "@mui/material/Grid";
+import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
+import { addDays, isBefore } from "date-fns";
+import { DAYS_UNTIL_EXPIRY } from "lib/pay";
+import { useStore } from "pages/FlowEditor/lib/store";
+
+import type { Submission } from "../types";
+import { getSucceededPayment, hasBeenSanitised } from "../utils";
+import { SubmissionDetails } from "./SubmissionDetails";
+import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
+
+// TODO: refactor into hooks / queries pattern
+export const GET_SUBMISSION_EVENTS = gql`
+  query GetSubmissionEvents($sessionId: uuid!) {
+    submissions: submission_services_log(
+      where: { session_id: { _eq: $sessionId } }
+      order_by: { created_at: desc }
+    ) {
+      flowId: flow_id
+      sessionId: session_id
+      eventId: event_id
+      eventType: event_type
+      status: status
+      retry: retry
+      response: response
+      address: address
+      createdAt: created_at
+      flowName: flow_name
+    }
+  }
+`;
+
+interface SubmissionDetailContentProps {
+  sessionId: string;
+}
+
+const getSubmittedAt = (events: Submission[]): string | undefined => {
+  const successfulSend = events.find(
+    (event) =>
+      event.eventType !== "Pay" &&
+      event.eventType !== "Started session" &&
+      event.eventType !== "Invited to pay" &&
+      event.status === "Success",
+  );
+
+  return successfulSend?.createdAt ?? undefined;
+};
+
+export const SubmissionDetailContent: React.FC<
+  SubmissionDetailContentProps
+> = ({ sessionId }) => {
+  const [teamSlug] = useStore((state) => [state.teamSlug]);
+
+  const { data, loading, error } = useQuery<{ submissions: Submission[] }>(
+    GET_SUBMISSION_EVENTS,
+    {
+      variables: { sessionId },
+      skip: !sessionId,
+    },
+  );
+
+  if (loading) return <DelayedLoadingIndicator />;
+  if (error) throw error;
+
+  const events = data?.submissions || [];
+  const latestEvent = events[0];
+  const submittedAt = getSubmittedAt(events);
+  const isSanitised = submittedAt
+    ? hasBeenSanitised(new Date(submittedAt))
+    : false;
+  const succeededPayment = getSucceededPayment(events);
+
+  const submissionExpirationDate = submittedAt
+    ? addDays(new Date(submittedAt), DAYS_UNTIL_EXPIRY)
+    : null;
+
+  const isSubmissionAvailable = submissionExpirationDate
+    ? isBefore(new Date(), submissionExpirationDate)
+    : false;
+
+  return (
+    <Grid container>
+      <Grid
+        size={{ xs: 12, md: 6 }}
+        sx={{
+          position: { md: "sticky" },
+          top: 0,
+          alignSelf: "flex-start",
+        }}
+      >
+        <SubmissionDetails
+          sessionId={sessionId}
+          latestEvent={latestEvent}
+          teamSlug={teamSlug}
+          submittedAt={submittedAt}
+          isSubmissionAvailable={isSubmissionAvailable}
+          isSanitised={isSanitised}
+          succeededPayment={succeededPayment}
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 6 }}>
+        <SubmissionEventsHistory
+          events={events}
+          isSubmissionAvailable={isSubmissionAvailable}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default SubmissionDetailContent;

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.test.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.test.tsx
@@ -1,0 +1,298 @@
+import { screen, waitFor } from "@testing-library/react";
+import { graphql, HttpResponse } from "msw";
+import React from "react";
+import server from "test/mockServer";
+import { setup } from "test/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mockPay,
+  mockSubmissionEvents,
+  mockSubmissionFailureEvents,
+  teamData,
+} from "../mockSubmissionsGrouped";
+import SubmissionDetailModal from "./SubmissionDetailModal";
+
+const mockGetUserRoleForCurrentTeam = vi.fn();
+const mockTeamSlug = "test-council";
+
+vi.mock("pages/FlowEditor/lib/store", () => ({
+  useStore: vi.fn((selector) =>
+    selector({
+      teamSlug: mockTeamSlug,
+      getUserRoleForCurrentTeam: mockGetUserRoleForCurrentTeam,
+    }),
+  ),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual("@tanstack/react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ flow: "test-flow" }),
+  };
+});
+
+const handlers = [
+  graphql.query("GetSubmissionEvents", () =>
+    HttpResponse.json({ data: { submissions: mockSubmissionEvents } }),
+  ),
+  graphql.query("GetTeamLogo", () => HttpResponse.json({ data: teamData })),
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  server.use(...handlers);
+  mockGetUserRoleForCurrentTeam.mockReturnValue("teamEditor");
+});
+
+describe("SubmissionDetailModal", () => {
+  describe("View submission button", () => {
+    it("renders view submission button when submission data is not expired", async () => {
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /View submission/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not render view button when submission data is expired", async () => {
+      const expiredEvents = mockSubmissionEvents.map((event) => ({
+        ...event,
+        createdAt: "2026-01-01T00:00:00.000000+00:00",
+      }));
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: expiredEvents } }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("Submission details")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /View submission/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render view submission button when all send events are failed", async () => {
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({
+            data: { submissions: mockSubmissionFailureEvents },
+          }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Submission details")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /View submission/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Download submission button", () => {
+    it("renders download button when submission data is not expired", async () => {
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /Download/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not render download button when submission data is expired", async () => {
+      const expiredEvents = mockSubmissionEvents.map((event) => ({
+        ...event,
+        createdAt: "2020-01-01T00:00:00.000000+00:00",
+      }));
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: expiredEvents } }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("Submission details")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /Download/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("View response button", () => {
+    it("renders view response button for relevant events", async () => {
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        const buttons = screen.getAllByLabelText(/View response/i);
+        expect(buttons.length).toBe(6);
+      });
+    });
+
+    it("opens modal with response data when clicked", async () => {
+      const { user } = await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByLabelText(/View response/i)[0],
+        ).toBeInTheDocument();
+      });
+
+      const viewResponseButton = screen.getAllByLabelText(/View response/i)[0];
+      await user.click(viewResponseButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Response for/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Resubmit button", () => {
+    it("does not render resubmit button when user is not platform admin", async () => {
+      mockGetUserRoleForCurrentTeam.mockReturnValue("teamEditor");
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({
+            data: { submissions: mockSubmissionFailureEvents },
+          }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("Submission details")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Resubmit/i)).not.toBeInTheDocument();
+    });
+
+    it("does not render resubmit button for successful events", async () => {
+      mockGetUserRoleForCurrentTeam.mockReturnValue("platformAdmin");
+
+      const successOnlyEvents = mockSubmissionEvents.filter(
+        (event) => event.status === "Success",
+      );
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: successOnlyEvents } }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("Submission details")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Resubmit/i)).not.toBeInTheDocument();
+    });
+
+    it("does not render resubmit button for Pay events", async () => {
+      mockGetUserRoleForCurrentTeam.mockReturnValue("platformAdmin");
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: [mockPay] } }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Pay")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Resubmit/i)).not.toBeInTheDocument();
+    });
+
+    it("only renders resubmit button for most recent failed event of each type", async () => {
+      mockGetUserRoleForCurrentTeam.mockReturnValue("platformAdmin");
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: mockSubmissionEvents } }),
+        ),
+      );
+
+      await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("Submission details")).toBeInTheDocument();
+      });
+
+      const resubmitButtons = await screen.findAllByText(/Resubmit/i);
+      expect(resubmitButtons.length).toEqual(1); // one resubmit per _type_ of failed event; keep in sync with different types of failures (not succeeded later on) in mocks
+    });
+
+    it("shows confirmation dialog when resubmit button is clicked", async () => {
+      mockGetUserRoleForCurrentTeam.mockReturnValue("platformAdmin");
+
+      server.use(
+        graphql.query("GetSubmissionEvents", () =>
+          HttpResponse.json({ data: { submissions: mockSubmissionEvents } }),
+        ),
+      );
+
+      const { user } = await setup(
+        <SubmissionDetailModal sessionId="6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5" />,
+      );
+
+      const resubmitButtons = await screen.findAllByText(/Resubmit/i);
+      expect(resubmitButtons.length).toBeGreaterThan(0);
+
+      const resubmitButton = resubmitButtons[0];
+      await user.click(resubmitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/You're about to resubmit this application/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,54 +1,27 @@
-import { gql, useQuery } from "@apollo/client";
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import Grid from "@mui/material/Grid";
 import { useNavigate } from "@tanstack/react-router";
-import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
-import { addDays, isBefore } from "date-fns";
-import { DAYS_UNTIL_EXPIRY } from "lib/pay";
-import { useStore } from "pages/FlowEditor/lib/store";
 import { CloseButton } from "ui/shared/CloseButton";
 
-import type { Submission } from "../types";
-import { getSucceededPayment } from "../utils";
-import { hasBeenSanitised } from "../utils";
-import { SubmissionDetails } from "./SubmissionDetails";
-import { SubmissionEventsHistory } from "./SubmissionEventsHistory";
-
-// TODO: refactor into hooks / queries pattern
-const GET_SUBMISSION_EVENTS = gql`
-  query GetSubmissionEvents($sessionId: uuid!) {
-    submissions: submission_services_log(
-      where: { session_id: { _eq: $sessionId } }
-      order_by: { created_at: desc }
-    ) {
-      flowId: flow_id
-      sessionId: session_id
-      eventId: event_id
-      eventType: event_type
-      status: status
-      retry: retry
-      response: response
-      address: address
-      createdAt: created_at
-      flowName: flow_name
-    }
-  }
-`;
+import { SubmissionDetailContent } from "./SubmissionDetailContent";
 
 interface SubmissionDetailModalProps {
   sessionId: string;
 }
 
-const SubmissionModalWrapper = ({
-  handleClose,
-  children,
-}: {
-  handleClose: () => void;
-  children: React.ReactNode;
+const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
+  sessionId,
 }) => {
+  const navigate = useNavigate();
+
+  const handleClose = () => {
+    navigate({
+      search: undefined,
+    });
+  };
+
   return (
     <Dialog
       open
@@ -75,98 +48,10 @@ const SubmissionModalWrapper = ({
         <CloseButton onClick={handleClose} sx={{ paddingTop: 2.5 }} />
       </Box>
 
-      <DialogContent children={children} />
+      <DialogContent>
+        <SubmissionDetailContent sessionId={sessionId} />
+      </DialogContent>
     </Dialog>
-  );
-};
-
-const getSubmittedAt = (events: Submission[]): string | undefined => {
-  const successfulSend = events.find(
-    (event) =>
-      event.eventType !== "Pay" &&
-      event.eventType !== "Started session" &&
-      event.eventType !== "Invited to pay" &&
-      event.status === "Success",
-  );
-
-  return successfulSend?.createdAt ?? undefined;
-};
-
-const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
-  sessionId,
-}) => {
-  const navigate = useNavigate();
-  const [teamSlug] = useStore((state) => [state.teamSlug]);
-
-  const { data, loading, error } = useQuery<{ submissions: Submission[] }>(
-    GET_SUBMISSION_EVENTS,
-    {
-      variables: { sessionId },
-      skip: !sessionId,
-    },
-  );
-
-  const handleClose = () => {
-    navigate({
-      search: undefined,
-    });
-  };
-
-  const events = data?.submissions || [];
-  const latestEvent = events[0];
-  const submittedAt = getSubmittedAt(events);
-  const isSanitised = submittedAt
-    ? hasBeenSanitised(new Date(submittedAt))
-    : false;
-  const succeededPayment = getSucceededPayment(events);
-
-  const submissionExpirationDate = submittedAt
-    ? addDays(new Date(submittedAt), DAYS_UNTIL_EXPIRY)
-    : null;
-
-  const isSubmissionAvailable = submissionExpirationDate
-    ? isBefore(new Date(), submissionExpirationDate)
-    : false;
-
-  if (loading) {
-    return (
-      <SubmissionModalWrapper handleClose={handleClose}>
-        <DelayedLoadingIndicator />
-      </SubmissionModalWrapper>
-    );
-  }
-
-  if (error) throw error;
-  return (
-    <SubmissionModalWrapper handleClose={handleClose}>
-      <Grid container>
-        <Grid
-          size={{ xs: 12, md: 6 }}
-          sx={{
-            position: { md: "sticky" },
-            top: 0,
-            alignSelf: "flex-start",
-          }}
-        >
-          <SubmissionDetails
-            sessionId={sessionId}
-            latestEvent={latestEvent}
-            teamSlug={teamSlug}
-            submittedAt={submittedAt}
-            isSubmissionAvailable={isSubmissionAvailable}
-            isSanitised={isSanitised}
-            succeededPayment={succeededPayment}
-          />
-        </Grid>
-
-        <Grid size={{ xs: 12, md: 6 }}>
-          <SubmissionEventsHistory
-            events={events}
-            isSubmissionAvailable={isSubmissionAvailable}
-          />
-        </Grid>
-      </Grid>
-    </SubmissionModalWrapper>
   );
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/components/SubmissionDetailModal.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
-import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import { useNavigate } from "@tanstack/react-router";
 import { CloseButton } from "ui/shared/CloseButton";
@@ -48,9 +47,7 @@ const SubmissionDetailModal: React.FC<SubmissionDetailModalProps> = ({
         <CloseButton onClick={handleClose} sx={{ paddingTop: 2.5 }} />
       </Box>
 
-      <DialogContent>
-        <SubmissionDetailContent sessionId={sessionId} />
-      </DialogContent>
+      <SubmissionDetailContent sessionId={sessionId} />
     </Dialog>
   );
 };

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
@@ -26,17 +26,6 @@ const sendToBOPSFailureSummary: SubmissionSummary = {
   consolidatedStatus: "Submit to BOPS failed",
 };
 
-const jsonErrorSummary: SubmissionSummary = {
-  id: "306c7498-9cd3-4e8e-bafe-2e2de5133caa",
-  flowId: "d0744118-f902-4538-b439-573f4b42a727",
-  flowName: "Report a breach",
-  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
-  eventCreatedAt: "2024-01-12T12:18:12.805747+00:00",
-  eventType: "Submit to Uniform",
-  status: "Failed (500)",
-  consolidatedStatus: "Submit to Uniform failed",
-};
-
 const invitedToPaySummary: SubmissionSummary = {
   id: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
   flowId: "d0744118-f902-4538-b439-573f4b42a727",
@@ -47,13 +36,6 @@ const invitedToPaySummary: SubmissionSummary = {
   status: "Success",
   consolidatedStatus: "Invited to pay",
 };
-
-export const mockSubmissionsGrouped: SubmissionSummary[] = [
-  sendToEmailSuccessSummary,
-  sendToBOPSFailureSummary,
-  jsonErrorSummary,
-  invitedToPaySummary,
-];
 
 // multiple events for the same sessionId are for the SubmissionDetailModal tests
 const sendToEmailSuccess: Submission = {

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
@@ -1,0 +1,121 @@
+import type { Submission, SubmissionSummary } from "./types";
+
+const sendToEmailSuccessSummary: SubmissionSummary = {
+  id: "126ec0c4-12f2-1209-aa09-11294ec3ee12",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Dsn impact metrics",
+  address: "1, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: "2024-01-12T12:17:42.275655+00:00",
+  eventType: "Send to email",
+  status: "Success",
+};
+
+const sendToBOPSFailureSummary: SubmissionSummary = {
+  id: "556ec0c4-55f2-7709-aa09-15599ec3ee99",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for a lawful development certificate",
+  address: "2, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: "2024-01-12T12:18:12.805747+00:00",
+  eventType: "Submit to BOPS",
+  status: "Failed (400)",
+  consolidatedStatus: "Submit to BOPS failed",
+};
+
+const jsonErrorSummary: SubmissionSummary = {
+  id: "306c7498-9cd3-4e8e-bafe-2e2de5133caa",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Report a breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: "2024-01-12T12:18:12.805747+00:00",
+  eventType: "Submit to Uniform",
+  status: "Failed (500)",
+  consolidatedStatus: "Submit to Uniform failed",
+};
+
+const invitedToPaySummary: SubmissionSummary = {
+  id: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for planning permission",
+  address: "4, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: "2025-01-12T12:18:12.805747+00:00",
+  eventType: "Invited to pay",
+  status: "Success",
+  consolidatedStatus: "Invited to pay",
+};
+
+export const mockSubmissionsGrouped: SubmissionSummary[] = [
+  sendToEmailSuccessSummary,
+  sendToBOPSFailureSummary,
+  jsonErrorSummary,
+  invitedToPaySummary,
+];
+
+// multiple events for the same sessionId are for the SubmissionDetailModal tests
+const sendToEmailSuccess: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "2023508e-0fee-4726-8b04-5fcbba7d37c9",
+  eventType: "Send to email",
+  status: "Success",
+  retry: true,
+  response: { data: { message: "Success!" } },
+  createdAt: "2026-08-20T09:03:00.021681+00:00", // events happen in specified sequence to test groupEvents logic
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+const sendToBOPSSuccess: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "7491cca7-833d-4680-91c0-b3faa1e23977",
+  eventType: "Submit to BOPS",
+  status: "Success",
+  retry: true,
+  response: { data: { message: "Success!" } },
+  createdAt: "2026-08-20T09:04:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+const sendToEmailFailure: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "2023508e-0fee-4726-8b04-5fcbba7d37c9",
+  eventType: "Send to email",
+  status: "Failed (500)",
+  retry: false,
+  response: { data: { message: "Failure" } },
+  createdAt: "2026-08-20T09:01:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+const sendToBOPSFailure: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "7491cca7-833d-4680-91c0-b3faa1e23977",
+  eventType: "Submit to BOPS",
+  status: "Failed (400)",
+  retry: false,
+  response: { data: { message: "Failure" } },
+  createdAt: "2026-08-20T09:00:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+
+export const submissionEvents = [
+  sendToEmailSuccess,
+  sendToBOPSSuccess,
+  sendToEmailFailure,
+  sendToBOPSFailure,
+];
+
+export const teamData = {
+  teams: [
+    {
+      id: 1,
+      name: "Test Council",
+      theme: {
+        logo: "https://example.com/logo.png",
+        primaryColour: "#0000FF",
+      },
+    },
+  ],
+};

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
@@ -10,6 +10,19 @@ const sendToEmailSuccessSummary: SubmissionSummary = {
   status: "Success",
 };
 
+export const sendToEmailSuccessSubmission: Submission = {
+  flowId: sendToEmailSuccessSummary.flowId,
+  sessionId: sendToEmailSuccessSummary.id,
+  eventId: sendToEmailSuccessSummary.id,
+  eventType: sendToEmailSuccessSummary.eventType,
+  status: sendToEmailSuccessSummary.status,
+  retry: false,
+  response: { data: { message: "Success!" } },
+  createdAt: sendToEmailSuccessSummary.eventCreatedAt,
+  flowName: sendToEmailSuccessSummary.flowName,
+  address: sendToEmailSuccessSummary.address,
+};
+
 const sendToBOPSFailureSummary: SubmissionSummary = {
   id: "556ec0c4-55f2-7709-aa09-15599ec3ee99",
   flowId: "d0744118-f902-4538-b439-573f4b42a727",

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
@@ -1,4 +1,9 @@
+import { subDays, subMonths } from "date-fns";
+
 import type { Submission, SubmissionSummary } from "./types";
+
+const daysAgo = (n: number): string => subDays(new Date(), n).toISOString();
+const monthsAgo = (n: number): string => subMonths(new Date(), n).toISOString();
 
 const sendToEmailSuccessSummary: SubmissionSummary = {
   id: "126ec0c4-12f2-1209-aa09-11294ec3ee12",
@@ -8,19 +13,6 @@ const sendToEmailSuccessSummary: SubmissionSummary = {
   eventCreatedAt: "2024-01-12T12:17:42.275655+00:00",
   eventType: "Send to email",
   status: "Success",
-};
-
-export const sendToEmailSuccessSubmission: Submission = {
-  flowId: sendToEmailSuccessSummary.flowId,
-  sessionId: sendToEmailSuccessSummary.id,
-  eventId: sendToEmailSuccessSummary.id,
-  eventType: sendToEmailSuccessSummary.eventType,
-  status: sendToEmailSuccessSummary.status,
-  retry: false,
-  response: { data: { message: "Success!" } },
-  createdAt: sendToEmailSuccessSummary.eventCreatedAt,
-  flowName: sendToEmailSuccessSummary.flowName,
-  address: sendToEmailSuccessSummary.address,
 };
 
 const sendToBOPSFailureSummary: SubmissionSummary = {
@@ -173,6 +165,113 @@ export const mockSubmissionSingleFailureEvents = [
   sendToBOPSFailure,
 ];
 
+const paymentInProgressSummary: SubmissionSummary = {
+  id: "1a2b3c4d-1111-4aaa-8aaa-111111111111",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for planning permission",
+  address: "5, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(1),
+  eventType: "Pay",
+  status: "Started",
+  consolidatedStatus: "Payment in progress",
+};
+
+const sendingSummary: SubmissionSummary = {
+  id: "1a2b3c4d-2222-4aaa-8aaa-222222222222",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for planning permission",
+  address: "6, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(1),
+  eventType: "Pay",
+  status: "Success",
+  consolidatedStatus: "Sending",
+};
+
+const sendToUniformFailureSummary: SubmissionSummary = {
+  id: "1a2b3c4d-3333-4aaa-8aaa-333333333333",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Report a breach",
+  address: "7, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(2),
+  eventType: "Submit to Uniform",
+  status: "Failed (500)",
+  consolidatedStatus: "Submit to Uniform failed",
+};
+
+const sendToEmailFailureSummary: SubmissionSummary = {
+  id: "1a2b3c4d-4444-4aaa-8aaa-444444444444",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Report a breach",
+  address: "8, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(2),
+  eventType: "Send to email",
+  status: "Failed (500)",
+  consolidatedStatus: "Send to email failed",
+};
+
+const noAddressSendToEmailSummary: SubmissionSummary = {
+  id: "aaaaaaaa-4444-4aaa-8aaa-444444444444",
+  flowId: "d119c271-7495-4d81-8c59-973c75137262",
+  flowName: "Attend a Public Inquiry",
+  address: "Not applicable",
+  eventCreatedAt: daysAgo(2),
+  eventType: "Send to email",
+  status: "Success",
+  consolidatedStatus: "Success",
+};
+
+const uploadToAWSFailureSummary: SubmissionSummary = {
+  id: "1a2b3c4d-5555-4aaa-8aaa-555555555555",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for a lawful development certificate",
+  address: "9, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(3),
+  eventType: "Upload to AWS S3",
+  status: "Failed (400)",
+  consolidatedStatus: "Upload to AWS S3 failed",
+};
+
+const submitToIdoxFailureSummary: SubmissionSummary = {
+  id: "1a2b3c4d-6666-4aaa-8aaa-666666666666",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for a lawful development certificate",
+  address: "10, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  eventCreatedAt: daysAgo(3),
+  eventType: "Submit to Idox Nexus",
+  status: "Failed (502)",
+  consolidatedStatus: "Submit to Idox Nexus failed",
+};
+
+const sanitisedApplicationSummary: SubmissionSummary = {
+  id: "1a2b3c4d-7777-4aaa-8aaa-777777777777",
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  flowName: "Apply for planning permission",
+  address: "No longer retained",
+  eventCreatedAt: monthsAgo(7),
+  eventType: "Submit to BOPS",
+  status: "Success",
+  consolidatedStatus: "Success",
+};
+
+export const mockSubmissionsGroupedAllStatuses: SubmissionSummary[] = [
+  sendToEmailSuccessSummary,
+  invitedToPaySummary,
+  paymentInProgressSummary,
+  sendingSummary,
+  sendToBOPSFailureSummary,
+  sendToUniformFailureSummary,
+  sendToEmailFailureSummary,
+  uploadToAWSFailureSummary,
+  submitToIdoxFailureSummary,
+  sanitisedApplicationSummary,
+  noAddressSendToEmailSummary,
+];
+
+export const mockSubmissionsGroupedPartialStatuses: SubmissionSummary[] = [
+  sendToEmailSuccessSummary,
+  sendToEmailFailureSummary,
+];
+
 export const teamData = {
   teams: [
     {
@@ -185,3 +284,72 @@ export const teamData = {
     },
   ],
 };
+
+export const mockInvitedToPayEvents: Submission[] = [
+  {
+    flowId: "d0744118-f902-4538-b439-573f4b42a727",
+    sessionId: "invited-to-pay-0000-0000-000000000000",
+    eventId: "invite-event-0000-0000-000000000000",
+    eventType: "Invited to pay",
+    status: "Success",
+    retry: false,
+    response: { emailSentTo: "applicant@example.com" },
+    createdAt: daysAgo(2),
+    flowName: "Apply for a lawful development certificate",
+    address: "11, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  },
+];
+
+export const mockUnresolvedFailureEvents: Submission[] = [
+  {
+    flowId: "d0744118-f902-4538-b439-573f4b42a727",
+    sessionId: "unresolved-failure-0000-0000-00000000",
+    eventId: "unresolved-bops-0000-0000-000000000000",
+    eventType: "Submit to BOPS",
+    status: "Failed (500)",
+    retry: false,
+    response: { data: { message: "Internal server error" } },
+    createdAt: daysAgo(1),
+    flowName: "Apply for planning permission",
+    address: "12, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  },
+  {
+    flowId: "d0744118-f902-4538-b439-573f4b42a727",
+    sessionId: "unresolved-failure-0000-0000-00000000",
+    eventId: "unresolved-pay-0000-0000-000000000000",
+    eventType: "Pay",
+    status: "Success",
+    retry: false,
+    response: { paymentId: "gov-pay-unresolved" },
+    createdAt: daysAgo(2),
+    flowName: "Apply for planning permission",
+    address: "12, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+  },
+];
+
+export const mockSanitisedSuccessEvents: Submission[] = [
+  {
+    flowId: "d0744118-f902-4538-b439-573f4b42a727",
+    sessionId: "sanitised-success-0000-0000-0000000",
+    eventId: "sanitised-bops-0000-0000-000000000000",
+    eventType: "Submit to BOPS",
+    status: "Success",
+    retry: false,
+    response: { data: { body: { message: "Application received" } } },
+    createdAt: monthsAgo(7),
+    flowName: "Apply for planning permission",
+    address: "No longer retained",
+  },
+  {
+    flowId: "d0744118-f902-4538-b439-573f4b42a727",
+    sessionId: "sanitised-success-0000-0000-0000000",
+    eventId: "sanitised-pay-0000-0000-000000000000",
+    eventType: "Pay",
+    status: "Success",
+    retry: false,
+    response: { paymentId: "gov-pay-sanitised" },
+    createdAt: monthsAgo(7),
+    flowName: "Apply for planning permission",
+    address: "No longer retained",
+  },
+];

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Submissions/mockSubmissionsGrouped.ts
@@ -87,6 +87,7 @@ const sendToEmailFailure: Submission = {
   flowName: "Report a planning breach",
   address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
 };
+
 const sendToBOPSFailure: Submission = {
   flowId: "d0744118-f902-4538-b439-573f4b42a727",
   sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
@@ -100,8 +101,60 @@ const sendToBOPSFailure: Submission = {
   address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
 };
 
-export const submissionEvents = [
+const sendToAWSFailureAttempt1: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "7491cca7-833d-4680-91c0-b3faa1e23977",
+  eventType: "Upload to AWS S3",
+  status: "Failed (400)",
+  retry: false,
+  response: { data: { message: "Failure" } },
+  createdAt: "2026-08-20T09:00:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+
+const sendToAWSFailureAttempt2: Submission = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "b28b9692-6097-4510-9c3e-a6cc79d6d1e8",
+  eventType: "Upload to AWS S3",
+  status: "Failed (400)",
+  retry: false,
+  response: { data: { message: "Failure" } },
+  createdAt: "2026-08-20T09:01:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+
+export const mockPay = {
+  flowId: "d0744118-f902-4538-b439-573f4b42a727",
+  sessionId: "6fcb873f-cc7f-4fc0-ad9d-b4148de7a3b5",
+  eventId: "pay-123",
+  eventType: "Pay" as const,
+  status: "Failed" as const,
+  retry: false,
+  response: {},
+  createdAt: "2026-08-20T09:05:00.021681+00:00",
+  flowName: "Report a planning breach",
+  address: "3, CALVERT AVENUE, COLINDALE, LONDON, BARNET, NW9 4EW",
+};
+
+export const mockSubmissionEvents = [
   sendToEmailSuccess,
+  sendToBOPSSuccess,
+  sendToEmailFailure,
+  sendToBOPSFailure,
+  sendToAWSFailureAttempt1,
+  sendToAWSFailureAttempt2,
+];
+
+export const mockSubmissionFailureEvents = [
+  sendToEmailFailure,
+  sendToBOPSFailure,
+];
+
+export const mockSubmissionSingleFailureEvents = [
   sendToBOPSSuccess,
   sendToEmailFailure,
   sendToBOPSFailure,


### PR DESCRIPTION
Overdue mocks, tests and stories for the `EventsLogGrouped` component and `SubmissionDetailModal`.

To get the `SubmissionDetailModal` to render properly in Storybook, I had to extract its content into SubmissionDetailContent (to make a story for that, and keep the `Dialog` in its parent wrapper).