### PR TITLE
feat: Install `pg_cron` from apt.postgresql.org instead of compiling from source

### DIFF
--- a/apps/postgres/Dockerfile
+++ b/apps/postgres/Dockerfile
@@ -1,16 +1,5 @@
-# XXX: pg_cron pinned to commit 465b38c (v1.6.7) - please update when bumping image
 FROM postgis/postgis:16-3.5
 
-# install build deps, build pg_cron and remove build deps to keep image small
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential git ca-certificates postgresql-server-dev-16 \
-  # as a safety catch, this build will automatically fail if we fall far behind in the pg_cron commit history
-  && git clone https://github.com/citusdata/pg_cron.git --depth 50 /tmp/pg_cron \
-  && cd /tmp/pg_cron \
-  && git checkout 465b38c737f584d520229f5a1d69d1d44649e4e5 \
-  && make \
-  && make install \
-  && rm -rf /tmp/pg_cron \
-  && apt-get purge -y --auto-remove build-essential git \
-  && apt-get clean \
+  && apt-get install -y --no-install-recommends postgresql-16-cron \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What's the problem?
CI is failing on the `start-containers-for-tests` job, and not passing on a simple retry. Regression tests have failed for the past few days for example - it's not as simple as just a retry.

## What's the cause?
As far as I can tell it's an issue with the Debian CDN - we've seen it a few times and it's usually cleared up within a few minutes. In this instance I think there's a persistent issue with the CDN (or at least the edge that the GH runner is hitting - I get varying results locally, probably hitting a different edge of the CDN).

We hit this to grab packages as part of the `apt get` we use to compile and install `pg_cron` from source.

## What's the solution?
Rather than running through a complex (and slow) build and fetch step, we can just grab the compiled `postgresql-16-cron` from apt.postgresql.org directly. This simplifies the whole process, and removed the dependencies on these Debian servers.

From memory, the current method was introduced as we had issues installing `pg_cron` like this on some developer machines. I've put out a request for testing on Slack here to make sure that all our operating systems can manage this.

My proposal here would be to merge this ASAP to unblock pipelines, and then tweak if we hit a local Windows issue.

## Testing
 - Can you rebuild the `postgres` container locally off this branch?
 - Can you confirm that `pg_cron` is installed and running once it's spun up?
 
 ```sql
SELECT * FROM cron.job;
 ```

This works as expected on the Pizza, proving that the DB container has built and `pg_cron` has been installed without issue.

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2a76e41c-7f12-484d-989d-3aa54b6be5f7" />

Regression tests are also [passing on this branch](https://github.com/theopensystemslab/planx-new/actions/runs/34113920633) ✅ 

### Prior art...
Before this method I tried [both simple retires and iterating over different mirrors](https://github.com/theopensystemslab/planx-new/pull/7378) but none reliably solved the core problem and both added a fair amount of complexity to what should be a simple process. Likewise an attempt to[ pre-build the image and host on GHCR](https://github.com/theopensystemslab/planx-new/pull/7378) worked but felt like a very complex solution (and could still fall down for the same reason).