### PR TITLE
chore[alt notes]: add editor modal tests for `Note` component

### DIFF
--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { useStore } from "pages/FlowEditor/lib/store";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { setup } from "test/utils";
+
+import NoteComponent from "./Editor";
+
+const { setState } = useStore;
+
+describe("Note component editor modal", () => {
+  it("renders", async () => {
+    await setup(
+      <DndProvider backend={HTML5Backend}>
+        <NoteComponent id="test" />
+      </DndProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Note")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tag this component")).toBeInTheDocument();
+  });
+
+  it("requires text", async () => {
+    const handleSubmit = vi.fn();
+    const { user } = await setup(
+      <DndProvider backend={HTML5Backend}>
+        <NoteComponent id="test" handleSubmit={handleSubmit} />
+      </DndProvider>,
+    );
+
+    fireEvent.submit(screen.getByTestId("noteEditorForm"));
+
+    expect(
+      await screen.findByText("Error: text is a required field"),
+    ).toBeVisible();
+  });
+});
+
+describe("Note component editor modal in a soure template", () => {
+  beforeEach(() => {
+    setState({
+      isTemplate: true,
+      user: {
+        id: 1,
+        firstName: "Editor",
+        lastName: "Test",
+        isPlatformAdmin: true,
+        isAnalyst: false,
+        email: "test@test.com",
+        teams: [],
+        defaultTeamId: null,
+      },
+      jwt: "x.y.z",
+    });
+  });
+
+  it("does not display templated node config", async () => {
+    await setup(
+      <DndProvider backend={HTML5Backend}>
+        <NoteComponent id="test" />
+      </DndProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Note")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tag this component")).toBeInTheDocument();
+
+    expect(screen.queryByTitle("Templates")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Allow edits")).not.toBeInTheDocument();
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -31,7 +31,11 @@ function NoteComponent(props: Props) {
 
   // Notes should never be "templated", therefore disable `showTemplateConfiguration` in footer here
   return (
-    <form onSubmit={formik.handleSubmit} id="modal">
+    <form
+      onSubmit={formik.handleSubmit}
+      id="modal"
+      data-testid="noteEditorForm"
+    >
       <ModalSection>
         <ModalSectionContent>
           <InputRow>
@@ -44,6 +48,7 @@ function NoteComponent(props: Props) {
               value={formik.values.text}
               onChange={formik.handleChange}
               disabled={props.disabled}
+              errorMessage={formik.errors.text as string}
             />
           </InputRow>
         </ModalSectionContent>

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -48,7 +48,7 @@ function NoteComponent(props: Props) {
               value={formik.values.text}
               onChange={formik.handleChange}
               disabled={props.disabled}
-              errorMessage={formik.errors.text as string}
+              errorMessage={getIn(formik.errors, "text")}
             />
           </InputRow>
         </ModalSectionContent>

--- a/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/Note/Editor.tsx
@@ -1,5 +1,6 @@
 import { ComponentType } from "@opensystemslab/planx-core/types";
 import { useFormikWithRef } from "@planx/components/shared/useFormikWithRef";
+import { getIn } from "formik";
 import { ModalFooter } from "ui/editor/ModalFooter";
 import ModalSection from "ui/editor/ModalSection";
 import ModalSectionContent from "ui/editor/ModalSectionContent";


### PR DESCRIPTION
`Note` component types uniquely should _not_ display templated node configuration inputs to editors when in a source template - this adds test coverage for this scenario as well as basic general flow rendering/validation.