### PR TITLE
style: Note tidy up styles

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/AddressInput/Editor.tsx
@@ -46,7 +46,7 @@ const AddressInputComponent: React.FC<Props> = (props) => {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Calculate/Editor.tsx
@@ -134,7 +134,7 @@ export default function Component(props: Props) {
           </Typography>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               placeholder="Title"
               name="title"
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Confirmation/Editor.tsx
@@ -37,6 +37,7 @@ function NextStepEditor(props: ListManagerEditorProps<Step>) {
             });
           }}
           placeholder="Title"
+          format="bold"
           disabled={props.disabled}
         />
       </InputRow>
@@ -92,6 +93,7 @@ export default function ConfirmationEditor(props: Props) {
             <Input
               placeholder="Heading"
               name="heading"
+              format="bold"
               value={formik.values.heading}
               onChange={formik.handleChange}
               disabled={props.disabled}

--- a/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/ContactInput/Editor.tsx
@@ -46,7 +46,7 @@ const ContactInputComponent: React.FC<Props> = (props) => {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DateInput/Editor.tsx
@@ -52,7 +52,7 @@ const DateInputComponent: React.FC<Props> = (props) => {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/DrawBoundary/Editor.tsx
@@ -46,7 +46,7 @@ function DrawBoundaryComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               placeholder={props.node?.data?.title}
               name="title"
               value={formik.values.title}
@@ -86,7 +86,7 @@ function DrawBoundaryComponent(props: Props) {
         >
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               placeholder={props.node?.data?.titleForUploading}
               name="titleForUploading"
               value={formik.values.titleForUploading}

--- a/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/EnhancedTextInput/Editor.tsx
@@ -104,7 +104,7 @@ const EnhancedTextInputComponent = (props: Props) => {
         <ModalSectionContent title="Initial screen">
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"
@@ -141,7 +141,7 @@ const EnhancedTextInputComponent = (props: Props) => {
           <ModalSectionContent title="Results screen">
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 name="revisionTitle"
                 value={formik.values.revisionTitle}
                 placeholder="Revision title"

--- a/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Feedback/Editor/Editor.tsx
@@ -51,7 +51,7 @@ export const FeedbackEditor = (props: FeedbackEditorProps) => {
             <InputRow>
               <InputLabel label="Title">
                 <Input
-                  format="large"
+                  format="bold"
                   placeholder={defaultContent.title}
                   name="title"
                   value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUpload/Editor.tsx
@@ -53,7 +53,7 @@ function Component(props: Props) {
           <InputRow>
             <Input
               required
-              format="large"
+              format="bold"
               placeholder="Title"
               name="title"
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FileUploadAndLabel/Editor.tsx
@@ -59,7 +59,7 @@ function FileUploadAndLabelComponent(props: Props) {
           <InputRow>
             <Input
               errorMessage={formik.errors.title}
-              format="large"
+              format="bold"
               name="title"
               placeholder={formik.values.title}
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/FindProperty/Editor.tsx
@@ -48,7 +48,7 @@ function FindPropertyComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               placeholder="Title"
               name="title"
               value={formik.values.title}
@@ -85,7 +85,7 @@ function FindPropertyComponent(props: Props) {
             <br />
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 placeholder="Title"
                 name="newAddressTitle"
                 value={formik.values.newAddressTitle}

--- a/apps/editor.planx.uk/src/@planx/components/List/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/List/Editor.tsx
@@ -126,7 +126,7 @@ function ListComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/MapAndLabel/Editor.tsx
@@ -84,7 +84,7 @@ function MapAndLabelComponent(props: Props) {
           <InputGroup>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 name="title"
                 placeholder={"Title"}
                 value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NextSteps/Editor.tsx
@@ -45,6 +45,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Step>> = (props) => {
             });
           }}
           placeholder="Title"
+          format="bold"
           disabled={props.disabled}
         />
       </InputRow>
@@ -120,7 +121,7 @@ const NextStepsComponent: React.FC<Props> = (props) => {
                 value={formik.values.title}
                 onChange={formik.handleChange}
                 placeholder="Main Title"
-                format="large"
+                format="bold"
                 disabled={props.disabled}
                 errorMessage={formik.errors.title}
               />

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -1,4 +1,3 @@
-import { lighten, useTheme } from "@mui/material/styles";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -29,19 +28,16 @@ function NoteComponent(props: Props) {
     },
     props.formikRef,
   );
-  const theme = useTheme();
 
   // Notes should never be "templated", therefore disable `showTemplateConfiguration` in footer here
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
-      <ModalSection
-        sectionBackgroundColor={lighten(theme.palette.background.note, 0.6)}
-      >
+      <ModalSection>
         <ModalSectionContent>
           <InputRow>
             <Input
               name="text"
-              format="large"
+              format="note"
               minRows={4}
               multiline={true}
               placeholder="Note"

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -1,3 +1,4 @@
+import { lighten, useTheme } from "@mui/material/styles";
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
 import { ModalFooter } from "ui/editor/ModalFooter";
@@ -28,11 +29,14 @@ function NoteComponent(props: Props) {
     },
     props.formikRef,
   );
+  const theme = useTheme();
 
   // Notes should never be "templated", therefore disable `showTemplateConfiguration` in footer here
   return (
     <form onSubmit={formik.handleSubmit} id="modal">
-      <ModalSection>
+      <ModalSection
+        sectionBackgroundColor={lighten(theme.palette.background.note, 0.6)}
+      >
         <ModalSectionContent>
           <InputRow>
             <Input

--- a/apps/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Notice/Editor.tsx
@@ -46,7 +46,7 @@ const NoticeEditor: React.FC<NoticeEditorProps> = ({ formik, disabled }) => {
           <InputRow>
             <Input
               name="title"
-              format="large"
+              format="bold"
               placeholder="Notice"
               value={values.title}
               onChange={handleChange}

--- a/apps/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/NumberInput/Editor.tsx
@@ -49,7 +49,7 @@ export default function NumberInputComponent(props: Props): FCReturn {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/Page/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Page/Editor.tsx
@@ -61,7 +61,7 @@ function PageComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/Editor.tsx
@@ -57,7 +57,7 @@ const Component: React.FC<Props> = (props: Props) => {
           <ModalSectionContent>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 placeholder="Page title"
                 name="title"
                 value={formik.values.title}
@@ -93,7 +93,7 @@ const Component: React.FC<Props> = (props: Props) => {
           <ModalSectionContent>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 placeholder="Instructions title"
                 name="instructionsTitle"
                 value={formik.values.instructionsTitle}

--- a/apps/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Pay/Editor/InviteToPaySection.tsx
@@ -41,7 +41,7 @@ export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({
               <InputRow>
                 <Input
                   required
-                  format="large"
+                  format="bold"
                   name="secondaryPageTitle"
                   placeholder="Card title"
                   value={values.secondaryPageTitle}
@@ -54,7 +54,7 @@ export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({
               <InputRow>
                 <Input
                   required
-                  format="large"
+                  format="bold"
                   name="nomineeTitle"
                   placeholder="Title"
                   value={values.nomineeTitle}
@@ -78,7 +78,7 @@ export const InviteToPaySection: React.FC<InviteToPaySectionProps> = ({
               <InputRow>
                 <Input
                   required
-                  format="large"
+                  format="bold"
                   name="yourDetailsTitle"
                   placeholder="Title"
                   value={values.yourDetailsTitle}

--- a/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PlanningConstraints/Editor.tsx
@@ -94,7 +94,7 @@ function PlanningConstraintsComponent(props: Props) {
           <InputGroup>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 name="title"
                 placeholder={formik.values.title}
                 value={formik.values.title}
@@ -187,7 +187,7 @@ function PlanningConstraintsComponent(props: Props) {
                             <InputGroup>
                               <InputRow>
                                 <Input
-                                  format="large"
+                                  format="bold"
                                   name="text"
                                   value={dataset.text}
                                   aria-label="Constraint name"

--- a/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/PropertyInformation/Editor.tsx
@@ -49,7 +49,7 @@ function PropertyInformationComponent(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               placeholder={formik.values.title}
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/Review/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Review/Editor.tsx
@@ -43,7 +43,7 @@ function Component(props: Props) {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               placeholder={formik.values.title}
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Section/Editor.tsx
@@ -83,7 +83,7 @@ function SectionComponent(props: Props) {
           <InputRow>
             <Input
               required
-              format="large"
+              format="bold"
               name="title"
               placeholder="Title"
               value={formik.values.title}

--- a/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Send/Editor.tsx
@@ -154,7 +154,7 @@ const SendComponent: React.FC<Props> = (props) => {
           <ModalSectionContent>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 name="title"
                 value={formik.values.title}
                 placeholder="Editor title"

--- a/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TaskList/Editor.tsx
@@ -46,6 +46,7 @@ const TaskEditor: React.FC<ListManagerEditorProps<Task>> = (props) => {
             });
           }}
           placeholder="Title"
+          format="bold"
           disabled={props.disabled}
           errorMessage={getIn(errors, `tasks[${props.index}].title`)}
         />
@@ -106,7 +107,7 @@ const TaskListComponent: React.FC<Props> = (props) => {
                     value={formik.values.title}
                     onChange={formik.handleChange}
                     placeholder="Main title"
-                    format="large"
+                    format="bold"
                     disabled={props.disabled}
                   />
                 </ErrorWrapper>

--- a/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/TextInput/Editor.tsx
@@ -80,7 +80,7 @@ const TextInputComponent: React.FC<Props> = (props) => {
         <ModalSectionContent>
           <InputRow>
             <Input
-              format="large"
+              format="bold"
               name="title"
               value={formik.values.title}
               placeholder="Title"

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseChecklist/Editor/index.tsx
@@ -52,7 +52,7 @@ export const BaseChecklistComponent: React.FC<Props> = (props) => {
           <InputGroup>
             <InputRow>
               <Input
-                format="large"
+                format="bold"
                 name="text"
                 value={formik.values.text}
                 placeholder="Text"

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseOptionsEditor/index.tsx
@@ -110,6 +110,7 @@ export const BaseOptionsEditor: React.FC<Props> = (props) => {
             <Input
               value={props.value.data.notes || ""}
               placeholder="Note"
+              format="note"
               multiline
               disabled={props.disabled}
               onChange={(ev) => updateSharedField("notes", ev.target.value)}

--- a/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/BaseQuestion/Editor/index.tsx
@@ -82,7 +82,7 @@ const BaseQuestionComponent: React.FC<Props> = (props) => {
             <InputRow>
               <Input
                 errorMessage={formik.errors.text}
-                format="large"
+                format="bold"
                 name="text"
                 value={formik.values.text}
                 placeholder="Text"

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -12,6 +12,7 @@ $folderBackground: #b5d1f7;
 $folderBorder: #2c4b88;
 $primaryAction: #0010a4;
 $noteBackground: #fffdb0;
+$lockedNoteBackground: #f5f4d2;
 
 $endpointWidth: 50px;
 $hangerWidth: 16px;
@@ -320,7 +321,7 @@ $fontMonospace: "Source Code Pro", monospace;
 
     .flow-locked & {
       border-color: $lockedBorder;
-      background: $lockedDataBackground;
+      background: $lockedNoteBackground;
     }
   }
 
@@ -723,16 +724,16 @@ $fontMonospace: "Source Code Pro", monospace;
   // TODO retire `.question.` prefix
   &.question.isNote {
     a {
-      background: #fffdb0 !important;
+      background: $noteBackground !important;
       position: relative;
       padding-right: 20px;
       .flow-locked & {
-        background: #f5f4d2 !important;
+        background: $lockedNoteBackground !important;
       }
     }
     & .template-card > a {
       .flow-locked & {
-        background: #fffdb0 !important;
+        background: $noteBackground !important;
         border-color: $nodeBorder;
       }
     }

--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -61,39 +61,6 @@ $fontMonospace: "Source Code Pro", monospace;
   }
 }
 
-// Triangle shapes to simulate a paper fold on a note's corner
-@mixin paperFoldFront($size: 12px, $background: #fff) {
-  content: "";
-  position: absolute;
-  right: -$nodeBorderWidth;
-  bottom: -$nodeBorderWidth;
-  width: 0;
-  height: 0;
-  border-bottom: $size solid $background;
-  border-left: $size solid transparent;
-}
-
-@mixin paperFoldBack($size: 12px, $foldColor: #555) {
-  content: "";
-  position: absolute;
-  right: -$nodeBorderWidth;
-  bottom: -$nodeBorderWidth;
-  width: 0;
-  height: 0;
-  border-top: $size solid $foldColor;
-  border-right: $size solid transparent;
-}
-
-// truncating styles for long notes
-@mixin lineClamp($lines: 3, $lineHeight: 1.4) {
-  display: -webkit-box;
-  -webkit-line-clamp: $lines;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: $lineHeight;
-}
-
 @mixin cloneStyle {
   content: "";
   position: absolute;
@@ -351,54 +318,9 @@ $fontMonospace: "Source Code Pro", monospace;
     overflow-wrap: break-word;
     word-break: break-word;
 
-    // TODO debug folded corner
-    &::before {
-      @include paperFoldFront;
-    }
-    &::after {
-      @include paperFoldBack;
-    }
-
     .flow-locked & {
       border-color: $lockedBorder;
       background: $lockedDataBackground;
-    }
-  }
-
-  // A note attached directly to a node - rendered as an extra row
-  & .attached-note {
-    position: relative;
-    display: block;
-    width: 100%;
-    font: inherit;
-    text-align: left;
-    appearance: none;
-    padding: 8px 20px 8px 8px;
-    border: $nodeBorderWidth solid $optionBorder;
-    border-top: none;
-    background: $noteBackground;
-    cursor: pointer;
-
-    & .note-text {
-      overflow-wrap: break-word;
-      word-break: break-word;
-      @include lineClamp(3);
-    }
-
-    &::before {
-      @include paperFoldFront;
-    }
-    &::after {
-      @include paperFoldBack;
-    }
-  }
-
-  // Wraps .attached-note so the clone outline (its own ::before) doesn't collide with the paper-fold pseudo-elements above
-  & .attached-note-wrapper {
-    position: relative;
-
-    &.isClone::before {
-      @include cloneStyle;
     }
   }
 
@@ -566,18 +488,6 @@ $fontMonospace: "Source Code Pro", monospace;
     @include disabledHanger();
   }
 
-  // decorative connector
-  &.note-connector {
-    [data-layout="top-down"] & {
-      min-height: $padding * 2;
-      min-width: $hangerWidth;
-    }
-    [data-layout="left-right"] & {
-      min-width: $padding * 2;
-      min-height: $hangerWidth;
-    }
-  }
-
   > a,
   > button {
     $size: $hangerWidth;
@@ -646,50 +556,6 @@ $fontMonospace: "Source Code Pro", monospace;
           content: none;
         }
       }
-    }
-  }
-}
-
-// positioned note i.e. rendered on a container line
-.note-card {
-  align-self: center;
-  position: relative;
-  z-index: 1;
-
-  &.isClone::before {
-    @include cloneStyle;
-  }
-
-  &.isDragging {
-    opacity: 0.5;
-    > button {
-      border-style: dashed;
-    }
-  }
-
-  > button {
-    position: relative;
-    display: inline-block;
-    font: inherit;
-    text-align: left;
-    appearance: none;
-    border: $nodeBorderWidth solid $optionBorder;
-    background: $noteBackground;
-    cursor: pointer;
-    max-width: $nodeMaxWidth;
-    padding: 8px 20px 8px 8px;
-
-    & .note-text {
-      overflow-wrap: break-word;
-      word-break: break-word;
-      @include lineClamp(3);
-    }
-
-    &::before {
-      @include paperFoldFront;
-    }
-    &::after {
-      @include paperFoldBack;
     }
   }
 }
@@ -868,18 +734,6 @@ $fontMonospace: "Source Code Pro", monospace;
       .flow-locked & {
         background: #fffdb0 !important;
         border-color: $nodeBorder;
-      }
-    }
-    // Triangle shapes to simulate paper fold on sticky note
-    &:not(.isClone) a {
-      &::before {
-        @include paperFoldFront;
-        .flow-locked & {
-          border-bottom-color: $lockedNodeBackground;
-        }
-      }
-      &::after {
-        @include paperFoldBack;
       }
     }
   }

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -40,7 +40,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     dark: "#2C2C2C",
     disabled: "#EEEEEE",
     data: "#F0F0F0",
-    note: "#fffdb0",
+    note: "#FFFDB0",
   },
   secondary: {
     main: "#F3F2F1",

--- a/apps/editor.planx.uk/src/theme.ts
+++ b/apps/editor.planx.uk/src/theme.ts
@@ -40,6 +40,7 @@ const DEFAULT_PALETTE: Partial<PaletteOptions> = {
     dark: "#2C2C2C",
     disabled: "#EEEEEE",
     data: "#F0F0F0",
+    note: "#fffdb0",
   },
   secondary: {
     main: "#F3F2F1",

--- a/apps/editor.planx.uk/src/themeOverrides.d.ts
+++ b/apps/editor.planx.uk/src/themeOverrides.d.ts
@@ -137,6 +137,7 @@ declare module "@mui/material/styles" {
     dark: string;
     disabled: string;
     data: string;
+    note: string;
   }
 
   interface TypeBackgroundOptions {
@@ -145,6 +146,7 @@ declare module "@mui/material/styles" {
     dark: string;
     disabled: string;
     data: string;
+    note: string;
   }
 }
 

--- a/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -1,5 +1,4 @@
 import StickyNote2Icon from "@mui/icons-material/StickyNote2";
-import { lighten, useTheme } from "@mui/material/styles";
 import type { ChangeEvent } from "react";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
@@ -20,12 +19,8 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
   onChange,
   disabled,
 }) => {
-  const theme = useTheme();
-
   return (
-    <ModalSection
-      sectionBackgroundColor={lighten(theme.palette.background.note, 0.6)}
-    >
+    <ModalSection>
       <ModalSectionContent title="Note" Icon={StickyNote2Icon}>
         <InputRow>
           <Input
@@ -35,6 +30,7 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
             onChange={onChange}
             multiline
             placeholder="Note"
+            format="note"
             rows={3}
             disabled={disabled}
           />

--- a/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/InternalNotes.tsx
@@ -1,4 +1,5 @@
 import StickyNote2Icon from "@mui/icons-material/StickyNote2";
+import { lighten, useTheme } from "@mui/material/styles";
 import type { ChangeEvent } from "react";
 import React from "react";
 import ModalSection from "ui/editor/ModalSection";
@@ -19,8 +20,12 @@ export const InternalNotes: React.FC<InternalNotesProps> = ({
   onChange,
   disabled,
 }) => {
+  const theme = useTheme();
+
   return (
-    <ModalSection>
+    <ModalSection
+      sectionBackgroundColor={lighten(theme.palette.background.note, 0.6)}
+    >
       <ModalSectionContent title="Note" Icon={StickyNote2Icon}>
         <InputRow>
           <Input

--- a/apps/editor.planx.uk/src/ui/shared/Input/Input.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/Input/Input.tsx
@@ -19,11 +19,10 @@ const classes: Partial<InputBaseClasses> = {
 };
 
 export interface Props extends Omit<InputBaseProps, "ref"> {
-  format?: "large" | "bold" | "data" | "note";
+  format?: "bold" | "data" | "note";
   classes?: InputBaseClasses;
   className?: string;
   grow?: boolean;
-  large?: boolean;
   bordered?: boolean;
   errorMessage?: string;
   onChange?: (ev: ChangeEvent<HTMLInputElement>) => void;
@@ -66,12 +65,6 @@ const StyledInputBase = styled(InputBase, {
     backgroundColor: lighten(theme.palette.background.note, 0.6),
   }),
   ...(format === "bold" && {
-    fontWeight: FONT_WEIGHT_SEMI_BOLD,
-  }),
-  ...(format === "large" && {
-    backgroundColor: theme.palette.common.white,
-    height: 50,
-    width: "100%",
     fontWeight: FONT_WEIGHT_SEMI_BOLD,
   }),
   [`&.${classes.multiline}`]: {

--- a/apps/editor.planx.uk/src/ui/shared/Input/Input.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/Input/Input.tsx
@@ -1,6 +1,6 @@
 import type { InputBaseClasses, InputBaseProps } from "@mui/material/InputBase";
 import InputBase from "@mui/material/InputBase";
-import { styled } from "@mui/material/styles";
+import { lighten, styled } from "@mui/material/styles";
 import type { ChangeEvent } from "react";
 import React, { forwardRef } from "react";
 import {
@@ -19,7 +19,7 @@ const classes: Partial<InputBaseClasses> = {
 };
 
 export interface Props extends Omit<InputBaseProps, "ref"> {
-  format?: "large" | "bold" | "data";
+  format?: "large" | "bold" | "data" | "note";
   classes?: InputBaseClasses;
   className?: string;
   grow?: boolean;
@@ -61,6 +61,9 @@ const StyledInputBase = styled(InputBase, {
     "& input": {
       fontSize: theme.typography.body2.fontSize,
     },
+  }),
+  ...(format === "note" && {
+    backgroundColor: lighten(theme.palette.background.note, 0.6),
   }),
   ...(format === "bold" && {
     fontWeight: FONT_WEIGHT_SEMI_BOLD,


### PR DESCRIPTION
## What does this PR do?

Tidies up and adds subtle note styles to component authoring:
- Remove obsolete styles from `floweditor.scss`
  - `.attached-note` no longer used
  - decorative `.note-connector` replaced with actual hanger
  - `.note-card` replaced with styled component
  - complete removal of paper fold visual treatment
- Note input on question options has subtle note background:
<img width="859" height="251" alt="image" src="https://github.com/user-attachments/assets/32f92227-ccca-4721-90fb-4558e9ab34da" />

- Note input on component has subtle note background:
<img width="859" height="316" alt="image" src="https://github.com/user-attachments/assets/04c72647-d1b1-4cd2-9989-0dd533ce5340" />

- Standalone note input has subtle note background:
<img width="859" height="316" alt="image" src="https://github.com/user-attachments/assets/9b44b48f-e1f0-46fe-a966-b21be33f9805" />

