### PR TITLE
feat: Autofocus on search input when opening modal (a11y compliant method)

### DIFF
--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -9,7 +9,7 @@ import List from "@mui/material/List";
 import Typography from "@mui/material/Typography";
 import DelayedLoadingIndicator from "components/DelayedLoadingIndicator/DelayedLoadingIndicator";
 import { useStore } from "pages/FlowEditor/lib/store";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { cardBoxShadow } from "theme";
 import { DebouncedSearchInput } from "ui/shared/SearchBox/DebouncedSearchInput";
 
@@ -38,6 +38,7 @@ interface SearchModalProps {
 }
 
 export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState("");
   const [tabIndex, setTabIndex] = useState(0);
   const [selectedFlow, setSelectedFlow] = useState<FlowSearchResult | null>(
@@ -82,6 +83,10 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
             flexDirection: "column",
           }),
         },
+        // Move focus into the search field once the dialog has finished opening
+        transition: {
+          onEntered: () => searchInputRef.current?.focus(),
+        },
       }}
     >
       <DialogContent
@@ -117,6 +122,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
             placeholder="Search flows across Plan✕"
             fullWidth
             hideLabel
+            inputRef={searchInputRef}
           />
         </Box>
         <Box sx={{ display: "flex", gap: 1, px: 3, pb: 2 }}>

--- a/apps/editor.planx.uk/src/ui/shared/SearchBox/DebouncedSearchInput.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/SearchBox/DebouncedSearchInput.tsx
@@ -1,5 +1,6 @@
 import type { DebouncedFunc } from "lodash";
 import { debounce } from "lodash";
+import type { Ref } from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { SearchInput } from "./SearchInput";
@@ -16,6 +17,7 @@ interface DebouncedSearchInputProps {
   fullWidth?: boolean;
   placeholder?: string;
   debounceMs?: number;
+  inputRef?: Ref<HTMLInputElement>;
 }
 
 /**
@@ -34,6 +36,7 @@ export const DebouncedSearchInput = ({
   fullWidth = false,
   placeholder,
   debounceMs = DEFAULT_DEBOUNCE_MS,
+  inputRef,
 }: DebouncedSearchInputProps) => {
   const [localValue, setLocalValue] = useState(value);
   const [isSearching, setIsSearching] = useState(false);
@@ -84,6 +87,7 @@ export const DebouncedSearchInput = ({
       compact={compact}
       fullWidth={fullWidth}
       placeholder={placeholder}
+      inputRef={inputRef}
     />
   );
 };


### PR DESCRIPTION
## What does this PR do?

Discussed earlier as part of broader search work: https://github.com/theopensystemslab/planx-new/pull/7296#issuecomment-5494219993

Adding a native `autoFocus` property throws an error, as it moves focus unexpectedly on load. Setting focus programatically using a ref ensures that focus only passes when the input is loaded, meaning focus moves only once the dialog is fully open, as a predictable result of the user opening it.
