### PR TITLE
chore: Update date-fns to v4.4.0

### DIFF
--- a/apps/api.planx.uk/package.json
+++ b/apps/api.planx.uk/package.json
@@ -27,7 +27,7 @@
     "copyfiles": "^2.4.1",
     "cors": "^2.8.6",
     "csv-stringify": "catalog:",
-    "date-fns": "^4.4.0",
+    "date-fns": "catalog:",
     "dompurify": "catalog:",
     "express": "^4.22.2",
     "express-async-errors": "^3.1.1",

--- a/apps/editor.planx.uk/package.json
+++ b/apps/editor.planx.uk/package.json
@@ -46,7 +46,7 @@
     "classnames": "^2.5.1",
     "core-js": "^3.48.0",
     "csv-stringify": "catalog:",
-    "date-fns": "^2.30.0",
+    "date-fns": "catalog:",
     "dompurify": "catalog:",
     "formik": "^2.4.9",
     "fuse.js": "7.1.0",

--- a/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/Preview/SummaryList.tsx
@@ -11,7 +11,7 @@ import { PASSPORT_REQUESTED_FILES_KEY } from "@planx/components/FileUploadAndLab
 import { formatSchemaDisplayValue } from "@planx/components/List/utils";
 import type { Page } from "@planx/components/Page/model";
 import { ConfirmationDialog } from "components/ConfirmationDialog";
-import format from "date-fns/format";
+import { format } from "date-fns/format";
 import { useBLPUCodes } from "hooks/data/useBLPUCodes";
 import find from "lodash/find";
 import { useAnalyticsTracking } from "pages/FlowEditor/lib/analytics/provider";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     csv-stringify:
       specifier: ^6.8.0
       version: 6.8.0
+    date-fns:
+      specifier: ^4.4.0
+      version: 4.4.0
     dompurify:
       specifier: ^3.4.13
       version: 3.4.13
@@ -196,7 +199,7 @@ importers:
         specifier: 'catalog:'
         version: 6.8.0
       date-fns:
-        specifier: ^4.4.0
+        specifier: 'catalog:'
         version: 4.4.0
       dompurify:
         specifier: 'catalog:'
@@ -542,8 +545,8 @@ importers:
         specifier: 'catalog:'
         version: 6.8.0
       date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
+        specifier: 'catalog:'
+        version: 4.4.0
       dompurify:
         specifier: 'catalog:'
         version: 3.4.13
@@ -6674,10 +6677,6 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -17533,10 +17532,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.2
 
   date-fns@4.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   "@vitest/eslint-plugin": ^1.6.20
   axios: ^1.18.1
   csv-stringify: ^6.8.0
+  date-fns: ^4.4.0
   dompurify: ^3.4.13
   dotenv: ^17.4.2
   eslint: ^9.39.5


### PR DESCRIPTION
## What does this PR do?

- Update Editor version of `date-fns` to v4.4.0
- Migrate to single `catalog:` version across workspace
- Replaces https://github.com/theopensystemslab/planx-new/pulls