### PR TITLE
fix(temp): Drop timeout from Vultr update step

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -364,7 +364,7 @@ jobs:
           host: ${{ env.FULL_DOMAIN }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          # command_timeout: 10m
           # TODO: some of below script might be superfluous for server update (rather than create)
           script: |
             apk update


### PR DESCRIPTION
Please see thread - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1788520367596309

This is a temporary drop the the `command_timeout` on the Vultr update step whilst I continue to debug this. Dropping the line means CI is not held up whilst I get to the bottom of this one.

[The previous fix](https://github.com/theopensystemslab/planx-new/pull/7372) appears to have worked (no rebuild I can spot in logs), but we're still hitting the 10 min mark on ocassion.

```sh
  net.ipv6.conf.all.disable_ipv6 = 1
  net.ipv6.conf.default.disable_ipv6 = 1
  latest: Pulling from planx/caddy-vultr
  Digest: sha256:139b7072c51b3b160fd4841e37806d8ea18b742a6e5f45bc05fc9910ff0662c3
  Status: Image is up to date for lhr.vultrcr.com/planx/caddy-vultr:latest
  lhr.vultrcr.com/planx/caddy-vultr:latest
  Caddy image pulled successfully
  ```