### PR TITLE
fix(a11y): Announce progressive loading stages to screen readers

### DIFF
--- a/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.test.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.test.tsx
@@ -42,6 +42,12 @@ describe("ProgressiveLoading", () => {
     expect(screen.getByRole("status")).not.toHaveAttribute("aria-hidden");
   });
 
+  it("moves focus to the live region on mount, so it is announced", async () => {
+    await setup(<ProgressiveLoading stages={STAGES} interval={1000} />);
+
+    expect(screen.getByRole("status")).toHaveFocus();
+  });
+
   it("does not contain accessibility violations", async () => {
     const { container } = await setup(
       <ProgressiveLoading stages={STAGES} interval={1000} />,

--- a/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/ProgressiveLoading.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import { keyframes, styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 const pulseAnimation = keyframes`
   0% {
@@ -60,6 +60,7 @@ const ProgressiveLoading: React.FC<ProgressiveLoadingProps> = ({
   interval = 1000,
 }) => {
   const [visibleStages, setVisibleStages] = useState(0);
+  const statusRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (visibleStages < stages.length - 1) {
@@ -69,6 +70,11 @@ const ProgressiveLoading: React.FC<ProgressiveLoadingProps> = ({
       return () => clearTimeout(timer);
     }
   }, [visibleStages, stages.length, interval]);
+
+  useEffect(() => {
+    // Move focus to the live region, allowing screen readers to announce the stages
+    statusRef.current?.focus();
+  }, []);
 
   return (
     <Box
@@ -80,7 +86,13 @@ const ProgressiveLoading: React.FC<ProgressiveLoadingProps> = ({
       }}
       aria-busy="true"
     >
-      <Box role="status" aria-live="polite" style={visuallyHidden}>
+      <Box
+        ref={statusRef}
+        tabIndex={-1}
+        role="status"
+        aria-live="polite"
+        style={visuallyHidden}
+      >
         {stages.join(". ")}
       </Box>
       <Box


### PR DESCRIPTION
## Issue

Relates to:
p.38 (V2 report) - DAC_Status_Messages_01
https://trello.com/c/Js7Xo4FE/3753-aa-dacstatusmessages01

`ProgressiveLoading` inserts as new page content with its `aria-live="polite"` status region already populated. Screen readers will usually only announce changes to an existing live region, so this insertion does not get announced, and focus is left on the `Continue` button that triggered it - a user non-sighted has no indication anything happened.

> Screen reader users are not alerted to the fact that content has been added to the page,
and focus stays on the ‘Continue’ control so that it may appear to users that nothing has
happened. Screen reader users would be required to search the page for changes to identify
what has occurred.

## Solution

Move focus into the region on mount instead, so the stages get read out and focus doesn't stay on the `Continue` button that triggered the loading state.

<img width="956" height="808" alt="image" src="https://github.com/user-attachments/assets/d1fb0bf9-3f20-497c-86cc-0d56b4892c34" />

