### PR TITLE
fix: Team data failing to load

### DIFF
--- a/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
+++ b/apps/editor.planx.uk/src/routes/_authenticated/app/$team/route.tsx
@@ -4,6 +4,7 @@ import RouteLoadingIndicator from "components/RouteLoadingIndicator";
 import gql from "graphql-tag";
 import { client } from "lib/graphql";
 import { CatchAllComponent } from "pages/ErrorPage/CatchAllComponent";
+import { useEffect } from "react";
 
 import { useStore } from "../../../../pages/FlowEditor/lib/store";
 
@@ -66,16 +67,17 @@ export const Route = createFileRoute("/_authenticated/app/$team")({
 
     return { team };
   },
-  loader: ({ context, cause }) => {
-    if (cause !== "preload") {
-      useStore.getState().setTeam(context.team);
-    }
-    return context.team;
-  },
+  loader: ({ context }) => context.team,
   component: FlowsLayout,
   notFoundComponent: CatchAllComponent,
 });
 
 function FlowsLayout() {
+  const team = Route.useLoaderData();
+
+  useEffect(() => {
+    useStore.getState().setTeam(team);
+  }, [team]);
+
   return <Outlet />;
 }


### PR DESCRIPTION
## Issue

Reported by @augustlindemer in Slack: 
https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1789128854532539

When accessing a team from the root / team select page, data is not load correctly, causing flow list and other entries to be empty.

## Solution

Moved `setTeam()` from the `$team` route's loader (which TanStack router's 30s preload cache was silently skipping after a hover) into a `useEffect` in the route component, which only mounts on actual navigation - fixing the root list hover+click case.