### PR TITLE
feat: Exclude template subscribed flows from search

### DIFF
--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -8,7 +8,7 @@ export interface FlowsWhere {
 
 export type FlowFilter = "all" | "templates" | "copyable";
 
-// Exclude templated flows, showing only source templates and subscriptions within that
+// Exclude templated flows, showing only source templates and subscriptions within those
 const EXCLUDE_TEMPLATED_FLOWS: FlowsWhere = {
   templated_from: { _is_null: true },
 };

--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -3,17 +3,25 @@ import { gql, useQuery } from "@apollo/client";
 export interface FlowsWhere {
   is_template?: { _eq: boolean };
   can_create_from_copy?: { _eq: boolean };
+  templated_from?: { _is_null: boolean };
 }
 
 export type FlowFilter = "all" | "templates" | "copyable";
 
-const FILTER_WHERE: Record<FlowFilter, FlowsWhere | undefined> = {
-  all: undefined,
+// Exclude templated flows, showing only source templates and subscriptions within that
+const EXCLUDE_TEMPLATED_FLOWS: FlowsWhere = {
+  templated_from: { _is_null: true },
+};
+
+const FILTER_WHERE: Record<FlowFilter, FlowsWhere> = {
+  all: EXCLUDE_TEMPLATED_FLOWS,
   templates: {
+    ...EXCLUDE_TEMPLATED_FLOWS,
     is_template: { _eq: true },
     can_create_from_copy: { _eq: true },
   },
   copyable: {
+    ...EXCLUDE_TEMPLATED_FLOWS,
     is_template: { _eq: false },
     can_create_from_copy: { _eq: true },
   },


### PR DESCRIPTION
## What does this PR do?

- Excludes subscriptions of templates from search results, showing only source templates, and listing subscriptions within details of those

<img width="1523" height="617" alt="image" src="https://github.com/user-attachments/assets/1bc6c721-5f58-4338-a142-ff12628732b9" />

### Testing

⛳️ Toggle feature flag `explore`

Search for `Templates demo flow` on  https://7388.planx.pizza/app/barnet/explore