### PR TITLE
[api][editor] wait on public file scans before returning

### DIFF
--- a/apps/api.planx.uk/cors.ts
+++ b/apps/api.planx.uk/cors.ts
@@ -31,7 +31,9 @@ const apiCors = cors({
     "Origin",
     "X-Requested-With",
   ],
-  exposedHeaders: ["Content-Disposition"],
+  // Content-Disposition lets browser JS read the filename off a download. Retry-After is sent with
+  // a 503 FILE_SCAN_PENDING, so a client waiting on a file it just uploaded can read the interval
+  exposedHeaders: ["Content-Disposition", "Retry-After"],
 });
 
 const skipApiCors = ["/proxy/ordnance-survey"];

--- a/apps/api.planx.uk/modules/file/controller.ts
+++ b/apps/api.planx.uk/modules/file/controller.ts
@@ -9,6 +9,7 @@ import {
   getFileFromS3,
   type GetFileResult,
   headFileInS3,
+  PUBLIC_FILE_CROSS_ORIGIN_RESOURCE_POLICY,
 } from "./service/getFile.js";
 import { uploadPrivateFile, uploadPublicFile } from "./service/uploadFile.js";
 import { buildFilePath, safeDecode } from "./service/utils.js";
@@ -96,6 +97,25 @@ type DownloadNext = Parameters<DownloadController>[2];
 const SCAN_RETRY_AFTER_SECONDS = 30;
 
 /**
+ * Public files are worth caching. Team logos in particular are served on many pages,
+ * and each uncached hit costs us a full S3 read into memory.
+ *
+ * Without this, browsers fall back to heuristic freshness based on `Last-Modified`.
+ * See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching
+ */
+const PUBLIC_FILE_CACHE_CONTROL_SUCCESS = {
+  "cache-control": "public, max-age=3600",
+} as const;
+
+/**
+ * Note the public GET route has no useNoCache (unlike private), so we set this on error responses to
+ * keep failures out of caches, e.g. a cached 503 would leave a file looking broken when it's servable.
+ */
+const PUBLIC_FILE_CACHE_CONTROL_SUCCESS_FAILURE = {
+  "cache-control": "no-store",
+} as const;
+
+/**
  * Map a failed read of the user-data bucket onto an HTTP response.
  *
  * Request bodies should carry a stable code: councils and their integrations can branch on
@@ -107,10 +127,13 @@ const handleFileError = (
   res: DownloadResponse,
   next: DownloadNext,
 ) => {
+  res.set({
+    ...PUBLIC_FILE_CROSS_ORIGIN_RESOURCE_POLICY,
+    ...PUBLIC_FILE_CACHE_CONTROL_SUCCESS_FAILURE,
+  });
+
   switch (result.outcome) {
     case "pending-scan":
-      // 503 is the only status where Retry-After is formally defined, and the code
-      // distinguishes this from a genuine outage
       return res
         .status(503)
         .set("Retry-After", String(SCAN_RETRY_AFTER_SECONDS))
@@ -164,8 +187,15 @@ export const publicDownloadController: DownloadController = async (
 
   // public route should not reveal that a private file exists
   if (result.isPrivate)
-    return res.status(404).json({ error: "FILE_NOT_FOUND" });
+    return res
+      .status(404)
+      .set({
+        ...PUBLIC_FILE_CROSS_ORIGIN_RESOURCE_POLICY,
+        ...PUBLIC_FILE_CACHE_CONTROL_SUCCESS_FAILURE,
+      })
+      .json({ error: "FILE_NOT_FOUND" });
 
+  res.set(PUBLIC_FILE_CACHE_CONTROL_SUCCESS);
   return sendFile(result, res);
 };
 

--- a/apps/api.planx.uk/modules/file/file.test.ts
+++ b/apps/api.planx.uk/modules/file/file.test.ts
@@ -618,7 +618,7 @@ describe("File download", () => {
 
     it("allows cross-origin embedding, which the editor relies on for public images", async () => {
       const res = await get("somekey/file_name.txt").expect(200);
-      expect(res.headers["cross-origin-resource-policy"]).toBe("cross-site");
+      expect(res.headers["cross-origin-resource-policy"]).toBe("cross-origin");
     });
 
     it("emits a valid HTTP-date for Last-Modified, and no phantom headers", async () => {
@@ -661,6 +661,15 @@ describe("File download", () => {
         .then((_res) => {
           expect(mockGetObject).toHaveBeenCalledTimes(1);
         });
+    });
+
+    it("lets a public file be cached", async () => {
+      await supertest(app)
+        .get("/file/public/somekey/file_name.txt")
+        .expect(200)
+        .then((res) =>
+          expect(res.headers["cache-control"]).toBe("public, max-age=3600"),
+        );
     });
 
     it("should not download private files", async () => {
@@ -837,6 +846,39 @@ describe("File download", () => {
         expect(mockGetObjectTagging).not.toHaveBeenCalled();
       });
 
+      it("relaxes helmet's cross-origin resource policy on a failure, as on a success", async () => {
+        getObjectResponse = {
+          ...getObjectResponse,
+          LastModified: new Date("2026-08-01T00:00:00Z"),
+          TagCount: 0,
+        };
+
+        await get()
+          .expect(503)
+          .then((res) =>
+            expect(res.headers["cross-origin-resource-policy"]).toBe(
+              "cross-origin",
+            ),
+          );
+      });
+
+      it.each([
+        // the private route is covered by useNoCache middleware in all cases
+        ["private", () => get()],
+        // whereas cache control for the public route is handled directly in the controller
+        ["public", () => supertest(app).get(`/file/public/${FILE_PATH}`)],
+      ])("refuses to let a %s failure be cached", async (_route, request) => {
+        getObjectResponse = {
+          ...getObjectResponse,
+          LastModified: new Date("2026-08-01T00:00:00Z"),
+          TagCount: 0,
+        };
+
+        await request()
+          .expect(503)
+          .then((res) => expect(res.headers["cache-control"]).toBe("no-store"));
+      });
+
       it("returns 503 FILE_SCAN_PENDING when non-Scanii tags are present", async () => {
         getObjectResponse = {
           ...getObjectResponse,
@@ -870,7 +912,12 @@ describe("File download", () => {
 
         await get()
           .expect(404)
-          .then((res) => expect(res.body.error).toBe("FILE_FLAGGED"));
+          .then((res) => {
+            expect(res.body.error).toBe("FILE_FLAGGED");
+            expect(res.headers["cross-origin-resource-policy"]).toBe(
+              "cross-origin",
+            );
+          });
       });
 
       // regression: "None" is what the Lambda actually writes for a clean file

--- a/apps/api.planx.uk/modules/file/service/getFile.ts
+++ b/apps/api.planx.uk/modules/file/service/getFile.ts
@@ -6,6 +6,17 @@ import { getScanStatus } from "./scanStatus.js";
 import { s3Factory } from "./utils.js";
 
 /**
+ * Relaxes helmet's default `same-origin` policy, which would otherwise have the browser block the response
+ * before the client sees it (recall that a subdomain is a separate origin, although the same site).
+ *
+ * Needed on error responses as well as success, o/w a client cannot tell a 'pending' file from other failures.
+ */
+export const PUBLIC_FILE_CROSS_ORIGIN_RESOURCE_POLICY = {
+  // one of `same-origin`, `same-site` or `cross-origin` - any other value is simply ignored
+  "cross-origin-resource-policy": "cross-origin",
+} as const;
+
+/**
  * Headers we are willing to pass on from S3, plus additional protections.
  *
  * Deliberately does *not* include Content-Type or Content-Disposition. Callers to getFile set both via
@@ -16,7 +27,7 @@ import { s3Factory } from "./utils.js";
 const buildHeaders = (file: GetObjectCommandOutput) => {
   const headers: Record<string, string> = {
     // allows the editor to load public-bucket images cross-origin
-    "cross-origin-resource-policy": "cross-site",
+    ...PUBLIC_FILE_CROSS_ORIGIN_RESOURCE_POLICY,
     // our Content-Type is authoritative - never let a browser sniff its way past it
     "X-Content-Type-Options": "nosniff",
   };

--- a/apps/editor.planx.uk/src/lib/api/fileUpload/requests.test.ts
+++ b/apps/editor.planx.uk/src/lib/api/fileUpload/requests.test.ts
@@ -1,0 +1,86 @@
+import { http, HttpResponse } from "msw";
+import server from "test/mockServer";
+
+import { waitForPublicFile } from "./requests";
+
+const FILE_URL = `${import.meta.env.VITE_APP_API_URL}/file/public/abc12345/logo.png`;
+let requestCount = 0;
+
+// answers each successive request with the next given status, repeating the last one thereafter
+const serve = (
+  ...responses: Array<{ status: number; retryAfter?: number }>
+) => {
+  requestCount = 0;
+
+  return http.get(FILE_URL, () => {
+    const { status, retryAfter } =
+      responses[Math.min(requestCount, responses.length - 1)];
+    requestCount++;
+
+    if (status === 200) {
+      return new HttpResponse("image-bytes", {
+        status,
+        headers: { "Content-Type": "image/png" },
+      });
+    }
+
+    return HttpResponse.json(
+      { error: status === 503 ? "FILE_SCAN_PENDING" : "FILE_FLAGGED" },
+      {
+        status,
+        headers:
+          retryAfter === undefined
+            ? undefined
+            : { "Retry-After": String(retryAfter) },
+      },
+    );
+  });
+};
+
+describe("waitForPublicFile", () => {
+  it("resolves as ready when the file is served straight away", async () => {
+    server.use(serve({ status: 200 }));
+
+    await expect(waitForPublicFile(FILE_URL)).resolves.toEqual({
+      status: "ready",
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  it("retries while the scan is pending, then resolves as ready", async () => {
+    server.use(serve({ status: 503 }, { status: 503 }, { status: 200 }));
+
+    await expect(
+      waitForPublicFile(FILE_URL, { delaysMs: [0, 0, 0] }),
+    ).resolves.toEqual({ status: "ready" });
+    expect(requestCount).toBe(3);
+  });
+
+  it("gives up as pending once the schedule is exhausted", async () => {
+    server.use(serve({ status: 503 }));
+
+    await expect(
+      waitForPublicFile(FILE_URL, { delaysMs: [0, 0] }),
+    ).resolves.toEqual({ status: "pending" });
+    // one attempt per delay, plus the initial one
+    expect(requestCount).toBe(3);
+  });
+
+  it("does not retry a file the scan has rejected", async () => {
+    server.use(serve({ status: 404 }));
+
+    await expect(
+      waitForPublicFile(FILE_URL, { delaysMs: [0, 0] }),
+    ).resolves.toEqual({ status: "rejected" });
+    expect(requestCount).toBe(1);
+  });
+
+  it("waits no longer than Retry-After asks for", async () => {
+    server.use(serve({ status: 503, retryAfter: 0 }, { status: 200 }));
+
+    await expect(
+      waitForPublicFile(FILE_URL, { delaysMs: [30_000] }),
+    ).resolves.toEqual({ status: "ready" });
+    expect(requestCount).toBe(2);
+  });
+});

--- a/apps/editor.planx.uk/src/lib/api/fileUpload/requests.ts
+++ b/apps/editor.planx.uk/src/lib/api/fileUpload/requests.ts
@@ -2,6 +2,7 @@ import type { AxiosProgressEvent } from "axios";
 import apiClient from "lib/api/client";
 
 import type {
+  FileWaitResult,
   UploadFileResponse,
   UploadFunction,
   UploadHandler,
@@ -33,3 +34,50 @@ export const uploadPrivateFile: UploadFunction = async (file, onProgress) =>
 
 export const uploadPublicFile: UploadFunction = async (file, onProgress) =>
   handleUpload(file, "/file/public/upload", onProgress);
+
+/**
+ * Delay before each retry when waiting for an uploaded file to become servable.
+ *
+ * Most objects are scanned in less than 3s, but it can take significantly longer,
+ * so we ramp up the delay after each attempt, ending on the API's blanket 30s `Retry-After`.
+ */
+export const DEFAULT_POLL_DELAYS_MS = [
+  1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 30_000,
+];
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Wait until an uploaded file can actually be fetched.
+ *
+ * An upload's 200 only means bytes reached S3. The API will not serve a file until Scanii has tagged it,
+ * answering `503 FILE_SCAN_PENDING` with a `Retry-After` until then, so an URL handed back will be broken
+ * for as long as the scan takes. Callers should wait on this before treating an upload as complete.
+ *
+ * Bonus: `delaysMs` is injectable so tests need no fake timers.
+ */
+export const waitForPublicFile = async (
+  fileUrl: string,
+  { delaysMs = DEFAULT_POLL_DELAYS_MS }: { delaysMs?: number[] } = {},
+): Promise<FileWaitResult> => {
+  let attempt = 0;
+  while (true) {
+    const { status, headers } = await apiClient.get(fileUrl, {
+      validateStatus: (status) => [200, 404, 503].includes(status),
+    });
+
+    if (status === 200) return { status: "ready" };
+    // FILE_FLAGGED or FILE_NOT_FOUND - no amount of waiting will help
+    if (status === 404) return { status: "rejected" };
+    if (attempt >= delaysMs.length) return { status: "pending" };
+
+    // we only defer to the header when it asks for *less* than planned
+    const retryAfterMs = Number(headers["retry-after"]) * 1000;
+    const plannedMs = delaysMs[attempt++];
+    await sleep(
+      Number.isFinite(retryAfterMs) && retryAfterMs >= 0
+        ? Math.min(retryAfterMs, plannedMs)
+        : plannedMs,
+    );
+  }
+};

--- a/apps/editor.planx.uk/src/lib/api/fileUpload/types.ts
+++ b/apps/editor.planx.uk/src/lib/api/fileUpload/types.ts
@@ -2,6 +2,19 @@ export type UploadFileResponse = {
   fileUrl: string;
 };
 
+/**
+ * Outcome of waiting for an uploaded file to become servable.
+ *
+ * ready - the API served it, so it can be handed to an <img> or saved
+ * pending - still awaiting its malware scan when we gave up waiting; URL is worth keeping
+ * rejected - flagged by the scan, or gone; waiting longer cannot help
+ */
+export type FileWaitStatus = "ready" | "pending" | "rejected";
+
+export type FileWaitResult = {
+  status: FileWaitStatus;
+};
+
 export type UploadFunction = (
   file: File,
   onProgress?: (progress: number) => void,

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.test.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.test.tsx
@@ -1,8 +1,13 @@
 import { MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MB } from "@planx/file-upload";
+import { waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import server from "test/mockServer";
 import { setup } from "test/utils";
 import { vi } from "vitest";
 
 import PublicFileUploadButton from "./PublicFileUploadButton";
+
+const FILE_URL = `${import.meta.env.VITE_APP_API_URL}/file/public/abc12345/logo.png`;
 
 /**
  * This dropzone used to pass neither `onDropRejected` nor `maxSize`, so an oversized or
@@ -50,4 +55,82 @@ it("reports an oversized image", async () => {
     ),
   ).toBeInTheDocument();
   expect(onChange).not.toHaveBeenCalled();
+});
+
+describe("waiting for the uploaded file to be servable", () => {
+  const uploadHandler = http.post(
+    `${import.meta.env.VITE_APP_API_URL}/file/public/upload`,
+    () => HttpResponse.json({ fileType: "image/png", fileUrl: FILE_URL }),
+  );
+
+  it("holds off firing onChange until the file can actually be fetched", async () => {
+    // hold the file request open with a deferred promise,
+    // so we can observe the button mid-wait rather than racing it
+    let serveFile: () => void;
+    const fileRequested = new Promise<void>((resolve) => {
+      serveFile = resolve;
+    });
+
+    server.use(
+      uploadHandler,
+      http.get(FILE_URL, async () => {
+        await fileRequested;
+        return new HttpResponse("image-bytes", { status: 200 });
+      }),
+    );
+
+    const { onChange, findByLabelText } = await dropFile(
+      new File(["x"], "logo.png", { type: "image/png" }),
+    );
+
+    // the button stays busy while the file is not yet servable
+    expect(await findByLabelText("Upload image")).toHaveAttribute("aria-busy");
+    expect(onChange).not.toHaveBeenCalled();
+
+    // resolve the deferred promise, i.e. have the file request come back
+    serveFile!();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(FILE_URL));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the upload but warns when the scan is still pending", async () => {
+    server.use(
+      uploadHandler,
+      http.get(FILE_URL, () =>
+        HttpResponse.json(
+          { error: "FILE_SCAN_PENDING" },
+          { status: 503, headers: { "Retry-After": "0" } },
+        ),
+      ),
+    );
+
+    const { onChange, findByLabelText } = await dropFile(
+      new File(["x"], "logo.png", { type: "image/png" }),
+    );
+
+    // the upload did succeed, so we keep the URL rather than discarding it
+    expect(
+      await findByLabelText(/may take a moment to appear/),
+    ).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(FILE_URL);
+  });
+
+  it("discards a file the scan has rejected", async () => {
+    server.use(
+      uploadHandler,
+      http.get(FILE_URL, () =>
+        HttpResponse.json({ error: "FILE_FLAGGED" }, { status: 404 }),
+      ),
+    );
+
+    const { onChange, findByLabelText } = await dropFile(
+      new File(["x"], "logo.png", { type: "image/png" }),
+    );
+
+    expect(
+      await findByLabelText(/File could not be processed/),
+    ).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
+++ b/apps/editor.planx.uk/src/ui/shared/PublicFileUploadButton.tsx
@@ -5,8 +5,14 @@ import { styled } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 import { createExtensionValidator } from "@planx/components/shared/extensionValidator";
 import { getRejectionMessage } from "@planx/components/shared/handleRejectedUpload";
-import { MAX_UPLOAD_SIZE_BYTES } from "@planx/file-upload";
-import { uploadPublicFile } from "lib/api/fileUpload/requests";
+import {
+  getAllowedExtensions,
+  MAX_UPLOAD_SIZE_BYTES,
+} from "@planx/file-upload";
+import {
+  uploadPublicFile,
+  waitForPublicFile,
+} from "lib/api/fileUpload/requests";
 import { useCallback, useEffect, useState } from "react";
 import type { FileRejection, FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
@@ -115,8 +121,23 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
       }
       setStatus({ type: "loading" });
       uploadPublicFile(file)
-        .then(({ fileUrl }) => {
-          setStatus({ type: "none" });
+        // we wait while uploaded object is scanned, i.e. until it is fetchable, else
+        // whatever we hand to onChange renders as a broken image until page refresh
+        .then(async ({ fileUrl }) => {
+          const { status } = await waitForPublicFile(fileUrl);
+
+          if (status === "rejected") {
+            return setStatus({
+              type: "error",
+              msg: "File could not be processed. Please try again.",
+            });
+          } else if (status === "pending") {
+            setStatus({
+              type: "error",
+              msg: "File uploaded - your image may take a moment to appear",
+            });
+          } else setStatus({ type: "none" });
+
           onChange && onChange(fileUrl);
         })
         .catch(() => {
@@ -130,10 +151,9 @@ export default function PublicFileUploadButton(props: Props): FCReturn {
   );
 
   const accept = acceptedFileTypes || DEFAULT_FILETYPES;
-
   // `accept` alone is not enough (see extensionValidator.ts). For example, DEFAULT_FILETYPES uses the
   // `image/*` wildcard, which would otherwise let through image formats the API refuses (e.g. .avif, .heic)
-  const allowedExtensions = Object.values(accept).flat();
+  const allowedExtensions = getAllowedExtensions(accept);
 
   // rather than using window.alert, we use the native error display in this component
   const onDropRejected = (fileRejections: FileRejection[]) =>

--- a/packages/file-upload/allowedFileTypes.ts
+++ b/packages/file-upload/allowedFileTypes.ts
@@ -77,11 +77,16 @@ export const PREVIEWABLE_MIME_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Flat, deduplicated list of allowed extensions, derived from ALLOWED_EXTENSIONS_BY_MIME_TYPE above.
+ * Get flat, deduplicated list of allowed extensions from a MIME type to extensions map.
  * Used to 'validate' files by extension only (since MIME types are not reliable).
  */
-export const ALLOWED_EXTENSIONS: string[] = Array.from(
-  new Set(Object.values(ALLOWED_EXTENSIONS_BY_MIME_TYPE).flat()),
+export const getAllowedExtensions = (
+  allowedExtensionsByMimeType: Record<string, string[]>,
+): string[] =>
+  Array.from(new Set(Object.values(allowedExtensionsByMimeType).flat()));
+
+export const ALLOWED_EXTENSIONS: string[] = getAllowedExtensions(
+  ALLOWED_EXTENSIONS_BY_MIME_TYPE,
 );
 
 /**


### PR DESCRIPTION
Builds on #7389. Again, relates to [this ticket](https://trello.com/c/kkt7dKkB), and relevant Slack thread [here](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1788521820727899).

This time we handle another issue - that of logos not appearing after upload in [team settings](https://editor.planx.dev/app/opensystemslab/settings/design), because it can't be fetched until it's been scanned. Like so:

<img width="626" height="270" alt="image" src="https://github.com/user-attachments/assets/d684c072-786a-4a89-acee-57839f9007ea" />

This was a general problem we'd have seen for any public file upload, so here we add logic such that the Editor tries successively to get a 200 from the API, rather than bailing out on the first 503.

[MDN on CORP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Resource-Policy) may be a useful reference here, I had to reap up :nerd_face: 