### PR TITLE
fix(a11y): Include descriptions when announcing radio options

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/Tasks/ProjectDescription.tsx
@@ -52,6 +52,15 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
   const radioGroupState = useRadioGroup();
   const isSelected = radioGroupState?.value === id;
   const recommendedTagId = `${id}-recommended`;
+  const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+
+  // Accessible name: "Recommended" (when present) then the visible choice
+  const labelledBy = [recommended ? recommendedTagId : "", titleId]
+    .filter(Boolean)
+    .join(" ");
+
+  const describedBy = description ? descriptionId : undefined;
 
   return (
     <Box sx={{ position: "relative" }}>
@@ -70,12 +79,14 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
           onChange={onChange}
           slotProps={{
             input: {
-              "aria-describedby": recommended ? recommendedTagId : undefined,
+              "aria-labelledby": labelledBy,
+              "aria-describedby": describedBy,
             },
           }}
         />
         <Box sx={{ position: "relative" }}>
           <Typography
+            id={titleId}
             variant="body1"
             sx={{
               color: "text.primary",
@@ -85,7 +96,13 @@ const DescriptionRadio: React.FC<DescriptionRadioProps> = ({
             {title}
           </Typography>
           {description && (
-            <QuoteDescription variant="subtitle1" component="blockquote">
+            <QuoteDescription
+              id={descriptionId}
+              // Excluded as referenced by the radio's aria-describedby
+              aria-hidden="true"
+              variant="subtitle1"
+              component="blockquote"
+            >
               {description}
             </QuoteDescription>
           )}


### PR DESCRIPTION
## Issue

Relates to:
p.18 (V2 report) - DAC_Labels_not_Programmatically_Associated_01
https://trello.com/c/JHk618Q9/3746-enhanced-text-input-daclabelsnotprogrammaticallyassociated01

Previous addressed with https://github.com/theopensystemslab/planx-new/pull/7243 but issue persists.

- Descriptions are not read out when navigating radio options with screen reader

## Solution

- Ensure description is included with `aria-describedby` property, meaning all info is read out

<img width="729" height="467" alt="image" src="https://github.com/user-attachments/assets/a21ce858-69fd-4f84-8dfc-aafdccdc6a2e" />

## Testing

https://7351.planx.pizza/lambeth/project-description-accessibility-testing/preview