### PR TITLE
fix(a11y): Correctly associate header as label on ModifyUserInput

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Public/ModifyUserInput.tsx
@@ -1,9 +1,6 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import {
-  DESCRIPTION_TEXT,
-  ERROR_MESSAGE,
-} from "@planx/components/shared/constants";
+import { ERROR_MESSAGE } from "@planx/components/shared/constants";
 import type { PublicProps } from "@planx/components/shared/types";
 import { TEXT_LIMITS, TextInputType } from "@planx/components/TextInput/model";
 import { useFormikContext } from "formik";
@@ -15,7 +12,6 @@ import InputRow from "ui/shared/InputRow";
 import type { EnhancedTextInput } from "../types";
 import type { FormValues } from "./types";
 
-const HEADING_ID = "confirm-project-description-heading";
 const NOT_CHECKED_HINT_ID = "confirm-project-description-not-checked-hint";
 
 const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
@@ -30,10 +26,12 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
 
   return (
     <Box sx={{ mb: 2 }}>
-      <Typography variant="h2" component="h1" id={HEADING_ID} sx={{ mb: 1 }}>
-        {isWritingNew
-          ? "Enter your new description"
-          : "Confirm your project description"}
+      <Typography variant="h2" component="h1" sx={{ mb: 1 }}>
+        <Box component="label" htmlFor={props.id}>
+          {isWritingNew
+            ? "Enter your new description"
+            : "Confirm your project description"}
+        </Box>
       </Typography>
       {!isWritingNew && (
         <Typography variant="subtitle1" component="p" sx={{ mb: 1 }}>
@@ -61,9 +59,7 @@ const ModifyUserInput: React.FC<PublicProps<EnhancedTextInput>> = (props) => {
             errorMessage={showError ? (errors.userInput as string) : undefined}
             id={props.id}
             inputProps={{
-              "aria-labelledby": HEADING_ID,
               "aria-describedby": [
-                props.description ? DESCRIPTION_TEXT : "",
                 NOT_CHECKED_HINT_ID,
                 "character-hint",
                 showError ? `${ERROR_MESSAGE}-${props.id}` : "",


### PR DESCRIPTION
## Issue

Relates to:
p.21 - DAC_Label_in_Name_01
https://trello.com/c/0SRg9qUj/3747-enhanced-text-input-daclabelinname01

Previously addressed with https://github.com/theopensystemslab/planx-new/pull/7244 , but testing in browser still shows a broken reference.

- Header is not correctly associated as a label for text input when modifying project description (final step)

> The label which enables users to identify the purpose of the field ‘Confirm your project
description’ is not contained within the accessible name of the component ‘Project
description’. Voice activation users rely on the visible label to present the programmatically
associated accessible name by which they may reference the component to their associative
technology. However, if this label is not contained within the accessible name of the control,
assistive technologies will not recognise this component and users may struggle to access it.

## Solution

As suggested in the report, follow the [Making labels and legends headings](https://design-system.service.gov.uk/get-started/labels-legends-headings/) guidance from GOV.UK, placing a `<label>` inside the page `<h1>`, to correctly reuse the page title as label.

## Testing

https://7357.planx.pizza/lambeth/project-description-accessibility-testing/preview