### PR TITLE
fix(ci): Retry failing PostGIS build on a different mirror

### DIFF
--- a/apps/postgres/Dockerfile
+++ b/apps/postgres/Dockerfile
@@ -2,15 +2,29 @@
 FROM postgis/postgis:16-3.5
 
 # install build deps, build pg_cron and remove build deps to keep image small
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential git ca-certificates postgresql-server-dev-16 \
+RUN set -eux; \
+  # The deb.debian.org CDN can cache a 404 for hours, blocking PRs, Vultr, or regression tests
+  # Retry on a different CDN if we hit issues
+  cp /etc/apt/sources.list /etc/apt/sources.list.orig; \
+  apt_ok=0; \
+  for mirror in deb.debian.org cloudfront.debian.net; do \
+    sed "s|deb.debian.org|$mirror|g" /etc/apt/sources.list.orig > /etc/apt/sources.list; \
+    if apt-get update && apt-get install -y --no-install-recommends \
+        build-essential git ca-certificates postgresql-server-dev-16; then \
+      apt_ok=1; break; \
+    fi; \
+    echo "apt failed via $mirror, trying next mirror..." >&2; \
+  done; \
+  [ "$apt_ok" = 1 ] || { echo "apt failed on all mirrors" >&2; exit 1; }; \
+  cp /etc/apt/sources.list.orig /etc/apt/sources.list; \
+  rm -f /etc/apt/sources.list.orig; \
   # as a safety catch, this build will automatically fail if we fall far behind in the pg_cron commit history
-  && git clone https://github.com/citusdata/pg_cron.git --depth 50 /tmp/pg_cron \
-  && cd /tmp/pg_cron \
-  && git checkout 465b38c737f584d520229f5a1d69d1d44649e4e5 \
-  && make \
-  && make install \
-  && rm -rf /tmp/pg_cron \
-  && apt-get purge -y --auto-remove build-essential git \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  git clone https://github.com/citusdata/pg_cron.git --depth 50 /tmp/pg_cron; \
+  cd /tmp/pg_cron; \
+  git checkout 465b38c737f584d520229f5a1d69d1d44649e4e5; \
+  make; \
+  make install; \
+  rm -rf /tmp/pg_cron; \
+  apt-get purge -y --auto-remove build-essential git; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What's the problem?
The `start-containers-for-tests` job intermittently fails to build the postgis image. This happened today for regression test and https://github.com/theopensystemslab/planx-new/pull/7375

```sh
5.745   404  Not Found [IP: 146.75.30.132 80]
5.745 Get:77 http://deb.debian.org/debian bullseye/main amd64 python3-pygments all 2.7.1+dfsg-2.1 [657 kB]
5.755 Get:78 http://deb.debian.org/debian bullseye/main amd64 python3-yaml amd64 5.3.1-5 [138 kB]
5.755 Get:79 http://deb.debian.org/debian bullseye/main amd64 llvm-16-tools amd64 1:16.0.6-15~deb11u2 [509 kB]
5.760 Get:80 http://deb.debian.org/debian bullseye/main amd64 llvm-16-dev amd64 1:16.0.6-15~deb11u2 [37.7 MB]
6.052 Fetched 172 MB in 1s (123 MB/s)
6.052 E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0%2bdeb11u8_amd64.deb  404  Not Found [IP: 146.75.30.132 80]
6.053 E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/i/icu/icu-devtools_67.1-7%2bdeb11u1_amd64.deb  404  Not Found [IP: 146.75.30.132 80]
6.053 E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/s/setuptools/python3-pkg-resources_52.0.0-4%2bdeb11u2_all.deb  404  Not Found [IP: 146.75.30.132 80]
6.054 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

## What's the solution?
Retry `apt-get` on `cloudfront.debian.net` (AWS CloudFront) if `deb.debian.org` (Fastly CDN) fails.