### PR TITLE
chore: Bump `msw-storybook-addon` to v3

### DIFF
--- a/apps/editor.planx.uk/.storybook/main.ts
+++ b/apps/editor.planx.uk/.storybook/main.ts
@@ -5,18 +5,19 @@ export default {
   addons: [
     "@storybook/addon-a11y",
     "@storybook/addon-docs",
-    "@storybook/addon-links"
+    "@storybook/addon-links",
+    "msw-storybook-addon",
   ],
   staticDirs: ["../public"],
   framework: {
     name: "@storybook/tanstack-react",
-    options: {}
+    options: {},
   },
   docs: {},
   typescript: {
     reactDocgen: "react-docgen-typescript",
     reactDocgenTypescriptOptions: {
-      exclude: ["**/*.stories.tsx", ".storybook/**"]
-    }
-  }
+      exclude: ["**/*.stories.tsx", ".storybook/**"],
+    },
+  },
 };

--- a/apps/editor.planx.uk/.storybook/preview.tsx
+++ b/apps/editor.planx.uk/.storybook/preview.tsx
@@ -9,7 +9,7 @@ import { StyledEngineProvider,ThemeProvider } from "@mui/material/styles";
 import { MyMap } from "@opensystemslab/map";
 import type { Decorator } from "@storybook/tanstack-react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { initialize, mswLoader } from "msw-storybook-addon";
+import { mswLoader } from "msw-storybook-addon/csf3";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -43,8 +43,6 @@ const testApolloClient = new ApolloClient({
   },
 });
 
-initialize();
-
 export const decorators: Decorator[] = [
   (Story, context) => (
     <ApolloProvider client={testApolloClient}>
@@ -64,7 +62,7 @@ export const decorators: Decorator[] = [
 
 export const tags = ["autodocs"];
 
-export const loaders = [mswLoader];
+export const loaders = [mswLoader()];
 
 export const parameters = {
   msw: {

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -119,7 +119,7 @@
     "eslint": "catalog:",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "catalog:",
-    "msw-storybook-addon": "^2.0.7",
+    "msw-storybook-addon": "^3.0.0",
     "prettier": "catalog:",
     "sass": "^1.97.3",
     "storybook": "10.4.1",

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/EnhancedTextInput.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/EnhancedTextInput.stories.tsx
@@ -33,21 +33,19 @@ const meta = {
       '<a href="https://www.legislation.gov.uk/ukpga/2023/36/section/3/made" target="_blank">https://www.legislation.gov.uk/ukpga/2023/36/section/3/made</a>',
     info: "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
   },
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/ai/project-description/enhance", async () => {
-          await delay(6_000);
-          return HttpResponse.json(
-            {
-              original: ORIGINAL,
-              enhanced: ENHANCED,
-            },
-            { status: 200 },
-          );
-        }),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.post("*/ai/project-description/enhance", async () => {
+        await delay(6_000);
+        return HttpResponse.json(
+          {
+            original: ORIGINAL,
+            enhanced: ENHANCED,
+          },
+          { status: 200 },
+        );
+      }),
+    );
   },
 } satisfies Meta<typeof Public>;
 
@@ -71,60 +69,54 @@ export const Basic: StoryObj = {
 };
 
 export const Invalid = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/ai/project-description/enhance", async () => {
-          await delay(3_000);
-          return HttpResponse.json(
-            {
-              error: "INVALID_INPUT",
-              message:
-                "The description doesn't appear to be related to a planning application.",
-            },
-            { status: 400 },
-          );
-        }),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.post("*/ai/project-description/enhance", async () => {
+        await delay(3_000);
+        return HttpResponse.json(
+          {
+            error: "INVALID_INPUT",
+            message:
+              "The description doesn't appear to be related to a planning application.",
+          },
+          { status: 400 },
+        );
+      }),
+    );
   },
 } satisfies Story;
 
 export const ServiceUnavailable = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/ai/project-description/enhance", async () => {
-          await delay(3_000);
-          return HttpResponse.json(
-            {
-              error: "GATEWAY_ERROR",
-              message:
-                "There was an error with the request to upstream AI gateway",
-            },
-            { status: 400 },
-          );
-        }),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.post("*/ai/project-description/enhance", async () => {
+        await delay(3_000);
+        return HttpResponse.json(
+          {
+            error: "GATEWAY_ERROR",
+            message:
+              "There was an error with the request to upstream AI gateway",
+          },
+          { status: 400 },
+        );
+      }),
+    );
   },
 } satisfies Story;
 
 export const RateLimitExceeded = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/ai/project-description/enhance", async () => {
-          await delay(3_000);
-          return HttpResponse.json(
-            {
-              error: "TOO_MANY_REQUESTS",
-            },
-            { status: 429 },
-          );
-        }),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.post("*/ai/project-description/enhance", async () => {
+        await delay(3_000);
+        return HttpResponse.json(
+          {
+            error: "TOO_MANY_REQUESTS",
+          },
+          { status: 429 },
+        );
+      }),
+    );
   },
 } satisfies Story;
 

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Public/FindProperty.stories.tsx
@@ -45,17 +45,15 @@ const setTeamBoundaryBBox = (boundaryBBox: Feature<Polygon> | undefined) => {
 export default {
   title: "PlanX Components/FindProperty",
   component: FindProperty,
-  parameters: {
-    msw: {
-      handlers: [
-        http.get("https://www.planning.data.gov.uk/*", async () =>
-          HttpResponse.json(localAuthorityMock, { status: 200 }),
-        ),
-        graphql.query("FetchBLPUCodes", () =>
-          HttpResponse.json({ data: fetchBLPUCodesMock }),
-        ),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get("https://www.planning.data.gov.uk/*", async () =>
+        HttpResponse.json(localAuthorityMock, { status: 200 }),
+      ),
+      graphql.query("FetchBLPUCodes", () =>
+        HttpResponse.json({ data: fetchBLPUCodesMock }),
+      ),
+    );
   },
 } satisfies Meta<typeof FindProperty>;
 
@@ -69,14 +67,12 @@ export const EmptyForm: StoryObj = {
 };
 
 export const OSDatastoreError: StoryObj = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get("*/proxy/ordnance-survey/search/places/v1/postcode", () =>
-          HttpResponse.json(osDatastoreErrorMock, { status: 500 }),
-        ),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get("*/proxy/ordnance-survey/search/places/v1/postcode", () =>
+        HttpResponse.json(osDatastoreErrorMock, { status: 500 }),
+      ),
+    );
   },
   render: () => (
     <FindProperty

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/PropertyInformation.stories.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/PropertyInformation.stories.tsx
@@ -33,14 +33,12 @@ export const WithPropertyTypeOverride: StoryObj = {
 };
 
 export const OSTileError: StoryObj = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get("*/proxy/ordnance-survey/maps/vector/v1/", () =>
-          HttpResponse.json(osTileError, { status: 500 }),
-        ),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get("*/proxy/ordnance-survey/maps/vector/v1/", () =>
+        HttpResponse.json(osTileError, { status: 500 }),
+      ),
+    );
   },
   render: () => (
     <Presentational

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/RecentFlows/RecentFlows.stories.tsx
@@ -36,19 +36,17 @@ const mockFlows: Record<string, ExternalPortal> = {
 const meta: Meta<typeof RecentFlows> = {
   title: "Design System/Molecules/RecentFlows",
   component: RecentFlows,
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query("GetExternalPortal", ({ variables }) => {
-          const requestedPortal = mockFlows[variables.id];
-          return HttpResponse.json({
-            data: {
-              externalPortal: requestedPortal || null,
-            },
-          });
-        }),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      graphql.query("GetExternalPortal", ({ variables }) => {
+        const requestedPortal = mockFlows[variables.id];
+        return HttpResponse.json({
+          data: {
+            externalPortal: requestedPortal || null,
+          },
+        });
+      }),
+    );
   },
 };
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/forms/AddComponentModal/AddComponentModal.stories.tsx
@@ -16,21 +16,19 @@ import { DETAIL_PANEL_WIDTH } from "./PatternsTab/PatternDetailPanel";
 const meta: Meta<typeof ModalTabs> = {
   title: "Editor Components/Modal/AddComponentModal",
   component: ModalTabs,
-  parameters: {
-    msw: {
-      handlers: [
-        graphql.query("GetPatterns", () =>
-          HttpResponse.json({ data: { patterns: mockPatterns } }),
-        ),
-        graphql.query("GetPatternData", ({ variables }) =>
-          HttpResponse.json({
-            data: {
-              pattern: { id: variables.id, data: mockPatternData },
-            },
-          }),
-        ),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      graphql.query("GetPatterns", () =>
+        HttpResponse.json({ data: { patterns: mockPatterns } }),
+      ),
+      graphql.query("GetPatternData", ({ variables }) =>
+        HttpResponse.json({
+          data: {
+            pattern: { id: variables.id, data: mockPatternData },
+          },
+        }),
+      ),
+    );
   },
 };
 

--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -46,7 +46,7 @@
     "@storybook/react-vite": "^10",
     "@storybook/react": "^10",
     "@types/node": "catalog:",
-    "msw-storybook-addon": "^2.0.7",
+    "msw-storybook-addon": "^3.0.0",
     "msw": "^2.14.3",
     "storybook": "^10",
     "typescript-plugin-css-modules": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,8 +765,8 @@ importers:
         specifier: 'catalog:'
         version: 30.0.1(@noble/hashes@1.8.0)
       msw-storybook-addon:
-        specifier: ^2.0.7
-        version: 2.0.7(msw@2.13.4(@types/node@24.10.15)(typescript@5.9.3))
+        specifier: ^3.0.0
+        version: 3.0.0(msw@2.13.4(@types/node@24.10.15)(typescript@5.9.3))(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       prettier:
         specifier: 'catalog:'
         version: 3.9.3
@@ -929,8 +929,8 @@ importers:
         specifier: ^2.14.3
         version: 2.14.6(@types/node@24.10.15)(typescript@5.9.3)
       msw-storybook-addon:
-        specifier: ^2.0.7
-        version: 2.0.7(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))
+        specifier: ^3.0.0
+        version: 3.0.0(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.6)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       storybook:
         specifier: ^10
         version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.6)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8914,10 +8914,12 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw-storybook-addon@2.0.7:
-    resolution: {integrity: sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==}
+  msw-storybook-addon@3.0.0:
+    resolution: {integrity: sha512-tyYmYAwSGcfFSHhrE5yzun/OXuVIkBGOt4YTsH5IR94N38F+hzZhvGqe5scu1ENJh/hOApI/8ZRQkWdFNFsKcw==}
+    hasBin: true
     peerDependencies:
-      msw: ^2.0.0
+      msw: '>=2'
+      storybook: '>=9'
 
   msw@2.13.4:
     resolution: {integrity: sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==}
@@ -20226,15 +20228,15 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@2.0.7(msw@2.13.4(@types/node@24.10.15)(typescript@5.9.3)):
+  msw-storybook-addon@3.0.0(msw@2.13.4(@types/node@24.10.15)(typescript@5.9.3))(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      is-node-process: 1.2.0
       msw: 2.13.4(@types/node@24.10.15)(typescript@5.9.3)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  msw-storybook-addon@2.0.7(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3)):
+  msw-storybook-addon@3.0.0(msw@2.14.6(@types/node@24.10.15)(typescript@5.9.3))(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.6)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      is-node-process: 1.2.0
       msw: 2.14.6(@types/node@24.10.15)(typescript@5.9.3)
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.9.6)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   msw@2.13.4(@types/node@24.10.15)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## What does this PR do?
Updates `msw-storybook-addon` to v3

Follows the migration docs here - https://github.com/mswjs/msw-storybook-addon/blob/HEAD/MIGRATION.md#from-2xx-to-3xx

Replaces https://github.com/theopensystemslab/planx-new/pull/7340

## Testing
Stories which use `msw-storybook-addon` to mock HTTPS requests work as expected - 
 - FindProperty
 - EnhancedTextInput
 - PropertyInformation
 - AddComponentModal
 - RecentFlows