### PR TITLE
[editor] align dropzones & enforce file validation by extension

### DIFF
--- a/apps/api.planx.uk/modules/file/controller.ts
+++ b/apps/api.planx.uk/modules/file/controller.ts
@@ -1,10 +1,9 @@
+import { getFileExtension, isAllowedExtension } from "@planx/file-upload";
 import assert from "assert";
-import path from "path";
 import { z } from "zod";
 
 import { ServerError } from "../../errors/index.js";
 import type { ValidatedRequestHandler } from "../../shared/middleware/validate.js";
-import { validateExtension } from "./middleware/useFileUpload.js";
 import { deleteFilesByKey } from "./service/deleteFile.js";
 import {
   getFileFromS3,
@@ -30,8 +29,8 @@ export const uploadFileSchema = z.object({
       .string()
       .trim()
       .min(1)
-      .refine(validateExtension, (input) => ({
-        message: `Unsupported file type for given filename: ${path.extname(input).toLowerCase()}`,
+      .refine(isAllowedExtension, (input) => ({
+        message: `Unsupported file type for given filename: ${getFileExtension(input)}`,
       }))
       .transform((filename) => encodeURIComponent(filename)),
   }),

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -99,6 +99,8 @@ describe("File upload", () => {
   describe.each([PRIVATE_ENDPOINT, PUBLIC_ENDPOINT])(
     "File type validation for %s",
     (ENDPOINT) => {
+      const auth = authHeader({ role: "teamEditor" });
+
       it("should not upload a file with an unsupported extension", async () => {
         await supertest(app)
           .post(ENDPOINT)
@@ -108,6 +110,36 @@ describe("File upload", () => {
           .then((res) => {
             expect(mockPutObject).not.toHaveBeenCalled();
             expect(res.body.error).toMatch(/Unsupported file type/);
+          });
+      });
+
+      it("should reject an executable sent as the catchall octet-stream MIME type", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .field("filename", "virus.com")
+          .attach("file", Buffer.from("some data"), {
+            filename: "virus.com",
+            contentType: "application/octet-stream",
+          })
+          .expect(415)
+          .then((res) => {
+            expect(mockPutObject).not.toHaveBeenCalled();
+            expect(res.body.error).toMatch(/Unsupported file type/);
+          });
+      });
+
+      it("should still accept an extension which has no reliable MIME type", async () => {
+        await supertest(app)
+          .post(ENDPOINT)
+          .set(auth)
+          .field("filename", "model.ifc")
+          .attach("file", Buffer.from("some data"), {
+            filename: "model.ifc",
+            contentType: "application/octet-stream",
+          })
+          .expect(200)
+          .then(() => {
+            expect(mockPutObject).toHaveBeenCalled();
           });
       });
 

--- a/apps/api.planx.uk/modules/file/middleware/useFileContentValidation.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileContentValidation.ts
@@ -1,7 +1,6 @@
+import { getFileExtension } from "@planx/file-upload";
 import type { RequestHandler } from "express";
 import { fileTypeFromBuffer, supportedExtensions } from "file-type";
-
-import { getFileExtension } from "./utils.js";
 
 /**
  * Maps our accepted extension variants to file-type's canonical 'ext' values

--- a/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
+++ b/apps/api.planx.uk/modules/file/middleware/useFileUpload.ts
@@ -1,22 +1,19 @@
-import { ALLOWED_EXTENSIONS, MAX_UPLOAD_SIZE_BYTES } from "@planx/file-upload";
+import {
+  getFileExtension,
+  isAllowedExtension,
+  MAX_UPLOAD_SIZE_BYTES,
+} from "@planx/file-upload";
 import type { RequestHandler } from "express";
 import multer from "multer";
 
-import { getFileExtension } from "./utils.js";
-
-export const validateExtension = (filename: string): boolean => {
-  return ALLOWED_EXTENSIONS.includes(getFileExtension(filename));
-};
-
 /**
  * Filter out invalid files based on their extension.
- * See @planx/file-upload for the shared, canonical ALLOWED_EXTENSIONS list
- * (kept in sync with the frontend dropzone's ALLOWED_EXTENSIONS_BY_MIME_TYPE map).
+ * See @planx/file-upload for the shared, canonical allowlist.
  *
- * NB. We would also validate ext against magic number here, but fileFilter runs before file is read into memory (i.e. no buffer)
+ * NB. We would also validate ext against magic number here, but fileFilter runs before file is read into memory (i.e. no buffer).
  */
 const fileFilter: multer.Options["fileFilter"] = (_req, file, callback) => {
-  if (!validateExtension(file.originalname)) {
+  if (!isAllowedExtension(file.originalname)) {
     return callback(
       new Error(
         `Unsupported file type. Extension: ${getFileExtension(file.originalname)}`,

--- a/apps/api.planx.uk/modules/file/middleware/utils.ts
+++ b/apps/api.planx.uk/modules/file/middleware/utils.ts
@@ -1,8 +1,0 @@
-import path from "path";
-
-/**
- * Returns a lowercased extension, keeping the leading dot, e.g. ".pdf", ".xlsx".
- */
-export const getFileExtension = (filename: string): string => {
-  return path.extname(filename).toLowerCase();
-};

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.test.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.test.tsx
@@ -1,0 +1,148 @@
+import type { FileUploadSlot } from "@planx/components/FileUpload/model";
+import { http, HttpResponse } from "msw";
+import server from "test/mockServer";
+import { setup } from "test/utils";
+import type { Mock } from "vitest";
+import { vi } from "vitest";
+
+import { Dropzone } from "./Dropzone";
+
+const UPLOAD_ENDPOINT = `${import.meta.env.VITE_APP_API_URL}/file/private/upload`;
+
+const successHandler = http.post(UPLOAD_ENDPOINT, () =>
+  HttpResponse.json({
+    fileUrl: "https://api.example.com/file/private/nanoid/plan.png",
+  }),
+);
+
+// fail loudly if a file we should reject editor-side is nonetheless sent to API
+const forbiddenHandler = http.post(UPLOAD_ENDPOINT, () => {
+  throw new Error("A rejected file should never be uploaded");
+});
+
+/**
+ * react-dropzone calls onDrop even when every file was rejected, so `setSlots` is called either
+ * way - with an updater which adds nothing. Replay the updaters to see what the user ends up with.
+ */
+const resolveSlots = (setSlots: Mock): FileUploadSlot[] =>
+  setSlots.mock.calls.reduce<FileUploadSlot[]>(
+    (slots, [updater]) =>
+      typeof updater === "function" ? updater(slots) : updater,
+    [],
+  );
+
+/**
+ * user-event filters by the input's `accept` attribute before the file ever reaches the input,
+ * which would stop our validator from running at all, so we disable it here to test that line
+ */
+const dropFile = async (file: File, createSlot?: () => FileUploadSlot) => {
+  const setSlots = vi.fn();
+  const { getByTestId, user } = await setup(
+    <Dropzone
+      slots={[]}
+      setSlots={setSlots}
+      setFileUploadStatus={vi.fn()}
+      createSlot={createSlot}
+    />,
+    { applyAccept: false },
+  );
+
+  await user.upload(getByTestId("upload-input"), file);
+
+  return { slots: () => resolveSlots(setSlots) };
+};
+
+const alertMock = vi.mocked(window.alert);
+const invalidTypeMessage = expect.stringContaining(
+  "File must be one of the following types",
+);
+
+describe("files we do not accept", () => {
+  beforeEach(() => {
+    server.use(forbiddenHandler);
+  });
+
+  it("rejects an executable which the browser types as application/octet-stream", async () => {
+    const { slots } = await dropFile(
+      new File(["x"], "virus.com", { type: "application/octet-stream" }),
+    );
+
+    expect(alertMock).toHaveBeenCalledWith(invalidTypeMessage);
+    expect(slots()).toHaveLength(0);
+  });
+
+  it("rejects an extension variant of a MIME type we accept", async () => {
+    // .jfif is mapped to image/jpeg by browsers, but is not in our allowlist
+    const { slots } = await dropFile(
+      new File(["x"], "photo.jfif", { type: "image/jpeg" }),
+    );
+
+    expect(alertMock).toHaveBeenCalledWith(invalidTypeMessage);
+    expect(slots()).toHaveLength(0);
+  });
+
+  it("rejects a file with no extension at all", async () => {
+    const { slots } = await dropFile(
+      new File(["x"], "photo", { type: "image/png" }),
+    );
+
+    expect(alertMock).toHaveBeenCalledWith(invalidTypeMessage);
+    expect(slots()).toHaveLength(0);
+  });
+
+  it("rejects a format we do not accept", async () => {
+    const { slots } = await dropFile(
+      new File(["x"], "doc.odt", {
+        type: "application/vnd.oasis.opendocument.text",
+      }),
+    );
+
+    expect(alertMock).toHaveBeenCalledWith(invalidTypeMessage);
+    expect(slots()).toHaveLength(0);
+  });
+
+  it("does not create a slot for a rejected file", async () => {
+    const createSlot = vi.fn();
+
+    await dropFile(
+      new File(["x"], "virus.exe", { type: "application/octet-stream" }),
+      createSlot,
+    );
+
+    expect(createSlot).not.toHaveBeenCalled();
+  });
+});
+
+describe("files we do accept", () => {
+  beforeEach(() => {
+    server.use(successHandler);
+  });
+
+  it("accepts a PNG", async () => {
+    const { slots } = await dropFile(
+      new File(["x"], "plan.png", { type: "image/png" }),
+    );
+
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(slots()).toHaveLength(1);
+  });
+
+  it("accepts a binary format the browser cannot type at all", async () => {
+    // files like .bim or .ifc have no reliable MIME type, so are matched on extension alone
+    const { slots } = await dropFile(
+      new File(["x"], "model.ifc", { type: "" }),
+    );
+
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(slots()).toHaveLength(1);
+  });
+
+  it("accepts an uppercase extension", async () => {
+    const { slots } = await dropFile(
+      new File(["x"], "PLAN.PDF", { type: "application/pdf" }),
+    );
+
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(slots()).toHaveLength(1);
+  });
+});

--- a/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
+++ b/apps/editor.planx.uk/src/@planx/components/shared/PrivateFileUpload/Dropzone.tsx
@@ -5,6 +5,7 @@ import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import type { FileUploadSlot } from "@planx/components/FileUpload/model";
 import { useOptionalListContext } from "@planx/components/List/Public/Context";
+import { validateExtension } from "@planx/components/shared/extensionValidator";
 import handleRejectedUpload from "@planx/components/shared/handleRejectedUpload";
 import {
   ALLOWED_EXTENSIONS_BY_MIME_TYPE,
@@ -166,6 +167,8 @@ export function Dropzone<T extends FileUploadSlot>({
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: ALLOWED_EXTENSIONS_BY_MIME_TYPE,
+    // `accept` alone is not enough - see extensionValidator.ts
+    validator: validateExtension,
     maxSize: MAX_UPLOAD_SIZE_BYTES,
     multiple: maxFiles !== 1,
     disabled: Boolean(maxFiles && slots.length >= maxFiles),

--- a/apps/editor.planx.uk/src/@planx/components/shared/extensionValidator.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/extensionValidator.ts
@@ -1,0 +1,35 @@
+import { getFileExtension, isAllowedExtension } from "@planx/file-upload";
+import type { FileError } from "react-dropzone";
+import { ErrorCode } from "react-dropzone";
+
+/**
+ * Extension checks for react-dropzone's `validator` option.
+ * See: https://react-dropzone.js.org/examples/validator#custom-validation
+ *
+ * react-dropzone's `accept` logic accepts files over-zealousy. That is, it accepts a file if its browser-reported
+ * MIME type OR its extension matches, so any MIME type we include also admits every other extension the browser maps
+ * onto that type. For example, the catchall 'application/octet-stream' admits .exe or .com files, which we don't allow.
+ * We therefore validate strictly by extension on the frontend, so they never hit the API (which will reject them anyway).
+ *
+ * We deliberately reuse react-dropzone's own `file-invalid-type` code so these rejections flow through
+ * the same handling as its built-in ones (see handleRejectedUpload).
+ */
+const invalidType = (file: File): FileError => ({
+  // we reuse react-dropzone's own `file-invalid-type` code so rejections flow through handleRejectedUpload
+  code: ErrorCode.FileInvalidType,
+  message: `File extension not allowed: ${file.name}`,
+});
+
+export const validateExtension = (file: File): FileError | null =>
+  isAllowedExtension(file.name) ? null : invalidType(file);
+
+/**
+ * As above, but for dropzones accepting a narrower list than the full allowlist (e.g. images only).
+ * Pass the extensions - with leading dots - which this dropzone accepts.
+ */
+export const createExtensionValidator =
+  (allowedExtensions: string[]) =>
+  (file: File): FileError | null =>
+    allowedExtensions.includes(getFileExtension(file.name))
+      ? null
+      : invalidType(file);

--- a/apps/editor.planx.uk/src/@planx/components/shared/handleRejectedUpload.ts
+++ b/apps/editor.planx.uk/src/@planx/components/shared/handleRejectedUpload.ts
@@ -1,30 +1,40 @@
-import { ALLOWED_EXTENSIONS, MAX_UPLOAD_SIZE_BYTES } from "@planx/file-upload";
+import { ALLOWED_EXTENSIONS, MAX_UPLOAD_SIZE_MB } from "@planx/file-upload";
 import type { FileRejection } from "react-dropzone";
+import { ErrorCode } from "react-dropzone";
 
 /**
- * Shows an alert to the user with errors that are probably going to
- * be related to either invalid file size or type.
+ * Builds a user-facing alert for a rejection by react-dropzone.
  *
  * @param fileRejections - array of errors provided by Dropzone
+ * @param allowedExtensions - defaults to the full allowlist; can also pass a narrower list
  */
-function handleRejectedUpload(fileRejections: Array<FileRejection>) {
+export const getRejectionMessage = (
+  fileRejections: Array<FileRejection>,
+  allowedExtensions: string[] = ALLOWED_EXTENSIONS,
+): string => {
   // XXX: There can be multiple file rejections with different errors
   // We display only the first error to keep the UI simple and easy to understand
-  const errorCode = fileRejections[0].errors[0].code;
-  const message = (() => {
-    switch (errorCode) {
-      case "file-too-large":
-        return `File must be smaller than ${MAX_UPLOAD_SIZE_BYTES * 1e-6}MB`;
-      case "file-invalid-type":
-        return (
-          "File must be one of the following types: " +
-          ALLOWED_EXTENSIONS.map((ext) => ext.replace(/^\./, "")).join(", ")
-        );
-      default:
-        return fileRejections[0].errors[0].message;
-    }
-  })();
-  window.alert(message);
+  const { code, message } = fileRejections[0].errors[0];
+
+  switch (code) {
+    case ErrorCode.FileTooLarge:
+      return `File must be smaller than ${MAX_UPLOAD_SIZE_MB}MB`;
+    case ErrorCode.FileInvalidType:
+      return (
+        "File must be one of the following types: " +
+        allowedExtensions.map((ext) => ext.replace(/^\./, "")).join(", ")
+      );
+    default:
+      return message;
+  }
+};
+
+/**
+ * Shows the above as an alert/modal. Dropzones with somewhere better to put an error
+ * (e.g. an ErrorWrapper or tooltip) should call getRejectionMessage directly.
+ */
+function handleRejectedUpload(fileRejections: Array<FileRejection>) {
+  window.alert(getRejectionMessage(fileRejections));
 }
 
 export default handleRejectedUpload;

--- a/apps/editor.planx.uk/src/test/utils.tsx
+++ b/apps/editor.planx.uk/src/test/utils.tsx
@@ -63,9 +63,14 @@ const testApolloClient = new ApolloClient({
  *
  * Note: This function is async to allow the router to finish rendering.
  * Tests must await the setup() call.
+ *
+ * All userEventOptions are accepted, to enable the rare test which needs to change user behaviour
+ * e.g. `{ applyAccept: false }` so that a file upload test can exercise a dropzone's own validation.
+ * See: http://testing-library.com/docs/user-event/options
  */
 export const setup = async (
   jsx: React.JSX.Element,
+  userEventOptions?: Parameters<typeof userEvent.setup>[0],
 ): Promise<Record<"user", UserEvent> & RenderResult> => {
   testQueryClient.clear();
   const user = userEvent.setup({
@@ -74,6 +79,7 @@ export const setup = async (
     // Drop this Never check if resolved
     // Source: https://github.com/jsdom/jsdom/issues/3985
     pointerEventsCheck: PointerEventsCheckLevel.Never,
+    ...userEventOptions,
   });
 
   const rootRoute = createRootRoute({

--- a/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
+++ b/apps/editor.planx.uk/src/ui/editor/ImgInput/ImgInput.tsx
@@ -80,7 +80,7 @@ export default function ImgInput({
         }}
       >
         <MenuItem component="a" href={img} target="_blank">
-          View
+          Download
         </MenuItem>
         <MenuItem onClick={handleRemove} disabled={disabled}>
           Remove

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.test.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.test.tsx
@@ -1,0 +1,53 @@
+import { MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MB } from "@planx/file-upload";
+import { setup } from "test/utils";
+import { vi } from "vitest";
+
+import PublicFileUploadButton from "./PublicFileUploadButton";
+
+/**
+ * This dropzone used to pass neither `onDropRejected` nor `maxSize`, so an oversized or
+ * wrong-typed image did nothing whatsoever - the file was dropped on the floor in silence.
+ *
+ * Note its `accept` uses the `image/*` wildcard, which admits image formats the API refuses
+ * (e.g. .avif, .heic), hence the extension validator - see extensionValidator.
+ */
+
+const dropFile = async (file: File) => {
+  const onChange = vi.fn();
+  // applyAccept: false because user-event otherwise filters by the input's `accept` attribute
+  const utils = await setup(<PublicFileUploadButton onChange={onChange} />, {
+    applyAccept: false,
+  });
+
+  await utils.user.upload(utils.getByTestId("upload-file-input"), file);
+
+  return { ...utils, onChange };
+};
+
+it("reports an image format we do not accept", async () => {
+  const file = new File(["x"], "logo.avif", { type: "image/avif" });
+
+  const { findByLabelText, onChange } = await dropFile(file);
+
+  // message is shared with applicant-facing Dropzone, but narrowed to a smaller field of accepted extensions
+  expect(
+    await findByLabelText(
+      /File must be one of the following types: jpg, jpeg, png, svg$/,
+    ),
+  ).toBeInTheDocument();
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+it("reports an oversized image", async () => {
+  const file = new File(["x"], "logo.png", { type: "image/png" });
+  Object.defineProperty(file, "size", { value: MAX_UPLOAD_SIZE_BYTES + 1 });
+
+  const { findByLabelText, onChange } = await dropFile(file);
+
+  expect(
+    await findByLabelText(
+      new RegExp(`File must be smaller than ${MAX_UPLOAD_SIZE_MB}MB`),
+    ),
+  ).toBeInTheDocument();
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -3,14 +3,28 @@ import Image from "@mui/icons-material/Image";
 import CircularProgress from "@mui/material/CircularProgress";
 import { styled } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
+import { createExtensionValidator } from "@planx/components/shared/extensionValidator";
+import { getRejectionMessage } from "@planx/components/shared/handleRejectedUpload";
+import { MAX_UPLOAD_SIZE_BYTES } from "@planx/file-upload";
 import { uploadPublicFile } from "lib/api/fileUpload/requests";
 import { useCallback, useEffect, useState } from "react";
-import type { FileWithPath } from "react-dropzone";
+import type { FileRejection, FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
 
 export type AcceptedFileTypes = Record<string, ImageFileExtensions[]>;
 
-export type ImageFileExtensions = ".jpg" | ".jpeg" | ".png" | ".svg" | ".ico";
+// all raster and vector graphic extensions from canonical allowlist in file-upload package
+export type ImageFileExtensions =
+  | ".bmp"
+  | ".gif"
+  | ".ico"
+  | ".jpg"
+  | ".jpeg"
+  | ".png"
+  | ".svg"
+  | ".tif"
+  | ".tiff"
+  | ".webp";
 
 export const DEFAULT_FILETYPES: AcceptedFileTypes = {
   "image/*": [".jpg", ".jpeg", ".png", ".svg"],
@@ -115,10 +129,26 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
     [onChange],
   );
 
+  const accept = acceptedFileTypes || DEFAULT_FILETYPES;
+
+  // `accept` alone is not enough (see extensionValidator.ts). For example, DEFAULT_FILETYPES uses the
+  // `image/*` wildcard, which would otherwise let through image formats the API refuses (e.g. .avif, .heic)
+  const allowedExtensions = Object.values(accept).flat();
+
+  // rather than using window.alert, we use the native error display in this component
+  const onDropRejected = (fileRejections: FileRejection[]) =>
+    setStatus({
+      type: "error",
+      msg: getRejectionMessage(fileRejections, allowedExtensions),
+    });
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    accept: acceptedFileTypes || DEFAULT_FILETYPES,
+    accept,
+    validator: createExtensionValidator(allowedExtensions),
+    maxSize: MAX_UPLOAD_SIZE_BYTES,
     disabled,
+    onDropRejected,
   });
 
   if (status.type === "loading") {

--- a/packages/file-upload/allowedFileTypes.ts
+++ b/packages/file-upload/allowedFileTypes.ts
@@ -1,8 +1,11 @@
 /**
- * Single source of truth for file types accepted for upload.
+ * Single source of truth for file types accepted for upload across the stack.
  *
- * Some formats do not have reliable MIME types, so files are ultimately checked API-side against extension only
- * (see ALLOWED_EXTENSIONS below). The MIME keys are best-effort hints for the native file picker on the frontend.
+ * Some formats do not have reliable MIME types, so files are ultimately checked against extension only.
+ *
+ * Note that the MIME keys act as hints for the native file picker (so users may see some files which they cannot upload),
+ * while react-dropzone 'accepts' a file if its browser-reported MIME type matches a key below, even if its extension does
+ * not feature in the following list. We therefore roll our own validator to narrow the field - see the editor's extensionValidator.ts.
  *
  * Refer to MDN for common MIME types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
  * And IANA for the source of truth: https://www.iana.org/assignments/media-types/media-types.xhtml
@@ -19,13 +22,15 @@ export const ALLOWED_EXTENSIONS_BY_MIME_TYPE: Record<string, string[]> = {
   "image/jpeg": [".jpg", ".jpeg"],
   "image/png": [".png"],
   "image/tiff": [".tif", ".tiff"],
+  "image/vnd.microsoft.icon": [".ico"],
   "image/webp": [".webp"],
+  "image/x-icon": [".ico"],
   // vector graphics
   "image/svg+xml": [".svg"],
   // CAD and BIM
   "image/vnd.dwg": [".dwg"],
   "image/vnd.dxf": [".dxf"],
-  // Text, MS Office documents and spreadsheets
+  // text, MS Office documents and spreadsheets
   "text/csv": [".csv"],
   "text/plain": [".txt"],
   "application/rtf": [".rtf"],
@@ -47,7 +52,7 @@ export const ALLOWED_EXTENSIONS_BY_MIME_TYPE: Record<string, string[]> = {
   "video/x-ms-wmv": [".wmv"],
   // GML (Geographic Markup Language)
   "application/gml+xml": [".gml"],
-  // binary files without custom MIME, for which we fall back to catchall octet-stream
+  // binary files with no registered and reliable MIME type, so we fall back to catchall octet-stream
   "application/octet-stream": [".bim", ".ifc", ".plt", ".rvt", ".skp"],
 };
 
@@ -73,8 +78,25 @@ export const PREVIEWABLE_MIME_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Flat, deduplicated list of allowed extensions, derived from ALLOWED_EXTENSIONS_BY_MIME_TYPE above.
- * Used by the backend to validate uploads by extension (since MIME types are not reliable).
+ * Used to 'validate' files by extension only (since MIME types are not reliable).
  */
 export const ALLOWED_EXTENSIONS: string[] = Array.from(
   new Set(Object.values(ALLOWED_EXTENSIONS_BY_MIME_TYPE).flat()),
 );
+
+/**
+ * Returns lowercased extension, with leading dot, e.g. '.pdf'.
+ * Returns  "" for a filename with no extension, or for dotfiles ().
+ *
+ * Modelled on node's `path.extname`, which we avoid using so this package can be imported by the frontend.
+ */
+export const getFileExtension = (filename: string): string => {
+  const lastDot = filename.lastIndexOf(".");
+  return lastDot <= 0 ? "" : filename.slice(lastDot).toLowerCase();
+};
+
+/**
+ * Single rule for whether we accept a file, shared by the API's upload middleware and frontend dropzones.
+ */
+export const isAllowedExtension = (filename: string): boolean =>
+  ALLOWED_EXTENSIONS.includes(getFileExtension(filename));


### PR DESCRIPTION
Bundles some forward-fixes for the enabling of many more file types in #7355. Relates to [this ticket](https://trello.com/c/kkt7dKkB). See also relevant Slack thread [here](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1788521820727899).

The big thing this PR brings is parity across the frontend/Editor and the API as to what file types are accepted for upload.

There are 2 instances of [react-dropzone](https://react-dropzone.js.org/) integrated into components in the Editor. Due to a quirk of how that package handles the `accept` option (it reads MIME type first and is satisfied by that even if extension doesn't match), the `Dropzone` component was allowing files through which would then be rejected by the API, making for pretty bad UX. Meanwhile the `PublicFileUploadButton` component had the same issue as well as no file size constraint.

So here we align the behaviour for both uses of `react-dropzone`, including adding custom validation to both to enforce file-type-validation-by-extension, all based on the canonical allowlist in the workspace `file-upload` package which the analogous logic in the API also references - so we have a single source of truth across the stack.