### PR TITLE
fix: Max width of nested flows with notes

### DIFF
--- a/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
+++ b/apps/editor.planx.uk/src/pages/FlowEditor/floweditor.scss
@@ -161,8 +161,12 @@ $fontMonospace: "Source Code Pro", monospace;
     }
   }
 
+  &.portal {
+    max-width: $nodeMaxWidth;
+  }
+
   &.portal .card-wrapper {
-    max-width: 260px;
+    max-width: $nodeMaxWidth;
     & > a {
       flex-direction: row;
     }
@@ -668,7 +672,7 @@ $fontMonospace: "Source Code Pro", monospace;
 
   &.external-portal {
     &[data-loading="true"] {
-      width: 260px;
+      width: $nodeMaxWidth;
     }
   }
 


### PR DESCRIPTION
## Issue

Reported in Slack here: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1789032724168159

<img width="2756" height="280" alt="image" src="https://github.com/user-attachments/assets/5fcdbaa0-0d6e-48da-98d0-81b8e5437c28" />

- Attached notes expand nested flow components in graph horizontally

## Solution

- Correctly apply max-width property to nested flows in graph, to ensure notes don't expand width beyond node max-width

<img width="404" height="329" alt="image" src="https://github.com/user-attachments/assets/77e4ae2e-e425-4213-8d2a-8ab1c15f59b2" />

### Testing

Flow containing the offending nested flow highlighted by Jonny:
https://7405.planx.pizza/app/opensystemslab/report-a-planning-breach%2CG7k8GO2YZC