### PR TITLE
feat[alt notes]: set visibility rules for templates

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -29,7 +29,7 @@ function NoteComponent(props: Props) {
     props.formikRef,
   );
 
-  // Notes will never be "templated", therefore no template fields here
+  // Notes should never be "templated", therefore disable `showTemplateConfiguration` in footer here
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
       <ModalSection>
@@ -54,6 +54,7 @@ function NoteComponent(props: Props) {
         showTags={true}
         showInternalNotes={false}
         showMoreInformation={false}
+        showTemplateConfiguration={false}
       />
     </form>
   );

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/AttachedNote.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/AttachedNote.tsx
@@ -1,15 +1,45 @@
 import Box from "@mui/material/Box";
 import { useStore } from "pages/FlowEditor/lib/store";
+import {
+  nodeIsChildOfTemplatedInternalPortal,
+  nodeIsTemplatedInternalPortal,
+} from "pages/FlowEditor/utils";
 import React from "react";
 
+import { getParentId } from "../lib/utils";
+
 export const AttachedNote: React.FC<{
+  nodeId: string;
   note: string;
   variant?: "option";
-}> = ({ note, variant }) => {
-  const showNotes = useStore((state) => state.showNotes);
+}> = ({ nodeId, note, variant }) => {
+  const [showNotes, isTemplatedFrom, flow, orderedFlow] = useStore((state) => [
+    state.showNotes,
+    state.isTemplatedFrom,
+    state.flow,
+    state.orderedFlow,
+  ]);
 
-  // TODO also return null if templated flow and *not* attached to a templated node?
-  if (!showNotes) return null;
+  // In templated flows, always hide `AttachedNote` in the graph
+  //   unless it is attached to a templated node or within a templated folder
+  const isAttachedToTemplatedNode = flow[nodeId]?.data?.isTemplatedNode;
+  const parent = getParentId(nodeId);
+  const indexedParent = orderedFlow?.find(({ id }) => id === parent);
+  const parentIsTemplatedInternalPortal = nodeIsTemplatedInternalPortal(
+    flow,
+    indexedParent,
+  );
+  const parentIsChildOfTemplatedInternalPortal =
+    nodeIsChildOfTemplatedInternalPortal(flow, indexedParent);
+
+  const showAttachedNote =
+    showNotes &&
+    (!isTemplatedFrom ||
+      isAttachedToTemplatedNode ||
+      parentIsTemplatedInternalPortal ||
+      parentIsChildOfTemplatedInternalPortal);
+
+  if (!showAttachedNote) return null;
 
   return (
     <Box

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Checklist.tsx
@@ -159,7 +159,9 @@ const Checklist: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
-          {props.data?.notes && <AttachedNote note={props.data.notes} />}
+          {props.data?.notes && (
+            <AttachedNote nodeId={props.id} note={props.data.notes} />
+          )}
         </TemplatedNodeContainer>
         {groupedOptions ? (
           <ol className="categories">

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Filter.tsx
@@ -9,7 +9,6 @@ import { useDrag } from "react-dnd";
 
 import { useStore } from "../../../lib/store";
 import { getParentId } from "../lib/utils";
-import { AttachedNote } from "./AttachedNote";
 import Hanger from "./Hanger";
 import Node from "./Node";
 
@@ -87,7 +86,6 @@ const Filter: React.FC<Props> = React.memo((props) => {
             {Icon && <Icon />}
             <span>{props.text}</span>
           </Link>
-          {props.data?.notes && <AttachedNote note={props.data.notes} />}
         </div>
         <ol className="options">
           {childNodes.map((child) => (

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Option.tsx
@@ -90,7 +90,11 @@ const Option: React.FC<any> = (props) => {
             <DataField value={props.data.val} variant="child" />
           )}
           {props.data?.notes && (
-            <AttachedNote note={props.data.notes} variant="option" />
+            <AttachedNote
+              nodeId={props.id}
+              note={props.data.notes}
+              variant="option"
+            />
           )}
         </Link>
       </div>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Portal.tsx
@@ -171,7 +171,9 @@ const ExternalPortal: React.FC<any> = (props) => {
               ))}
             </Box>
           )}
-          {props.data?.notes && <AttachedNote note={props.data.notes} />}
+          {props.data?.notes && (
+            <AttachedNote nodeId={props.id} note={props.data.notes} />
+          )}
         </Box>
       </li>
     </>
@@ -271,7 +273,9 @@ const InternalPortal: React.FC<any> = (props) => {
                 ))}
               </Box>
             )}
-            {props.data?.notes && <AttachedNote note={props.data.notes} />}
+            {props.data?.notes && (
+              <AttachedNote nodeId={props.id} note={props.data.notes} />
+            )}
           </TemplatedNodeContainer>
         </Box>
       </li>

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Question.tsx
@@ -140,7 +140,9 @@ const Question: React.FC<Props> = React.memo((props) => {
               ))}
             </Box>
           )}
-          {props.data?.notes && <AttachedNote note={props.data.notes} />}
+          {props.data?.notes && (
+            <AttachedNote nodeId={props.id} note={props.data.notes} />
+          )}
         </TemplatedNodeContainer>
         <ol className="options">
           {childNodes.map((child: any) => (

--- a/apps/editor.planx.uk/src/ui/editor/ModalFooter.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ModalFooter.tsx
@@ -13,6 +13,7 @@ interface Props<T extends BaseNodeData> {
   showMoreInformation?: boolean;
   showInternalNotes?: boolean;
   showTags?: boolean;
+  showTemplateConfiguration?: boolean;
   disabled?: boolean;
 }
 
@@ -21,6 +22,7 @@ export const ModalFooter = <T extends BaseNodeData>({
   showMoreInformation = true,
   showInternalNotes = true,
   showTags = true,
+  showTemplateConfiguration = true,
   disabled,
 }: Props<T>) => {
   const isTemplate = useStore.getState().isTemplate;
@@ -45,7 +47,7 @@ export const ModalFooter = <T extends BaseNodeData>({
           disabled={disabled}
         />
       )}
-      {isTemplate && (
+      {showTemplateConfiguration && isTemplate && (
         <TemplatedNodeConfiguration
           formik={formik}
           isTemplatedNode={formik.values.isTemplatedNode}


### PR DESCRIPTION
**Current rules:** 
- In a source template, a Note component type should never be "templated" aka made customisable, so hide this section in editor modal
- In a source template, graph note visbility is controlled as usual by "Show notes" 
- In a templated flow, even when "Show notes" is toggled on, standalone and attached notes should always be hidden from the graph view unless:
  - It is an attached note to a templated node
  - It is a standalone or attached note within a templated folder

**Open questions:**
- In a templated flow, when I open the read-only modal for a non-templated node, I can still see its' "Note" input (disabled) - is this okay or would we expect to be hidden / fully invisible?
- [Jonny's user story / testing feedback] In a source template, if I update only the content of a note and want to push out updates, how can I get around "Found no changes to publish" ? 
  - Current workaround for this would be remove + re-add note to trigger _position_ change that will be captured by diff and therefore _is_ publishable
  - Longer term, we can adjust publish diff logic to have special rule for source templates (eg found changes _or_ has operations since last publish?). The blocker here is _just_ the "check for changes diff" (relies on flattened data which now has sanitised note content), the actual function to push out updates to templated flow children reads from live flow data (unflattened, contains all notes)
- What is role of attached notes alongside templated node "instructions" going forward / how does content team anticipate using either? Should instructions have graph visibility same way attached notes do?

I think / hope that all these template open questions are revisitable and don't hold up wider feature release/call for testing among councils ! Publishing questions only impact source template authors (us).

**Testing flows:**
- Source template example https://7334.planx.pizza/app/opensystemslab/notes-in-templates-testing
- Templated flow example https://7334.planx.pizza/app/opensystemslab/notes-in-templates-testing-templated
- :exclamation: Please note that I've run full content migration against this pizza too since staging now reset - see `temp_data_migrations_audit` table on this pizza's Hasura