### PR TITLE
fix(lps): Configure prettier

### DIFF
--- a/apps/localplanning.services/package.json
+++ b/apps/localplanning.services/package.json
@@ -56,5 +56,6 @@
     "workerDirectory": [
       "public"
     ]
-  }
+  },
+  "prettier": "@planx/prettier-config"
 }


### PR DESCRIPTION
Quick config issue I spotted - we aren't pointing to our custom config, just the standard prettier config.

I've ran `pnpm lint:fix` on this branch and there's no changes to pick up 👌 