### PR TITLE
chore(postgres): Update to Debian 13 (Trixie)

### DIFF
--- a/apps/hasura.planx.uk/migrations/default/1739787604658_create_postgis_extensions/down.sql
+++ b/apps/hasura.planx.uk/migrations/default/1739787604658_create_postgis_extensions/down.sql
@@ -1,0 +1,3 @@
+DROP EXTENSION IF EXISTS postgis_tiger_geocoder;
+DROP EXTENSION IF EXISTS postgis_topology;
+DROP EXTENSION IF EXISTS fuzzystrmatch;

--- a/apps/hasura.planx.uk/migrations/default/1739787604658_create_postgis_extensions/up.sql
+++ b/apps/hasura.planx.uk/migrations/default/1739787604658_create_postgis_extensions/up.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+CREATE EXTENSION IF NOT EXISTS postgis_topology;
+CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;

--- a/apps/postgres/Dockerfile
+++ b/apps/postgres/Dockerfile
@@ -1,5 +1,5 @@
-FROM postgis/postgis:16-3.5
+FROM postgres:16-trixie
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends postgresql-16-cron \
+  && apt-get install -y --no-install-recommends postgresql-16-postgis-3 postgresql-16-cron \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What's the problem?
This is a follow up to the issues initially addressed here - https://github.com/theopensystemslab/planx-new/pull/7379

CI is failing this morning with the following error - 

```sh
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 12h 2min 30s). Updates for this repository will not be applied.
```

## What's the cause?
Our `postgres` Docker image relies on Debian 11 Bullseye which hit end of LTS on 31/08/26. As as a result the error above is thrown - there are no more security releases available for this OS. 

Debian releases here - https://www.debian.org/releases/

## What's the solution?
Upgrade! This PR takes us to Debian 13 which has an end of LTS date of 30/06/30.

I've shifted from the PostGIS image ([which does not have a newer Debian release for Postgres 16](https://hub.docker.com/r/postgis/postgis/tags)) across to plain [`postgres:16-trixie`](https://hub.docker.com/layers/library/postgres/16-trixie/images/sha256-f5745ce5089cd73eb8ed78267752540bb632b4083ce6d3f0dd80806b70b65edb) in order to get us up and running. The alternative (to stick with `postgis` Docker images) would be to upgrade PostgreSQL from 16 to 18 across both Docker and AWS RDS which I'm not too keen to get into just now. There's a knock on impact of switching away from PostGIS, see code comment on the migration below.
