### PR TITLE
Search UI tweaks

### DIFF
--- a/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/FlowDetailsPanel.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { formatLastEditMessage } from "pages/FlowEditor/utils";
 import { cardBoxShadow } from "theme";
 import FlowTag from "ui/editor/FlowTag/FlowTag";
-import { FlowTagType } from "ui/editor/FlowTag/types";
+import { FlowTagType, StatusVariant } from "ui/editor/FlowTag/types";
 
 import { Badge } from "../../../components/Badge/Badge";
 import { BadgeVariant } from "../../../components/Badge/types";
@@ -33,16 +33,24 @@ export const FlowDetailsPanel: React.FC<FlowDetailsPanelProps> = ({
     : undefined;
 
   const hasSendComponent = Boolean(flow.publishedFlows[0]?.hasSendComponent);
+  const statusVariant =
+    flow.status === "online" ? StatusVariant.Online : StatusVariant.Offline;
 
   const result: SearchResult = {
     icon: <Badge variant={BadgeVariant.Team} team={flow.team} size="compact" />,
     sourceTeam: flow.team.name,
-    statusLabel: flow.status === "online" ? "Online" : undefined,
     title: flow.name,
     meta: editMessage,
-    tag: hasSendComponent ? (
-      <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
-    ) : undefined,
+    tag: (
+      <>
+        <FlowTag tagType={FlowTagType.Status} statusVariant={statusVariant}>
+          {statusVariant}
+        </FlowTag>
+        {hasSendComponent && (
+          <FlowTag tagType={FlowTagType.ServiceType}>Submission</FlowTag>
+        )}
+      </>
+    ),
     description: flow.summary ?? undefined,
     primaryAction:
       canCopy && flow.canCreateFromCopy

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -11,14 +11,12 @@ import type { SearchResult } from "./SearchResult";
 interface SearchListItemProps {
   result: SearchResult;
   onClick?: () => void;
-  onHover?: () => void;
   selected?: boolean;
 }
 
 export const SearchListItem: React.FC<SearchListItemProps> = ({
   result: { icon, title, description, statusLabel },
   onClick,
-  onHover,
   selected,
 }) => {
   const content = (
@@ -61,8 +59,6 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
     return (
       <ListItemButton
         onClick={onClick}
-        onMouseEnter={onHover}
-        onFocus={onHover}
         alignItems="center"
         selected={selected}
         sx={{ px: 2, py: 1.5, gap: 1.5 }}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItem.tsx
@@ -11,12 +11,14 @@ import type { SearchResult } from "./SearchResult";
 interface SearchListItemProps {
   result: SearchResult;
   onClick?: () => void;
+  onHover?: () => void;
   selected?: boolean;
 }
 
 export const SearchListItem: React.FC<SearchListItemProps> = ({
   result: { icon, title, description, statusLabel },
   onClick,
+  onHover,
   selected,
 }) => {
   const content = (
@@ -59,6 +61,8 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({
     return (
       <ListItemButton
         onClick={onClick}
+        onMouseEnter={onHover}
+        onFocus={onHover}
         alignItems="center"
         selected={selected}
         sx={{ px: 2, py: 1.5, gap: 1.5 }}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchListItemDetail.tsx
@@ -54,7 +54,7 @@ export const SearchListItemDetail: React.FC<SearchListItemDetailProps> = ({
           {meta}
         </Typography>
       )}
-      {tag && <Box sx={{ mt: 1.5, display: "flex" }}>{tag}</Box>}
+      {tag && <Box sx={{ mt: 1.5, display: "flex", gap: 1 }}>{tag}</Box>}
       {description && (
         <Typography variant="body1" sx={{ mt: 2 }}>
           {description}

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -177,7 +177,9 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                 No results found
               </Typography>
               <Typography sx={{ color: "text.secondary", pt: 1 }}>
-                Check your search term and try again
+                {search.trim()
+                  ? "Check your search term and try again"
+                  : "Nothing to show here yet"}
               </Typography>
             </Box>
           )}
@@ -231,6 +233,7 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                             : flow.team.name,
                         }}
                         onClick={() => setSelectedFlow(flow)}
+                        onHover={() => setSelectedFlow(flow)}
                         selected={selectedFlow?.id === flow.id}
                       />
                     </React.Fragment>

--- a/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
+++ b/apps/editor.planx.uk/src/pages/Explore/components/SearchModal.tsx
@@ -233,7 +233,6 @@ export const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
                             : flow.team.name,
                         }}
                         onClick={() => setSelectedFlow(flow)}
-                        onHover={() => setSelectedFlow(flow)}
                         selected={selectedFlow?.id === flow.id}
                       />
                     </React.Fragment>

--- a/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
+++ b/apps/editor.planx.uk/src/pages/Explore/components/useSearchFlows.ts
@@ -4,13 +4,17 @@ export interface FlowsWhere {
   is_template?: { _eq: boolean };
   can_create_from_copy?: { _eq: boolean };
   templated_from?: { _is_null: boolean };
+  team?: { slug: { _nin: string[] } };
 }
 
 export type FlowFilter = "all" | "templates" | "copyable";
 
+const SEARCH_EXCLUDED_TEAMS = ["testing"];
+
 // Exclude templated flows, showing only source templates and subscriptions within those
 const EXCLUDE_TEMPLATED_FLOWS: FlowsWhere = {
   templated_from: { _is_null: true },
+  team: { slug: { _nin: SEARCH_EXCLUDED_TEAMS } },
 };
 
 const FILTER_WHERE: Record<FlowFilter, FlowsWhere> = {
@@ -54,6 +58,37 @@ export interface FlowSearchResult {
 
 const RESULTS_LIMIT = 50;
 
+// Fields shared by the ranked search_flows query and the unranked browse-all query
+const FLOW_SEARCH_RESULT_FIELDS = `
+  id
+  name
+  slug
+  summary
+  status
+  isTemplate: is_template
+  canCreateFromCopy: can_create_from_copy
+  templatedFrom: templated_from
+  team {
+    id
+    name
+    slug
+    theme {
+      primaryColour: primary_colour
+      logo
+    }
+  }
+  publishedFlows: published_flows(order_by: { created_at: desc }, limit: 1) {
+    hasSendComponent: has_send_component
+  }
+  operations(limit: 1, order_by: { created_at: desc }) {
+    createdAt: created_at
+    actor {
+      firstName: first_name
+      lastName: last_name
+    }
+  }
+`;
+
 const SEARCH_FLOWS = gql`
   query SearchFlows($search: String!, $where: flows_bool_exp, $limit: Int!) {
     results: search_flows(
@@ -61,53 +96,66 @@ const SEARCH_FLOWS = gql`
       where: $where
       limit: $limit
     ) {
-      id
-      name
-      slug
-      summary
-      status
-      isTemplate: is_template
-      canCreateFromCopy: can_create_from_copy
-      templatedFrom: templated_from
-      team {
-        id
-        name
-        slug
-        theme {
-          primaryColour: primary_colour
-          logo
-        }
-      }
-      publishedFlows: published_flows(
-        order_by: { created_at: desc }
-        limit: 1
-      ) {
-        hasSendComponent: has_send_component
-      }
-      operations(limit: 1, order_by: { created_at: desc }) {
-        createdAt: created_at
-        actor {
-          firstName: first_name
-          lastName: last_name
-        }
-      }
+      ${FLOW_SEARCH_RESULT_FIELDS}
+    }
+  }
+`;
+
+// Powers browsing "Templates" / "Flows I can copy" with no search term entered,
+// mirroring the ranked SEARCH_FLOWS shape so callers don't need to branch on result shape
+const BROWSE_FLOWS = gql`
+  query BrowseFlows($where: flows_bool_exp, $limit: Int!) {
+    results: flows(where: $where, order_by: { name: asc }, limit: $limit) {
+      ${FLOW_SEARCH_RESULT_FIELDS}
     }
   }
 `;
 
 const MIN_SEARCH_LENGTH = 3;
 
+// "All flows" has no browse-all view (too broad) - it only shows results once you search
+const BROWSABLE_FILTERS: FlowFilter[] = ["templates", "copyable"];
+
 export const useSearchFlows = (search: string, filter: FlowFilter) => {
+  const trimmedSearch = search.trim();
   // search_flows won't return anything for under 3 characters so don't execute
-  const skip = search.trim().length < MIN_SEARCH_LENGTH;
+  const isSearching = trimmedSearch.length >= MIN_SEARCH_LENGTH;
+  const isPartialSearch = trimmedSearch.length > 0 && !isSearching;
+  const canBrowse = BROWSABLE_FILTERS.includes(filter);
 
-  const { data, loading } = useQuery<{ results: FlowSearchResult[] }>(
-    SEARCH_FLOWS,
-    {
-      variables: { search, where: FILTER_WHERE[filter], limit: RESULTS_LIMIT },
-      skip,
+  const { data: searchData, loading: searchLoading } = useQuery<{
+    results: FlowSearchResult[];
+  }>(SEARCH_FLOWS, {
+    variables: {
+      search: trimmedSearch,
+      where: FILTER_WHERE[filter],
+      limit: RESULTS_LIMIT,
     },
-  );
+    skip: !isSearching,
+  });
 
-  return { results: data?.results, loading, skipped: skip };
+  const { data: browseData, loading: browseLoading } = useQuery<{
+    results: FlowSearchResult[];
+  }>(BROWSE_FLOWS, {
+    variables: { where: FILTER_WHERE[filter], limit: RESULTS_LIMIT },
+    skip: isSearching || isPartialSearch || !canBrowse,
+  });
+
+  if (isSearching) {
+    return {
+      results: searchData?.results,
+      loading: searchLoading,
+      skipped: false,
+    };
+  }
+
+  if (canBrowse && !isPartialSearch) {
+    return {
+      results: browseData?.results,
+      loading: browseLoading,
+      skipped: false,
+    };
+  }
+
+  return { results: undefined, loading: false, skipped: true };
 };


### PR DESCRIPTION
Implements suggested changes from the [Slack thread](https://opensystemslab.slack.com/archives/C5Q59R3HB/p1788350690391159):

- Hide 'Testing' team's flows from results
- 'Templates' and 'Flows I can copy' chips show all flows in the set until a term is entered
- Details panel shows on result hover as well as click
- Use more chip variants for styling