### PR TITLE
fix(ci): Ensure `update.sh` doesn't trigger `xcaddy build`

### DIFF
--- a/scripts/pullrequest/update.sh
+++ b/scripts/pullrequest/update.sh
@@ -4,6 +4,15 @@ set -o errexit -o pipefail
 # run from project root
 cd "$(dirname $0)/../.."
 
+# caddy runs up against kernel buffer limits of host OS, so we increase them
+# see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+sysctl -w net.core.rmem_max=7500000
+sysctl -w net.core.wmem_max=7500000
+
+# ensure docker does not pull caddy image via ipv6 (no subnet configured, it will fail)
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
 # set env for this shell
 set -o allexport
 source .env.pizza


### PR DESCRIPTION
## What's the problem?
PR pizza deploys often hit the 10-minute SSH `command_timeout`, with the logs showing `xcaddy build ...` (Caddy compiling from source) running when it fires.

## What's the cause?
Caddy is normally pulled as a pre-built image and we only compile from source (via [the failover config](https://github.com/theopensystemslab/planx-new/blob/main/docker-compose.pizza.failover.yml)) when that pull fails. The `create.sh` script already handles this before pulling, but `update.sh` does not include this config.

## What's the fix?
Copy the `sysctls`s from `create.sh`'s into `update.sh` so this value is always in place before each new deploy. This should be persisting anyway from the initial `create.sh` call but that doesn't seem to be the case here. Possibly the small Vultr instances are falling over and restarting between commits, losing this config (no direct evidence of this I've seen!). At a minimum, this PR won't do any harm and will rule out this if it's not the cause.

Once merged, we'll monitor this and then I can follow up if it happens again.