### PR TITLE
fix [alt notes]: account for undefined ID on initial component creation and correctly show in graph

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/components/Flow/components/Node.tsx
@@ -107,7 +107,6 @@ const Node: React.FC<any> = (props) => {
       //   from the source template unless within a templated folder
       const showNoteComponent =
         showNotes &&
-        node.id &&
         (!isTemplatedFrom ||
           showNoteInTemplatedFlow(node.id, flow, orderedFlow));
 

--- a/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/showNoteInTemplatedFlow.ts
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/lib/store/utils/showNoteInTemplatedFlow.ts
@@ -10,10 +10,12 @@ import type { Store } from "..";
 // In templated flows, always hide `Note` components and attached `notes` props in the graph
 //   unless either is attached to a templated node or within a templated folder
 export const showNoteInTemplatedFlow = (
-  nodeId: string,
+  nodeId: string | undefined,
   flow: Store.Flow,
   orderedFlow: OrderedFlow | undefined,
 ) => {
+  if (!nodeId || !flow[nodeId]) return false;
+
   const isAttachedToTemplatedNode = flow[nodeId]?.data?.isTemplatedNode;
   const parent = getParentId(nodeId);
   const indexedParent = orderedFlow?.find(({ id }) => id === parent);


### PR DESCRIPTION
Realised I introduced a small bug to staging upon merging #7396 

To test: 
- On staging: toggle "show notes" on in a regular, non-templated flow. Add a standalone "Note" component and it doesn't display on graph :x: 
- On this pizza: repeat and expect "Note" to display as corrected ! 