### PR TITLE
[ci] bump vultr update timeout to 15m

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -364,7 +364,7 @@ jobs:
           host: ${{ env.FULL_DOMAIN }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          # command_timeout: 10m
+          command_timeout: 15m
           # TODO: some of below script might be superfluous for server update (rather than create)
           script: |
             apk update


### PR DESCRIPTION
We commented out the `command_timeout` for the Vultr update step in #7384, but it hasn't worked because that just drops us down to the [appleboy/ssh-action default timeout](https://github.com/appleboy/ssh-action#%EF%B8%8F-ssh-command-settings), which is also 10 minutes!

So bumping it here to 15 mins explicitly to hopefully abate CI problems - intended as a temporary measure until we resolve whatever is slowing things down.