### PR TITLE
[api][editor] finalise file types

### DIFF
--- a/apps/api.planx.uk/modules/file/controller.ts
+++ b/apps/api.planx.uk/modules/file/controller.ts
@@ -12,7 +12,7 @@ import {
   headFileInS3,
 } from "./service/getFile.js";
 import { uploadPrivateFile, uploadPublicFile } from "./service/uploadFile.js";
-import { buildFilePath } from "./service/utils.js";
+import { buildFilePath, safeDecode } from "./service/utils.js";
 
 assert(process.env.AWS_S3_BUCKET);
 assert(process.env.AWS_S3_REGION);
@@ -130,6 +130,26 @@ const handleFileError = (
   }
 };
 
+/**
+ * Hand back the bytes, as a download rather than something the browser will render 'inline'.
+ *
+ * `res.attachment` does several jobs: it sets `Content-Disposition: attachment`, derives Content-Type
+ * from the filename's extension (which we validated against actual content at upload), and sets the
+ * Content-Disposition 'filename = ' parameter. Unknown extensions fall back to application/octet-stream.
+ *
+ * NB. This does not affect `<img src>` embeds: Content-Disposition applies to navigations/downloads, not subresource loads.
+ */
+const sendFile = (
+  result: Extract<GetFileResult, { outcome: "ok" }>,
+  res: DownloadResponse,
+) => {
+  // we decode first, or the browser saves the file under our own escaping (e.g. "my%20plan.pdf")
+  // Express can re-encode as required,see: https://expressjs.com/en/4x/api/response/#resattachment
+  res.attachment(safeDecode(result.filename));
+  res.set(result.headers);
+  return res.send(result.body);
+};
+
 export const publicDownloadController: DownloadController = async (
   _req,
   res,
@@ -147,8 +167,7 @@ export const publicDownloadController: DownloadController = async (
   if (result.isPrivate)
     return res.status(404).json({ error: "FILE_NOT_FOUND" });
 
-  res.set(result.headers);
-  return res.send(result.body);
+  return sendFile(result, res);
 };
 
 export const privateDownloadController: DownloadController = async (
@@ -164,8 +183,7 @@ export const privateDownloadController: DownloadController = async (
   if (result.outcome !== "ok")
     return handleFileError(result, filePath, res, next);
 
-  res.set(result.headers);
-  return res.send(result.body);
+  return sendFile(result, res);
 };
 
 export type DeleteController = ValidatedRequestHandler<

--- a/apps/api.planx.uk/modules/file/docs.yaml
+++ b/apps/api.planx.uk/modules/file/docs.yaml
@@ -68,7 +68,21 @@ components:
                 type: string
                 example: "File too large"
     DownloadFile:
-      description: Successful response
+      description: |
+        Successful response. Files are always served as a download, never inline, and the
+        `Content-Type` is derived from the file's extension rather than from anything the
+        uploading client supplied - so it may differ from the type given at upload.
+      headers:
+        Content-Disposition:
+          description: Always `attachment`, with the stored filename
+          schema:
+            type: string
+            example: 'attachment; filename="site-plan.pdf"'
+        X-Content-Type-Options:
+          description: Always `nosniff` - our Content-Type is authoritative
+          schema:
+            type: string
+            example: nosniff
       content:
         application/octet-stream:
           schema:

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -333,9 +333,27 @@ describe("File upload", () => {
       expect(getSignedUrl).toHaveBeenCalledTimes(1);
     });
 
-    // TODO: re-evaluate this test when re-enabling commented out file types
-    // eslint-disable-next-line vitest/no-disabled-tests
-    it.skip.each([
+    // objects are written with a public-read ACL, so what we persist is what a client fetching
+    // straight from S3 would be handed - it should match what the API itself would serve
+    it("should store headers we chose, not ones the client supplied", async () => {
+      await supertest(app)
+        .post(PRIVATE_ENDPOINT)
+        .field("filename", "some_file.png")
+        .attach("file", Buffer.from("some data"), {
+          filename: "some_file.png",
+          contentType: "text/html", // an uploader's claim about their own bytes
+        })
+        .expect(200);
+
+      expect(mockPutObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ContentType: "image/png",
+          ContentDisposition: 'attachment;filename="some_file.png"',
+        }),
+      );
+    });
+
+    it.each([
       "drawing.plt",
       "model.gml",
       "report.docx",
@@ -498,6 +516,105 @@ describe("File download", () => {
 
     mockGetObject = vi.fn(() => Promise.resolve(getObjectResponse));
     mockGetObjectTagging = vi.fn(() => Promise.resolve(CLEAN_TAGS));
+  });
+
+  // we set Content-Type and Content-Disposition ourselves rather than echoing what S3 holds
+  describe.each([
+    ["public", "/file/public", {}],
+    ["private", "/file/private", { "api-key": "test" }],
+  ])("response headers on the %s route", (_name, route, headers) => {
+    const get = (key: string) =>
+      supertest(app).get(`${route}/${key}`).set(headers);
+
+    it("serves as an attachment rather than inline", async () => {
+      const res = await get("somekey/file_name.txt").expect(200);
+
+      expect(res.headers["content-disposition"]).toBe(
+        'attachment; filename="file_name.txt"',
+      );
+    });
+
+    /**
+     * S3 keys use the %-encoded filename, and the signed-URL we build API URLs from
+     * escapes that again - so a real request path is double-encoded. Express decodes
+     * path params once, leaving our own encoding for the handler to undo.
+     */
+    const requestPathFor = (filename: string) =>
+      `somekey/${encodeURIComponent(encodeURIComponent(filename))}`;
+
+    it.each([
+      "my plan.pdf",
+      "my file (1).pdf",
+      "it's a plan.pdf",
+      "star*.png",
+      "plain.png",
+    ])("serves %j under its decoded name", async (original) => {
+      const res = await get(requestPathFor(original)).expect(200);
+
+      expect(res.headers["content-disposition"]).toBe(
+        `attachment; filename="${original}"`,
+      );
+    });
+
+    it("derives Content-Type from the extension, ignoring what S3 stored", async () => {
+      getObjectResponse = {
+        ...getObjectResponse,
+        // as if an uploader had claimed their .png was HTML
+        ContentType: "text/html",
+      };
+
+      const res = await get("somekey/picture.png").expect(200);
+      expect(res.headers["content-type"]).toMatch(/^image\/png/);
+    });
+
+    it("serves an SVG as an attachment, so it is never loaded as a document", async () => {
+      const res = await get("somekey/drawing.svg").expect(200);
+
+      expect(res.headers["content-disposition"]).toMatch(/^attachment/);
+      expect(res.headers["content-type"]).toMatch(/^image\/svg\+xml/);
+    });
+
+    it("falls back to octet-stream for an extension with no known type", async () => {
+      const res = await get("somekey/model.ifc").expect(200);
+      expect(res.headers["content-type"]).toMatch(/^application\/octet-stream/);
+    });
+
+    it("sets nosniff so the browser cannot second-guess our Content-Type", async () => {
+      const res = await get("somekey/file_name.txt").expect(200);
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    });
+
+    it("allows cross-origin embedding, which the editor relies on for public images", async () => {
+      const res = await get("somekey/file_name.txt").expect(200);
+      expect(res.headers["cross-origin-resource-policy"]).toBe("cross-site");
+    });
+
+    it("emits a valid HTTP-date for Last-Modified, and no phantom headers", async () => {
+      const res = await get("somekey/file_name.txt").expect(200);
+
+      expect(res.headers["last-modified"]).toBe(
+        "Tue, 31 May 2022 12:21:37 GMT",
+      );
+      // absent S3 fields used to be echoed as the literal string "undefined"
+      expect(res.headers["cache-control"]).not.toBe("undefined");
+      expect(res.headers["expires"]).not.toBe("undefined");
+      expect(res.headers["content-encoding"]).toBeUndefined();
+    });
+  });
+
+  // useNoCache runs before the controller, so echoing S3's (absent) Cache-Control and Expires
+  // used to overwrite both - meaning private files were served without no-store at all
+  it("does not let echoed S3 headers overwrite the private route's no-store", async () => {
+    const res = await supertest(app)
+      .get("/file/private/somekey/file_name.txt")
+      .set({ "api-key": "test" })
+      .expect(200);
+
+    expect(res.headers["cache-control"]).toBe(
+      "no-store, no-cache, must-revalidate, proxy-revalidate",
+    );
+    expect(res.headers["expires"]).toBe("0");
+    expect(res.headers["surrogate-control"]).toBe("no-store");
   });
 
   describe("Public", () => {

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -158,6 +158,64 @@ describe("File upload", () => {
           .expect(200);
         expect(mockPutObject).toHaveBeenCalledTimes(1);
       });
+
+      // file-type has no doc/xls entries - legacy Office files are OLE compound documents, which are
+      // reported as "cfb" - without the CONTAINER_TYPES mapping these would skip validation altogether
+      const CFB_HEADER = Buffer.concat([
+        Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+        Buffer.alloc(512),
+      ]);
+      const EXE_HEADER = Buffer.concat([
+        Buffer.from("MZ\x90\x00", "binary"),
+        Buffer.alloc(512),
+      ]);
+
+      it("should reject an executable disguised as a legacy Office file", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .set(auth)
+          .field("filename", "some_file.doc")
+          .attach("file", EXE_HEADER, "some_file.doc")
+          .expect(415)
+          .then((res) => {
+            expect(mockPutObject).not.toHaveBeenCalled();
+            expect(res.body.error).toMatch(
+              /File content does not match given extension/,
+            );
+          });
+      });
+
+      it("should reject an image disguised as a legacy Office file", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .set(auth)
+          .field("filename", "some_file.xls")
+          .attach("file", PNG_FIXTURE, "some_file.xls")
+          .expect(415);
+        expect(mockPutObject).not.toHaveBeenCalled();
+      });
+
+      it("should allow a genuine OLE compound document as .doc", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .set(auth)
+          .field("filename", "some_file.doc")
+          .attach("file", CFB_HEADER, "some_file.doc")
+          .expect(200);
+        expect(mockPutObject).toHaveBeenCalledTimes(1);
+      });
+
+      // file-type cannot identify plain text, so these are allowed through unchecked - we only
+      // reject confirmed mismatches rather than penalising formats we cannot verify
+      it("should allow a newly-enabled extension file-type cannot sniff", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .set(auth)
+          .field("filename", "some_file.csv")
+          .attach("file", Buffer.from("a,b,c\n1,2,3"), "some_file.csv")
+          .expect(200);
+        expect(mockPutObject).toHaveBeenCalledTimes(1);
+      });
     },
   );
 

--- a/apps/api.planx.uk/modules/file/middleware/useFileContentValidation.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileContentValidation.ts
@@ -13,6 +13,20 @@ const EXTENSION_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Extensions file-type has no entry for doc/xls, whose container format it can still identify.
+ *
+ * Legacy Office files are OLE compound documents, which file-type reports as 'cfb' rather than
+ * as 'doc'/'xls'. Without this they would skip validation entirely (see the supportedExtensions
+ * check below) - which would make them the only widely-used formats we accept whose content is
+ * never checked at all. Verifying the container does not say anything about macros; it just
+ * stops arbitrary bytes being accepted under a .doc or .xls name.
+ */
+const CONTAINER_TYPES: Record<string, string> = {
+  doc: "cfb",
+  xls: "cfb",
+};
+
+/**
  * Verify sniffed file content against the claimed extension, for any extension file-type is
  * able to reliably detect (see `supportedExtensions`).
  *
@@ -31,9 +45,10 @@ export const validateModernFileContent = async (
 ): Promise<boolean> => {
   const bareExt = ext.replace(/^\./, "");
   const canonicalExt = EXTENSION_ALIASES[bareExt] || bareExt;
+  const expectedExt = CONTAINER_TYPES[canonicalExt] ?? canonicalExt;
 
   // full list of supported types: https://github.com/sindresorhus/file-type#supported-file-types
-  if (!supportedExtensions.has(canonicalExt)) return true;
+  if (!supportedExtensions.has(expectedExt)) return true;
 
   const detected = await fileTypeFromBuffer(buffer, {
     // allow some grace in case an audio MPEG is misaligned (technically invalid, but it happens)
@@ -41,7 +56,7 @@ export const validateModernFileContent = async (
   });
   if (!detected) return true;
 
-  return detected.ext === canonicalExt;
+  return detected.ext === expectedExt;
 };
 
 /**
@@ -50,8 +65,10 @@ export const validateModernFileContent = async (
  * This middleware should be used after useFileUpload, so the extension itself is
  * already validated, and the file has been read into memory and can be analysed.
  *
- * TODO: add logic to detect and drop macros in office files (a la defense in depth)
- * inspiration: https://github.com/decalage2/oletools/wiki/olevba
+ * Note this checks content against the claimed extension only - it is not a malware or macro
+ * check. Every upload is scanned by Scanii, and councils are expected to run their own scans
+ * and to take responsibility for files they choose to open. See the scan verification section
+ * of doc/how-to/how-to-identify-missing-files.md.
  */
 export const useFileContentValidation: RequestHandler = async (
   req,

--- a/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -17,7 +17,7 @@ export const validateExtension = (filename: string): boolean => {
  */
 const fileFilter: multer.Options["fileFilter"] = (_req, file, callback) => {
   if (!validateExtension(file.originalname)) {
-    callback(
+    return callback(
       new Error(
         `Unsupported file type. Extension: ${getFileExtension(file.originalname)}`,
       ),

--- a/apps/api.planx.uk/modules/file/service/getFile.ts
+++ b/apps/api.planx.uk/modules/file/service/getFile.ts
@@ -5,23 +5,46 @@ import { Readable } from "stream";
 import { getScanStatus } from "./scanStatus.js";
 import { s3Factory } from "./utils.js";
 
-const buildHeaders = (file: GetObjectCommandOutput) => ({
-  "Content-Type": file.ContentType,
-  "Content-Length": file.ContentLength,
-  "Content-Disposition": file.ContentDisposition,
-  "Content-Encoding": file.ContentEncoding,
-  "Cache-Control": file.CacheControl,
-  Expires: file.ExpiresString,
-  "Last-Modified": file.LastModified,
-  ETag: file.ETag,
-  "cross-origin-resource-policy": "cross-site",
-});
+/**
+ * Headers we are willing to pass on from S3, plus additional protections.
+ *
+ * Deliberately does *not* include Content-Type or Content-Disposition. Callers to getFile set both via
+ * `res.attachment(filename)` instead, deriving the type from the extension we validated at upload time.
+ *
+ * We also don't echo Cache-Control or Expires to avoid overruling our useNoCache middleware.
+ */
+const buildHeaders = (file: GetObjectCommandOutput) => {
+  const headers: Record<string, string> = {
+    // allows the editor to load public-bucket images cross-origin
+    "cross-origin-resource-policy": "cross-site",
+    // our Content-Type is authoritative - never let a browser sniff its way past it
+    "X-Content-Type-Options": "nosniff",
+  };
+
+  if (file.ETag) headers["ETag"] = file.ETag;
+  // an HTTP-date must be RFC7231-safe: https://www.rfc-editor.org/info/rfc7231/#section-7.1.1.1
+  if (file.LastModified)
+    headers["Last-Modified"] = file.LastModified.toUTCString();
+
+  return headers;
+};
+
+/**
+ * S3 keys are `<nanoid>/<filename>`, so the name to serve under is the last segment.
+ *
+ * Falls back to a generic name without extension, so that `res.attachment`
+ * determines Content-Type as application/octet-stream, which is the safe default.
+ */
+const filenameFromKey = (fileId: string): string =>
+  fileId.split("/").filter(Boolean).pop() || "download";
 
 export type GetFileResult =
   | {
       outcome: "ok";
       body: Buffer;
       isPrivate: boolean;
+      /** Name to serve the file as - drives both Content-Disposition and Content-Type */
+      filename: string;
       headers: ReturnType<typeof buildHeaders>;
     }
   | { outcome: "pending-scan" }
@@ -70,6 +93,7 @@ export const getFileFromS3 = async (fileId: string): Promise<GetFileResult> => {
       outcome: "ok",
       body,
       isPrivate: file.Metadata?.is_private === "true",
+      filename: filenameFromKey(fileId),
       headers: buildHeaders(file),
     };
   } catch (error) {

--- a/apps/api.planx.uk/modules/file/service/uploadFile.ts
+++ b/apps/api.planx.uk/modules/file/service/uploadFile.ts
@@ -96,8 +96,12 @@ export function generateFileParams(
     Bucket: process.env.AWS_S3_BUCKET,
     Key: key,
     Body: file.buffer,
-    ContentDisposition: `inline;filename="${filename}"`,
-    ContentType: file.mimetype,
+    // We practice defence in depth for any fetch that bypasses the API by storing the headers we would serve.
+    // Notably we do not persist file.mimetype because we want to control how the bytes are interpreted.
+    ContentDisposition: `attachment;filename="${filename}"`,
+    // `filename` is %-encoded on upload, so it is guaranteed ASCII with no quotes to break out of the header,
+    // so interpolating here is safe. Downloads via the API get the decoded name - see sendFile.
+    ContentType: fileType ?? "application/octet-stream",
   };
 
   return {

--- a/apps/api.planx.uk/modules/file/service/utils.test.ts
+++ b/apps/api.planx.uk/modules/file/service/utils.test.ts
@@ -1,4 +1,4 @@
-import { getS3KeyFromURL, s3Factory } from "./utils.js";
+import { getS3KeyFromURL, s3Factory, safeDecode } from "./utils.js";
 
 describe("s3 Factory", () => {
   afterEach(() => vi.unstubAllEnvs());
@@ -44,4 +44,26 @@ describe("getS3KeyFromURL()", () => {
     const badURL = "this is not a url";
     expect(() => getS3KeyFromURL(badURL)).toThrow();
   });
+});
+
+describe("safeDecode()", () => {
+  it.each([
+    ["my%20plan.pdf", "my plan.pdf"],
+    ["my%20file%20(1).pdf", "my file (1).pdf"],
+    ["it's%20a%20plan.pdf", "it's a plan.pdf"],
+    ["plain.png", "plain.png"],
+  ])("decodes %j to %j", (encoded, decoded) => {
+    expect(safeDecode(encoded)).toBe(decoded);
+  });
+
+  // decodeURIComponent throws on these. Express rejects a malformed path param with a 400
+  // before our handlers see it, but getFileFromS3 is also reached from the zip builder with
+  // keys derived elsewhere - a name we cannot decode is no reason to fail a download
+  it.each(["malformed%.pdf", "%E0%A4%A.pdf", "100%.pdf"])(
+    "returns %j unchanged rather than throwing",
+    (undecodable) => {
+      expect(() => safeDecode(undecodable)).not.toThrow();
+      expect(safeDecode(undecodable)).toBe(undecodable);
+    },
+  );
 });

--- a/apps/api.planx.uk/modules/file/service/utils.ts
+++ b/apps/api.planx.uk/modules/file/service/utils.ts
@@ -35,6 +35,21 @@ export function buildFilePath(fileKey: string, fileName: string): string {
 }
 
 /**
+ * Reverse the `encodeURIComponent` applied to filenames at upload.
+ *
+ * Falls back to the encoded value rather than throwing: `decodeURIComponent` rejects malformed
+ * input (a lone `%`, say), but inability to decode a filename is no reason to fail the download.
+ */
+export function safeDecode(filename: string): string {
+  try {
+    return decodeURIComponent(filename);
+  } catch {
+    console.debug(`Failed to decode filename: ${filename}`);
+    return filename;
+  }
+}
+
+/**
  * Return an S3 key in the fileKey/fileName format, based on a file's API URL
  */
 export function getS3KeyFromURL(fileURL: string): string {

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/react";
+import React from "react";
+import { setup } from "test/utils";
+import { vi } from "vitest";
+
+import { UploadedFileCard } from "./UploadedFileCard";
+
+/**
+ * Only formats in PREVIEWABLE_MIME_TYPES may be rendered inline. SVG in particular must not be,
+ * since it is the one type we accept that can carry active content, and the one type our
+ * content validation cannot sniff.
+ */
+type UploadedFileCardProps = React.ComponentProps<typeof UploadedFileCard>;
+
+const buildProps = (file: File): UploadedFileCardProps => ({
+  file,
+  status: "success",
+  progress: 1,
+  id: "test-slot",
+  drawingNumber: undefined,
+  removeFile: vi.fn(),
+});
+
+const previewImage = () => screen.queryByAltText(/Preview of uploaded file/);
+
+describe("thumbnail previews", () => {
+  beforeAll(() => {
+    // jsdom does not implement object URLs
+    globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("previews a PNG", async () => {
+    const file = new File(["x"], "plan.png", { type: "image/png" });
+    await setup(<UploadedFileCard {...buildProps(file)} />);
+
+    expect(previewImage()).toBeInTheDocument();
+  });
+
+  it("does not preview an SVG", async () => {
+    const file = new File(["<svg/>"], "plan.svg", { type: "image/svg+xml" });
+    await setup(<UploadedFileCard {...buildProps(file)} />);
+
+    expect(previewImage()).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["application/pdf", "plan.pdf"],
+    ["text/csv", "data.csv"],
+    ["video/mp4", "walkthrough.mp4"],
+    ["image/vnd.dwg", "site.dwg"],
+    ["image/tiff", "scan.tif"],
+  ])("does not preview %s", async (type, name) => {
+    const file = new File(["x"], name, { type });
+    await setup(<UploadedFileCard {...buildProps(file)} />);
+
+    expect(previewImage()).not.toBeInTheDocument();
+  });
+
+  it("does not preview a file recovered from a saved session", async () => {
+    // cached slots carry a plain object rather than a File, so there are no bytes to preview
+    const notAFile = { name: "plan.png", type: "image/png" } as unknown as File;
+    await setup(<UploadedFileCard {...buildProps(notAFile)} />);
+
+    expect(previewImage()).not.toBeInTheDocument();
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/UploadedFileCard.tsx
@@ -7,6 +7,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { visuallyHidden } from "@mui/utils";
 import type { FileUploadSlot } from "@planx/components/FileUpload/model";
+import { PREVIEWABLE_MIME_TYPES } from "@planx/file-upload";
 import ImagePreview from "components/ImagePreview";
 import React from "react";
 import ErrorWrapper from "ui/shared/ErrorWrapper";
@@ -94,7 +95,6 @@ export const UploadedFileCard: React.FC<Props> = ({
   id,
   file,
   progress,
-  url,
   removeFile,
   onChange,
   changeLabel = "Edit",
@@ -133,8 +133,9 @@ export const UploadedFileCard: React.FC<Props> = ({
               }}
             >
               <FilePreview>
-                {file instanceof File && file?.type?.includes("image") ? (
-                  <ImagePreview file={file} url={url} />
+                {file instanceof File &&
+                PREVIEWABLE_MIME_TYPES.has(file.type) ? (
+                  <ImagePreview file={file} />
                 ) : (
                   <FileIcon />
                 )}

--- a/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/hooks.ts
@@ -5,21 +5,21 @@ import {
 } from "lib/planningData/requests";
 import { useEffect, useState } from "react";
 
-export type UseFileUrlProps =
-  { file: File } | { url: string } | { file: File; url: string };
+export type UseFileUrlProps = { file: File };
 
 /**
- * Returns fileUrl for uploaded files, either private or public.
+ * Returns a local object URL for a file the user has just selected.
+ *
+ * Deliberately only ever resolves to a `blob:` URL for an in-memory File - it must not be given
+ * a remote URL to hand back. Rendering a stored file inline would mean loading user-uploaded
+ * bytes into our own origin, which is precisely what we don't want to do.
  */
-export const useFileUrl = (props: UseFileUrlProps) => {
+export const useFileUrl = ({ file }: UseFileUrlProps) => {
   const [fileUrl, setFileUrl] = useState("");
 
   useEffect(() => {
-    if ("file" in props && props.file instanceof File) {
-      setFileUrl(URL.createObjectURL(props.file));
-    } else if ("url" in props && props.url) {
-      // XXX: Backwards compatibility to accept files uploaded directly to S3.
-      setFileUrl(props.url);
+    if (file instanceof File) {
+      setFileUrl(URL.createObjectURL(file));
     }
 
     return () => {

--- a/apps/editor.planx.uk/src/components/ImagePreview.tsx
+++ b/apps/editor.planx.uk/src/components/ImagePreview.tsx
@@ -2,10 +2,10 @@ import type { UseFileUrlProps } from "@planx/components/shared/hooks";
 import { useFileUrl } from "@planx/components/shared/hooks";
 import React from "react";
 
-export default function ImagePreview(props: UseFileUrlProps) {
-  const { fileUrl } = useFileUrl(props);
+export default function ImagePreview({ file }: UseFileUrlProps) {
+  const { fileUrl } = useFileUrl({ file });
 
   if (!fileUrl) return null;
 
-  return <img src={fileUrl} alt={`Preview of uploaded file: ${fileUrl}`} />;
+  return <img src={fileUrl} alt={`Preview of uploaded file: ${file.name}`} />;
 }

--- a/doc/how-to/how-to-identify-missing-files.md
+++ b/doc/how-to/how-to-identify-missing-files.md
@@ -15,6 +15,13 @@ As these images are automatically deleted, this can lead to issues when trying t
 
 Once Scanii has scanned an object, a callback Lambda tags it with `ScaniiId` and `ScaniiFindings`. The API will not serve a file from the user-data bucket unless those tags are present, so a file that has not yet been scanned is never handed to a council. This is controlled by the `ENFORCE_SCAN_FROM` env var (an ISO8601 date), which is set in every environment backed by a bucket Scanii watches: staging and production (from Pulumi config) and pizzas (from `.env.staging`). When unset the check is disabled entirely, which is the case in local development and in e2e/integration tests - both run against Minio, which has no Scanii equivalent, so no object is ever tagged.
 
+<!-- TODO: this policy-statement as regards file uploads belongs elsewhere, e.g. in an ADR -->
+### Where our responsibility ends
+
+We accept a broad range of file types (see `ALLOWED_EXTENSIONS_BY_MIME_TYPE` in `packages/file-upload`), and we do two things with every upload: check that its content matches its claimed extension, and scan it with Scanii, deleting anything flagged. We deliberately do **not** attempt to detect or strip macros in Office files, and we do not treat "accepted by PlanX" as "safe to execute".
+
+End-users are expected to run their own scanning if they wish to, and fundamentally to take responsibility for any file delivered via PlanX that they choose to open or execute.
+
 The API response tells you which situation you're in before you go near CloudWatch:
 
 | Response | Meaning |

--- a/packages/file-upload/allowedFileTypes.ts
+++ b/packages/file-upload/allowedFileTypes.ts
@@ -14,44 +14,62 @@ export const ALLOWED_EXTENSIONS_BY_MIME_TYPE: Record<string, string[]> = {
   // PDFs
   "application/pdf": [".pdf"],
   // raster images
-  // "image/bmp": [".bmp"],
-  // "image/gif": [".gif"],
+  "image/bmp": [".bmp"],
+  "image/gif": [".gif"],
   "image/jpeg": [".jpg", ".jpeg"],
   "image/png": [".png"],
-  // "image/tiff": [".tif", ".tiff"],
-  // "image/webp": [".webp"],
+  "image/tiff": [".tif", ".tiff"],
+  "image/webp": [".webp"],
   // vector graphics
   "image/svg+xml": [".svg"],
   // CAD and BIM
-  // "image/vnd.dwg": [".dwg"],
-  // "image/vnd.dxf": [".dxf"],
+  "image/vnd.dwg": [".dwg"],
+  "image/vnd.dxf": [".dxf"],
   // Text, MS Office documents and spreadsheets
-  // "text/csv": [".csv"],
-  // "text/plain": [".txt"],
-  // "application/rtf": [".rtf"],
-  // TODO: handle macros in old office files (.doc, .xls); in the meantime, we don't accept them
-  // (bundle this logic with ability to upload open source office files, e.g. .odt, .ods)
-  // "application/msword": [".doc"],
-  // "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
-  //   ".docx",
-  // ],
-  // "application/vnd.ms-excel": [".xls"],
-  // "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
-  //   ".xlsx",
-  // ],
+  "text/csv": [".csv"],
+  "text/plain": [".txt"],
+  "application/rtf": [".rtf"],
+  "application/msword": [".doc"],
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
+    ".docx",
+  ],
+  "application/vnd.ms-excel": [".xls"],
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+    ".xlsx",
+  ],
   // videos
-  // "video/x-msvideo": [".avi"],
-  // "video/x-matroska": [".mkv"],
-  // "video/quicktime": [".mov"],
-  // "video/mp4": [".mp4"],
-  // "video/mpeg": [".mpg", ".mpeg"],
-  // "video/webm": [".webm"],
-  // "video/x-ms-wmv": [".wmv"],
+  "video/x-msvideo": [".avi"],
+  "video/x-matroska": [".mkv"],
+  "video/quicktime": [".mov"],
+  "video/mp4": [".mp4"],
+  "video/mpeg": [".mpg", ".mpeg"],
+  "video/webm": [".webm"],
+  "video/x-ms-wmv": [".wmv"],
   // GML (Geographic Markup Language)
-  // "application/gml+xml": [".gml"],
+  "application/gml+xml": [".gml"],
   // binary files without custom MIME, for which we fall back to catchall octet-stream
-  // "application/octet-stream": [".bim", ".ifc", ".plt", ".rvt", ".skp"],
+  "application/octet-stream": [".bim", ".ifc", ".plt", ".rvt", ".skp"],
 };
+
+/**
+ * MIME types we are willing to render as a thumbnail in the browser.
+ *
+ * Deliberately a hand-maintained allowlist rather than anything derived from the map above:
+ * it covers only raster formats every browser can decode, so no other accepted type can start
+ * being rendered inline just by being added to ALLOWED_EXTENSIONS_BY_MIME_TYPE.
+ *
+ * Notably excludes SVG. Although browsers disable scripting for SVGs loaded via <img>, SVG is
+ * the one format we accept that can carry active content, and it is the one format `file-type`
+ * cannot sniff - so its bytes are never validated. We would rather not lean on that single
+ * browser behaviour. Also excludes TIFF and the CAD types, which browsers cannot render at all.
+ */
+export const PREVIEWABLE_MIME_TYPES: ReadonlySet<string> = new Set([
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
 
 /**
  * Flat, deduplicated list of allowed extensions, derived from ALLOWED_EXTENSIONS_BY_MIME_TYPE above.


### PR DESCRIPTION
Re-enable all file types, with attendant fixes/countermeasures as discussed in [this comment](https://github.com/theopensystemslab/planx-new/pull/7039#pullrequestreview-4884317780).

Original PR was #7039, with a crucial intervention meanwhile in the form of #7279.

Relates to [this ticket](https://trello.com/c/kkt7dKkB) - see full technical plan there, for which it handles the 2 crucial remaining points on the technical plan which were blocking it from staging.