### PR TITLE
refactor: use fire-and-forget approach for data sanitation cron trigger

### DIFF
--- a/apps/api.planx.uk/modules/webhooks/controller.ts
+++ b/apps/api.planx.uk/modules/webhooks/controller.ts
@@ -3,6 +3,7 @@ import isNull from "lodash/isNull.js";
 import { ServerError } from ".././../errors/index.js";
 import { sendSlackMessage } from "../slack/utils.js";
 import { analyzeSessions } from "./service/analyzeSessions/index.js";
+import type { AnalyzeSessions } from "./service/analyzeSessions/types.js";
 import { getDailyFailedSubmissions } from "./service/dailyFailedSubmissions/index.js";
 import type { FailedSubmissionController } from "./service/dailyFailedSubmissions/types.js";
 import { softDeleteSession } from "./service/deleteSession/index.js";
@@ -217,9 +218,11 @@ export const deleteSessionController: DeleteSessionController = async (
 export const sanitiseApplicationDataController: SanitiseApplicationData =
   async (_req, res, next) => {
     try {
-      const { operationFailed, results } = await sanitiseApplicationData();
-      if (operationFailed) res.status(500);
-      return res.json(results);
+      res.status(202).json({ message: "Sanitation job started" });
+
+      sanitiseApplicationData().catch((error) => {
+        console.error("Unhandled error in sanitiseApplicationData", error);
+      });
     } catch (error) {
       return next(
         new ServerError({
@@ -230,7 +233,7 @@ export const sanitiseApplicationDataController: SanitiseApplicationData =
     }
   };
 
-export const analyzeSessionsController: SanitiseApplicationData = async (
+export const analyzeSessionsController: AnalyzeSessions = async (
   _req,
   res,
   next,

--- a/apps/api.planx.uk/modules/webhooks/service/analyzeSessions/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/analyzeSessions/index.ts
@@ -1,6 +1,6 @@
+import type { OperationResult } from "../../types.js";
 import { postToSlack } from "../sanitiseApplicationData/index.js";
 import { operationHandler } from "../sanitiseApplicationData/operations.js";
-import type { OperationResult } from "../sanitiseApplicationData/types.js";
 import { getAnalyzeSessionOperations } from "./operations.js";
 
 /**

--- a/apps/api.planx.uk/modules/webhooks/service/analyzeSessions/types.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/analyzeSessions/types.ts
@@ -1,0 +1,9 @@
+import type { z } from "zod";
+
+import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
+import type { OperationResult } from "../../types.js";
+
+export type AnalyzeSessions = ValidatedRequestHandler<
+  z.ZodUndefined,
+  OperationResult[]
+>;

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.test.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.test.ts
@@ -1,6 +1,7 @@
 import supertest from "supertest";
 
 import app from "../../../../server.js";
+import { sanitiseApplicationData } from "./index.js";
 import * as operations from "./operations.js";
 
 const mockSend = vi.fn();
@@ -12,6 +13,59 @@ vi.mock("slack-notify", () => ({
 }));
 
 const { post } = supertest(app);
+
+describe("sanitiseApplicationData", () => {
+  it("aggregates results and does not post to Slack when all operations succeed", async () => {
+    const mockOperation1 = vi.fn().mockResolvedValue(["123"]);
+    const mockOperation2 = vi.fn().mockResolvedValue(["456", "789"]);
+
+    vi.spyOn(operations, "getOperations").mockReturnValueOnce([
+      mockOperation1,
+      mockOperation2,
+    ]);
+
+    const { operationFailed, results } = await sanitiseApplicationData();
+
+    expect(operationFailed).toBe(false);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "success", count: 1 }),
+        expect.objectContaining({ status: "success", count: 2 }),
+      ]),
+    );
+    expect(mockSlackNotify).not.toHaveBeenCalled();
+  });
+
+  it("posts to Slack and marks operationFailed when an operation fails", async () => {
+    const mockOperation1 = vi.fn().mockResolvedValue(["123"]);
+    const mockOperation2 = vi
+      .fn()
+      .mockRejectedValue(new Error("Query failed!"));
+
+    vi.spyOn(operations, "getOperations").mockReturnValueOnce([
+      mockOperation1,
+      mockOperation2,
+    ]);
+
+    const { operationFailed, results } = await sanitiseApplicationData();
+
+    expect(operationFailed).toBe(true);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "failure",
+          errorMessage: "Query failed!",
+        }),
+      ]),
+    );
+    expect(mockSlackNotify).toHaveBeenCalledWith(process.env.SLACK_WEBHOOK_URL);
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringMatching(/Error: Query failed!/),
+      }),
+    );
+  });
+});
 
 describe("Sanitise application data webhook", () => {
   const ENDPOINT = "/webhooks/hasura/sanitise-application-data";
@@ -26,151 +80,44 @@ describe("Sanitise application data webhook", () => {
       });
   });
 
-  it("returns a 500 if an unhandled error is thrown whilst running operations", async () => {
-    const mockOperationHandler = vi.spyOn(operations, "operationHandler");
-    mockOperationHandler.mockRejectedValueOnce("Unhandled error!");
-
-    await post(ENDPOINT)
-      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
-      .expect(500)
-      .then((response) =>
-        expect(response.body.error).toMatch(
-          /Failed to sanitise application data/,
-        ),
-      );
-  });
-
-  it("returns a 200 when all operations are successful", async () => {
+  it("returns a 202 when called with correct authorization", async () => {
     const mockOperation1 = vi.fn().mockResolvedValue(["123"]);
-    const mockOperation2 = vi.fn().mockResolvedValue(["456", "789"]);
-    const mockOperation3 = vi.fn().mockResolvedValue(["abc", "def", "ghi"]);
-
-    const mockGetOperations = vi.spyOn(operations, "getOperations");
-    mockGetOperations.mockImplementationOnce(() => [
-      mockOperation1,
-      mockOperation2,
-      mockOperation3,
-    ]);
+    vi.spyOn(operations, "getOperations").mockReturnValueOnce([mockOperation1]);
 
     await post(ENDPOINT)
       .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
-      .expect(200)
+      .expect(202)
       .then((response) => {
-        expect(mockOperation1).toHaveBeenCalled();
-        expect(mockOperation2).toHaveBeenCalled();
-        expect(mockOperation3).toHaveBeenCalled();
-
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              status: "success",
-              count: 1,
-            }),
-            expect.objectContaining({
-              status: "success",
-              count: 2,
-            }),
-            expect.objectContaining({
-              status: "success",
-              count: 3,
-            }),
-          ]),
-        );
+        expect(response.body).toEqual({
+          message: "Sanitation job started",
+        });
       });
   });
 
-  it("returns a 500 when only a single operation fails", async () => {
-    const mockOperation1 = vi.fn().mockResolvedValue(["123"]);
-    const mockOperation2 = vi
-      .fn()
-      .mockRejectedValue(new Error("Query failed!"));
-    const mockOperation3 = vi.fn().mockResolvedValue(["abc", "def", "ghi"]);
-
-    const mockGetOperations = vi.spyOn(operations, "getOperations");
-    mockGetOperations.mockImplementationOnce(() => [
-      mockOperation1,
-      mockOperation2,
-      mockOperation3,
-    ]);
+  it("still returns a 202 and logs the error if sanitiseApplicationData rejects", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const sanitiseModule = await import("./index.js");
+    const mockSanitiseApplicationData = vi
+      .spyOn(sanitiseModule, "sanitiseApplicationData")
+      .mockRejectedValueOnce(new Error("Unhandled failure!"));
 
     await post(ENDPOINT)
       .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
-      .expect(500)
+      .expect(202)
       .then((response) => {
-        expect(mockOperation1).toHaveBeenCalled();
-        expect(mockOperation2).toHaveBeenCalled();
-        expect(mockOperation3).toHaveBeenCalled();
-
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              status: "success",
-              count: 1,
-            }),
-            expect.objectContaining({
-              status: "failure",
-              errorMessage: "Query failed!",
-            }),
-            expect.objectContaining({
-              status: "success",
-              count: 3,
-            }),
-          ]),
-        );
-
-        expect(mockSlackNotify).toHaveBeenCalledWith(
-          process.env.SLACK_WEBHOOK_URL,
-        );
-        expect(mockSend).toHaveBeenCalledWith(
-          expect.objectContaining({
-            text: expect.stringMatching(/Error: Query failed!/),
-          }),
-        );
+        expect(response.body).toEqual({ message: "Sanitation job started" });
       });
-  });
 
-  it("returns a 500 if all operations fail", async () => {
-    const mockOperation1 = vi
-      .fn()
-      .mockRejectedValue(new Error("Query failed!"));
-    const mockOperation2 = vi
-      .fn()
-      .mockRejectedValue(new Error("Query failed!"));
-    const mockOperation3 = vi
-      .fn()
-      .mockRejectedValue(new Error("Query failed!"));
+    await vi.waitFor(() =>
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Unhandled error in sanitiseApplicationData",
+        expect.any(Error),
+      ),
+    );
 
-    const mockGetOperations = vi.spyOn(operations, "getOperations");
-    mockGetOperations.mockImplementationOnce(() => [
-      mockOperation1,
-      mockOperation2,
-      mockOperation3,
-    ]);
-
-    await post(ENDPOINT)
-      .set({ Authorization: process.env.HASURA_PLANX_API_KEY! })
-      .expect(500)
-      .then((response) => {
-        expect(mockOperation1).toHaveBeenCalled();
-        expect(mockOperation2).toHaveBeenCalled();
-        expect(mockOperation3).toHaveBeenCalled();
-
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              status: "failure",
-              errorMessage: "Query failed!",
-            }),
-            expect.objectContaining({
-              status: "failure",
-              errorMessage: "Query failed!",
-            }),
-            expect.objectContaining({
-              status: "failure",
-              errorMessage: "Query failed!",
-            }),
-          ]),
-        );
-      });
+    mockSanitiseApplicationData.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
@@ -16,8 +16,27 @@ export const sanitiseApplicationData = async () => {
     results.push(result);
   }
 
-  const operationFailed = results.some((result) => result.status === "failure");
-  if (operationFailed) await postToSlack(results, "Data Sanitation");
+  const failedOperations = results.filter(
+    (result) => result.status === "failure",
+  );
+  const operationFailed = failedOperations.length > 0;
+
+  if (operationFailed) {
+    const failedOperationNames = failedOperations.map(
+      (result) => result.operationName,
+    );
+    console.error(
+      `Data Sanitation failed for: ${failedOperationNames.join(", ")}`,
+    );
+    await postToSlack(results, "Data Sanitation");
+  } else {
+    const succeededOperationNames = results.map(
+      (result) => result.operationName,
+    );
+    console.log(
+      `Data Sanitation succeeded for: ${succeededOperationNames.join(", ")}`,
+    );
+  }
 
   return { operationFailed, results };
 };

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/index.ts
@@ -1,7 +1,7 @@
 import { getFormattedEnvironment } from "../../../../helpers.js";
 import { sendSlackMessage } from "../../../slack/utils.js";
+import type { OperationResult } from "../../types.js";
 import { getOperations, operationHandler } from "./operations.js";
-import type { OperationResult } from "./types.js";
 
 /**
  * Called by Hasura cron job `sanitise_application_data` on a nightly basis

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/operations.ts
@@ -6,7 +6,8 @@ import { ClientError, gql } from "graphql-request";
 import { $api } from "../../../../client/index.js";
 import { runSQL } from "../../../../lib/hasura/schema/index.js";
 import { deleteFilesByURL } from "../../../file/service/deleteFile.js";
-import type { Operation, OperationResult, QueryResult } from "./types.js";
+import type { OperationResult } from "../../types.js";
+import type { Operation, QueryResult } from "./types.js";
 
 export const RETENTION_PERIOD_MONTHS = 6;
 export const getRetentionPeriod = () =>

--- a/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/types.ts
+++ b/apps/api.planx.uk/modules/webhooks/service/sanitiseApplicationData/types.ts
@@ -2,18 +2,11 @@ import type { z } from "zod";
 
 import type { ValidatedRequestHandler } from "../../../../shared/middleware/validate.js";
 
-export interface OperationResult {
-  operationName: string;
-  status: "processing" | "success" | "failure";
-  count?: number;
-  errorMessage?: string;
-}
-
 export type QueryResult = string[] | string;
 
 export type Operation = () => Promise<QueryResult>;
 
 export type SanitiseApplicationData = ValidatedRequestHandler<
   z.ZodUndefined,
-  OperationResult[]
+  { message: string }
 >;

--- a/apps/api.planx.uk/modules/webhooks/types.ts
+++ b/apps/api.planx.uk/modules/webhooks/types.ts
@@ -1,0 +1,6 @@
+export interface OperationResult {
+  operationName: string;
+  status: "processing" | "success" | "failure";
+  count?: number;
+  errorMessage?: string;
+}

--- a/apps/hasura.planx.uk/metadata/cron_triggers.yaml
+++ b/apps/hasura.planx.uk/metadata/cron_triggers.yaml
@@ -30,11 +30,6 @@
   schedule: 0 2 * * *
   include_in_metadata: true
   payload: {}
-  retry_conf:
-    num_retries: 0
-    retry_interval_seconds: 10
-    timeout_seconds: 120
-    tolerance_seconds: 21600
   headers:
     - name: authorization
       value_from_env: HASURA_PLANX_API_KEY


### PR DESCRIPTION
This PR is an alternative version of #7369 following Daf's comment. Instead of splitting the one cron trigger into 4 separate ones (with the same 10 operations run), this trigger returns a 202 right away, the API runs the operation, and if any errors they are logged to Slack. 

I tested the endpoint locally (both a success and a failure--the latter by revoking API privileges on updating `lowcal_sessions` and saw a Slack notification as expected. I could also create some dummy data to test the actual cron part. 